### PR TITLE
Tal'Dorei Campaign Guide subclasses

### DIFF
--- a/subclass/College of the Maestro.json
+++ b/subclass/College of the Maestro.json
@@ -1,0 +1,157 @@
+{
+	"subclass": [
+		{
+			"class": "Bard",
+			"authors": [
+				"Matthew Mercer"
+			],
+			"version": "1.2",
+			"url": "http://www.dmsguild.com/product/183630/College-of-the-Maestro--Bard-College-Option",
+			"name": "College of the Maestro",
+					"subclassFeatures": [
+						[
+							{
+								"name": "College of the Maestro",
+								"entries": [
+									"Music is a powerful thing. It can bolster a burning passion, inspire the meek to bravery, and sooth a cluttered mind. Wandering bards have mastered the art of creating music to shape and manipulate the thoughts and hearts of the world through song, words, and instrument. However, it is the Maestro who has learned to evoke music from the natural world around them and weave these notes with arcane skill into melodies of dynamic and potent magic.",
+									"With but a raised hand or wand, a Maestro listens for the clang of arms on armor, the heavy footfalls of a giant, the crackle of a bolt of lightning, and catches them, crafting them into a symphony of rousing musical movements. They conduct the sounds of the battlefield like a phantom orchestra, empowering the blows of their allies, altering the minds and moods of their opponents, and changing the pace of the fray in their favor.",
+									"The College of the Maestro calls to those who enjoy enabling their companions to become even more adept, working in unison with your sonata. It refines those of raw talent into majestic performers who can pluck the thoughts from a mind like a musical note, amplify the fears of lesser beings through sourceless, ominous tones, and seemingly stretch time by commanding the tempo of a heartbeat. Maestros become heroes who can take the chaos of the world and carve it as they see fit by controlling the vibrations of music that subtly guide the realm.",
+									{
+										"type": "entries",
+										"name": "Battle Muse",
+										"entries": [
+											"When you join the College of the Maestro at 3rd level, you gain one additional use ofyour Bardic Inspiration feature.",
+											"This feature grants you another additional use of Bardic Inspiration at 6th level, and again at 14th level."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Symphony of Conflict",
+										"entries": [
+											"You've been trained in the bardic art of magically manipulating the sounds of combat into a concert of powerful melodies that can alter the very battlefield around you.", 
+											"When you select this bardic school at 3rd level, you learn '2 conducting techniques of your choice, which are detailed under “Conducting Techniques“ below. All techniques require at least one free hand, baton, or wand to utilize. For these techniques to function, you must be able to see your target, and they must be able to hear you.",
+											"You learn 1 additional conducting technique of your choice at 6th and 14th level. Each time you learn a new technique, you can also replace one technique you know with a different one."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Conducting Techniques",
+										"entries":[
+											{
+												"type": "options",
+												"entries": [
+													{
+														"type": "entries",
+														"name": "Aria of Suspense (Ansia)",
+														"entries": [
+															"You build an air of tension and paranoia with subtle, droning tones. As an action, you expend and roll a Bardic Inspiration die. For the next 10 minutes, any creatures of your choice within 60 feet cannot be surprised, and gain a bonus on saving throws against traps and environmental hazards equal to your Bardic Inspiration die roll."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Crash (Marcato).",
+														"entries": [
+															"You learn how to harness and amplify the roar of a well-placed blow into a violent explosion of sound. When a creature other than yourself within 60 feet of you hits with an attack, you can use your reaction to expend and roll a Bardic Inspiration die. The target of the triggering attack must make a Strength saving throw against your Spell save DC or take thunder damage equal to half of the number rolled and be knocked prone."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Dirge of Dread (Finale)",
+														"entries": [
+															"You play a terrifying dirge to accompany a deathblow, striking fear into the hearts of your nearby enemies. When an ally brings a creature within 60 feet to 0 hitpoints, you can use your reaction to expend and roll a Bardic Inspiration die. Select a number of creatures within 15 feet of the triggering ally equal to half of the number rolled (minimum 1). Each target must make a Wisdom saving throw against your Spell save DC or become frightened of the triggering ally until the end of that ally’s next turn. After the effect ends, or the save is successful, targeted creatures are immune to Dirge of Dread for the next 24 hours."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Dissonance (Discordria)",
+														"entries": [
+															"Summoning a harsh, discordant tone, you muddle the mind of an opponent, lessening their defenses. When a creature within 60 feet is forced to make a saving throw, you can use your reaction to expend and roll a Bardic Inspiration die. You reduce their saving throw by half of the number rolled. You can use this feature after the creature makes its saving throw roll, but before the DM determines a success or failure."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Guiding Tone (Fermata)",
+														"entries": [
+															"You drag a sharp, powerful chord through the mind of a creature, forcing it to suddenly stumble in a direction you wish. As a bonus action, you expend and roll a Bardic Inspiration die and select a creature other than yourself within 60 feet. The target must succeed on a Wisdom saving throw against your Spell save DC or take psychic damage equal to half of the number rolled and be pushed 10 feet in a direction you choose. A target can fail the saving throw voluntarily."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Hasten Tempo (Accelerando)",
+														"entries": [
+															"Your manipulation of tempo and song can inspire others to act more quickly. You can use a Bonus action on your turn to choose one creature other than yourself within 60 feet. Expend and roll a Bardic Inspiration die, adding the number rolled to the creature’s initiative and moving them up the initiative order accordingly. If this would move them higher than you, they immediately take their turn after you this round. A creature cannot be affected by Hasten Tempo again until they’ve finished a short or long rest."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Hymn of Harmony (Ammonia)",
+														"entries": [
+															"The melodies surrounding your allies promote rapid recovery. When a creature that has a Bardic Inspiration die from you regains any hitpoints, they can expend and roll their inspiration die to regain additional hitpoints equal to the number rolled."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Majestic Anthem (Maestoso)",
+														"entries": [
+															"Pulled from the chaos, you muster an uplifting melody that bolsters the resolve of your allies. You can expend and roll a Bardic Inspiration die as an action, and all other creatures you choose within 60 ft gain temporary hitpoints equal to the number rolled plus your Charisma modifier (minimum of 1). These temporary hitpoints last until the end of your next turn."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Resonance (Risonanza)",
+														"entries": [
+															"You shape the harmonic vibrations of a weapon’s movements into a dangerous, sonic enhancement. Using a bonus action, you can expend and roll a Bardic Inspiration die, choosing one weapon within 60 feet of you. Until the end of your next turn, all attacks with that weapon deal additional thunder damage equal to half of number rolled (minimum of 1)."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Sprint (Presto)",
+														"entries": [
+															"The song you conjure can stir the winds, pushing along those who require expedient travel. A creature that has a Bardic Inspiration die from you can expend and roll their inspiration to increase their speed for that turn. A roll of 1—4 increases their speed by 10 feet. a roll of 5-8 increases their Speed by 15 feet, and a roll of 9—12 increases their speed by 20 feet."
+														]
+													}
+												]
+											}
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Frenetic Crescendo",
+										"entries": [
+											"At 6th level, you can harness the beat of battle, whipping it into a frenzy of drums, chants, and glory. You can use your action to expend any number of uses of your Bardic Inspiration feature. For each expended use, you can immediately grant a Bardic Inspiration die to a creature other than yourself within 60 feet that you can see. A creature can have only one Bardic Inspiration die at a time.", 
+											"Once you use this feature, you must finish a long rest before you can use it again."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Virtuoso of Captivation",
+										"entries": [
+											"Upon reaching 14th level, you can begin conducting a mystical symphony as an action, distracting and capturing the minds of of nearby creatures. For up to 10 minutes, any number of creatures you choose within 60 feet who can hear you have disadvantage on any saving throws against being charmed and against magical steep.",
+											"In addition, affected targets have disadvantage on Wisdom (Perception) rolls that rely on sight or sound to detect targets other than you.",
+											"In combat, you must spend your action each turn to continue the performance or the effect ends. Once you use Virtuoso of Captivation, you must finish a short or long rest before you can use it again."
+										]
+									}
+								]
+							}
+						]
+					],
+					"source": "Homebrew",
+					"shortName": "Maestro"
+				}
+							
+							
+							
+	]
+}

--- a/subclass/TalDorei Campaign Guide.json
+++ b/subclass/TalDorei Campaign Guide.json
@@ -1,0 +1,423 @@
+{
+	"subclass": [
+		{
+			"class": "Cleric",
+			"authors": [
+				"Matthew Mercer"
+			],
+			"version": "1.0",
+			"url": "https://greenroninstore.com/products/critical-role-tal-dorei-campaign-setting",
+			"name": "Blood Domain",
+					"subclassFeatures": [
+						[
+							{
+								"name": "Blood Domain",
+								"entries": [
+									"Originally developed in Wildemount by the Claret Orders, the Blood domain centers around the understanding of the natural life force within one’s own physical body. The power of blood is the power of sacrifice, the balance of life and death, and the spirit’s anchor within the mortal shell. The Gods of Blood seek to tap into the connection between body and soul through divine means, exploit the hidden reserves of will within one’s own vitality, and even manipulate or corrupt the body of others through these secret rites of crimson. Almost any neutral or evil deity can claim some influence over the secrets of blood magic and this domain, while the gods who watch from more moral realms shun its use beyond extenuating circumstance.",
+									"When casting divine spells as a Blood Domain cleric, consider ways to occasionally flavor your descriptions to tailor the magic’s effect on the opponent’s blood and vitality. Hold person might involve locking a target’s body into place from the blood stream out, preventing them from moving. Cure wounds may feature the controlling of blood like a needle and thread to close lacerations. Guardian of Faith could be a floating, crimson spirit of dripping viscera who watches the vicinity with burning red eyes. Have fun with the themes!",
+									{
+										"type": "table",
+										"caption": "Blood Domain Spells",
+										"colLabels": [
+											"Cleric Level",
+											"Spells"
+										],
+										"colStyles": [
+											"col-xs-3 text-align-center",
+											"col-xs-9"
+										],
+										"rows": [
+											[
+												"1st",
+												"{@spell sleep}, {@spell ray of sickness}"
+											],
+											[
+												"3rd",
+												"{@spell ray of enfeeblement}, {@spell crown of madness}"
+											],
+											[
+												"5th",
+												"{@spell haste}, {@spell slow}"
+											],
+											[
+												"7th",
+												"{@spell blight}, {@spell stoneskin}"
+											],
+											[
+												"9th",
+												"{@spell dominate person}, {@spell hold monster}"
+											]
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Bonus Proficiency",
+										"entries": [
+											"When you choose this domain at 1st level, you gain proficiency with martial weapons."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Bloodletting Focus",
+										"entries": [
+											"From 1st level, your divine magics draw the blood from inflicted wounds, worsening the agony of your nearby foes. When you use a spell of 1st level or higher to damage to any creatures that have blood, those creatures suffer additional necrotic damage equal to 2 + the spell’s level. "
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Channel Divinity: Blood Puppet",
+										"entries": [
+											"Starting at 2nd level, you can use your Channel Divinity to briefly control a creature’s actions against their will. ",
+											"As an action, you target a Large or smaller creature that has blood within 60 feet of you. That creature must succeed on a Constitution saving throw against your spell save DC or immediately move up to half of their movement in any direction of your choice and make a single weapon attack against a creature of your choice within range. Dead or unconscious creatures automatically fail their saving throw."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Spell Breaker",
+										"entries": [
+											"Starting at 6th level, you can use your Channel Divinity to focus on a sample of blood from a creature that is at least 2 ounces, and that has been spilt no longer than a week ago. As an action, you can focus on the blood of the creature to form a bond and gain information about their current circumstances. You know their approximate distance and direction from you, as well as their general state of health, as long as they are within 10 miles of you. You can maintain Concentration on this bond for up to 1 hour.",
+											"During your bond, you can spend an action to attempt to connect with the bonded creature’s senses. The target makes a Constitution saving throw against your spell save DC. If they succeed, the connection is resisted, ending the bond. You suffer 2d6 necrotic damage. Upon a failed saving throw, you can choose to either see through the eyes of or hear through their ears of the target for a number of rounds equal to your Wisdom modifier (minimum of 1). During this time, you are blind or deaf (respectively) with regard to your own senses. Once this connection ends, the Crimson Bond is lost.",
+											{
+												"type": "table",
+												"caption": "Arcane Banishment",
+												"colLabels": [
+													"Cleric level",
+													"Banishes Creatures of CR..."
+												],
+												"colStyles": [
+													"col-xs-3 text-align-center",
+													"col-xs-9"
+												],
+												"rows": [
+													[
+														"100%",
+														"Untouched"
+													],
+													[
+														"99%-50%",
+														"Injured"
+													],
+													[
+														"49%-1%",
+														"Heavily Wounded"
+													],
+													[
+														"0%",
+														"Unconscious or dying"
+													],
+													[
+														"-",
+														"Dead"
+													]
+												]
+											}
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Sanguine Recall",
+										"entries": [
+											"At 8th level, you can sacrifice a portion of your own vitality to recover expended spell slots. As an action, you recover spell slots that have a combined level equal to or less than half of your cleric level (rounded up), and none of the slots can be 6th level or higher. You immediately suffer 1d6 damage per spell slot level recovered. You can’t use this feature again until you finish a long rest.",
+											"For example, if you’re a 4th-level Cleric, you can recover up to two levels of spell slots. You can recover either a 2nd-level spell slot or two 1st-level spell slots. You then suffer 2d6 damage"
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Vascular Corruption Aura",
+										"entries": [
+											"At 17th level, you can emit a powerful aura as an action that extends 30 feet out from you that pulses necrotic energy through the veins of nearby foes, causing them to burst and bleed. For 1 minute, any enemy creatures with blood that begin their turn within the aura or enter it for the first time on their turn immediately suffer 2d6 necrotic damage. Any enemy creature with blood that would regain hit points while within the aura only regains half of the intended number of hit points (rounded up).",
+											"Once you use this feature, you can’t use it again until you finish a long rest."
+										]
+									}
+								]
+							}
+						]
+					],
+					"source": "TDCS",
+					"shortName": "Blood"
+		},
+		{
+			"class": "Barbarian",
+			"authors": [
+				"Matthew Mercer"
+			],
+			"version": "1.0",
+			"url": "https://greenroninstore.com/products/critical-role-tal-dorei-campaign-setting",
+			"name": "Path of the Juggernaut",
+					"subclassFeatures": [
+						[
+							{
+							"name": "Path of the Juggernaut",
+								"entries": [
+									"When the Herd of Storms led their terrible raids across the continent under the leadership of Kevdak, tales spread of their bloodlust, brutality, and nigh unstoppable strength. Walls crumbled and legions fell to but a handful of fearsome warriors as they cut a path for the herd to charge in and take what they wished before vanishing back into the Dividing Plains. These fearsome barbarians that would break through the shields and towers of nearby townships became known as the Juggernauts.",
+									"While the Herd of Storms is no more, the lineage of trained juggernauts that survived to join the Rivermaw still teach the ways of their unbreakable rage. Honed to assault the lairs of powerful threats to their way of life, or defend against armed hordes of snarling goblinoids, the juggernauts represent the finest of frontline destroyers within the primal lands of Tal’Dorei and beyond.",
+									{
+										"type": "entries",
+										"name": "Thunderous Blows",
+										"entries": [
+											"Starting when you choose this path at 3rd level, your rage instills you with the strength to batter around your foes, making any battlefield your domain. Once per turn while raging, when you damage a creature with a melee attack, you can force the target to make a Strength saving throw (DC 8 + your proficiency bonus + your Strength modifier). On a failure, you push the target 5 feet away from you, and you can choose to immediately move 5 feet into the target’s previous position."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Stance of the Mountain",
+										"entries": [
+											"You harness your fury to anchor your feet to the earth, shrugging off the blows of those who wish to topple you. Upon choosing this path at 3rd level, you cannot be knocked prone while raging unless you become unconscious."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Demolishing Might",
+										"entries": [
+											"Beginning at 6th level, you can muster destructive force with your assault, shaking the core of even the strongest structures. All of your melee attacks gain the siege property (your attacks deal double damage to objects and structures). Your melee attacks against creatures of the construct type deal an additional 1d8 weapon damage."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Overwhelming Cleave",
+										"entries": [
+											"Upon reaching 10th level, you wade into armies of foes, great swings of your weapon striking many who threaten you. When you make a weapon attack while raging, you Chapter 3: Character Options 103 tal’dorei campaign guide can make another attack as a bonus action with the same weapon against a different creature that is within 5 feet of the original target and within range of your weapon. "
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Unstoppable",
+										"entries": [
+											"Starting at 14th level, you can become “unstoppable” when you rage. If you do so, for the duration of the rage your speed cannot be reduced, and you are immune to the frightened, paralyzed, and stunned conditions. If you are frightened, paralyzed, or stunned, you can still take your bonus action to enter your rage and suspend the effects for the duration of the rage. When your rage ends, you suffer one level of exhaustion (as described in appendix A, PHB)."
+										]
+									}
+								]
+							}
+						]
+					],
+					"source": "TDCS",
+					"shortName": "Juggernaut"
+		},
+		{
+			"class": "Sorcerer",
+			"authors": [
+				"Matthew Mercer"
+			],
+			"version": "1.0",
+			"url": "https://greenroninstore.com/products/critical-role-tal-dorei-campaign-setting",
+			"name": "Runechild",
+					"subclassFeatures": [
+						[
+							{
+								"name": "Runechild",
+								"entries": [
+									"The weave and flow of magic is mysterious and feared by many across Exandria. Many study the nature of the arcane in hopes of learning to harness it, while sorcerers carry innate talent to sculpt and wield the errant strands of power that shape the world. Some sorcerers occasionally find their body itself becomes a conduit for such energies, their flesh collecting and storing remnants of their magic in the form of natural runes. These anomalies are known in erudite circles as runechildren.",
+									"The talents of a runechild are rare indeed, and many are sought after for study by mages and scholars alike, driven by a prevalent belief that the secrets within their body can help understand many mysteries of the arcane. Others seek to enslave them, using their bodies as tortured spell batteries for their own diabolic pursuits. Their subjugation all throughout the Age of Arcanum has driven the few that exist this day into hiding their essence – a task that is not easy, given the revealing nature of their gifts.",
+									{
+										"type": "entries",
+										"name": "Tempestuous Magic",
+										"entries": [
+											"At 1st level, your body has begun to express your innate magical energies as natural runes that hide beneath your skin. You begin with 1 Essence Rune, and gain an additional rune whenever you gain a level in this class. Runes can manifest anywhere on your body, though the first usually manifests on the forehead. They remain invisible when inert.",
+											"At the end of a turn where you spent any number of sorcery points for any of your class features, an equal number of essence runes glow with stored energy, becoming charged runes. If you expend a charged rune to use one of your Runechild features, it returns to being an inert essence rune.",
+											"As a bonus action, you may spend any number of sorcery points to convert an equal number of essence runes into charged runes. If you have no sorcery points and no charged runes, you can convert a single essence rune into a charged rune as an action.",
+											"If you have 5 or more charged runes, you emit bright light in a 5 foot radius and dim light for an additional 5 feet. Any charged runes revert to inert essence runes after you complete a long rest."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Glyphs of Aegis",
+										"entries": [
+											"Beginning at 1st level, you can release the stored arcane power within your runes to absorb or deflect threatening attacks against you. Whenever you take damage from an attack, hazard, or spell, you can use a reaction to expend any number of charged runes, rolling 1d6 per charged rune. You subtract the total rolled from the damage inflicted by the attack, hazard, or spell.",
+											"At 6th level, you can use an action to expend a charged rune, temporarily transferring a Glyph of Aegis to a creature you touch. A creature can only hold a single glyph, and it lasts for 1 hour, or until the creature is damaged by an attack, hazard, or spell. The next time that creature takes damage from any of those sources, roll 1d6 and subtract the number rolled from the damage roll. The glyph is then lost."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Sigilic Augmentation",
+										"entries": [
+											"Upon reaching 6th level, you can channel your runes to temporarily bolster your physical capabilities. You can expend a charged rune as a bonus action to enhance either your Strength, Dexterity, or Constitution, granting you advantage on ability checks with the chosen ability score until the start of your next turn. You can choose to maintain this benefit additional rounds by expending a charged rune at the start of each of your following turns."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Manifest Inscriptions",
+										"entries": [
+											"At 6th level, you can reveal hidden glyphs and enchantments that surround you. As an action, you can expend a charged rune to cause any hidden magical marks, runes, wards, or glyphs within 15 feet of you to reveal themselves with a glow for 1 round. This glow is considered dim light for a 5 foot radius around the mark or glyph."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Runic Torrent",
+										"entries": [
+											"Upon reaching 14th level, you can channel your stored runic energy to instill your spells with overwhelming arcane power, bypassing even the staunchest defenses. Whenever you cast a spell, you can expend a number of charged runes equal to the spell's level to allow it to ignore any resistance or immunity to the spell's damage type the targets may have. "
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Arcane Exemplar",
+										"entries": [
+											"Beginning at 18th level, you can use a bonus action and expend 6 or more charged runes to temporarily become a being of pure magical energy. This new form lasts for 3 rounds plus 1 round for each charged rune expended over 6. While you are in your exemplar form, you gain the following benefits:",
+											{
+											"type":"list",
+											"items": [
+												"You have a flying speed of 40 feet.",
+												"Your spell save DC is increased by 2.",
+												"You have resistance to damage from spells.",
+												"When you cast a spell of 1st level or higher, you regain hit points equal to the spell's level."
+												]
+											},
+											"When your Arcane Exemplar form ends, you can’t move or take actions until after your next turn, as your body recovers from the transformation. Once you use this feature, you must finish a long rest before you can use it again."
+										]
+									}
+								]
+							}
+						]
+					],
+					"source": "TDCS",
+					"shortName": "Runechild"
+		},
+		{
+			"class": "Monk",
+			"authors": [
+				"Matthew Mercer"
+			],
+			"version": "1.0",
+			"url": "https://greenroninstore.com/products/critical-role-tal-dorei-campaign-setting",
+			"name": "Way of the Cobalt Soul",
+					"subclassFeatures": [
+						[
+							{	
+								"name": "Way of the Cobalt Soul",
+								"entries": [
+									"Driven by the pursuit of knowledge and their worship of the Knowing Mistress, the monastery of the Cobalt Soul (known as the library of the Cobalt Reserve) stands as one of the most well-respected and most heavily guarded repository of tomes, history, and information across Exandria. Here, young people seeking the clarity of truth and the strength of knowledge pledge to learn the arts of seeking enlightenment by understanding the world around them, and mastering the techniques to defend it. To become a Cobalt Soul is to give one’s self to the quest for unveiling life’s mysteries, bringing light to the secrets of the dark, and guarding the most powerful and dangerous of truths from those who would seek to pervert the sanctity of civilization.",
+									"The monks of the Cobalt Soul are the embodiment of the phrase “know your enemy”. Through research, they prepare themselves against the ever-coming tides of evil. Through careful training, they have learned to puncture and manipulate the spiritual flow of an opponent’s body. Through understanding the secrets of their foe, they can adapt and surmount them. Then, once the fight is done, they return to record their findings for future generations of monks to study from.",
+									{
+										"type": "entries",
+										"name": "Mystical Erudition",
+										"entries": [
+											"Upon choosing this tradition at 3rd level, you’ve undergone extensive training with the Cobalt Soul, allowing you to mystically recall information on history and lore from the monastery’s collected volumes. Whenever you make an Intelligence (Arcana), Intelligence (History), or Intelligence (Religion) check, you can spend 1 ki point to gain advantage on the roll.",
+											"In addition, you learn one language of your choice. You gain additional languages at 11th and 17th level."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Extract Aspects",
+										"entries": [
+											"Beginning at 3rd level when choosing this tradition, when you pummel an opponent and connect with multiple pressure points, you can extract crucial information about your foe. Whenever you hit a single creature with two or more attacks in one round, you can spend 1 ki point to force the target to make a Constitution saving throw. On a failure, you learn one aspect about the creature of your choice: Creature Type, Armor Class, Senses, Highest Saving Throw Modifier, Lowest Saving Throw Modifier, Damage Vulnerabilities, Damage Resistances, Damage Immunities, or Condition Immunities.",
+											"Upon reaching 6th level, if the target fails their saving throw, you can choose two aspects to learn. This increases to three aspects at 11th level, and four aspects at 17th level."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Extort Truth",
+										"entries": [
+											"At 6th level, you can hit a series of hidden nerves on a creature with precision, temporarily causing them to be unable to mask their true thoughts and intent. If you manage to hit a single creature with two or more attacks in one round, you can spend 2 ki points to force them to make a Charisma saving throw. You can choose to have these attacks deal no damage. On a failed save, the creature is unable to speak a deliberate lie for 1 minute. You know if they succeeded or failed on their saving throw.",
+											"An affected creature is aware of the effect and can thus avoid answering questions to which it would normally respond with a lie. Such a creature can be evasive in its answers as long as the effect lasts."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Mind of Mercury",
+										"entries": [
+											"Starting at 6th level, you’ve honed your awareness and reflexes through mental aptitude and pattern recognition. You can take a number of additional reactions each round equal to your Intelligence modifier (minimum of 1), at the cost of 1 ki point per reaction beyond the first. You can only use one reaction per trigger.", 
+											"In addition, whenever you make an Intelligence (Investigation) check, you can spend 1 ki point to gain advantage on the roll."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Preternatural Counter",
+										"entries": [
+											"Beginning at 11th level, your quick mind and study of your foe allows you to use their failure to your advantage. If a creature misses you with an attack, you can immediately use your reaction to make a melee attack against that creature. "
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"entries": [
+									{
+										"type": "entries",
+										"name": "Debilitating Barrage",
+										"entries": [
+											"Upon reaching 17th level, you’ve gained the knowledge to temporarily alter and lower a creature’s fortitude by striking a series of pressure points. Whenever you hit a single creature with three or more attacks in one round, you can spend 3 ki points to give the creature disadvantage to their attack rolls until the end of your next turn, and they must make a Constitution saving throw. On a failure, the creature suffers vulnerability to a damage type of your choice for 1 minute, or until after they take any damage of that type.", 
+											"Creatures with resistance or immunity to the chosen damage type do not suffer this vulnerability, which is revealed after the damage type is chosen. You can select the damage type from the following list: acid, bludgeoning, cold, fire, force, lightning, necrotic, piercing, poison, psychic, radiant, slashing, thunder. "
+										]
+									}
+								]
+							}
+						]
+					],
+					"source": "TDCS",
+					"shortName": "Cobalt Soul"
+				}
+		
+	]
+}


### PR DESCRIPTION
More stuff from Matt Mercer: Blood Domain Cleric, Juggernaut Barbarian, Runechild Sorcerer, Cobalt Soul Monk. All from the Critical Role setting book. Also College of the Maestro Bard from DMs Guild.