### PR TITLE
fix(data): Formatting and data fixes + errata

### DIFF
--- a/creature/Kobold Press; Tome of Beasts.json
+++ b/creature/Kobold Press; Tome of Beasts.json
@@ -49,7 +49,7 @@
 					"type": "list",
 					"items": [
 						"The Bear King magically conjures up a swarm of eight giant bees (use {@creature giant wasp} statistics) to defend his lair. The bees act immediately, and on initiative count 20 in subsequent rounds. The bees remain until they're killed or until the Bear King dismisses them as an action. The Bear King can use this action again, but no more than eight giant bees can be present at a time.",
-						"The Bear King targets a creature within the lair that he can see. The creature must succeed on a DC 15 Constitution saving throw or be magically transformed into a brown bear as if by a {@spell polymorph} spell. At the beginning of its turn, a transformed creature repeats the saving throw. If it fails, the creature must use its action to attack one of the Bear King's foes. If it succeeds, the effect ends and the creature returns to its normal form. The effect lasts until the creature succeeds on the saving throw or until the Bear King uses this lair action again",
+						"The Bear King targets a creature within the lair that he can see. The creature must succeed on a DC 15 Constitution saving throw or be magically transformed into a brown bear as if by a {@spell polymorph} spell. At the beginning of its turn, a transformed creature repeats the saving throw. If it fails, the creature must use its action to attack one of the Bear King's foes. If it succeeds, the effect ends and the creature returns to its normal form. The effect lasts until the creature succeeds on the saving throw or until the Bear King uses this lair action again.",
 						"The Bear King causes the ground in a 20-foot radius to tremble and shake. Any creatures in the affected area must succeed on a DC 15 Strength saving throw or suffer 7 (2d6) bludgeoning damage and fall prone. The ground continues to tremble until initiative count 20 on the following round, during which time the area is difficult terrain."
 					]
 				}
@@ -59,12 +59,12 @@
 				{
 					"type": "list",
 					"items": [
-						"Within 10 miles of the Bear King's lair, creatures have disadvantage on saving throws made to avoid contractinglycanthropy from a werebear.",
+						"Within 10 miles of the Bear King's lair, creatures have disadvantage on saving throws made to avoid contracting lycanthropy from a werebear.",
 						"Bees within 10 miles of the Bear King's lair are easily agitated and quick to attack. Insect swarms (bees or hornets) are common in the area, but they tend to ignore locals.",
 						"Emotions within 5 miles of the Bear King's lair run high. Arguments quickly descend into physical scuffles and enjoyable get-togethers are likely to become raucous carousing or even brawls."
 					]
 				},
-				"If the Bear King dies, conditions in the area surrounding the lair return to normal over the course of 1d6 days"
+				"If the Bear King dies, conditions in the area surrounding the lair return to normal over the course of 1d6 days."
 			]
 		},
 		{
@@ -75,7 +75,7 @@
 					"type": "list",
 					"items": [
 						"The Lord of the Hunt chooses a point he can see within the lair. Plants erupt from the ground in a 20-foot radius surrounding that point, creating difficult terrain. Any creatures in the area at the start of their turn, or who enter the area for the first time on a turn, must make a successful DC 15 Dexterity saving throw or become restrained by the vines and take 13 (3d8) poison damage. A creature can be freed if it or an adjacent ally uses an action to make a successful DC 15 Strength check. This effect lasts until the Lord of the Hunt uses this lair action again, or dies.",
-						"The Lord of the Hunt lets out a war cry. A creature the Lord can see within 120 feet must succeed on a DC 15 Wisdom saving throw or be frightened for 1 minute. A frightened creature repeats the saving throw at the end of its turn, ending the effect on itself on a success",
+						"The Lord of the Hunt lets out a war cry. A creature the Lord can see within 120 feet must succeed on a DC 15 Wisdom saving throw or be frightened for 1 minute. A frightened creature repeats the saving throw at the end of its turn, ending the effect on itself on a success.",
 						"The Lord of the Hunt magically marks a target he can see within 120 feet. The Lord has advantage on attack rolls against the marked target. The mark lasts until initiative count 20 on the following turn."
 					]
 				}
@@ -86,7 +86,7 @@
 					"type": "list",
 					"items": [
 						"Game animals become plentiful within 3 miles of the lair. Wisdom (Survival) checks to hunt for food are made with advantage, but patrols from the Wild Hunt don't take kindly to poachers.",
-						"Domesticated animals within 3 miles of the lair become skittish and fearful. They are more difficult to handle and flee the area if left to their own devices",
+						"Domesticated animals within 3 miles of the lair become skittish and fearful. They are more difficult to handle and flee the area if left to their own devices.",
 						"Areas of natural terrain within 3 miles of the lair subtly rearrange themselves to create game trails through even the densest wilderness."
 					]
 				},
@@ -112,7 +112,7 @@
 					"type": "list",
 					"items": [
 						"Dreams and fears take on a life of their own. Minor visual and auditory hallucinations plague creatures within 6 miles of the lair.",
-						"The Moonlit King can communicate telepathically with and share the senses of any {@creature stryx|ToB 3pp} within 10 miles of his lair",
+						"The Moonlit King can communicate telepathically with and share the senses of any {@creature stryx|ToB 3pp} within 10 miles of his lair.",
 						"Weather conditions don't inhibit moonlight shining within 10 miles of the lair; clouds part, rain seems to channel moonbeams, snow takes on a luminous silver glow."
 					]
 				},
@@ -133,16 +133,16 @@
 				}
 			],
 			"regionalEffects": [
-				"The region containing the Queen of Night and Magic's lair is warped by her magic, which creates one or more of the following effects:",
+				"The region containing the Queen of Night and Magic's lair is warped by her magic, which creates one or more of the following effects. While the Summer Court rules, the regional effects of the Queen's lair extend into the Winter Palace, but they are diminished and weaker than normal. During the Winter Court's reign, the Winter Palace is not subject to the regional effects.",
 				{
 					"type": "list",
 					"items": [
 						"Shadows come to life within 6 miles of the Queen's lair. Most of the time these living shadows are unnerving and nothing more, but when a creature acts against the interests of the Queen, the shadows can interfere and cause any relevant die roll to be made with disadvantage.",
-						"Magic saturates the area within 6 miles of the lair, causing minor random effects similar to a {@spell prestidigitation} cantrip",
+						"Magic saturates the area within 6 miles of the lair, causing minor random effects similar to a {@spell prestidigitation} cantrip.",
 						"The Queen of Night and Magic can cast her senses to any area containing darkness, dim light, or shadows within 6 miles of her lair, similar to a {@spell clairvoyance} spell."
 					]
 				},
-				"While the Summer Court rules, the regional effects of the Queen's lair extend into the Winter Palace, but they are diminished and weaker than normal. During the Winter Court's reign, the Winter Palace is not subject to the regional effects. If the Queen of Night and Magic dies, conditions in the area surrounding the lair gradually return to normal over the course of 2d10 days."
+				"If the Queen of Night and Magic dies, conditions in the area surrounding the lair gradually return to normal over the course of {@dice 2d10} days."
 			]
 		},
 		{
@@ -163,7 +163,7 @@
 				{
 					"type": "list",
 					"items": [
-						"Calling Nicnevin's name under the light of the moon within 10 miles of her lair draws Nicnevin's attention (as if she cast a {@spell scrying} spell). She may visit the supplicant and hear a request, especially if the request is repeated on multiple nights. For 24 hours after the invocation, Nicenvin has a connection to the area that allows her to target it with teleportation circle",
+						"Calling Nicnevin's name under the light of the moon within 10 miles of her lair draws Nicnevin's attention (as if she cast a {@spell scrying} spell). She may visit the supplicant and hear a request, especially if the request is repeated on multiple nights. For 24 hours after the invocation, Nicenvin has a connection to the area that allows her to target it with teleportation circle.",
 						"Despite the weather, the moon is always visible for most of the night within 10 miles of the lair. Cloud cover has many breaks, or the moon's light sharply penetrates the clouds.",
 						"Silvery fog is common within 10 miles of the lair, and strange whispers are heard within the mist."
 					]
@@ -190,8 +190,8 @@
 					"type": "list",
 					"items": [
 						"The current of rivers and streams within 6 miles of the lair becomes strong and erratic. Creatures without a swim speed who start their turns in running water must succeed on a DC 15 Strength (Athletics) check or be swept 60 feet downriver.",
-						"Lakes, ponds, rivers, and streams within 6 miles of the lair teem with fish and other wildlife",
-						"Rain and thunderstorms are common within 6 miles of the lair, and often build to torrential downpours that create heavy obscurement and cause waterways to overflow their banks"
+						"Lakes, ponds, rivers, and streams within 6 miles of the lair teem with fish and other wildlife.",
+						"Rain and thunderstorms are common within 6 miles of the lair, and often build to torrential downpours that create heavy obscurement and cause waterways to overflow their banks."
 					]
 				},
 				"If the River King dies, conditions in the area surrounding the lair return to normal over the course of 1d10 days."
@@ -215,12 +215,12 @@
 				{
 					"type": "list",
 					"items": [
-						"Within 10 miles of the lair, snow and ice resist melting. Snow and ice can be melted only with prolonged contact with fire",
-						"The sky is overcast most of the time within 10 miles of the lair, and snowfall is common. The area is difficult terrain for Tiny, Small, and Medium creatures because of deep snow",
+						"Within 10 miles of the lair, snow and ice resist melting. Snow and ice can be melted only with prolonged contact with fire.",
+						"The sky is overcast most of the time within 10 miles of the lair, and snowfall is common. The area is difficult terrain for Tiny, Small, and Medium creatures because of deep snow.",
 						"Light snowfall or swirling powder blown by the wind lightly obscures the area within 5 miles of the lair."
 					]
 				},
-				"If the Snow Queen dies, conditions in the area surrounding the lair return to normal over the course of 1d10 days."
+				"If the Snow Queen dies, conditions in the area surrounding the lair return to normal over the course of {@dice 1d10} days."
 			]
 		},
 		{
@@ -232,7 +232,7 @@
 					"items": [
 						"A cloud of smoke swirls in a 20-foot-radius sphere centered on a point the dragon can see within 120 feet of it. The cloud spreads around corners and the area is lightly obscured. Each creature in the cloud must succeed on a DC 15 Constitution saving throw or be blinded for 1 minute. A blinded creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success.",
 						"The ground erupts with volcanic force at a point the dragon can see within 120 feet of it. Any creature within 20 feet of the point must make a successful DC 15 Dexterity saving throw or be knocked prone and trapped in the ground. A creature trapped in this way is restrained and can't stand up. A creature can end the restraint if it or another creature takes an action to make a successful DC 15 Strength check.",
-						"wall of fire rises up from the ground within 120 feet of the dragon. The wall is up to 60 feet long, 10 feet high, and 5 feet thick, can take any shape the dragon wants, and blocks line of sight. When the wall appears, each creature in its area must make a DC 15 Dexterity saving throw. A creature that fails the saving throw takes 21 (6d6) fire damage. Each creature that enters the wall for the first time each turn or ends its turn there takes 21 (6d6) fire damage. The wall is extinguished when the dragon uses this lair action again or when the dragon dies."
+						"A wall of fire rises up from the ground within 120 feet of the dragon. The wall is up to 60 feet long, 10 feet high, and 5 feet thick, can take any shape the dragon wants, and blocks line of sight. When the wall appears, each creature in its area must make a DC 15 Dexterity saving throw. A creature that fails the saving throw takes 21 ({@dice 6d6}) fire damage. Each creature that enters the wall for the first time each turn or ends its turn there takes 21 ({@dice 6d6}) fire damage. The wall is extinguished when the dragon uses this lair action again or when the dragon dies."
 					]
 				}
 			],
@@ -243,10 +243,285 @@
 					"items": [
 						"Arguments and misunderstandings erupt easily within 6 miles of the lair. Friendships are easily broken and criminal acts are common.",
 						"Temperatures rise within 6 miles of the lair. Crops wither, producing famines.",
-						"Sulfur geysers form in and around the dragon's lair. Some of them erupt only once an hour, so they're spotted only with a successful DC 20 Wisdom (Perception) check. A creature on top of an erupting geyser takes 21 (6d6) fire damage, or half damage with a successful DC 15 Dexterity saving throw."
+						"Sulfur geysers form in and around the dragon's lair. Some of them erupt only once an hour, so they're spotted only with a successful DC 20 Wisdom (Perception) check. A creature on top of an erupting geyser takes 21 ({@dice 6d6}) fire damage, or half damage with a successful DC 15 Dexterity saving throw."
 					]
 				},
-				"If the dragon dies, the arguments and misunderstandings disappear immediately and the temperatures go back to normal within 1d10 days. Any geysers remain where they are."
+				"If the dragon dies, the arguments and misunderstandings disappear immediately and the temperatures go back to normal within {@dice 1d10} days. Any geysers remain where they are."
+			]
+		},
+		{
+			"name": "Sea Dragon",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), the dragon takes a lair action and generates one of the following effects. The dragon can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+						"Four vortexes, each 5 feet in diameter and up to 30 feet tall, appear within the lair where the dragon wishes. Creatures occupying the space where a vortex appears or who enter the vortex for the first time on a turn must make a DC 15 Dexterity save or be restrained. As an action, a creature can free itself or another creature from a vortex by succeeding on a DC 15 Strength check. The vortexes last until the dragon uses this lair action again or until the dragon dies.",
+						"The dragon creates a wall of living coral on a solid surface it can see within 120 feet of it. The wall can be up to 30 feet long, 30 feet high, and 1 foot thick. When the wall appears, each creature within its area takes damage as if touching the wall and is pushed 5 feet out of the wall's space, on whichever side of the wall it wants. Touching the wall releases painful stings that deal 18 ({@dice 4d8}) poison damage, or half that with a successful DC 15 Constitution saving throw. Each 10-foot section of the wall has AC 5, 30 hit points, resistance to fire damage, and immunity to psychic damage. The wall lasts until the dragon uses this lair action again or until the dragon dies.",
+						"The dragon bends time around its enemies. Four creatures the dragon can see within 120 feet of it must succeed on a DC 15 Wisdom save or be affected by a slow spell. This effect lasts until initiative count 20 on the following round."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing a legendary sea dragon's lair is warped by the dragon's magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Sea life becomes richer within 6 miles of the lair. Schools of fish move into new waters, sharks become common, and whale migration paths shift to pass near the area.",
+						"Water temperatures drop sharply within 6 miles of the lair. Creatures not accustomed to cold suffer exposure to extreme cold while swimming in this water.",
+						"Storms and rough water are more common within 6 miles of the lair."
+					]
+				},
+				"If the dragon dies, conditions of the sea surrounding the lair return to normal over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Void Dragon",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), the dragon takes a lair action and generates one of the following effects. The dragon can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+						"The dragon negates natural gravity within its lair (an area affected by its gravitic breath is unaffected). Creatures drift 10 feet away from the ground over the course of a round and are restrained. Flying creatures can move at half speed, unless they have the (hover) tag or use magical flight, in which case they move normally. This effect persists until initiative count 20 on the following round.",
+						"The Void briefly overlaps the dragon's lair in a 20-foot-radius sphere of blackness punctuated by deep blue streaks and pinpoints of light. The sphere is centered on a point the dragon can see within 120 feet of the dragon. The area spreads around corners, is heavily obscured, and contains no air (creatures must hold their breath). Each creature in the sphere when it appears must make a DC 15 Constitution saving throw, taking 10 ({@dice 3d6}) cold damage on a failed save or half as much on a successful one. Any creature that ends its turn in the sphere takes 10 ({@dice 3d6}) cold damage. The sphere lasts until the dragon uses this lair action again or until the dragon dies.",
+						"The dragon rips the fabric of space, forcing two creatures it can see within 120 feet of it to suddenly exist in the same place. Space itself repels the creatures to their original positions. Each creature takes 16 ({@dice 3d10}) force damage and is knocked prone, or takes half as much damage and is not knocked prone with a successful DC 15 Strength saving throw."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing a legendary void dragon's lair is warped by the dragon's magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Secrets have a way of coming to light within 6 miles of the lair. Clues are inadvertently discovered, slips of the tongue hint at a hidden truth, and creatures become morbidly curious for forbidden knowledge.",
+						"Light is muted within 6 miles of the lair. Nonmagical illumination, including sunlight, can't create bright light in this area.",
+						"Visitations from otherworldly beings occur and disembodied voices whisper in the night within 6 miles of the dragon's lair. Celestials, fey, and fiends of CR 2 or lower can slip into the world in this area."
+					]
+				},
+				"If the dragon dies, these effects fade over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Wind Dragon",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), the dragon takes a lair action and generates one of the following effects. The dragon can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+						"Sand and dust swirls up from the floor in a 20-foot radius sphere within 120 feet of the dragon at a point the dragon can see. The sphere spreads around corners. The area inside the sphere is lightly obscured, and each creature in the sphere at the start of its turn must make a successful DC 15 Constitution saving throw or be blinded for 1 minute. A blinded creature repeats the saving throw at the start of each of its turns, ending the effect on itself with a success.",
+						"Fragments of ice and stone are torn from the lair's wall by a blast of wind and flung along a 15-foot cone. Creatures in the cone take 18 ({@dice 4d8}) bludgeoning damage, or half damage with a successful DC 15 Dexterity saving throw.",
+						"A torrent of wind blasts outward from the dragon in a 60-foot radius, either racing just above the floor or near the ceiling. If near the floor, it affects all creatures standing in the radius; if near the ceiling, it affects all creatures flying in the radius. Affected creatures must make a successful DC 15 Strength saving throw or be knocked prone and stunned until the end of their next turn."
+					]
+				}
+			]
+		},
+		{
+			"name": "Emperor Of The Ghouls",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), the Emperor takes a lair action to cause one of the following effects.The Emperor can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+						"Until initiative count 20 on the following round, all creatures other than undead and constructs who take necrotic damage take an additional 7 ({@dice 2d6}) necrotic damage.",
+						"The emperor targets a creature within 30 feet that he can see. The creature must succeed on a DC 15 Constitution saving throw or take 18 ({@dice 4d8}) necrotic damage. The emperor regains hit points equal to the damage.",
+						"A wall of ice springs up from a surface within 100 feet of the emperor. The wall is 60 feet long, 10 feet high, and 5 feet thick. A creature in the wall's space when it appears must succeed on a DC 15 Dexterity saving throw or take 10 ({@dice 3d6}) cold damage; then the creature is pushed to either side of the wall (the creature's choice). Each 5-foot section of the wall has AC 10, 15 hit points, resistance to piercing and slashing damage, immunity to cold, poison, and psychic damage, and vulnerability to fire damage. The wall lasts until the emperor uses this action again, or dies."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region around the emperor's lair is warped by its magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Creatures within 1 mile of the lair who are infected with darakhul fever have disadvantage on Wisdom saving throws against spells and effects generated by ghouls or darakhul.",
+						"Dead bodies within 1 mile of the lair have an 80 percent chance to reanimate as skeletons or zombies 24 hours after their death. These undead never attack ghouls or dharakul, but instinctively obey their commands.",
+						"Phantom lights appear within 10 miles of the lair, more frequently the closer they are to the lair. The lights shed dim light out to 10 feet. Undead within such a light gain {@dice 1d6} temporary hit points at the start of their turn; the light can't raise an undead's hit points above 150 percent of its normal hit point maximum."
+					]
+				},
+				"If the emperor dies, conditions in the area surrounding the lair return to normal over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Hraesvelgr",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), Hraesvelgr takes a lair action to cause one of the following effects. Hraesvelgr can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+						"Hraesvelgr unleashes a blast of wind in a 60-foot cone. All creatures in the area must succeed on a DC 15 Dexterity saving throw or be knocked prone.",
+						"One creature within 60 feet that Hraesvelgr can see must succeed on a DC 15 Strength saving throw or be swept up in a pillar of wind. The creature is restrained and suspended 15 feet off the ground. If the creature has something to pull on, it can pull itself out of the wind by using an action and making a successful DC 15 Strength check; another creature who can reach the suspended creature can pull it free in the same way. Alternatively, a flying creature can repeat the saving throw as an action. On a success, it moves 5 feet out of the pillar of wind. This effect lasts until Hraesvelgr takes this action again or dies.",
+						"Hraesvelgr lets out a thunderous bellow in giant form or an ear-splitting shriek in roc form. All creatures within 30 feet must make a successful DC 15 Constitution saving throw or be frightened for 1 minute. A frightened creature repeats the saving throw at the end of its turn, ending the effect on itself on a success."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing Hraesvelgr's lair is warped by the corpse swallower's magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Strong windstorms are common within 6 miles of the lair.",
+						"Giant avian beasts are drawn to the lair and fiercely defend it against intruders.",
+						"The wind within 10 miles of the lair bears a pungent carrion stench."
+					]
+				},
+				"If Hraesvelgr dies, conditions in the area surrounding the lair return to normal over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Koschei",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), Koschei takes a lair action to cause one of the following effects. Koschei can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+						"Koschei creates a whirlwind centered on a point he can see within 100 feet. The whirlwind is 10 feet wide and up to 50 feet tall. A creature in the area of the whirlwind when it's created, or who enters the area for the first time on a turn, must make a DC 15 Strength saving throw. On a failed save, the creature is restrained and takes 18 ({@dice 4d8}) bludgeoning damage from the buffeting wind. A restrained creature can escape from the whirlwind by using its action to repeat the saving throw; on a success, it moves 5 feet outside the area of the whirlwind. The whirlwind lasts until Koschei uses this action again or dies.",
+						"Tortured spirits appear and attack up to three creatures Koschei can see within the lair. One attack is made against each targeted creature; each attack has +8 to hit and does 10 ({@dice 3d6}) necrotic damage.",
+						"Koschei disrupts the flow of magic in his lair. Until initiative count 20 on the following round, any creature other than a fiend who targets Koschei with a spell must make a DC 15 Wisdom saving throw. On a failure, the creature still casts the spell, but it must target a creature other than Koschei."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing Koschei's lair is warped by Koschei's magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Rabbits, ducks, and other game animals become hostile toward intruders within 5 miles of the lair. They behave aggressively, but only attack if cornered. Foraging for food by hunting is difficult and only yields half the normal amount of food.",
+						"Wind and snowstorms are common within 5 miles of the lair.",
+						"Koschei is aware of any spell cast within 5 miles of his lair. He knows the source of the magic (innate, the caster's class, or a magic item) and knows the direction to the caster."
+					]
+				},
+				"If Koschei dies, conditions in the area surrounding his lair return to normal over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Mammon",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), Mammon takes a lair action to cause one of the following effects; Mammon can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+					"Mammon infuses a pile of treasure in his lair with life. It becomes an earth elemental made of precious metals and gems. The elemental acts immediately and lasts until destroyed or until Mammon uses this action again.",
+					"Stacked piles of treasure shift and slide, collapsing onto a creature Mammon can see. The creature is restrained until initiative count 20 on the following round, or until it or an adjacent ally uses an action to make a successful DC 18 Strength check to free it.",
+					"Mammon magically teleports from one area of treasure to another within 150 feet."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing Mammon's lair is warped by the archdevil's magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Treasure in the possession of creatures other than Mammon turns to worthless materials such as lead, wood, or gravel, after spending 24 hours within 1 mile of the lair. The resulting junk resumes its valuable form when Mammon claims it, or by means of a wish spell or comparable magic.",
+						"Creatures that spend more than 1 hour within 1 mile of Mammon's lair become obsessed with gaining the most generous payment or portion of wealth in any dealing unless they succeed on a DC 18 Wisdom saving throw. A creature that saves successfully is immune to this effect for 24 hours. The effect can be removed by a greater restoration spell or comparable magic.",
+						"Any naturally occurring treasure in Mammon's home plane reverts to worthless junk if removed from the plane. Similarly, any mundane item left behind transforms into something fantastically valuable, as long as it remains on the plane."
+					]
+				},
+				"If Mammon dies, conditions in the area surrounding the lair return to normal over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Mechuiti",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), Mechuiti takes a lair action to cause one of the following effects. Mechuiti can't use the same effect two rounds in a row.",
+				{
+					"type": "list",
+					"items": [
+						"Mechuiti targets one creature it can see within 120 feet of it, and a fissure full of lava opens under the target's feet. The target must succeed on a DC 20 Dexterity saving throw or take 28 ({@dice 8d6}) fire damage.",
+						"The whole volcano trembles and shakes. Each creature on a solid surface other than a demon must succeed on a DC 20 Dexterity saving throw or be knocked prone. All ground in the volcano becomes difficult terrain for creatures other than a demon until initiative count 20 on the next round.",
+						"Volcanic gases form a cloud in a 20-foot-radius sphere centered on a point Mechuiti can see within 120 feet of it. The sphere spreads around corners, and its area is lightly obscured. It lasts until initiative count 20 on the next round. Each creature that starts its turn in the cloud must succeed on a DC 15 Constitution saving throw or be poisoned until the end of its next turn. While poisoned in this way, a creature is incapacitated.",
+						"The pain of all creatures other than demons within 120 feet of Mechuiti is intensified. Until initiative count 20 on the next round, every time a creature affected this way takes damage, he must succeed on a DC 15 Constitution saving throw or be stunned until the end of its next turn."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing Mechuiti's lair is warped by its presence, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Mechuiti can make the volcano erupt at will. A cloud of hot ashes and smoke covers a 6 mile area around the volcano, and magma flows from the volcano's cone.",
+						"When intelligent creatures within 6 miles sleep, they dream with Mechuiti. Unless they make a successful DC 15 Wisdom saving throw, they are compelled to seek out and join Mechuiti's cult.",
+						"Water within 1 mile of the lair carries Mechuiti's Ichor disease. Any creature that drinks the water must make a successful DC 15 Constitution saving throw against disease or be infected. An infected creature is poisoned until the disease is cured. Every 24 hours that elapse, the target must repeat the saving throw. On a failure, its hit point maximum is reduced by 5 (2d4). The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured."
+					]
+				},
+				"When Mechuiti dies, all these regional effects fade immediately."
+			]
+		},
+		{
+			"name": "Nihileth",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), the nihileth can take a lair action to create one of the magical effects listed below. The nihileth cannot use the same effect two rounds in a row.",
+				{
+					"type": "list",
+					"items": [
+						"The nihileth casts {@spell phantasmal force} (no components required) on any number of creatures it can see within 60 feet of it. While maintaining concentration on this effect, the nihileth can't take other lair actions. If a target succeeds on the saving throw or if the effect ends for it, the target is immune to the nihileth's phantasmal force lair action for the next 24 hours, although such a creature can choose to be affected.",
+						"Pools of water within 90 feet of the nihileth surge outward in a grasping tide. Any creature on the ground within 20 feet of such a pool must succeed on a DC 14 Strength saving throw or be pulled up to 20 feet into the water and knocked prone. The nihileth can't use this lair action again until it has used a different one.",
+						"Water in the nihileth's lair magically becomes a conduit for the creature's rage. The nihileth can target any number of creatures it can see in such water within 90 feet of it. A target must succeed on a DC 14 Wisdom saving throw or take 7 (2d6) psychic damage. The nihileth can't use this lair action again until it has used a different one.",
+						"A nihileth can pull the life force from those it has converted to nihilethic zombies to replenish its own life. This takes 18 ({@dice 6d6}) hit points from zombies within 30 feet of the nihileth, spread evenly between the zombies, and healing the nihileth. If a zombie reaches 0 hit points from this action, it perishes with no Undead Fortitude saving throw."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing an nihileth's lair is warped by the creature's presence, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Underground surfaces within 1 mile of the nihileth's lair are slimy and wet and are difficult terrain.",
+						"Water sources within 1 mile of the lair are supernaturally fouled. Enemies of the nihileth that drink such water vomit it within minutes, and  must make a successful DC 14 Constitution check or become infected with the same disease caused by the nihileth's tentacle attack.",
+						"As an action, the nihileth can create an illusory image of itself within 1 mile of the lair. The copy can appear at any location the nihileth has seen before or in any location a creature charmed by the nihileth can currently see. Once created, the image lasts for as long as the nihileth maintains concentration, as if concentrating on a spell. Although the image is intangible, it looks, sounds, and can move like the nihileth. The nihileth can sense, speak, and use telepathy from the image's position as if present at that position. If the image takes any damage, it disappears."
+					]
+				},
+				"If the nihileth dies, the first two effects fade over the course of {@dice 3d10} days."
+			]
+		},
+		{
+			"name":"Qorgeth",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), Qorgeth takes a lair action to cause one of the following effects; Qorgeth can't use the same effect two rounds in a row:",
+				{
+					"type": "list",
+					"items": [
+				"Until initiative count 20 on the following round, Qorgeth twists space through the tunnels of its lair. Any creature other than a demon that tries to move must succeed on a DC 15 Charisma saving throw or move half its speed in a random direction before getting its bearings; it can then finish moving as it wants.",
+				"A section of ceiling in the lair collapses, raining debris onto a 20-foot-radius area. Each creature in the area must make a successful DC 15 Dexterity saving throw or take 18 ({@dice 4d8}) bludgeoning damage and be restrained until the end of its next turn.",
+				"Thick tangles of demonic worms erupt in the space of up to three creatures Qorgeth can see within 60 feet. Each targeted creature is attacked once by the worms (Melee Weapon Attack: {@hit 7} to hit, reach 0 ft., one target; Hit: 14 ({@dice 4d6}) piercing)."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing Qorgeth's lair is warped by the demon lord's magic, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Within 1 mile of the lair, food rots and spontaneously erupts with maggots.",
+						"One day worth of food carried by creatures spoils every 24 hours it remains in the area. It is impossible to forage for food in this area.",
+						"Dead bodies within 1 mile of the lair decay quickly. Any corpse is reduced to bones in 24 hours. Magic that prevents decay staves off this decomposition normally. Anointing the body with holy water prevents decomposition for one day but no longer."
+					]
+				},
+				"If Qorgeth dies, conditions in the area surrounding the lair return to normal over the course of {@dice 1d10} days."
+			]
+		},
+		{
+			"name": "Tosculi Hive-Queen",
+			"lairActions": [
+				"On initiative count 20 (losing initiative ties), the hive-queen takes a lair action to cause one of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"The tosculi hive-queen releases a cloud of pheromones that drives the tosculi to fight harder. All tosculi within 60 feet of the hive-queen (including the hive-queen herself) regain 7 ({@dice 2d6}) hit points.",
+						"A swarm of tiny tosculi offspring crawls from its nest and attacks a creature within 120 feet of the hive-queen, automatically doing 10 ({@dice 4d4}) piercing damage. Then the swarm dies.",
+						"The ceiling above one creature that the hive-queen can see within 120 feet of her drips sticky resin. The creature must make a successful DC 15 Dexterity saving throw or be encased in rapidly-hardening resin. A creature encased this way is restrained. It can free itself, or another creature within 5 feet can free it, by using an action to make a successful DC 15 Strength check. If the creature is still encased the next time the initiative count reaches 20, the resin hardens, trapping it. The trapped creature can't move or speak; attack rolls against it have disadvantage because it is encased in resin armor; it automatically fails Strength and Dexterity saving throws; and it has resistance to all damage. The trapped creature is released when the resin is destroyed (AC 10, 20 HP, immune to cold, fire, necrotic, poison, psychic, radiant, and piercing damage)."
+					]
+				}
+			],
+			"regionalEffects": [
+				"The region containing a tosculi hive-queen's lair is warped by the creature's presence, which creates one or more of the following effects:",
+				{
+					"type": "list",
+					"items": [
+						"Intelligent creatures within 6 miles suffer frequent headaches. It's as if they had a constant buzzing inside their heads.",
+						"Beasts within 6 miles are more irritable and violent than usual and have the Blood Frenzy trait:Blood Frenzy. The beast has advantage on melee attack rolls against a creature that doesn't have all its hit points."
+					]
+				},
+				"If the tosculi hive-queen dies, the buzzing disappears immediately, and the beasts go back to normal within {@dice 1d10} days."
 			]
 		}
 	],
@@ -257,7 +532,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -308,7 +583,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"{@hit +8} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) damage plus 28 ({@dice 8d6}) fire damage."
+						"{@hit 8} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) damage plus 28 ({@dice 8d6}) fire damage."
 					]
 				},
 				{
@@ -339,7 +614,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -410,7 +685,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one creature. Hit: 11 ({@dice 2d6+4}) bludgeoning damage. If a creature is hit by this attack twice in the same round (from the same or different accursed defilers), the target must make a DC 13 Constitution saving throw or gain one level of exhaustion."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one creature. Hit: 11 ({@dice 2d6+4}) bludgeoning damage. If a creature is hit by this attack twice in the same round (from the same or different accursed defilers), the target must make a DC 13 Constitution saving throw or gain one level of exhaustion."
 					]
 				},
 				{
@@ -429,7 +704,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -468,6 +743,9 @@
 				"poison",
 				"thunder"
 			],
+			"conditionImmune": [
+				"poisoned"
+			],
 			"senses": "blindsight 120 ft.",
 			"passive": 20,
 			"languages": "Common, Darakhul, Draconic, Dwarvish, Goblin",
@@ -490,12 +768,6 @@
 					"entries": [
 						"If the dragon fails a saving throw, it can choose to succeed instead."
 					]
-				},
-				{
-					"name": "Ruff Spikes",
-					"entries": [
-						"When a creature tries to enter a space adjacent to a cave dragon, the dragon can use a reaction to prevent the move by flaring its many feelers and spikes. The creature cannot enter a space adjacent to the dragon unless it makes a successful DC 18 Dexterity saving throw. If the saving throw fails, the creature can keep moving but only into spaces that aren't within 5 feet of the dragon and takes 10 ({@dice 3d6}) piercing damage from spikes."
-					]
 				}
 			],
 			"action": [
@@ -508,19 +780,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 18 ({@dice 3d6+8}) plus 3 ({@dice 1d6}) poison damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 18 ({@dice 3d6+8}) plus 3 ({@dice 1d6}) poison damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d6+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d6+8}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 17 ({@dice 2d8+8}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 17 ({@dice 2d8+8}) bludgeoning damage."
 					]
 				},
 				{
@@ -533,6 +805,14 @@
 					"name": "Poison Breath (Recharge 5—6)",
 					"entries": [
 						"The dragon exhales a cone of black poison gas in a 60-foot cone. Each target in that area takes 56 ({@dice 16d6}) poison damage and is poisoned if it is a creature; a successful DC 18 Constitution saving throw reduces damage by half and negates the poisoned condition. The poisoned condition lasts until the target takes a long or short rest or it's removed with lesser restoration or comparable magic."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Ruff Spikes",
+					"entries": [
+						"When a creature tries to enter a space adjacent to a cave dragon, the dragon flares its many feelers and spikes. The creature cannot enter a space adjacent to the dragon unless it makes a successful DC 18 Dexterity saving throw. If the saving throw fails, the creature can keep moving but only into spaces that aren't within 5 feet of the dragon and takes 10 ({@dice 3d6}) piercing damage from spikes."
 					]
 				}
 			],
@@ -632,7 +912,7 @@
 				"insight": "+7",
 				"perception": "+12",
 				"persuasion": "+10",
-				"stealth": "+15"
+				"stealth": "+7"
 			},
 			"immune": [
 				"fire"
@@ -665,19 +945,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage plus 7 ({@dice 2d6}) fire damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage plus 7 ({@dice 2d6}) fire damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 15 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 15 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
 					]
 				},
 				{
@@ -796,19 +1076,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 19 ({@dice 2d10+8}) piercing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 19 ({@dice 2d10+8}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d6+8}) slashing damage, and the target loses 4 hit points from bleeding at the start of each of its turns for six rounds unless it receives magical healing. Bleeding damage is cumulative; the target loses 4 hp per round for each bleeding wound it's taken from a mithral dragon's claws."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d6+8}) slashing damage, and the target loses 4 hit points from bleeding at the start of each of its turns for six rounds unless it receives magical healing. Bleeding damage is cumulative; the target loses 4 hp per round for each bleeding wound it's taken from a mithral dragon's claws."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 17 ({@dice 2d8+8}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 17 ({@dice 2d8+8}) bludgeoning damage."
 					]
 				},
 				{
@@ -974,13 +1254,13 @@
 				{
 					"name": "Tendril",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 8 ({@dice 1d6+5}) slashing damage. If both tendril attacks hit the same target in a single turn, that target is grappled (escape DC 15). The rime worm can grapple one creature at a time, and it can't use its tendril or devour attacks against a different target while it has a creature grappled."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 8 ({@dice 1d6+5}) slashing damage. If both tendril attacks hit the same target in a single turn, that target is grappled (escape DC 15). The rime worm can grapple one creature at a time, and it can't use its tendril or devour attacks against a different target while it has a creature grappled."
 					]
 				},
 				{
 					"name": "Devour",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d12+5}) slashing damage. If the target was grappled by the rime worm, it takes an additional 13 ({@dice 2d12}) cold damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d12+5}) slashing damage. If the target was grappled by the rime worm, it takes an additional 13 ({@dice 2d12}) cold damage."
 					]
 				},
 				{
@@ -999,7 +1279,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -1072,19 +1352,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d10+7}) piercing damage plus 5 ({@dice 1d10}) cold damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d10+7}) piercing damage plus 5 ({@dice 1d10}) cold damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 15 ft., one target. Hit: 16 ({@dice 2d8+7}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 15 ft., one target. Hit: 16 ({@dice 2d8+7}) bludgeoning damage."
 					]
 				},
 				{
@@ -1100,6 +1380,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Sea Dragon",
 			"legendary": [
 				{
 					"name": "Detect",
@@ -1211,19 +1492,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d10+7}) piercing damage plus 7 ({@dice 2d6}) cold damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d10+7}) piercing damage plus 7 ({@dice 2d6}) cold damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage plus 3 ({@dice 1d6}) cold damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage plus 3 ({@dice 1d6}) cold damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 15 ft., one target. Hit: 16 ({@dice 2d8+7}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 15 ft., one target. Hit: 16 ({@dice 2d8+7}) bludgeoning damage."
 					]
 				},
 				{
@@ -1265,10 +1546,11 @@
 				{
 					"name": "Void Twist",
 					"entries": [
-						"When the dragon is hit by a ranged attack it can create a small rift in space to increase its AC by 2 against that attack. If the attack misses because of this increase the dragon can choose a creature within 30 feet to become the new target for that attack. Use the original attack roll to determine if the attack hits the new target."
+						"When the dragon is hit by a ranged attack it can create a small rift in space to increase its AC by 5 against that attack. If the attack misses because of this increase the dragon can choose a creature within 30 feet to become the new target for that attack. Use the original attack roll to determine if the attack hits the new target."
 					]
 				}
 			],
+			"legendaryGroup": "Void Dragon",
 			"legendary": [
 				{
 					"name": "Detect",
@@ -1342,12 +1624,14 @@
 				"stealth": "+10"
 			},
 			"immune": [
-				"lightning"
+				"lightning",
+				"ranged weapons"
 			],
 			"conditionImmune": [
 				"charmed",
 				"exhaustion",
-				"paralyzed"
+				"paralyzed",
+				"restrained"
 			],
 			"senses": "blindsight 10 ft., darkvision 60 ft.",
 			"passive": 24,
@@ -1395,19 +1679,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d10+7}) piercing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d10+7}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 16 ({@dice 2d8+7}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 16 ({@dice 2d8+7}) bludgeoning damage."
 					]
 				},
 				{
@@ -1561,7 +1845,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) slashing damage."
 					]
 				},
 				{
@@ -1676,7 +1960,7 @@
 				{
 					"name": "Bound",
 					"entries": [
-						"The al-Aeshma must always be anchored to the earth. Even in gaseous form or sandstorm form, part of it must always touch the ground. The al-Aeshma's maximum altitude while flying is 50 ft. If it is not touching, it gains vulnerability to lightning and thunder."
+						"The al-Aeshma must always be anchored to the earth. Even in gaseous form or sandstorm form, part of it must always touch the ground. The al-Aeshma's maximum altitude while flying is 50 ft. If it is not touching, it loses its immunities and gains vulnerability to lightning and thunder."
 					]
 				},
 				{
@@ -1708,7 +1992,7 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage, plus 3 ({@dice 1d6}) necrotic damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage, plus 3 ({@dice 1d6}) necrotic damage."
 					]
 				},
 				{
@@ -1789,6 +2073,9 @@
 				"poison",
 				"thunder"
 			],
+			"conditionImmune": [
+				"poisoned"
+			],
 			"senses": "darkvision 60 ft.",
 			"passive": 19,
 			"languages": "Common, Draconic",
@@ -1823,19 +2110,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d10+5}) piercing damage, and the target must succeed on a DC 16 saving throw or take 10 ({@dice 3d6}) poison damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d10+5}) piercing damage, and the target must succeed on a DC 16 saving throw or take 10 ({@dice 3d6}) poison damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Lightning's Kiss (Recharge 5—6)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 50 ft., one target. Hit: 28 ({@dice 8d6}) lightning damage, or half damage with a successful DC 16 Dexterity saving throw. Jagged bolts of lightning flash through and around the ala's whirlwind. It can hurl this lightning with a sudden whipping motion of its tail."
+						"One target within 50 feet must make a DC 16 Dexterity saving throw. It takes 28 ({@dice 8d6}) lightning damage on a failed save, or half as much damage on a successful one."
 					]
 				}
 			],
@@ -1888,13 +2175,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage."
 					]
 				},
 				{
@@ -1937,7 +2224,7 @@
 				{
 					"name": "Forgetful Spellcasting",
 					"headerEntries": [
-						"When an alehouse drake targets a creature with a mind-affecting spell, the creature must succeed on a DC 15 Wisdom save or immediately forget the source of the spell."
+						"When a creature fails an Intelligence, Wisdom, or Charisma saving throw against a spell cast by an alehouse drake, the creature immediately forgets the source of the spellcasting."
 					]
 				}
 			],
@@ -1991,6 +2278,9 @@
 				"cold",
 				"lightning"
 			],
+			"immune": [
+				"poison"
+			],
 			"conditionImmune": [
 				"charmed",
 				"exhaustion",
@@ -2021,7 +2311,7 @@
 				{
 					"name": "Logic Razor",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 31 ({@dice 4d12+5}) force damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 31 ({@dice 4d12+5}) force damage."
 					]
 				},
 				{
@@ -2125,6 +2415,12 @@
 					"note": "from nonmagical weapons"
 				}
 			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"poisoned"
+			],
 			"senses": "truesight 120 ft.",
 			"passive": 22,
 			"languages": "all, telepathy 120 ft.",
@@ -2171,20 +2467,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 26 ({@dice 4d10+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 26 ({@dice 4d10+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Wing",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 15 ft., one target. Hit: 17 ({@dice 3d8+4}) bludgeoning damage and the target must succeed on a DC 17 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 15 ft., one target. Hit: 17 ({@dice 3d8+4}) bludgeoning damage and the target must succeed on a DC 17 Strength saving throw or be knocked prone."
 					]
 				},
 				{
 					"name": "Talons",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage and the target is grappled and restrained (escape DC 17). Alquam can grapple one creature at a time if it is on the ground or two if it is flying.",
-						"Talons grappling a creature can't attack any other creature."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage and the target is grappled and restrained (escape DC 17). Alquam can grapple one creature at a time if it is on the ground or two if it is flying. Talons grappling a creature can't attack any other creature."
 					]
 				}
 			],
@@ -2214,7 +2509,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"Alquam's innate spellcasting ability is Charisma (save DC 18). It can innately cast the following spells without material components."
+						"Alquam's innate spellcasting ability is Charisma (save DC 18). It can innately cast the following spells without material components:"
 					],
 					"will": [
 						"{@spell darkness}",
@@ -2287,13 +2582,13 @@
 				{
 					"name": "Spear",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +3} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 ({@dice 1d6+1}) piercing damage, or 5 ({@dice 1d8+1}) piercing damage if used with two hands to make a melee attack."
+						"Melee or Ranged Weapon Attack: {@hit 3} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 ({@dice 1d6+1}) piercing damage, or 5 ({@dice 1d8+1}) piercing damage if used with two hands to make a melee attack."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				}
 			],
@@ -2338,7 +2633,7 @@
 			},
 			"senses": "darkvision 60 ft.",
 			"passive": 15,
-			"languages": "Common, Elvish, Sylvan",
+			"languages": "Common, Elvish, Sylvan, Druidic",
 			"cr": "3",
 			"trait": [
 				{
@@ -2352,13 +2647,13 @@
 				{
 					"name": "Quarterstaff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit (+5 with shillelagh), reach 5 ft., one creature. Hit: 4 ({@dice 1d6+1}) bludgeoning damage or 5 ({@dice 1d8+1}) bludgeoning damage if used in two hands, or 7 ({@dice 1d8+3}) bludgeoning damage with shillelagh."
+						"Melee Weapon Attack: {@hit 3} to hit (+5 with shillelagh), reach 5 ft., one creature. Hit: 4 ({@dice 1d6+1}) bludgeoning damage or 5 ({@dice 1d8+1}) bludgeoning damage if used in two hands, or 7 ({@dice 1d8+3}) bludgeoning damage with shillelagh."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				}
 			],
@@ -2468,13 +2763,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d6+4}) piercing damage plus 10 ({@dice 3d6}) poison damage, and the target must make a successful DC 13 Constitution saving throw or be poisoned for 1 hour."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d6+4}) piercing damage plus 10 ({@dice 3d6}) poison damage, and the target must make a successful DC 13 Constitution saving throw or be poisoned for 1 hour."
 					]
 				}
 			],
@@ -2557,19 +2852,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 17 ({@dice 2d10+6}) piercing damage plus 14 ({@dice 4d6}) fire damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 17 ({@dice 2d10+6}) piercing damage plus 14 ({@dice 4d6}) fire damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 20 ft., one target. Hit: 15 ({@dice 2d8+6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 20 ft., one target. Hit: 15 ({@dice 2d8+6}) bludgeoning damage."
 					]
 				},
 				{
@@ -2695,19 +2990,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +15} to hit, reach 15 ft., one target. Hit: 22 ({@dice 2d12+9}) piercing damage."
+						"Melee Weapon Attack: {@hit 15} to hit, reach 15 ft., one target. Hit: 22 ({@dice 2d12+9}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +15} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d8+9}) slashing damage, and the target loses 5 hit point from bleeding at the start of each of its turns for six rounds unless it receives magical healing. Bleeding damage is cumulative; the target loses 5 hp per round for each bleeding wound it's taken from a mithral dragon's claws."
+						"Melee Weapon Attack: {@hit 15} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d8+9}) slashing damage, and the target loses 5 hit point from bleeding at the start of each of its turns for six rounds unless it receives magical healing. Bleeding damage is cumulative; the target loses 5 hp per round for each bleeding wound it's taken from a mithral dragon's claws."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +15} to hit, reach 20 ft., one target. Hit: 20 ({@dice 2d10+9}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 15} to hit, reach 20 ft., one target. Hit: 20 ({@dice 2d10+9}) bludgeoning damage."
 					]
 				},
 				{
@@ -2845,7 +3140,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -2918,19 +3213,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 15 ft., one target. Hit: 20 ({@dice 2d10+9}) piercing damage plus 11 ({@dice 2d10}) cold damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 15 ft., one target. Hit: 20 ({@dice 2d10+9}) piercing damage plus 11 ({@dice 2d10}) cold damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d6+9}) slashing damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d6+9}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 20 ft., one target. Hit: 18 ({@dice 2d8+9}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 20 ft., one target. Hit: 18 ({@dice 2d8+9}) bludgeoning damage."
 					]
 				},
 				{
@@ -2946,6 +3241,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Sea Dragon",
 			"legendary": [
 				{
 					"name": "Detect",
@@ -3046,13 +3342,13 @@
 				{
 					"name": "Greatsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 38 ({@dice 8d6+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 38 ({@dice 8d6+8}) slashing damage."
 					]
 				},
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 150/640 ft., one target. Hit: 19 ({@dice 4d8+1}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 150/640 ft., one target. Hit: 19 ({@dice 4d8+1}) piercing damage."
 					]
 				},
 				{
@@ -3175,19 +3471,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 15 ft., one target. Hit: 20 ({@dice 2d10+9}) piercing damage plus 14 ({@dice 4d6}) cold damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 15 ft., one target. Hit: 20 ({@dice 2d10+9}) piercing damage plus 14 ({@dice 4d6}) cold damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d6+9}) slashing damage plus 7 ({@dice 2d6}) cold damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d6+9}) slashing damage plus 7 ({@dice 2d6}) cold damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 20 ft., one target. Hit: 18 ({@dice 2d8+9}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 20 ft., one target. Hit: 18 ({@dice 2d8+9}) bludgeoning damage."
 					]
 				},
 				{
@@ -3229,10 +3525,11 @@
 				{
 					"name": "Void Twist",
 					"entries": [
-						"When the dragon is hit by a ranged attack, it can create a small rift in space to increase its AC by 2 against that attack. If the attack misses because of this increase, the dragon can choose a creature within 30 feet to become the new target for that attack. Use the original attack roll to determine if the attack hits the new target."
+						"When the dragon is hit by a ranged attack, it can create a small rift in space to increase its AC by 7 against that attack. If the attack misses because of this increase, the dragon can choose a creature within 30 feet to become the new target for that attack. Use the original attack roll to determine if the attack hits the new target."
 					]
 				}
 			],
+			"legendaryGroup": "Void Dragon",
 			"legendary": [
 				{
 					"name": "Detect",
@@ -3317,12 +3614,14 @@
 				}
 			],
 			"immune": [
-				"lightning"
+				"lightning",
+				"ranged weapons"
 			],
 			"conditionImmune": [
 				"charmed",
 				"exhaustion",
-				"paralyzed"
+				"paralyzed",
+				"restrained"
 			],
 			"senses": "blindsight 10 ft., darkvision 60 ft.",
 			"passive": 27,
@@ -3370,19 +3669,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 15 ft., one target. Hit: 22 ({@dice 2d12+9}) piercing damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 15 ft., one target. Hit: 22 ({@dice 2d12+9}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d8+9}) slashing damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d8+9}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 20 ft., one target. Hit: 20 ({@dice 2d10+9}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 20 ft., one target. Hit: 20 ({@dice 2d10+9}) bludgeoning damage."
 					]
 				},
 				{
@@ -3398,6 +3697,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Wind Dragon",
 			"legendary": [
 				{
 					"name": "Detect",
@@ -3523,13 +3823,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +15} to hit, reach 20 ft., one target. Hit: 36 ({@dice 4d12+10}) piercing damage."
+						"Melee Weapon Attack: {@hit 15} to hit, reach 20 ft., one target. Hit: 36 ({@dice 4d12+10}) piercing damage."
 					]
 				},
 				{
 					"name": "Constrict",
 					"entries": [
-						"Melee Weapon Attack: {@hit +15} to hit, reach 5 ft., one target. Hit: 36 ({@dice 4d12+10}) bludgeoning damage, and the target is grappled (escape DC 20). Until this grapple ends the target is restrained, and the andrenjinyi can't constrict another target."
+						"Melee Weapon Attack: {@hit 15} to hit, reach 5 ft., one target. Hit: 36 ({@dice 4d12+10}) bludgeoning damage, and the target is grappled (escape DC 20). Until this grapple ends the target is restrained, and the andrenjinyi can't constrict another target."
 					]
 				},
 				{
@@ -3587,7 +3887,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -3663,7 +3963,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one creature. Hit: 10 ({@dice 2d4+5}) piercing damage, and the creature must succeed on a DC 15 Constitution saving throw or be paralyzed by pain until the end of its next turn."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one creature. Hit: 10 ({@dice 2d4+5}) piercing damage, and the creature must succeed on a DC 15 Constitution saving throw or be paralyzed by pain until the end of its next turn."
 					]
 				}
 			],
@@ -3700,6 +4000,9 @@
 			"int": 3,
 			"wis": 14,
 			"cha": 1,
+			"immune": [
+				"poison"
+			],
 			"conditionImmune": [
 				"blinded",
 				"charmed",
@@ -3740,13 +4043,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one creature. Hit: 9 ({@dice 2d6+2}) piercing damage plus 3 ({@dice 1d6}) acid damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one creature. Hit: 9 ({@dice 2d6+2}) piercing damage plus 3 ({@dice 1d6}) acid damage."
 					]
 				},
 				{
 					"name": "Coils",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 10 ft., one creature. Hit: 13 ({@dice 3d8}) acid damage, and the target creature must make a successful DC 12 Dexterity saving throw or be pulled adjacent to the angler worm (if it wasn't already) and grappled in the angler worm's coils (escape DC 12). While grappled this way, the creature is restrained by the angler worm (but not by its snare lines), it can't breathe, and it takes 22 ({@dice 5d8}) acid damage at the start of each of the angler worm's turns. A creature that escapes from the angler worm's coils may need to make an immediate DC 12 Dexterity saving throw to avoid being restrained again, if it escapes into a space occupied by more snare lines."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 10 ft., one creature. Hit: 13 ({@dice 3d8}) acid damage, and the target creature must make a successful DC 12 Dexterity saving throw or be pulled adjacent to the angler worm (if it wasn't already) and grappled in the angler worm's coils (escape DC 12). While grappled this way, the creature is restrained by the angler worm (but not by its snare lines), it can't breathe, and it takes 22 ({@dice 5d8}) acid damage at the start of each of the angler worm's turns. A creature that escapes from the angler worm's coils may need to make an immediate DC 12 Dexterity saving throw to avoid being restrained again, if it escapes into a space occupied by more snare lines."
 					]
 				},
 				{
@@ -3818,7 +4121,7 @@
 				{
 					"name": "Sand Step",
 					"entries": [
-						"Instead of moving, the anubian's humanoid form collapses into loose sand and immediately reforms at another unoccupied space within 10 feet. This movement doesn't provoke opportunity attacks. After using this trait in sand terrain, the anubian can take a Hide action even if under direct observation. Anubians can sand step under doors or through similar obstacles, provided there's a gap large enough for sand to sift through."
+						"Instead of moving, the anubian's humanoid form collapses into loose sand and immediately reforms at another unoccupied space within 10 feet. This movement doesn't provoke opportunity attacks. After using this trait in sand terrain, the anubian can Hide as part of this movement even if under direct observation. Anubians can sand step under doors or through similar obstacles, provided there's a gap large enough for sand to sift through."
 					]
 				},
 				{
@@ -3838,13 +4141,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Haboob (1/Day)",
 					"entries": [
-						"The anubian creates a sandstorm that fills a 5-foot-radius, 30-foot-tall cylinder centered on itself. The area is heavily obscured, and each creature other than an anubian that enters the sandstorm or ends its turn there must make a successful DC 13 Strength saving throw or be restrained by it. Also, each creature other than an anubian that ends its turn inside the sandstorm takes 3 ({@dice 1d6}) slashing damage. The anubian can maintain the haboob for up to 10 minutes as if concentrating on a spell. While maintaining the haboob, the anubian's speed is reduced to 5 feet and it can't sand step. Creatures restrained by the sandstorm move with the anubian. A creature can free itself or an adjacent creature from the sandstorm by using its action and making a DC 13 Strength check. A successful check ends the restraint on the target creature."
+						"The anubian creates a sandstorm in a cylinder 30-feet high, that reaches to within 5 feet of it. The storm moves with the anubian. The area is heavily obscured, and each creature other than an anubian that enters the sandstorm or ends its turn there must make a successful DC 13 Strength saving throw or be restrained by it. Also, each creature other than an anubian that ends its turn inside the sandstorm takes 3 ({@dice 1d6}) slashing damage. The anubian can maintain the haboob for up to 10 minutes as if concentrating on a spell. While maintaining the haboob, the anubian's speed is reduced to 5 feet and it can't sand step. Creatures restrained by the sandstorm move with the anubian. A creature can free itself or an adjacent creature from the sandstorm by using its action and making a DC 13 Strength check. A successful check ends the restraint on the target creature."
 					]
 				}
 			],
@@ -3942,13 +4245,19 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The apau perape makes one bite attack and two claw attacks. Bite. Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage."
+						"The apau perape makes one bite attack and two claw attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
 					]
 				}
 			],
@@ -3979,7 +4288,7 @@
 			"tokenURL": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/ToB%20(3pp)/Apau%20Perape.png"
 		},
 		{
-			"name": "Arch-Devil Arbeyach, Prince of Swarms",
+			"name": "Arbeyach, Prince of Swarms",
 			"size": "L",
 			"type": {
 				"type": "fiend",
@@ -4055,7 +4364,7 @@
 			],
 			"senses": "truesight 120 ft.",
 			"passive": 22,
-			"languages": "Celestial, Common, Draconic, Infernal, telepathy",
+			"languages": "Celestial, Common, Draconic, Infernal, telepathy 120 ft.",
 			"cr": "21",
 			"trait": [
 				{
@@ -4105,13 +4414,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d8+6}) piercing damage plus 9 ({@dice 2d8}) poison damage. If the target is a creature, it must succeed on a DC 22 Constitution saving throw or be cursed with Arbeyach rot. The cursed target is poisoned, can't regain hit points, its hit point maximum decreases by 13 ({@dice 3d8}) for every 24 hours that elapse, and vermin attack the creature on sight. If the curse reduces the target's hit point maximum to 0, the target dies and immediately transforms into a randomly chosen swarm of insects. The curse lasts until removed by the remove curse spell or comparable magic."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d8+6}) piercing damage plus 9 ({@dice 2d8}) poison damage. If the target is a creature, it must succeed on a DC 22 Constitution saving throw or be cursed with Arbeyach rot. The cursed target is poisoned, can't regain hit points, its hit point maximum decreases by 13 ({@dice 3d8}) for every 24 hours that elapse, and vermin attack the creature on sight. If the curse reduces the target's hit point maximum to 0, the target dies and immediately transforms into a randomly chosen swarm of insects. The curse lasts until removed by the remove curse spell or comparable magic."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage plus 9 ({@dice 2d8}) poison damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage plus 9 ({@dice 2d8}) poison damage."
 					]
 				},
 				{
@@ -4173,7 +4482,7 @@
 			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -4229,13 +4538,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Tentacle",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 10 ft., one target. Hit: 10 ({@dice 2d6+3}) bludgeoning damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained and the tentacle can't be used to attack a different target. The arboreal grappler has two tentacles, each of which can grapple one target. When the arboreal grappler moves, it can drag a Medium or smaller target it is grappling at full speed."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 10 ft., one target. Hit: 10 ({@dice 2d6+3}) bludgeoning damage, and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained and the tentacle can't be used to attack a different target. The arboreal grappler has two tentacles, each of which can grapple one target. When the arboreal grappler moves, it can drag a Medium or smaller target it is grappling at full speed."
 					]
 				}
 			],
@@ -4248,7 +4557,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -4339,7 +4648,7 @@
 				{
 					"name": "Spectral Rend",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) necrotic damage. If the target is a creature, it must succeed on a DC 14 Wisdom saving throw or be frightened and have its speed reduced to 0; both effects last until the end of its next turn."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) necrotic damage. If the target is a creature, it must succeed on a DC 14 Wisdom saving throw or be frightened and have its speed reduced to 0; both effects last until the end of its next turn."
 					]
 				}
 			],
@@ -4406,7 +4715,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -4456,13 +4765,13 @@
 				{
 					"name": "Short Sword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Pixie Bow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 40/160 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 40/160 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
 					]
 				},
 				{
@@ -4552,8 +4861,7 @@
 				{
 					"name": "Arboreal",
 					"entries": [
-						"While up in trees, the asanbosam can take the",
-						"Disengage or Hide action as a bonus action on each of its turns."
+						"While up in trees, the asanbosam can take the Disengage or Hide action as a bonus action on each of its turns."
 					]
 				}
 			],
@@ -4567,13 +4875,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw against disease. If the saving throw fails, the target takes 11 ({@dice 2d10}) poison damage immediately and becomes poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw and reduce its hit point maximum by 5 ({@dice 1d10}) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw against disease. If the saving throw fails, the target takes 11 ({@dice 2d10}) poison damage immediately and becomes poisoned until the disease is cured. Every 24 hours that elapse, the creature must repeat the saving throw and reduce its hit point maximum by 5 ({@dice 1d10}) on a failure. This reduction lasts until the disease is cured. The creature dies if the disease reduces its hit point maximum to 0."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 20 ({@dice 3d10+4}) piercing damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained and the asanbosam can't claw a different target. If the target is a creature, it must succeed on a DC 14 Constitution saving throw against disease or contract the disease described in the bite attack."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 20 ({@dice 3d10+4}) piercing damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained and the asanbosam can't claw a different target. If the target is a creature, it must succeed on a DC 14 Constitution saving throw against disease or contract the disease described in the bite attack."
 					]
 				}
 			],
@@ -4586,7 +4894,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -4638,13 +4946,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) piercing damage+3 ({@dice 1d6}) fire damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) piercing damage + 3 ({@dice 1d6}) fire damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
 					]
 				},
 				{
@@ -4774,19 +5082,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d10+7}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d10+7}) slashing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
 					]
 				},
 				{
 					"name": "Whip",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 15 ft., one target. Hit: 11 ({@dice 1d8+7}) slashing damage and the target is grappled (escape DC 17) and restrained. Only two targets can be grappled by the automata devil at one time, and each grappled target prevents one whip from being used to attack. An individual target can be grappled by only one whip at a time. A grappled target takes 9 ({@dice 2d8}) piercing damage at the start of its turn."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 15 ft., one target. Hit: 11 ({@dice 1d8+7}) slashing damage and the target is grappled (escape DC 17) and restrained. Only two targets can be grappled by the automata devil at one time, and each grappled target prevents one whip from being used to attack. An individual target can be grappled by only one whip at a time. A grappled target takes 9 ({@dice 2d8}) piercing damage at the start of its turn."
 					]
 				},
 				{
@@ -4798,7 +5106,7 @@
 				{
 					"name": "Fear Aura",
 					"entries": [
-						"Automata devils radiate fear in a 10-foot radius. A creature that starts its turn in the affected area must make a successful DC 16 Wisdom saving throw or become frightened. A creature that makes the save successfully cannot"
+						"Automata devils radiate fear in a 10-foot radius. A creature that starts its turn in the affected area must make a successful DC 16 Wisdom saving throw or become frightened. A creature that makes the save successfully cannot be affected by the same automata devil's fear aura again."
 					]
 				}
 			],
@@ -4808,7 +5116,12 @@
 		{
 			"name": "Avatar of Boreas",
 			"size": "M",
-			"type": "elemental",
+			"type": {
+				"type": "elemental",
+				"tags": [
+					"shapechanger"
+				]
+			},
 			"source": "ToB 3pp",
 			"alignment": [
 				"C",
@@ -4860,7 +5173,7 @@
 				"petrified",
 				"poisoned"
 			],
-			"senses": "darkvision 60 ft., truesight",
+			"senses": "darkvision 60 ft., truesight 120 ft.",
 			"passive": 20,
 			"languages": "Common, Dwarvish, Giant, Infernal",
 			"cr": "17",
@@ -4900,19 +5213,19 @@
 				{
 					"name": "Ice Spear (Humanoid Form)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d8+7}) piercing damage plus 17 ({@dice 5d6}) cold damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d8+7}) piercing damage plus 17 ({@dice 5d6}) cold damage."
 					]
 				},
 				{
 					"name": "North Wind Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +12} to hit, range 150/600 ft., one target. Hit: 10 ({@dice 1d8+6}) piercing damage plus 9 ({@dice 2d8}) cold damage."
+						"Ranged Weapon Attack: {@hit 12} to hit, range 150/600 ft., one target. Hit: 10 ({@dice 1d8+6}) piercing damage plus 9 ({@dice 2d8}) cold damage."
 					]
 				},
 				{
 					"name": "Whirlwind Blast (Wind Form Only)",
 					"entries": [
-						"Ranged Spell Attack: {@hit +11} to hit, range 50 ft., one target. Hit: 37 ({@dice 5d12+5}) slashing damage."
+						"Ranged Spell Attack: {@hit 11} to hit, range 50 ft., one target. Hit: 37 ({@dice 5d12+5}) slashing damage."
 					]
 				}
 			],
@@ -5025,7 +5338,7 @@
 				{
 					"name": "Lightning Jolt",
 					"entries": [
-						"Melee or Ranged Spell Attack: {@hit +6} to hit, reach 5 ft. or range 30 ft., one creature. Hit: 3 ({@dice 1d6}) lightning damage, and the target is affected by Contagious Lightning."
+						"Melee or Ranged Spell Attack: {@hit 6} to hit, reach 5 ft. or range 30 ft., one creature. Hit: 3 ({@dice 1d6}) lightning damage, and the target is affected by Contagious Lightning."
 					]
 				}
 			],
@@ -5142,13 +5455,13 @@
 				{
 					"name": "Lance",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft. (disadvantage within 5 ft.), one target. Hit: 12 ({@dice 1d12+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft. (disadvantage within 5 ft.), one target. Hit: 12 ({@dice 1d12+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage."
 					]
 				},
 				{
@@ -5292,13 +5605,13 @@
 				{
 					"name": "Lance",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft. (disadvantage within 5 ft.), one target. Hit: 12 ({@dice 1d12+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft. (disadvantage within 5 ft.), one target. Hit: 12 ({@dice 1d12+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage."
 					]
 				},
 				{
@@ -5442,13 +5755,13 @@
 				{
 					"name": "Lance",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft. (disadvantage within 5 ft.), one target. Hit: 12 ({@dice 1d12+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft. (disadvantage within 5 ft.), one target. Hit: 12 ({@dice 1d12+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage."
 					]
 				},
 				{
@@ -5544,13 +5857,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 18 ({@dice 4d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 18 ({@dice 4d6+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Acid Spray",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 15 ft., one target. Hit: 14 ({@dice 2d10+3}) acid damage. The target must make a successful DC 13 Dexterity saving throw or fall prone in the slick oil, which covers an area 5 feet square. A creature that enters the oily area or ends its turn there must also make the Dexterity saving throw to avoid falling prone. A creature needs to make only one saving throw per 5-foot-square per turn, even if it enters and ends its turn in the area. The slippery effect lasts for 3 rounds."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 15 ft., one target. Hit: 14 ({@dice 2d10+3}) acid damage. The target must make a successful DC 13 Dexterity saving throw or fall prone in the slick oil, which covers an area 5 feet square. A creature that enters the oily area or ends its turn there must also make the Dexterity saving throw to avoid falling prone. A creature needs to make only one saving throw per 5-foot-square per turn, even if it enters and ends its turn in the area. The slippery effect lasts for 3 rounds."
 					]
 				}
 			],
@@ -5626,13 +5939,13 @@
 				{
 					"name": "Greatsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
@@ -5703,7 +6016,7 @@
 				{
 					"name": "Priestly Purr",
 					"entries": [
-						"When a cleric or paladin who worships Bastet spends an hour preparing spells while a Bastet temple cat is within 5 feet, that spellcaster can choose two 1st-level spells and one 2nd-level spell that they are able to cast and imbue them into the temple cat. The temple cat can cast these spells 1/Day each without a verbal component. These spells are cast as if they were included in the temple cat's Innate Spellcasting trait."
+						"When a cleric or paladin who worships Bastet spends an hour preparing spells while a Bastet temple cat is within 5 feet, that spellcaster can choose two 1st-level spells and one 2nd-level spell that they are able to cast and imbue them into the temple cat. The temple cat can cast these spells 1/day each without a verbal component. These spells are cast as if they were included in the temple cat's Innate Spellcasting trait."
 					]
 				}
 			],
@@ -5717,13 +6030,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d4+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d4+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d4+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d4+4}) slashing damage."
 					]
 				},
 				{
@@ -5842,7 +6155,7 @@
 					]
 				},
 				{
-					"name": "Regeneration (Alternate Form Only)",
+					"name": "Regeneration (Alternate Form only)",
 					"entries": [
 						"The Bear King regains 10 hit points at the start of his turn if he has at least 1 hit point."
 					]
@@ -5858,25 +6171,25 @@
 				{
 					"name": "Bite (Grizzly or Hybrid Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d10+5}) piercing damage. A target creature other than a construct or undead must make a successful DC 17 Constitution saving throw at the start of each of its turns or lose 10 ({@dice 3d6}) hit points from blood loss. Each time the Bear King hits the wounded creature with this attack, the hit point loss increases by 10 ({@dice 3d6}). A creature can take an action to staunch the bleeding on itself or an adjacent ally with a successful DC 12 Wisdom (Medicine) check. The bleeding also stops if the creature receives any magical healing."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d10+5}) piercing damage. A target creature other than a construct or undead must make a successful DC 17 Constitution saving throw at the start of each of its turns or lose 10 ({@dice 3d6}) hit points from blood loss. Each time the Bear King hits the wounded creature with this attack, the hit point loss increases by 10 ({@dice 3d6}). A creature can take an action to staunch the bleeding on itself or an adjacent ally with a successful DC 12 Wisdom (Medicine) check. The bleeding also stops if the creature receives any magical healing."
 					]
 				},
 				{
 					"name": "Claws (Grizzly or Hybrid Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Maul (Human or Hybrid Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage. A creature hit by two maul attacks in the same turn must succeed on a DC 17 Strength saving throw or fall prone."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage. A creature hit by two maul attacks in the same turn must succeed on a DC 17 Strength saving throw or fall prone."
 					]
 				},
 				{
 					"name": "Javelin (Human Form Only)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +9} to hit, range 30/60 ft., one target. Hit: 8 ({@dice 1d6+5}) piercing damage."
+						"Ranged Weapon Attack: {@hit 9} to hit, range 30/60 ft., one target. Hit: 8 ({@dice 1d6+5}) piercing damage."
 					]
 				}
 			],
@@ -5891,7 +6204,7 @@
 				{
 					"name": "Honey Toss",
 					"entries": [
-						"The Bear King reaches into the jar he carries at his side and hurls a glob of honey at a target within 30 feet as a ranged weapon attack ({@hit +9} to hit). If the attack hits, the creature is restrained (escape DC 17)."
+						"The Bear King reaches into the jar he carries at his side and hurls a glob of honey at a target within 30 feet as a ranged weapon attack ({@hit 9} to hit). If the attack hits, the creature is restrained (escape DC 17)."
 					]
 				},
 				{
@@ -5947,7 +6260,7 @@
 				{
 					"name": "Frenzy (1/rest)",
 					"entries": [
-						"As a bonus action, the bearfolk can trigger a berserk frenzy that lasts 1 minute. While in frenzy, it gains resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons and has advantage on attack rolls. Attack rolls made against a frenzied bearfolk have advantage."
+						"As a bonus action, the bearfolk can trigger a berserk frenzy that lasts 1 minute. While in frenzy, it gains resistance to bludgeoning, piercing, and slashing damage and has advantage on attack rolls. Attack rolls made against a frenzied bearfolk have advantage."
 					]
 				},
 				{
@@ -5961,25 +6274,25 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The bearfolk makes attacks once with its battleaxe, once with its warhammer, and once with its bite."
+						"The bearfolk makes three attacks: one with its battleaxe, one with its warhammer, and one with its bite."
 					]
 				},
 				{
 					"name": "Battleaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage, or 9 ({@dice 1d10+4}) slashing damage if used two-handed."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage, or 9 ({@dice 1d10+4}) slashing damage if used two-handed."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Warhammer",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage, or 9 ({@dice 1d10+4}) bludgeoning damage if used two-handed."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage, or 9 ({@dice 1d10+4}) bludgeoning damage if used two-handed."
 					]
 				}
 			],
@@ -6027,7 +6340,7 @@
 				{
 					"name": "Pack Tactics",
 					"entries": [
-						"The beggar ghoul has advantage on an attack roll against a creature if at least one other allied beggar ghoul is within 5 feet of the creature and the ally isn't incapacitated."
+						"The beggar ghoul has advantage on an attack roll against a creature if at least one of the beggar ghoul's allies is within 5 feet of the creature and the ally isn't incapacitated."
 					]
 				},
 				{
@@ -6041,13 +6354,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d4+2}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d4+2}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 10 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -6105,13 +6418,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Shortspear",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
@@ -6136,7 +6449,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -6202,13 +6515,13 @@
 				{
 					"name": "Ice Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 2 ({@dice 1d4}) cold damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 2 ({@dice 1d4}) cold damage."
 					]
 				},
 				{
 					"name": "Icy Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 2 ({@dice 1d4}) cold damage, and the target must make a successful DC 13 Constitution saving throw or gain 2 levels of exhaustion from the arrow's icy chill. If the save succeeds, the target also becomes immune to further exhaustion from beli arrows for 24 hours (but any levels of exhaustion already gained remain in effect). A character who gains a sixth level of exhaustion doesn't die automatically but drops to 0 hit points and must make death saving throws as normal. The exhaustion lasts until the target recovers fully from the cold damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 2 ({@dice 1d4}) cold damage, and the target must make a successful DC 13 Constitution saving throw or gain 2 levels of exhaustion from the arrow's icy chill. If the save succeeds, the target also becomes immune to further exhaustion from beli arrows for 24 hours (but any levels of exhaustion already gained remain in effect). A character who gains a sixth level of exhaustion doesn't die automatically but drops to 0 hit points and must make death saving throws as normal. The exhaustion lasts until the target recovers fully from the cold damage."
 					]
 				}
 			],
@@ -6237,7 +6550,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -6281,7 +6594,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage."
 					]
 				},
 				{
@@ -6394,7 +6707,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage and the target is grappled (escape DC 16)."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage and the target is grappled (escape DC 16)."
 					]
 				},
 				{
@@ -6486,13 +6799,13 @@
 				{
 					"name": "Mace",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Lance",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
 					]
 				},
 				{
@@ -6560,19 +6873,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 19 ({@dice 4d6+5}) piercing damage. If the target is a Medium or smaller incapacitated creature, that creature is swallowed. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects from outside the blemmyes, and it takes 14 ({@dice 4d6}) acid damage at the start of each of the blemmyes' turns. If the blemmyes takes 20 damage or more during a single turn from a creature inside it, the blemmyes must succeed on a DC 16 Constitution saving throw at the end of that turn or regurgitate the swallowed creature, which falls prone in a space within 5 feet of the blemmyes. The blemmyes can have only one target swallowed at a time. If the blemmyes dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 19 ({@dice 4d6+5}) piercing damage. If the target is a Medium or smaller incapacitated creature, that creature is swallowed. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects from outside the blemmyes, and it takes 14 ({@dice 4d6}) acid damage at the start of each of the blemmyes' turns. If the blemmyes takes 20 damage or more during a single turn from a creature inside it, the blemmyes must succeed on a DC 16 Constitution saving throw at the end of that turn or regurgitate the swallowed creature, which falls prone in a space within 5 feet of the blemmyes. The blemmyes can have only one target swallowed at a time. If the blemmyes dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Wisdom saving throw or be stunned until the end of its next turn."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Wisdom saving throw or be stunned until the end of its next turn."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 30/120 ft., one target. Hit: 27 ({@dice 4d10+5}) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Wisdom saving throw or be frightened until the end of its next turn."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 30/120 ft., one target. Hit: 27 ({@dice 4d10+5}) bludgeoning damage. If the target is a creature, it must succeed on a DC 16 Wisdom saving throw or be frightened until the end of its next turn."
 					]
 				}
 			],
@@ -6647,13 +6960,13 @@
 				{
 					"name": "Blood-Drinking Hair",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 18 ({@dice 3d8+5}) piercing damage and a Medium or smaller target is grappled (escape DC 15). A grappled creature takes 13 ({@dice 2d8+3}) necrotic damage at the start of the hag's turns, and the hag heals half as many hit points. The hag gains excess healing as temporary hit points. The hag can grapple one or two creatures at a time. Also see Face Peel."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 18 ({@dice 3d8+5}) piercing damage and a Medium or smaller target is grappled (escape DC 15). A grappled creature takes 13 ({@dice 2d8+3}) necrotic damage at the start of the hag's turns, and the hag heals half as many hit points. The hag gains excess healing as temporary hit points. The hag can grapple one or two creatures at a time. Also see Face Peel."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 19 ({@dice 4d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 19 ({@dice 4d6+5}) slashing damage."
 					]
 				},
 				{
@@ -6711,7 +7024,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -6757,7 +7070,7 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
 					]
 				},
 				{
@@ -6881,19 +7194,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 31 ({@dice 4d12+5}) piercing damage, and the target must make a DC 16 Constitution save or suffer the effects of Wyrmblood Venom."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 31 ({@dice 4d12+5}) piercing damage, and the target must make a DC 16 Constitution save or suffer the effects of Wyrmblood Venom."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 25 ({@dice 3d12+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 25 ({@dice 3d12+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Swarm",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 0 ft., one creature in the swarm's space. Hit: 57 ({@dice 8d12+5}) piercing damage, or 31 ({@dice 4d12+5}) piercing damage if the bone collective has half its hit points or fewer. If the attack hits, the target must make a successful DC 15 Constitution save or suffer the effects of Wyrmblood Venom."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 0 ft., one creature in the swarm's space. Hit: 57 ({@dice 8d12+5}) piercing damage, or 31 ({@dice 4d12+5}) piercing damage if the bone collective has half its hit points or fewer. If the attack hits, the target must make a successful DC 15 Constitution save or suffer the effects of Wyrmblood Venom."
 					]
 				},
 				{
@@ -6998,7 +7311,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
 					]
 				},
 				{
@@ -7107,13 +7420,13 @@
 				{
 					"name": "Swirling Bones",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 0 ft., one creature in the swarm's space. Hit: 31 ({@dice 5d8+9}) bludgeoning, piercing, or slashing damage (includes Strength of Bone special ability)."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 0 ft., one creature in the swarm's space. Hit: 31 ({@dice 5d8+9}) bludgeoning, piercing, or slashing damage (includes Strength of Bone special ability)."
 					]
 				},
 				{
 					"name": "Death's Embrace (Recharge 5—6)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 0 ft., one creature in the swarm's space. Hit: the target is grappled (escape DC 16) and enveloped within the swarm's bones. The swarm can force the creature to move at its normal speed wherever the bone swarm wishes. Any non-area attack against the bone swarm has a 50% chance of hitting a creature grappled in Death's Embrace instead."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 0 ft., one creature in the swarm's space. Hit: the target is grappled (escape DC 16) and enveloped within the swarm's bones. The swarm can force the creature to move at its normal speed wherever the bone swarm wishes. Any non-area attack against the bone swarm has a 50% chance of hitting a creature grappled in Death's Embrace instead."
 					]
 				}
 			],
@@ -7126,7 +7439,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -7211,13 +7524,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) plus {@dice 1d4} Strength damage, and the target must succeed on a DC 17 Constitution saving throw or be paralyzed for {@dice 1d4+1} rounds. If the target creature is humanoid, it must succeed on a second DC 19 Constitution saving throw or contract darakhul fever."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) plus {@dice 1d4} Strength damage, and the target must succeed on a DC 17 Constitution saving throw or be paralyzed for {@dice 1d4+1} rounds. If the target creature is humanoid, it must succeed on a second DC 19 Constitution saving throw or contract darakhul fever."
 					]
 				},
 				{
 					"name": "Gravedust",
 					"entries": [
-						"A bonepowder ghoul can project a 40 foot cone of grave dust. All targets within the area must make a DC 19 Dexterity saving throw to avoid taking {@dice 4d8} necrotic damage, and must make a second DC 17 Constitution saving throw to avoid being infected with darakhul fever."
+						"A bonepowder ghoul can project a 40-foot cone of grave dust. All targets within the area must make a DC 19 Dexterity saving throw to avoid taking {@dice 4d8} necrotic damage, and must make a second DC 17 Constitution saving throw to avoid being infected with darakhul fever."
 					]
 				},
 				{
@@ -7268,10 +7581,15 @@
 		{
 			"name": "Bouda",
 			"size": "M",
-			"type": "fiend",
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"shapechanger"
+				]
+			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -7357,13 +7675,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage plus 10 ({@dice 3d6}) poison damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage plus 10 ({@dice 3d6}) poison damage."
 					]
 				},
 				{
 					"name": "Mephitic Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage, and the target must make a successful DC 15 Constitution saving throw or become poisoned for 1 round by the visible cloud of vermin swarming around the bouda's forearms."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage, and the target must make a successful DC 15 Constitution saving throw or become poisoned for 1 round by the visible cloud of vermin swarming around the bouda's forearms."
 					]
 				},
 				{
@@ -7444,6 +7762,9 @@
 					"note": "from nonmagical weapons"
 				}
 			],
+			"immune": [
+				"poison"
+			],
 			"conditionImmune": [
 				"charmed",
 				"exhaustion",
@@ -7479,7 +7800,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d10+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d10+2}) piercing damage."
 					]
 				},
 				{
@@ -7498,7 +7819,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -7550,7 +7871,7 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Damage: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw against poison or take {@dice 1d2} Strength damage. The target must repeat the saving throw at the end of each of its turns, and it loses another {@dice 1d2} Strength for each failed saving throw. The effect ends when one of the saving throws succeeds or automatically after 4 rounds. All lost Strength returns after a long rest."
+						"Melee Weapon Damage: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw against poison or take {@dice 1d2} Strength damage. The target must repeat the saving throw at the end of each of its turns, and it loses another {@dice 1d2} Strength for each failed saving throw. The effect ends when one of the saving throws succeeds or automatically after 4 rounds. All lost Strength returns after a long rest."
 					]
 				}
 			],
@@ -7581,7 +7902,7 @@
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -7645,19 +7966,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) slashing damage and grapples (escape DC 15). A bukavac can grapple up to 2 Medium size foes."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) slashing damage and grapples (escape DC 15). A bukavac can grapple up to 2 Medium size foes."
 					]
 				},
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
 					]
 				},
 				{
@@ -7749,7 +8070,13 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The buraq makes two attacks with its hooves. Hooves. Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) bludgeoning damage plus 18 ({@dice 4d8}) radiant damage."
+						"The buraq makes two attacks with its hooves."
+					]
+				},
+				{
+					"name": "Hooves",
+					"entries": [
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) bludgeoning damage plus 18 ({@dice 4d8}) radiant damage."
 					]
 				},
 				{
@@ -7848,19 +8175,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Sling",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 30/120 ft., one target. Hit: 5 ({@dice 1d4+3}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 30/120 ft., one target. Hit: 5 ({@dice 1d4+3}) bludgeoning damage."
 					]
 				}
 			],
@@ -7929,7 +8256,7 @@
 				{
 					"name": "Tendril",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 15 ft., one creature. Hit: 10 ({@dice 2d6+3}) bludgeoning damage plus 3 ({@dice 1d6}) piercing damage, and a Medium or smaller target is grappled (escape DC 13). Until this grapple ends, the target is restrained. If the target is neither undead nor a construct, the cactid drains the target's body fluids; at the start of each of the target's turns, the target must make a DC 13 Constitution saving throw. On a failed save, the creature's hit point maximum is reduced by 3 ({@dice 1d6}). If a creature's hit point maximum is reduced to 0 by this effect, the creature dies. This reduction lasts until the creature finishes a long rest and drinks abundant water or until it receives a greater restoration spell or comparable magic. The cactid has two tendrils, each of which can grapple one target at a time."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 15 ft., one creature. Hit: 10 ({@dice 2d6+3}) bludgeoning damage plus 3 ({@dice 1d6}) piercing damage, and a Medium or smaller target is grappled (escape DC 13). Until this grapple ends, the target is restrained. If the target is neither undead nor a construct, the cactid drains the target's body fluids; at the start of each of the target's turns, the target must make a DC 13 Constitution saving throw. On a failed save, the creature's hit point maximum is reduced by 3 ({@dice 1d6}). If a creature's hit point maximum is reduced to 0 by this effect, the creature dies. This reduction lasts until the creature finishes a long rest and drinks abundant water or until it receives a greater restoration spell or comparable magic. The cactid has two tendrils, each of which can grapple one target at a time."
 					]
 				},
 				{
@@ -8086,19 +8413,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +17} to hit, reach 5 ft., one target. Hit: 38 ({@dice 8d6+10}) piercing damage plus 7 ({@dice 2d6}) fire damage, and the target must make a successful DC 22 Constitution saving throw or take {@dice 1d4} Strength damage."
+						"Melee Weapon Attack: {@hit 17} to hit, reach 5 ft., one target. Hit: 38 ({@dice 8d6+10}) piercing damage plus 7 ({@dice 2d6}) fire damage, and the target must make a successful DC 22 Constitution saving throw or have its Strength score reduced by {@dice 1d4}. A creature reduced to 0 Strength dies."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +17} to hit, reach 10 ft., one target. Hit: 31 ({@dice 6d6+10}) slashing damage plus 7 ({@dice 2d6}) fire damage, and the target must make a successful DC 22 Constitution saving throw or take {@dice 1d4} Strength damage."
+						"Melee Weapon Attack: {@hit 17} to hit, reach 10 ft., one target. Hit: 31 ({@dice 6d6+10}) slashing damage plus 7 ({@dice 2d6}) fire damage, and the target must make a successful DC 22 Constitution saving throw or have its Strength score reduced by {@dice 1d4}. A creature reduced to 0 Strength dies."
 					]
 				},
 				{
 					"name": "Fire Breath (Recharge 5—6)",
 					"entries": [
-						"Camazotz can breathe a 30-foot cone of unholy fire. Any creature caught in the area takes 55 ({@dice 10d10}) fire damage and {@dice 1d4} Constitution damage, or one-half fire damage and no Constitution damage with a successful DC 22 Dexterity saving throw."
+						"Camazotz can breathe a 30-foot cone of unholy fire. Any creature caught in the area takes 55 ({@dice 10d10}) damage, half of which is fire, the other half is necrotic, or half as much damage with a successful DC 22 Dexterity saving throw."
 					]
 				}
 			],
@@ -8154,7 +8481,7 @@
 			"type": "fiend",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -8214,13 +8541,13 @@
 				{
 					"name": "Needle Fingers",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage. In addition, the target must make a DC 19 Constitution saving throw; if it fails, the cambium can either inflict Ability Damage or Imbalance Humors. A target makes this saving throw just once per turn, even if struck by more than one needle fingers attack."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage. In addition, the target must make a DC 19 Constitution saving throw; if it fails, the cambium can either inflict Ability Damage or Imbalance Humors. A target makes this saving throw just once per turn, even if struck by more than one needle fingers attack."
 					]
 				},
 				{
 					"name": "Ability Damage (3/Day)",
 					"entries": [
-						"When the target of the cambium's needle fingers fails its Constitution saving throw, the cambium can choose to inflict {@dice 1d4} damage to one of the target's ability scores. A greater restoration or greater magic is required to restore this damage."
+						"When the target of the cambium's needle fingers fails its Constitution saving throw, one of its ability scores (cambium's choice) is reduced by {@dice 1d4} until it finishes a long rest. If this reduces a score to 0, the creature is unconscious until it regains at least one point."
 					]
 				},
 				{
@@ -8313,13 +8640,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d12+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d12+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
 					]
 				},
 				{
@@ -8338,7 +8665,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -8378,6 +8705,9 @@
 				"poison",
 				"thunder"
 			],
+			"conditionImmune": [
+				"poisoned"
+			],
 			"senses": "blindsight 120 ft.",
 			"passive": 12,
 			"languages": "Draconic",
@@ -8394,7 +8724,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage plus 3 ({@dice 1d6}) poison damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage plus 3 ({@dice 1d6}) poison damage."
 					]
 				},
 				{
@@ -8466,7 +8796,6 @@
 				"deafened",
 				"frightened",
 				"paralyzed",
-				"poisoned",
 				"prone",
 				"stunned",
 				"unconscious"
@@ -8486,7 +8815,7 @@
 				{
 					"name": "Tendrils",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 33 ({@dice 4d12+7}) bludgeoning damage. If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the cavelight moss can't use its tendrils against another target."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 33 ({@dice 4d12+7}) bludgeoning damage. If the target is a creature, it is grappled (escape DC 17). Until this grapple ends, the target is restrained, and the cavelight moss can't use its tendrils against another target."
 					]
 				},
 				{
@@ -8505,7 +8834,7 @@
 			"type": "celestial",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -8551,15 +8880,9 @@
 			"cr": "8",
 			"trait": [
 				{
-					"name": "Dark Halo",
-					"entries": [
-						"A chained angel is immune to direct damage spells from divine casters."
-					]
-				},
-				{
 					"name": "Redemption",
 					"entries": [
-						"Any caster brave enough to cast a knock spell on a chained angel can remove the creature's shackles—but this always exposes the caster to an immediate fiery greatsword attack as a reaction. If the caster survives that attack, the angel makes an immediate DC 20 Wisdom saving throw; if it succeeds, the angel's chains fall away and it is restored to its senses and to a Good alignment. If the saving throw fails, any further attempts to cast knock on the angel's chains fail automatically for one week."
+							"Any caster brave enough to cast a knock spell on a chained angel can remove the creature's shackles—but this always exposes the caster to a blast of unholy flame as a reaction. The caster takes 16 ({@dice 3d10}) fire damage and 16 ({@dice 3d10}) radiant damage, or half as much with a successful DC 16 Dexterity saving throw. If the caster survives that attack, the angel makes an immediate DC 20 Wisdom saving throw; if it succeeds, the angel's chains fall away and it is restored to its senses and to a Good alignment. If the saving throw fails, any further attempts to cast knock on the angel's chains fail automatically for one week."
 					]
 				}
 			],
@@ -8573,13 +8896,13 @@
 				{
 					"name": "Fiery Greatsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 16 ({@dice 3d10}) fire damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 16 ({@dice 3d10}) fire damage."
 					]
 				},
 				{
 					"name": "Fallen Glory (Recharge 5—6)",
 					"entries": [
-						"Ranged Spell Attack: All creatures within 50 feet of the chained angel and in its line of sight take 19 ({@dice 3d12}) radiant damage and are knocked prone, or take half damage and aren't knocked prone with a successful DC 15 Strength saving throw."
+						"All creatures within 50 feet of the chained angel and in its line of sight take 19 ({@dice 3d12}) radiant damage and are knocked prone, or take half damage and aren't knocked prone with a successful DC 15 Strength saving throw."
 					]
 				}
 			],
@@ -8587,7 +8910,7 @@
 				{
 					"name": "Fiendish Cunning",
 					"entries": [
-						"A chained angel can counter and destroy the ongoing effect of one divine spell each round. This functions as a counterspell with +7 spellcasting ability."
+						"When a creature within 60 feet casts a divine spell, the chained angel can counter the spell if it succeeds on a Charisma check against a DC of 10 + the spell's level."
 					]
 				}
 			],
@@ -8600,7 +8923,7 @@
 			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -8657,7 +8980,7 @@
 					"name": "Siphon Spell Slots",
 					"entries": [
 						"The chelicerae cannot replenish its spells naturally. Instead, it uses grappled spellcasters as spell reservoirs, draining uncast spells to power its own casting. Whenever the chelicerae wishes to cast a spell, it consumes a number of spell slots from its victim equal to the spell slots necessary to cast the spell. If the victim has too few spell slots available, the chelicerae cannot cast that spell.",
-						"However, the chelicerae can also draw out spell slots from drained spellcasters or creatures without magic ability. Instead of moving, the chelicerae can inflict {@dice 1d4} Wisdom damage to any creature grappled in its mandibles, adding 2 spell slots to its spell reservoir for every point of damage inflicted. A victim reduced to 0 Wisdom cannot power any more magical abilities. Victims do not heal ability damage or regain spell slots while this grapple is maintained."
+						"The chelicerae can also draw power from drained spellcasters or creatures without magic ability. It can reduce a grappled creature's Wisdom by {@dice 1d4}, adding 2 spell slots to its spell reservoir for every point lowered. A creature reduced to 0 Wisdom is unconscious until it regains at least one point, and can't offer any more power. A creature regains all lost Wisdom when it finishes a long rest."
 					]
 				},
 				{
@@ -8677,13 +9000,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 17 ({@dice 2d10+6}) piercing damage, and the target is grappled (escape DC 16). The target must also make a successful DC 16 Constitution saving throw or become poisoned. While poisoned this way, the target is unconscious and takes {@dice 1d4} Strength damage at the start of each of its turns. The poisoning ends after 4 rounds or when the target makes a successful DC 16 Constitution save at the end of its turn."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 17 ({@dice 2d10+6}) piercing damage, and the target is grappled (escape DC 16). The target must also make a successful DC 16 Constitution saving throw or become poisoned. While poisoned this way, the target is unconscious and takes {@dice 1d4} Strength damage at the start of each of its turns. The poisoning ends after 4 rounds or when the target makes a successful DC 16 Constitution save at the end of its turn."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) slashing damage."
 					]
 				}
 			],
@@ -8776,7 +9099,7 @@
 						"piercing",
 						"slashing"
 					],
-					"note": "from nonmagical weapons that aren't silvered"
+					"note": "from nonmagical attacks not made with silver weapons"
 				}
 			],
 			"senses": "darkvision 60 ft.",
@@ -8787,7 +9110,7 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
 					]
 				},
 				{
@@ -8828,7 +9151,7 @@
 			"type": "plant",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -8877,13 +9200,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Spitdart Tongue (Recharge 4—6)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage. Every child of the briar can shoot thorns from its mouth."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage. Every child of the briar can shoot thorns from its mouth."
 					]
 				},
 				{
@@ -8970,7 +9293,7 @@
 			],
 			"senses": "darkvision 120 ft.",
 			"passive": 19,
-			"languages": "Celestial, Common, Draconic, Infernal, Primordial;",
+			"languages": "Celestial, Common, Draconic, Infernal, Primordial; telepathy (120 ft.)",
 			"cr": "12",
 			"trait": [
 				{
@@ -8996,13 +9319,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d4+7}) slashing damage plus 2 ({@dice 1d4}) Charisma damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d4+7}) slashing damage plus 2 ({@dice 1d4}) Charisma damage."
 					]
 				},
 				{
 					"name": "Flaming Ranseur",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft., one target. Hit: 12 ({@dice 1d10+7}) piercing damage plus 10 ({@dice 3d6}) fire damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft., one target. Hit: 12 ({@dice 1d10+7}) piercing damage plus 10 ({@dice 3d6}) fire damage."
 					]
 				},
 				{
@@ -9108,7 +9431,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) bludgeoning damage."
 					]
 				},
 				{
@@ -9138,7 +9461,7 @@
 		{
 			"name": "Cikavak",
 			"size": "T",
-			"type": "monstrosity",
+			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
 				"N"
@@ -9177,7 +9500,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, range 5 ft., one target. Hit: 7 ({@dice 1d4+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, range 5 ft., one target. Hit: 7 ({@dice 1d4+2}) piercing damage."
 					]
 				}
 			],
@@ -9259,25 +9582,25 @@
 				{
 					"name": "Rapier",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Disarming Attack",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: the target must make a successful DC 13 Strength saving throw or drop one item it's holding of the city watch captain's choice. The item lands up to 10 feet from the target, in a spot selected by the captain."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: the target must make a successful DC 13 Strength saving throw or drop one item it's holding of the city watch captain's choice. The item lands up to 10 feet from the target, in a spot selected by the captain."
 					]
 				},
 				{
@@ -9294,10 +9617,9 @@
 			"name": "Clockwork Abomination",
 			"size": "L",
 			"type": {
-				"type": "fiend",
+				"type": "construct",
 				"tags": [
-					"devil",
-					"construct"
+					"devil"
 				]
 			},
 			"source": "ToB 3pp",
@@ -9400,13 +9722,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 15 ft., one target. Hit: 13 ({@dice 2d6+6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 15 ft., one target. Hit: 13 ({@dice 2d6+6}) bludgeoning damage."
 					]
 				},
 				{
@@ -9489,7 +9811,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 5 ({@dice 2d4}) poison damage, or one-half poison damage with a successful DC 10 Constitution saving throw."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 5 ({@dice 2d4}) poison damage, or one-half poison damage with a successful DC 10 Constitution saving throw."
 					]
 				}
 			],
@@ -9530,19 +9852,23 @@
 			"wis": 12,
 			"cha": 7,
 			"resist": [
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical weapons"
-				}
+				"bludgeoning",
+				"piercing",
+				"slashing"
 			],
 			"immune": [
 				"fire",
 				"poison",
 				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained",
+				"stunned"
 			],
 			"senses": "darkvision 60 ft.",
 			"passive": 11,
@@ -9559,7 +9885,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 0 ft., up to 4 creatures in the swarm's space. Hit: 17 ({@dice 5d6}) piercing damage plus 3 ({@dice 1d6}) poison damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 0 ft., up to 4 creatures in the swarm's space. Hit: 17 ({@dice 5d6}) piercing damage plus 3 ({@dice 1d6}) poison damage."
 					]
 				}
 			],
@@ -9643,13 +9969,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Tripping Tongue",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 15 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage, and the target must succeed on a DC 13 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 15 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage, and the target must succeed on a DC 13 Strength saving throw or be knocked prone."
 					]
 				},
 				{
@@ -9728,19 +10054,19 @@
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Net Cannon",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 5/15 ft., one target, size Large or smaller. Hit: the target is restrained. A mechanism within the clockwork huntsman's chest can fire a net with a 20-foot trailing cable anchored within the huntsman's chest. A creature can free itself (or another creature) from the net by using its action to make a successful DC 10 Strength check or by dealing 5 slashing damage to the net. The huntsman can fire up to four nets before it must be reloaded."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 5/15 ft., one target, size Large or smaller. Hit: the target is restrained. A mechanism within the clockwork huntsman's chest can fire a net with a 20-foot trailing cable anchored within the huntsman's chest. A creature can free itself (or another creature) from the net by using its action to make a successful DC 10 Strength check or by dealing 5 slashing damage to the net. The huntsman can fire up to four nets before it must be reloaded."
 					]
 				},
 				{
@@ -9830,13 +10156,13 @@
 				{
 					"name": "Heavy Pick",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) bludgeoning damage."
 					]
 				},
 				{
@@ -9931,19 +10257,19 @@
 				{
 					"name": "Halberd",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d10+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d10+2}) slashing damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Net Cannon",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +3} to hit, range 5/15 ft., one target, size Large or smaller. Hit: the target is restrained. A mechanism within the clockwork huntsman's chest can fire a net with a 20-foot trailing cable anchored within the watchman's chest. A creature can free itself (or another creature) from the net by using its action to make a successful DC 10 Strength check or by dealing 5 slashing damage to the net at AC 10. The watchman can fire up to four nets before it must be reloaded."
+						"Ranged Weapon Attack: {@hit 3} to hit, range 5/15 ft., one target, size Large or smaller. Hit: the target is restrained. A mechanism within the clockwork huntsman's chest can fire a net with a 20-foot trailing cable anchored within the watchman's chest. A creature can free itself (or another creature) from the net by using its action to make a successful DC 10 Strength check or by dealing 5 slashing damage to the net at AC 10. The watchman can fire up to four nets before it must be reloaded."
 					]
 				}
 			],
@@ -10008,13 +10334,13 @@
 				{
 					"name": "Unarmed Strike",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one creature. Hit: 2 (1+1) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one creature. Hit: 2 (1+1) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Improvised Weapon",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +3} to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 3 ({@dice 1d4+1}) bludgeoning, piercing, or slashing damage, depending on weapon."
+						"Melee or Ranged Weapon Attack: {@hit 3} to hit, reach 5 ft. or range 20/60 ft., one creature. Hit: 3 ({@dice 1d4+1}) bludgeoning, piercing, or slashing damage, depending on weapon."
 					]
 				}
 			],
@@ -10096,8 +10422,13 @@
 				{
 					"name": "False Appearance",
 					"entries": [
-						"While the swarm remains motionless, it is indistinguishable from normal stones.",
-						"Shift and Tumble. As a bonus action, the swarm can push a prone creature whose space it occupies 5 feet."
+						"While the swarm remains motionless, it is indistinguishable from normal stones."
+					]
+				},
+				{
+					"name": "Shift and Tumble",
+					"entries": [
+						"As a bonus action, the swarm can push a prone creature whose space it occupies 5 feet."
 					]
 				},
 				{
@@ -10117,7 +10448,7 @@
 				{
 					"name": "Stings",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 0 ft., one target in the swarm's space. Hit: 10 ({@dice 4d4}) piercing damage, or 5 ({@dice 2d4}) piercing damage if the swarm has half its hit points or fewer."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 0 ft., one target in the swarm's space. Hit: 10 ({@dice 4d4}) piercing damage, or 5 ({@dice 2d4}) piercing damage if the swarm has half its hit points or fewer."
 					]
 				}
 			],
@@ -10130,7 +10461,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -10200,19 +10531,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage, and the target must succeed on a DC 15 Constitution saving throw or take 7 ({@dice 2d6}) poison damage at the start of each of its turns for 4 rounds. The creature can repeat the saving throw at the end of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage, and the target must succeed on a DC 15 Constitution saving throw or take 7 ({@dice 2d6}) poison damage at the start of each of its turns for 4 rounds. The creature can repeat the saving throw at the end of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -10231,7 +10562,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -10306,13 +10637,13 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d10+7}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage and the target is grappled (escape DC 17). Until this grapple ends, the target is restrained."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d10+7}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage and the target is grappled (escape DC 17). Until this grapple ends, the target is restrained."
 					]
 				},
 				{
 					"name": "Bone Shard",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +11} to hit, range 30/120 ft., one target. Hit: 14 ({@dice 2d6+7}) piercing damage and 10 ({@dice 3d6}) necrotic damage. When hit, the target must make a successful DC 17 Strength check or be knocked prone, pinned to the ground by the shard, and restrained. To end this restraint, the target or a creature adjacent to it must use an action to make a successful DC 17 Strength (Athletics) check to remove the shard."
+						"Ranged Weapon Attack: {@hit 11} to hit, range 30/120 ft., one target. Hit: 14 ({@dice 2d6+7}) piercing damage and 10 ({@dice 3d6}) necrotic damage. When hit, the target must make a successful DC 17 Strength check or be knocked prone, pinned to the ground by the shard, and restrained. To end this restraint, the target or a creature adjacent to it must use an action to make a successful DC 17 Strength (Athletics) check to remove the shard."
 					]
 				},
 				{
@@ -10331,7 +10662,7 @@
 			"type": "ooze",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -10365,7 +10696,8 @@
 			],
 			"immune": [
 				"acid",
-				"fire"
+				"fire",
+				"posion"
 			],
 			"conditionImmune": [
 				"exhaustion",
@@ -10395,7 +10727,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) bludgeoning damage plus 3 ({@dice 1d6}) acid damage, and the target is grappled (escape DC 13)."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) bludgeoning damage plus 3 ({@dice 1d6}) acid damage, and the target is grappled (escape DC 13)."
 					]
 				}
 			],
@@ -10469,13 +10801,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus 4 ({@dice 1d8}) fire damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus 4 ({@dice 1d8}) fire damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target takes 2 ({@dice 1d4}) poison damage at the start of each of its turns for 3 rounds. The target may repeat the saving throw at the end of its turn to end the effect early."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or become poisoned for 1 hour. If the saving throw fails by 5 or more, the target takes 2 ({@dice 1d4}) poison damage at the start of each of its turns for 3 rounds. The target may repeat the saving throw at the end of its turn to end the effect early."
 					]
 				},
 				{
@@ -10590,7 +10922,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				},
 				{
@@ -10685,7 +11017,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d6+3}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage, and the dau regains hit points equal to the necrotic damage dealt. The target must succeed on a DC 13 Constitution saving throw or its hit point maximum is reduced by an amount equal to the necrotic damage taken. This reduction lasts until the creature finishes a long rest."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d6+3}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage, and the dau regains hit points equal to the necrotic damage dealt. The target must succeed on a DC 13 Constitution saving throw or its hit point maximum is reduced by an amount equal to the necrotic damage taken. This reduction lasts until the creature finishes a long rest."
 					]
 				},
 				{
@@ -10766,12 +11098,7 @@
 			"wis": 12,
 			"cha": 15,
 			"resist": [
-				{
-					"resist": [
-						"slashing"
-					],
-					"note": "against nonmagical weapons"
-				},
+				"slashing",
 				"bludgeoning",
 				"piercing"
 			],
@@ -10821,7 +11148,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 0 ft., every target in the swarm's space. Hit: 22 ({@dice 6d6+1}) piercing damage, or 11 ({@dice 3d6+1}) piercing damage if the swarm has half of its hit points or fewer. The target also takes 10 ({@dice 3d6}) poison damage and becomes poisoned for {@dice 1d4} rounds; a successful DC 13 Constitution saving throw reduces poison damage by half and prevents the poisoned condition."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 0 ft., every target in the swarm's space. Hit: 22 ({@dice 6d6+1}) piercing damage, or 11 ({@dice 3d6+1}) piercing damage if the swarm has half of its hit points or fewer. The target also takes 10 ({@dice 3d6}) poison damage and becomes poisoned for {@dice 1d4} rounds; a successful DC 13 Constitution saving throw reduces poison damage by half and prevents the poisoned condition."
 					]
 				}
 			],
@@ -10834,7 +11161,7 @@
 			"type": "plant",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -10885,7 +11212,7 @@
 				{
 					"name": "Fist",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 11 ({@dice 4d4+1}) bludgeoning damage plus 10 ({@dice 4d4}) poison damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 11 ({@dice 4d4+1}) bludgeoning damage plus 10 ({@dice 4d4}) poison damage."
 					]
 				},
 				{
@@ -10897,7 +11224,7 @@
 				{
 					"name": "Slumber Spores (3/Day)",
 					"entries": [
-						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 13 Constitution saving throw or fall prone and unconscious for 1 minute."
+						"The myconid ejects spores at one creature it can see within 5 feet of it. The target must succeed on a DC 13 Constitution saving throw or be poisoned and unconscious for 1 minute. A creature wakes up if it takes damage, or if another creature uses its action to shake it awake."
 					]
 				}
 			],
@@ -10910,7 +11237,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -11011,7 +11338,7 @@
 				{
 					"name": "Life Drain",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 36 ({@dice 7d8+5}) necrotic damage. The target must succeed on a DC 15 Constitution saving throw, or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 36 ({@dice 7d8+5}) necrotic damage. The target must succeed on a DC 15 Constitution saving throw, or its hit point maximum is reduced by an amount equal to the damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
 					]
 				},
 				{
@@ -11094,19 +11421,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 7 ({@dice 2d6}) poison damage, and the target must succeed on a DC 16 Constitution saving throw or become poisoned for 4 rounds. While poisoned this way, the target takes {@dice 1d4} Constitution damage per round. The target can repeat the saving throw at the end of each of its turns, ending the effect with a success. When animate dead is cast on creatures killed by this poison, the caster requires no material components."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 7 ({@dice 2d6}) poison damage, and the target must succeed on a DC 16 Constitution saving throw or become poisoned for 4 rounds. While poisoned this way, the target must repeat the save at the start of its turn, ending the condition on a success. On a failure, it takes 10 ({@dice 3d6}) poison damage. When animate dead is cast on creatures killed by this poison, the caster requires no material components:"
 					]
 				},
 				{
@@ -11195,7 +11522,7 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
 					]
 				}
 			],
@@ -11295,13 +11622,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Unholy Trident",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage plus 13 ({@dice 2d12}) necrotic damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage plus 13 ({@dice 2d12}) necrotic damage."
 					]
 				}
 			],
@@ -11423,7 +11750,7 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				}
 			],
@@ -11509,13 +11836,13 @@
 				{
 					"name": "Greatclub",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 20 ({@dice 3d8+7}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 20 ({@dice 3d8+7}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +10} to hit, range 60/240 ft., one target. Hit: 29 ({@dice 4d10+7}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 10} to hit, range 60/240 ft., one target. Hit: 29 ({@dice 4d10+7}) bludgeoning damage."
 					]
 				},
 				{
@@ -11527,7 +11854,7 @@
 				{
 					"name": "Shout of the Void (Recharge 4—6)",
 					"entries": [
-						"The degenerate titan utters a scream that rends reality in a 30-foot cone. Any ongoing spell or magical effect of 3rd level or lower in the area ends. For every spell or effect of 4th level or higher in the area, the degenerate titan makes a Constitution check against DC (10+the level of the spell or effect). On a success, the spell or effect ends."
+						"The degenerate titan utters a scream that rends reality in a 30-foot cone. Any ongoing spell or magical effect of 3rd level or lower in the area ends. For every spell or effect of 4th level or higher in the area, the degenerate titan makes a Constitution check against DC (10 + the level of the spell or effect). On a success, the spell or effect ends."
 					]
 				}
 			],
@@ -11695,6 +12022,12 @@
 					"entries": [
 						"The derro's weapon attacks deal 9 ({@dice 2d8}) necrotic damage (included in its Actions list)."
 					]
+				},
+				{
+					"name": "Sunlight Sensitivity",
+					"entries": [
+						"While in sunlight, the derro shadow antipaladin has disadvantage on attack rolls and Wisdom (Perception) checks that rely on sight."
+					]
 				}
 			],
 			"action": [
@@ -11707,13 +12040,13 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage plus 9 ({@dice 2d8}) necrotic damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage plus 9 ({@dice 2d8}) necrotic damage."
 					]
 				},
 				{
 					"name": "Heavy Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +7} to hit, range 100/400 ft., one target, Hit: 9 ({@dice 1d10+4}) piercing damage plus 9 ({@dice 2d8}) necrotic damage."
+						"Ranged Weapon Attack: {@hit 7} to hit, range 100/400 ft., one target, Hit: 9 ({@dice 1d10+4}) piercing damage plus 9 ({@dice 2d8}) necrotic damage."
 					]
 				},
 				{
@@ -11823,13 +12156,13 @@
 				{
 					"name": "Falchion",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 23 ({@dice 6d4+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 23 ({@dice 6d4+8}) slashing damage."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +12} to hit, range 60/240 ft., one target. Hit: 30 ({@dice 4d10+8}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 12} to hit, range 60/240 ft., one target. Hit: 30 ({@dice 4d10+8}) bludgeoning damage."
 					]
 				}
 			],
@@ -11934,7 +12267,7 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				}
 			],
@@ -12065,7 +12398,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 0 ft., one creature in the dipsa's space. Hit: 1 piercing damage, and the dipsa attaches to the target. A creature with a dipsa attached takes 3 ({@dice 1d6}) acid damage per round per dipsa, and it must make a successful DC 12 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. If a creature's hit point maximum is reduced to 0 by this effect, the creature dies. This reduction to a creature's hit point maximum lasts until it is affected by a lesser restoration spell or comparable magic."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 0 ft., one creature in the dipsa's space. Hit: 1 piercing damage, and the dipsa attaches to the target. A creature with a dipsa attached takes 3 ({@dice 1d6}) acid damage per round per dipsa, and it must make a successful DC 12 Constitution saving throw or have its hit point maximum reduced by an amount equal to the damage taken. If a creature's hit point maximum is reduced to 0 by this effect, the creature dies. This reduction to a creature's hit point maximum lasts until it is affected by a lesser restoration spell or comparable magic."
 					]
 				}
 			],
@@ -12147,11 +12480,9 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 15 ({@dice 3d8+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 15 ({@dice 3d8+2}) slashing damage."
 					]
-				}
-			],
-			"reaction": [
+				},
 				{
 					"name": "Terrifying Mask",
 					"entries": [
@@ -12220,13 +12551,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 12 ({@dice 3d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 12 ({@dice 3d6+2}) slashing damage."
 					]
 				}
 			],
@@ -12292,7 +12623,7 @@
 				{
 					"name": "Wormkiller Rage",
 					"entries": [
-						"Wild dogmole juggernaut packs are famed for their battles against the monsters of the dark caverns of the world. If a dogmole juggernaut draws blood against vermin, purple worms, or other underground invertebrate, it gains a +4 bonus to Strength and Constitution but suffers a -2 penalty to AC. The wormkiller rage lasts for a number of rounds equal to 1+ its Constitution modifier (minimum 1 round). It cannot end the rage voluntarily while the creatures that sent it into a rage still live."
+						"Wild dogmole juggernaut packs are famed for their battles against the monsters of the dark caverns of the world. If a dogmole juggernaut draws blood against vermin, purple worms, or other underground invertebrate, it gains a +4 bonus to Strength and Constitution but suffers a -2 penalty to AC. The wormkiller rage lasts for a number of rounds equal to 1 + its Constitution modifier (minimum 1 round). It cannot end the rage voluntarily while the creatures that sent it into a rage still live."
 					]
 				}
 			],
@@ -12306,13 +12637,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 19 ({@dice 4d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 19 ({@dice 4d6+5}) slashing damage."
 					]
 				}
 			],
@@ -12371,7 +12702,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
 					]
 				}
 			],
@@ -12444,14 +12775,14 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 1 piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 1 piercing damage."
 					]
 				},
 				{
 					"name": "Arcane Doubling (recharges after 10 minutes)",
 					"entries": [
 						"A doppelrat under duress creates clones of itself at the beginning of its turn. Each round for 4 rounds, the number of live doppelrats quadruples but never exceeds 20. For example, when the doppelrat triggers arcane doubling, 1 rat becomes 4; at the start of the rat's next turn, those 4 become 16; and at the start of the rat's third turn, those 16 become 20, the maximum allowed. If one of the duplicates was destroyed between the original doppelrat's 1st and 2nd turns, then the surviving 3 would become 12, and so on.",
-						"Each duplicate appears in the same space as any other rat, can either move or take an action the round it appears, and has 4 hit points and AC 13. Any surviving duplicates perish 1 minute (10 rounds) after the first ones were created. If the original doppelrat dies, its clones stop duplicating but the pre-existing clones remain until their time expires. A creature can identify the original doppelrat from its duplicates by taking the search action and making a successful DC 15 Intelligence (Nature) or Wisdom (Perception) check."
+						"Each duplicate appears in the same space as any other rat, can either move or take an action the round it appears, and has 4 hit points and AC 13. Any surviving duplicates perish 1 minute (10 rounds) after the first ones were created. If the original doppelrat dies, its clones stop duplicating but the pre-existing clones remain until their time expires. A creature can identify the original doppelrat from its duplicates as an action and making a successful DC 15 Intelligence (Nature) or Wisdom (Perception) check."
 					]
 				},
 				{
@@ -12470,7 +12801,7 @@
 			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -12530,13 +12861,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Tentacle",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage. If both tentacles hit the same target in a single turn, the target is grappled (escape DC 14) and pulled within reach of the bite attack, if it was farther than 5 feet away. The target must be size Large or smaller to be pulled this way. The dorreq can maintain a grapple on one Large, two Medium, or two Small creatures at one time."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage. If both tentacles hit the same target in a single turn, the target is grappled (escape DC 14) and pulled within reach of the bite attack, if it was farther than 5 feet away. The target must be size Large or smaller to be pulled this way. The dorreq can maintain a grapple on one Large, two Medium, or two Small creatures at one time."
 					]
 				},
 				{
@@ -12649,13 +12980,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 26 ({@dice 4d8+8}) piercing damage plus 5 ({@dice 1d10}) lightning damage, and the target must succeed on a DC 18 Constitution saving throw or become paralyzed for {@dice 1d4} rounds."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 26 ({@dice 4d8+8}) piercing damage plus 5 ({@dice 1d10}) lightning damage, and the target must succeed on a DC 18 Constitution saving throw or become paralyzed for {@dice 1d4} rounds."
 					]
 				},
 				{
 					"name": "Tail Slap",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 30 ({@dice 5d8+8}) bludgeoning damage plus 5 ({@dice 1d10}) lightning damage and push the target up to 10 feet away."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 30 ({@dice 5d8+8}) bludgeoning damage plus 5 ({@dice 1d10}) lightning damage and push the target up to 10 feet away."
 					]
 				},
 				{
@@ -12720,7 +13051,7 @@
 				{
 					"name": "Loyal to Dragon Master",
 					"entries": [
-						"A dragonleaf tree only follows commands from its designated master (or from any creatures to whom the master grants control). It has advantage on saving throws against any charm or compulsion spell or effect. Additionally, the tree has advantage on any saving throw to resist Bluff, Diplomacy, or intimidation checks made to influence it to act against its masters."
+						"A dragonleaf tree only follows commands from its designated master (or from any creatures to whom the master grants control). It has advantage on saving throws against any charm or compulsion spell or effect. Additionally, the tree has advantage on any saving throw to resist Deception, Intimidation, or Persuasion checks made to influence it to act against its masters."
 					]
 				},
 				{
@@ -12734,13 +13065,13 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 58 ({@dice 10d10+3}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 58 ({@dice 10d10+3}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Leaves",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +3} to hit, range 30/60 ft., one target. Hit: 45 ({@dice 10d8}) slashing damage."
+						"Ranged Weapon Attack: {@hit 3} to hit, range 30/60 ft., one target. Hit: 45 ({@dice 10d8}) slashing damage."
 					]
 				},
 				{
@@ -12815,13 +13146,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage plus 10 ({@dice 4d4}) acid damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage plus 10 ({@dice 4d4}) acid damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage."
 					]
 				},
 				{
@@ -12911,13 +13242,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) piercing damage, and the target is grappled (escape DC 12)."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) piercing damage, and the target is grappled (escape DC 12)."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 24 ({@dice 4d10+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 24 ({@dice 4d10+2}) slashing damage."
 					]
 				},
 				{
@@ -12964,7 +13295,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -13036,13 +13367,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Hair",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 20 ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage, and the target is grappled (escape DC 16). Three creatures can be grappled at a time."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 20 ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage, and the target is grappled (escape DC 16). Three creatures can be grappled at a time."
 					]
 				},
 				{
@@ -13162,7 +13493,7 @@
 				{
 					"name": "Spine Whip",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d10+4}) slashing damage plus 10 ({@dice 3d10}) necrotic damage. If the target is a creature it must make a DC 15 Constitution saving throw or be wracked with pain and fall prone."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d10+4}) slashing damage plus 10 ({@dice 3d10}) necrotic damage. If the target is a creature it must make a DC 15 Constitution saving throw or be wracked with pain and fall prone."
 					]
 				},
 				{
@@ -13288,7 +13619,7 @@
 				{
 					"name": "Pseudopod",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage. If the dune mimic is in object or terrain form, the target is subjected to the mimic's Adhesive trait."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage. If the dune mimic is in object or terrain form, the target is subjected to the mimic's Adhesive trait."
 					]
 				},
 				{
@@ -13379,13 +13710,13 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +7} to hit, range 150/600 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage."
+						"Ranged Weapon Attack: {@hit 7} to hit, range 150/600 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage."
 					]
 				}
 			],
@@ -13432,7 +13763,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -13479,13 +13810,13 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				}
 			],
@@ -13572,7 +13903,7 @@
 				{
 					"name": "Ring-Staff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d6}) bludgeoning damage."
 					]
 				}
 			],
@@ -13683,7 +14014,7 @@
 				{
 					"name": "Wing Blades",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage."
 					]
 				},
 				{
@@ -13710,7 +14041,7 @@
 			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -13747,10 +14078,10 @@
 			"resist": [
 				"acid",
 				"cold",
-				"lightning",
-				"poison"
+				"lightning"
 			],
 			"immune": [
+				"poison",
 				{
 					"immune": [
 						"bludgeoning",
@@ -13797,7 +14128,7 @@
 				{
 					"name": "Mawblade",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, one target. Hit: 19 ({@dice 4d6+5}) piercing damage, and the target must make a successful DC 17 Constitution saving throw or gain one level of exhaustion."
+						"Melee Weapon Attack: {@hit 9} to hit, one target. Hit: 19 ({@dice 4d6+5}) piercing damage, and the target must make a successful DC 17 Constitution saving throw or gain one level of exhaustion."
 					]
 				}
 			],
@@ -13906,7 +14237,7 @@
 				{
 					"name": "Water Siphon",
 					"entries": [
-						"Melee Spell Attack: {@hit +7} to hit, reach 5 ft., one creature. Hit: 21 ({@dice 6d6}) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken and it is stunned for 1 minute and gains one level of exhaustion. A stunned creature repeats the saving throw at the end of each of its turns, ending the stun on itself on a success. The hit point reduction lasts until the creature finishes a long rest and drinks abundant water or until it is affected by greater restoration or comparable magic. The target dies if this effect reduces its hit point maximum to 0."
+						"Melee Spell Attack: {@hit 7} to hit, reach 5 ft., one creature. Hit: 21 ({@dice 6d6}) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken and it is stunned for 1 minute and gains one level of exhaustion. A stunned creature repeats the saving throw at the end of each of its turns, ending the stun on itself on a success. The hit point reduction lasts until the creature finishes a long rest and drinks abundant water or until it is affected by greater restoration or comparable magic. The target dies if this effect reduces its hit point maximum to 0."
 					]
 				}
 			],
@@ -13973,7 +14304,7 @@
 				{
 					"name": "Slithering Bite",
 					"entries": [
-						"When an eel hound moves adjacent to an enemy and makes a bite attack, it may immediately move up to 5 feet, as long as it stays within 5 feet of the enemy it attacked. If another eel hound already occupies that space, the moving eel hound can keep moving until it reaches an empty space that's still adjacent to that same enemy."
+						"A creature an eel hound attacks can't make opportunity attacks against it until the start of the creature's next turn."
 					]
 				}
 			],
@@ -13981,7 +14312,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage, and the target is grappled (escape DC 14)."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage, and the target is grappled (escape DC 14)."
 					]
 				}
 			],
@@ -14077,13 +14408,13 @@
 				{
 					"name": "Asgardian Battleaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d8+6}) slashing damage when used one handed or 17 ({@dice 2d10+6}) when used two-handed."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d8+6}) slashing damage when used one handed or 17 ({@dice 2d10+6}) when used two-handed."
 					]
 				},
 				{
 					"name": "Handaxe",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
+						"Melee or Ranged Weapon Attack: {@hit 7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
 					]
 				}
 			],
@@ -14156,7 +14487,7 @@
 				"unconscious"
 			],
 			"vulnerable": [
-				"fire"
+				"radiant"
 			],
 			"senses": "darkvision 120 ft.",
 			"passive": 15,
@@ -14192,13 +14523,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 22 ({@dice 3d10+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 22 ({@dice 3d10+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Tail Slap",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 19 ({@dice 3d8+6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 19 ({@dice 3d8+6}) bludgeoning damage."
 					]
 				},
 				{
@@ -14277,13 +14608,13 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d4+4}) slashing damage plus 3 ({@dice 1d6}) poison damage."
+						"Melee or Ranged Weapon Attack: {@hit 7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d4+4}) slashing damage plus 3 ({@dice 1d6}) poison damage."
 					]
 				},
 				{
 					"name": "Reed Flower Net",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +7} to hit, range 5/15 ft., one Large or smaller creature. Hit: The target has disadvantage on Wisdom saving throws for 1 minute, and is restrained. A creature can free itself or another creature within reach from restraint by using an action to make a successful DC 15 Strength check or by doing 5 slashing damage to the net (AC 10)."
+						"Ranged Weapon Attack: {@hit 7} to hit, range 5/15 ft., one Large or smaller creature. Hit: The target has disadvantage on Wisdom saving throws for 1 minute, and is restrained. A creature can free itself or another creature within reach from restraint by using an action to make a successful DC 15 Strength check or by doing 5 slashing damage to the net (AC 10)."
 					]
 				}
 			],
@@ -14371,20 +14702,12 @@
 				}
 			],
 			"conditionImmune": [
-				"blinded",
 				"charmed",
-				"deafened",
 				"exhaustion",
 				"frightened",
-				"grappled",
-				"incapacitated",
-				"invisible",
 				"paralyzed",
 				"petrified",
 				"poisoned",
-				"prone",
-				"restrained",
-				"stunned",
 				"unconscious"
 			],
 			"senses": "darkvision 120 ft., tremorsense 120 ft.",
@@ -14433,7 +14756,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +15} to hit, reach 15 ft., one target. Hit: 36 ({@dice 6d8+9}) bludgeoning damage. If the target is a creature, it must succeed on a DC 23 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 15} to hit, reach 15 ft., one target. Hit: 36 ({@dice 6d8+9}) bludgeoning damage. If the target is a creature, it must succeed on a DC 23 Strength saving throw or be knocked prone."
 					]
 				}
 			],
@@ -14542,13 +14865,13 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 150/600 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 150/600 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
 					]
 				},
 				{
@@ -14649,7 +14972,7 @@
 				{
 					"name": "Slash",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 14 ({@dice 5d4+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 14 ({@dice 5d4+2}) slashing damage."
 					]
 				},
 				{
@@ -14757,7 +15080,7 @@
 				{
 					"name": "Mace",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d6}) bludgeoning damage."
 					]
 				}
 			],
@@ -14853,7 +15176,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -14911,7 +15234,7 @@
 			],
 			"senses": "darkvision 120 ft.",
 			"passive": 19,
-			"languages": "Common, Draconic, Gnoll, Undercommon",
+			"languages": "Common, Darakhul, Draconic, Gnoll, Undercommon",
 			"cr": "20",
 			"trait": [
 				{
@@ -14943,19 +15266,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage, and a creature must make a successful DC 18 Constitution saving throw or contract darakhul fever."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage, and a creature must make a successful DC 18 Constitution saving throw or contract darakhul fever."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage, and a creature must make a successful DC 18 Constitution saving throw or be paralyzed for 1 minute. A paralyzed creature repeats the saving throw at the ends of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage, and a creature must make a successful DC 18 Constitution saving throw or be paralyzed for 1 minute. A paralyzed creature repeats the saving throw at the ends of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Scepter",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d10+4}) bludgeoning damage plus 17 ({@dice 5d6}) necrotic damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d10+4}) bludgeoning damage plus 17 ({@dice 5d6}) necrotic damage."
 					]
 				},
 				{
@@ -14979,6 +15302,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Emperor Of The Ghouls",
 			"legendary": [
 				{
 					"name": "Attack",
@@ -15162,21 +15486,21 @@
 			],
 			"action": [
 				{
-					"name": "Longsword",
+					"name": "Razor Cloak",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Shadow Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Shadow Snare",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 20/60 ft., one target. Hit: Large or smaller creatures are restrained. To escape, the restrained creature or an adjacent ally must use an action to make a successful DC 14 Strength check. The shadow snare has 15 hit points and AC 12."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 20/60 ft., one target. Hit: Large or smaller creatures are restrained. To escape, the restrained creature or an adjacent ally must use an action to make a successful DC 14 Strength check. The shadow snare has 15 hit points and AC 12."
 					]
 				}
 			],
@@ -15235,7 +15559,7 @@
 				{
 					"name": "Time Warping Staff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d10+2}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d10+2}) bludgeoning damage."
 					]
 				},
 				{
@@ -15330,13 +15654,13 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				}
 			],
@@ -15417,13 +15741,13 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) slashing damage."
 					]
 				},
 				{
 					"name": "Sling",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +3} to hit, range 30/120 ft., one target. Hit: 4 ({@dice 1d4+2}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 3} to hit, range 30/120 ft., one target. Hit: 4 ({@dice 1d4+2}) bludgeoning damage."
 					]
 				}
 			],
@@ -15517,7 +15841,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5ft., one target. Hit: 24 ({@dice 4d8+6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5ft., one target. Hit: 24 ({@dice 4d8+6}) bludgeoning damage."
 					]
 				},
 				{
@@ -15597,7 +15921,7 @@
 				{
 					"name": "Antler Glaive",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft. or 10 ft., one target. Hit: 7 ({@dice 1d10+2}) slashing damage and the target must make a successful DC 13 Strength saving throw or either be disarmed or fall prone; the attacking far darrig chooses which effect occurs."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft. or 10 ft., one target. Hit: 7 ({@dice 1d10+2}) slashing damage and the target must make a successful DC 13 Strength saving throw or either be disarmed or fall prone; the attacking far darrig chooses which effect occurs."
 					]
 				},
 				{
@@ -15704,7 +16028,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 26 ({@dice 5d8+4}) slashing damage plus 11 ({@dice 2d10}) necrotic damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 26 ({@dice 5d8+4}) slashing damage plus 11 ({@dice 2d10}) necrotic damage."
 					]
 				},
 				{
@@ -15713,7 +16037,7 @@
 						"When a fate eater scores a critical hit against a target, it damages not only the creature but also the threads of its fate, changing the character's past or future. The target must roll {@dice 1d6} on the chart below for each critical hit that isn't negated by a successful DC 15 Charisma saving throw:",
 						"1. Seeing the Alternates: Suffers the effects of the confusion spell for {@dice 1d4} rounds",
 						"2. Untied from the Loom: Character's speed is randomized for four rounds. Roll {@dice 3d20} at the start of each of the character's turns to determine his or her speed in feet that turn",
-						"3. Shifting Memories: Permanently loses 2 from a random skill and gains 2 in a random untrained skill",
+						"3. Shifting Memories: Permanently loses proficiency in a random proficient skill and gains proficiency in random unproficient skill",
 						"4. Not So Fast: Loses the use of one class ability, chosen at random",
 						"5. Lost Potential: Loses 1 point from one randomly chosen ability score",
 						"6. Took the Lesser Path: The character's current hit point total becomes his or her hit point maximum",
@@ -15825,7 +16149,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one creature. Hit: 16 ({@dice 2d12+3}) slashing damage. If the target is disoriented by Distortion Gaze, this attack does an additional 13 ({@dice 3d8}) psychic damage and heals the fear smith by an equal amount."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one creature. Hit: 16 ({@dice 2d12+3}) slashing damage. If the target is disoriented by Distortion Gaze, this attack does an additional 13 ({@dice 3d8}) psychic damage and heals the fear smith by an equal amount."
 					]
 				},
 				{
@@ -15840,7 +16164,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The fear smith's innate spellcasting ability is Charisma (spell save DC 16). The fear smith can innately cast the following spells, requiring no verbal or material components :"
+						"The fear smith's innate spellcasting ability is Charisma (spell save DC 16). The fear smith can innately cast the following spells, requiring no verbal or material components:"
 					],
 					"will": [
 						"{@spell detect thoughts}",
@@ -15860,12 +16184,7 @@
 		{
 			"name": "Fellforged",
 			"size": "M",
-			"type": {
-				"type": "construct",
-				"tags": [
-					"undead"
-				]
-			},
+			"type": "construct",
 			"source": "ToB 3pp",
 			"alignment": [
 				"L",
@@ -15918,7 +16237,7 @@
 				{
 					"name": "Expelled Spirit",
 					"entries": [
-						"While the body the fellforged inhabits was made to bind spirits, the foul presence of the wraith within is vulnerable to turning attempts. Any successful turn attempt exorcises the wraith from its clockwork frame, but has no other effect. The expelled wraith retains its current hp total."
+						"While the fellforged body was made to bind spirits, the wraith within is vulnerable to turning attempts. Any successful turn attempt exorcises the wraith from its clockwork frame. The expelled wraith retains its current hp total and fights normally. The construct dies without an animating spirit."
 					]
 				},
 				{
@@ -15944,7 +16263,7 @@
 				{
 					"name": "Necrotic Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) bludgeoning damage plus 4 ({@dice 1d8}) necrotic damage, and the target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the total damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) bludgeoning damage plus 4 ({@dice 1d8}) necrotic damage, and the target must succeed on a DC 14 Constitution saving throw or its hit point maximum is reduced by an amount equal to the total damage taken. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
 					]
 				},
 				{
@@ -16031,7 +16350,7 @@
 				{
 					"name": "Patron Blessing",
 					"entries": [
-						"A fext is infused with a portion of their patron's power. They have an Armor Class equal to 10+their Charisma modifier+their Dexterity modifier."
+						"A fext is infused with a portion of their patron's power. They have an Armor Class equal to 10 + their Charisma modifier + their Dexterity modifier."
 					]
 				}
 			],
@@ -16045,13 +16364,13 @@
 				{
 					"name": "Eldritch Blade",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage plus 16 ({@dice 3d10}) force damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage plus 16 ({@dice 3d10}) force damage."
 					]
 				},
 				{
 					"name": "Eldritch Fury",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 60/200 ft., one creature. Hit: 25 ({@dice 4d10+3}) force damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 60/200 ft., one creature. Hit: 25 ({@dice 4d10+3}) force damage."
 					]
 				}
 			],
@@ -16184,7 +16503,7 @@
 				{
 					"name": "Razor-Leafed Branch",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 15 ft., one target. Hit: 21 ({@dice 3d8+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 15 ft., one target. Hit: 21 ({@dice 3d8+8}) slashing damage."
 					]
 				},
 				{
@@ -16303,7 +16622,7 @@
 					]
 				},
 				{
-					"name": "Unshakable Fidelity",
+					"name": "Unshakeable Fidelity",
 					"entries": [
 						"Fidele angels are never voluntarily without their partners. No magical effect or power can cause a fidele angel to act against its mate, and no charm or domination effect can cause them to leave their side or to change their feelings of love and loyalty toward each other."
 					]
@@ -16317,27 +16636,27 @@
 					]
 				},
 				{
-					"name": "Longsword",
+					"name": "+1 Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage or 11 ({@dice 1d10+6}) slashing damage if used with two hands."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage or 11 ({@dice 1d10+6}) slashing damage if used with two hands."
 					]
 				},
 				{
-					"name": "Longbow",
+					"name": "+1 Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 150/600 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 150/600 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Beak (Eagle Form)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Talons (Eagle Form)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				}
 			],
@@ -16381,7 +16700,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -16458,7 +16777,7 @@
 				{
 					"name": "Swarm",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 0 ft., one target in the swarm's space. Hit: 21 ({@dice 6d6}) fire damage, or 10 ({@dice 3d6}) fire damage if the swarm has half or fewer hit points."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 0 ft., one target in the swarm's space. Hit: 21 ({@dice 6d6}) fire damage, or 10 ({@dice 3d6}) fire damage if the swarm has half or fewer hit points."
 					]
 				}
 			],
@@ -16559,13 +16878,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d8+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d8+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d8+4}) slashing damage."
 					]
 				},
 				{
@@ -16613,7 +16932,7 @@
 			"type": "elemental",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -16669,7 +16988,7 @@
 				{
 					"name": "Magical Light Sensitivity",
 					"entries": [
-						"A firegeist detests magical light of any intensity. It suffers the effects of being poisoned when inside the radius of a magical light source."
+						"While in magical light, the firegeist has disadvantage on attack rolls and ability checks."
 					]
 				},
 				{
@@ -16689,7 +17008,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) bludgeoning damage."
 					]
 				},
 				{
@@ -16738,6 +17057,9 @@
 			"skill": {
 				"perception": "+3"
 			},
+			"immune": [
+				"poison"
+			],
 			"conditionImmune": [
 				"poisoned"
 			],
@@ -16762,7 +17084,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage."
 					]
 				},
 				{
@@ -16831,7 +17153,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d10+1}) piercing damage plus 3 ({@dice 1d6}) fire damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d10+1}) piercing damage plus 3 ({@dice 1d6}) fire damage."
 					]
 				},
 				{
@@ -16916,7 +17238,7 @@
 			"cr": "12",
 			"trait": [
 				{
-					"name": "Magic weapons",
+					"name": "Magic Weapons",
 					"entries": [
 						"The flutterflesh's attacks are magical."
 					]
@@ -16950,7 +17272,7 @@
 				{
 					"name": "Bone Spur",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 17 ({@dice 2d12+4}) slashing damage plus 11 ({@dice 2d10}) necrotic damage. If both attacks hit a single creature in the same turn, it is grappled (escape DC 10). As a bonus action, the flutterflesh can choose whether this attack does bludgeoning, piercing, or slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 17 ({@dice 2d12+4}) slashing damage plus 11 ({@dice 2d10}) necrotic damage. If both attacks hit a single creature in the same turn, it is grappled (escape DC 10). As a bonus action, the flutterflesh can choose whether this attack does bludgeoning, piercing, or slashing damage."
 					]
 				},
 				{
@@ -16962,7 +17284,7 @@
 				{
 					"name": "Slash",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage. On a critical hit, the target takes an additional 27 ({@dice 5d10}) slashing damage and must make a DC 12 Constitution saving throw. On a failure, the flutterflesh lops off and absorbs one of the target's limbs (chosen randomly) and heals hit points equal to the additional slashing damage it inflicted."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage. On a critical hit, the target takes an additional 27 ({@dice 5d10}) slashing damage and must make a DC 12 Constitution saving throw. On a failure, the flutterflesh lops off and absorbs one of the target's limbs (chosen randomly) and heals hit points equal to the additional slashing damage it inflicted."
 					]
 				}
 			],
@@ -16975,7 +17297,7 @@
 			"type": "humanoid",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -17044,19 +17366,19 @@
 				{
 					"name": "Etheric Harpoon",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 30 ft., one target. Hit: 10 ({@dice 1d8+6}) necrotic damage, and the target must make a successful DC 13 Wisdom saving throw or be grappled (escape DC 13). In addition, armor has no effect against the attack roll of an etheric harpoon; only the Dexterity modifier factored into the target's AC is considered."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 30 ft., one target. Hit: 10 ({@dice 1d8+6}) necrotic damage, and the target must make a successful DC 13 Wisdom saving throw or be grappled (escape DC 13). In addition, armor has no effect against the attack roll of an etheric harpoon; only the Dexterity modifier factored into the target's AC is considered."
 					]
 				},
 				{
 					"name": "Psychic Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage plus 3 ({@dice 1d6}) psychic damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage plus 3 ({@dice 1d6}) psychic damage."
 					]
 				},
 				{
 					"name": "Hooked Spider Net (Recharge 5—6)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 20/50 ft., one target. Hit: 3 ({@dice 1d6}) piercing damage plus 19 ({@dice 3d12}) poison damage, and the target is restrained. A successful DC 14 Constitution saving throw halves the poison damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 20/50 ft., one target. Hit: 3 ({@dice 1d6}) piercing damage plus 19 ({@dice 3d12}) poison damage, and the target is restrained. A successful DC 14 Constitution saving throw halves the poison damage."
 					]
 				}
 			],
@@ -17126,7 +17448,7 @@
 				{
 					"name": "Light Sensitivity",
 					"entries": [
-						"While in bright light, the marauder has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
+						"While in sunlight, the forest marauder has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
 					]
 				}
 			],
@@ -17140,13 +17462,13 @@
 				{
 					"name": "Boar Spear",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit:16 ({@dice 2d10+5}) piercing damage, and the forest marauder can choose to push the target 10 feet away if it fails a DC 16 Strength saving throw."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage, and the forest marauder can choose to push the target 10 feet away if it fails a DC 16 Strength saving throw."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 30/120 ft., one target. Hit: 19 ({@dice 3d8+5}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 30/120 ft., one target. Hit: 19 ({@dice 3d8+5}) bludgeoning damage."
 					]
 				}
 			],
@@ -17159,7 +17481,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -17211,19 +17533,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +4} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 4} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Sling",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 30/120 ft., one target. Hit: 4 ({@dice 1d4+2}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 30/120 ft., one target. Hit: 4 ({@dice 1d4+2}) bludgeoning damage."
 					]
 				}
 			],
@@ -17294,9 +17616,9 @@
 					]
 				},
 				{
-					"name": "Freeze",
+					"name": "False Apperance",
 					"entries": [
-						"Against snowy ground or when flying in a blizzard, the frostveil has advantage on Stealth checks to hide in plain sight, appearing to be a patch of snow."
+						"While the frostveil remains motionless, it is indistinguishable from a formation of frost and ice."
 					]
 				},
 				{
@@ -17316,7 +17638,7 @@
 				{
 					"name": "Tendril",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage. If two tendrils hit the same target in a single turn, the target is engulfed."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage. If two tendrils hit the same target in a single turn, the target is engulfed."
 					]
 				},
 				{
@@ -17362,7 +17684,7 @@
 			"dex": 14,
 			"con": 19,
 			"int": 2,
-			"wis": 12,
+			"wis": 13,
 			"cha": 7,
 			"skill": {
 				"perception": "+4",
@@ -17388,13 +17710,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 24 ({@dice 3d12+5}) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the gbahali can't bite another target."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 24 ({@dice 3d12+5}) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 15). Until this grapple ends, the target is restrained, and the gbahali can't bite another target."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) slashing damage."
 					]
 				}
 			],
@@ -17486,13 +17808,13 @@
 				{
 					"name": "Glaive",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d10+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d10+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Javelin",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 30/120 ft., one target. Hit: 8 ({@dice 1d6+5}) piercing damage."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 30/120 ft., one target. Hit: 8 ({@dice 1d6+5}) piercing damage."
 					]
 				},
 				{
@@ -17566,13 +17888,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) slashing damage."
 					]
 				}
 			],
@@ -17660,25 +17982,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Battleaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage or 8 ({@dice 1d10+3}) slashing damage if used with two hands, plus 10 ({@dice 3d6}) necrotic damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage or 8 ({@dice 1d10+3}) slashing damage if used with two hands, plus 10 ({@dice 3d6}) necrotic damage."
 					]
 				},
 				{
 					"name": "Lance",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 9 ({@dice 1d12+3}) piercing damage plus 10 ({@dice 3d6}) necrotic damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 9 ({@dice 1d12+3}) piercing damage plus 10 ({@dice 3d6}) necrotic damage."
 					]
 				}
 			],
@@ -17691,7 +18013,7 @@
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -17767,13 +18089,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 13 ({@dice 3d8}) poison damage, or half poison damage with a successful DC 15 Constitution saving throw. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned and paralyzed for 1 hour, even after regaining hit points. While using Ghostwalk, the spider's bite and poison do half damage to targets that aren't affected by Ghostly Snare (see below)."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 13 ({@dice 3d8}) poison damage, or half poison damage with a successful DC 15 Constitution saving throw. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned and paralyzed for 1 hour, even after regaining hit points. While using Ghostwalk, the spider's bite and poison do half damage to targets that aren't affected by Ghostly Snare (see below)."
 					]
 				},
 				{
-					"name": "Ghostly Snare (During Ghostwalk Only, Recharge 5-6)",
+					"name": "Ghostly Snare (During Ghostwalk Only, Recharge 5—6)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +9} to hit, range 40/160 ft., one target. Hit: The target is restrained by ghostly webbing. While restrained in this way, the target is invisible to all creatures except ghostwalk spiders, and it has resistance to acid, cold, fire, lightning, and thunder damage. A creature restrained by Ghostly Snare can escape by using an action to make a successful DC 14 Strength check, or the webs can be attacked and destroyed (AC 10; hp 5)."
+						"Ranged Weapon Attack: {@hit 9} to hit, range 40/160 ft., one target. Hit: The target is restrained by ghostly webbing. While restrained in this way, the target is invisible to all creatures except ghostwalk spiders, and it has resistance to acid, cold, fire, lightning, and thunder damage. A creature restrained by Ghostly Snare can escape by using an action to make a successful DC 14 Strength check, or the webs can be attacked and destroyed (AC 10; hp 5)."
 					]
 				}
 			],
@@ -17786,7 +18108,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -17798,7 +18120,7 @@
 				},
 				{
 					"ac": 18,
-					"condition":"with {@item shield|phb}"
+					"condition": "with {@item shield|phb}"
 				}
 			],
 			"hp": {
@@ -17869,19 +18191,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage, and if the target creature is humanoid it must succeed on a DC 11 Constitution saving throw or contract darakhul fever."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage, and if the target creature is humanoid it must succeed on a DC 11 Constitution saving throw or contract darakhul fever."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage. If the target is a creature other than an undead, it must make a successful DC 12 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If a humanoid creature is paralyzed for 2 or more rounds (the victim fails at least 2 saving throws), consecutive or nonconsecutive, the creature contracts darakhul fever."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage. If the target is a creature other than an undead, it must make a successful DC 12 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If a humanoid creature is paralyzed for 2 or more rounds (the victim fails at least 2 saving throws), consecutive or nonconsecutive, the creature contracts darakhul fever."
 					]
 				},
 				{
 					"name": "War Pick",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
 					]
 				},
 				{
@@ -17961,20 +18283,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target.",
-						"Hit: 12 ({@dice 2d8+3}) piercing damage, and if the target creature is humanoid it must succeed on a DC 11 Constitution saving throw or contract darakhul fever."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage, and if the target creature is humanoid it must succeed on a DC 11 Constitution saving throw or contract darakhul fever."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach, one target. Hit: 17 ({@dice 4d6+3}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 11 Constitution saving throw or be paralyzed for 1 minute. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 5} to hit, reach, one target. Hit: 17 ({@dice 4d6+3}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 11 Constitution saving throw or be paralyzed for 1 minute. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 80/320, one target. Hit: 8 ({@dice 1d8+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 80/320, one target. Hit: 8 ({@dice 1d8+2}) piercing damage."
 					]
 				},
 				{
@@ -18054,25 +18375,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If the target is humanoid, it must succeed on a separate DC 13 Constitution saving throw or contract darakhul fever."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If the target is humanoid, it must succeed on a separate DC 13 Constitution saving throw or contract darakhul fever."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 18 ({@dice 4d6+4}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If the target is humanoid, it must succeed on a separate DC 13 Constitution saving throw or contract darakhul fever."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 18 ({@dice 4d6+4}) slashing damage. If the target is a creature other than an elf or undead, it must succeed on a DC 13 Constitution saving throw or be paralyzed for 1 minute. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If the target is humanoid, it must succeed on a separate DC 13 Constitution saving throw or contract darakhul fever."
 					]
 				},
 				{
 					"name": "Glaive",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 20 ({@dice 1d10+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 20 ({@dice 1d10+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Heavy Bone Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 100/400, one target. Hit: 8 ({@dice 1d10+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 100/400, one target. Hit: 8 ({@dice 1d10+3}) piercing damage."
 					]
 				},
 				{
@@ -18141,13 +18462,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) bludgeoning damage and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained and the giant ant can't bite a different target."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) bludgeoning damage and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained and the giant ant can't bite a different target."
 					]
 				},
 				{
 					"name": "Sting",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage plus 22 ({@dice 4d10}) poison damage, or half as much poison damage with a successful DC 12 Constitution saving throw."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage plus 22 ({@dice 4d10}) poison damage, or half as much poison damage with a successful DC 12 Constitution saving throw."
 					]
 				}
 			],
@@ -18210,13 +18531,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) bludgeoning damage and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the giant ant can't bite a different target."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) bludgeoning damage and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained, and the giant ant can't bite a different target."
 					]
 				},
 				{
 					"name": "Sting",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage plus 22 ({@dice 4d10}) poison damage, or half as much poison damage with a successful DC 14 Constitution saving throw."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage plus 22 ({@dice 4d10}) poison damage, or half as much poison damage with a successful DC 14 Constitution saving throw."
 					]
 				}
 			],
@@ -18291,7 +18612,7 @@
 			],
 			"senses": "darkvision 60 ft.",
 			"passive": 14,
-			"languages": "Celestial, Common, Draconic, Infernal;",
+			"languages": "Celestial, Common, Draconic, Infernal; telepathy (120 ft.)",
 			"cr": "7",
 			"trait": [
 				{
@@ -18317,29 +18638,6 @@
 					"entries": [
 						"The gilded devil's weapon attacks are magical."
 					]
-				}
-			],
-			"action": [
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The gilded devil makes two heavy flail attacks. Heavy Flail (Scourge of Avarice). Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d10+5}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Betrayal of Riches (Recharge 5—6)",
-					"entries": [
-						"As a bonus action, a gilded devil can turn rings, necklaces, and other jewelry momentarily against their wearer. The devil can affect any visible item of jewelry on up to two items of value within 60 feet, twisting them into cruel barbs and spikes. Each target must succeed on a DC 15 Wisdom saving throw to halve the damage from this effect. If the saving throw fails, the victim takes 13 ({@dice 3d8}) piercing damage and an additional effect based on the item slot targeted.",
-						"Slot Save Effect",
-						"Arms Str Melee damage halved until short rest",
-						"Hand Str Drop any held item",
-						"Eyes Dex Permanently blinded",
-						"Head Dex Disadvantage on Int checks until long rest",
-						"Feet Dex Speed halved for 24 hours",
-						"Neck Con Stunned, unable to breathe for 1 round",
-						"Other—No additional effect",
-						"An item is treated as jewelry if it is made of a precious material (such as silver, gold, ivory, or adamantine), adorned with gems, or both, and is worth at least 100 gp."
-					]
 				},
 				{
 					"name": "Scorn Base Metals",
@@ -18351,6 +18649,35 @@
 					"name": "Scourge of Avarice",
 					"entries": [
 						"As a bonus action, a gilded devil wearing jewelry worth at least 1,000 gp can reshape it into a +2 heavy flail. A creature struck by this jeweled flail suffers disadvantage on all Wisdom saving throws until his or her next short rest, in addition to normal weapon damage. The flail reverts to its base components 1 minute after it leaves the devil's grasp, or upon the gilded devil's death."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The gilded devil makes two heavy flail attacks."
+					]
+				},
+				{
+					"name": "Heavy Flail (Scourge of Avarice)",
+					"entries": [
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d10+5}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Betrayal of Riches (Recharge 5—6)",
+					"entries": [
+						"As a bonus action, a gilded devil can turn rings, necklaces, and other jewelry momentarily against their wearer. The devil can affect any visible item of jewelry on up to two creatures within 60 feet, twisting them into cruel barbs and spikes. Each target must succeed on a DC 15 Wisdom saving throw to halve the damage from this effect. If the saving throw fails, the victim takes 13 ({@dice 3d8}) piercing damage and an additional effect based on the item location targeted.",
+						"Location Effect",
+						"Arms Melee damage halved until short rest",
+						"Hand Drop any held item",
+						"Eyes Permanently blinded",
+						"Head Disadvantage on Int checks until long rest",
+						"Feet Speed halved for 24 hours",
+						"Neck Stunned, unable to breathe for 1 round",
+						"Other—No additional effect",
+						"An item is treated as jewelry if it is made of a precious material (such as silver, gold, ivory, or adamantine), adorned with gems, or both, and is worth at least 100 gp."
 					]
 				},
 				{
@@ -18454,7 +18781,7 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d4+2}) slashing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained and the glass gator can't attack a different target."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d4+2}) slashing damage, and the target is grappled (escape DC 12). Until this grapple ends, the target is restrained and the glass gator can't attack a different target."
 					]
 				},
 				{
@@ -18539,7 +18866,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d8+6}) piercing damage, and the target must succeed on a DC 16 Dexterity saving throw or fall prone."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d8+6}) piercing damage, and the target must succeed on a DC 16 Dexterity saving throw or fall prone."
 					]
 				},
 				{
@@ -18625,13 +18952,13 @@
 				{
 					"name": "Battleaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage or 8 ({@dice 1d10+3}) slashing damage if used in two hands."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage or 8 ({@dice 1d10+3}) slashing damage if used in two hands."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				}
 			],
@@ -18712,13 +19039,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
 					]
 				}
 			],
@@ -18731,7 +19058,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -18789,13 +19116,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one creature. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Withering Turban",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 10 ft., one creature. Hit: 5 ({@dice 1d4+3}) necrotic damage. If the target failed a saving throw against the Thirst trait at any point in this encounter, its hit point maximum is reduced by an amount equal to the damage it took from this attack. This reduction lasts until the target has no exhaustion levels."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 10 ft., one creature. Hit: 5 ({@dice 1d4+3}) necrotic damage. If the target failed a saving throw against the Thirst trait at any point in this encounter, its hit point maximum is reduced by an amount equal to the damage it took from this attack. This reduction lasts until the target has no exhaustion levels."
 					]
 				},
 				{
@@ -18901,7 +19228,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 0 ft., every target in the swarm's space. Hit: 24 ({@dice 6d6+3}) piercing damage, or 13 ({@dice 3d6+3}) piercing damage if the swarm has half of its hit points or fewer. The target also takes 17 ({@dice 5d6}) poison damage and becomes poisoned for {@dice 1d4} rounds; a successful DC 15 Constitution saving throw reduces poison damage by half and prevents the poisoned condition."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 0 ft., every target in the swarm's space. Hit: 24 ({@dice 6d6+3}) piercing damage, or 13 ({@dice 3d6+3}) piercing damage if the swarm has half of its hit points or fewer. The target also takes 17 ({@dice 5d6}) poison damage and becomes poisoned for {@dice 1d4} rounds; a successful DC 15 Constitution saving throw reduces poison damage by half and prevents the poisoned condition."
 					]
 				}
 			],
@@ -19003,6 +19330,12 @@
 					"entries": [
 						"The jester performs an ancient, nihilistic joke of necromantic power. This joke has no effect on undead or constructs. All other creatures within 60 feet of the jester must make a DC 17 Wisdom saving throw. Those that fail fall prone in a fit of deadly laughter. The laughter lasts {@dice 1d4} rounds, during which time the victim is incapacitated and unable to stand up from prone. At the end of its turn each round, an incapacitated victim must make a successful DC 17 Constitution saving throw or be reduced to 0 hit points. The laughter can be ended early by rendering the victim unconscious or with greater restoration or comparable magic."
 					]
+				},
+				{
+					"name": "Joker's Shuffle (recharge 6)",
+					"entries": [
+						"The jester forces one Medium or Small humanoid within 60 feet to make a DC 17 Charisma saving throw. If the saving throw fails, the jester and the target exchange locations via teleportation and an illusion causes them to swap appearance: the jester looks and sounds like the target, and the target looks and sounds like the jester. The illusion lasts for 1 hour unless it is dismissed earlier by the jester as a bonus action, or dispelled (DC 17)."
+					]
 				}
 			],
 			"reaction": [
@@ -19010,12 +19343,6 @@
 					"name": "Ridicule Hope (Recharge 4—6)",
 					"entries": [
 						"When a spell that restores hit points is cast within 60 feet of the jester, the jester can cause that spell to inflict damage instead of curing it. The damage equals the hit points the spell would have cured."
-					]
-				},
-				{
-					"name": "Joker's Shuffle (recharge 6)",
-					"entries": [
-						"The jester forces one Medium or Small humanoid within 60 feet to make a DC 17 Charisma saving throw. If the saving throw fails, the jester and the target exchange locations via teleportation and an illusion causes them to swap appearance: the jester looks and sounds like the target, and the target looks and sounds like the jester. The illusion lasts for 1 hour unless it is dismissed earlier by the jester as a bonus action, or dispelled (DC 17)."
 					]
 				}
 			],
@@ -19055,7 +19382,7 @@
 			"type": "giant",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -19120,13 +19447,13 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft., one creature. Hit: 16 ({@dice 2d8+7}) bludgeoning damage. If a creature is hit by this attack twice in the same turn, the target must make a successful DC 19 Constitution saving throw or gain one level of exhaustion."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft., one creature. Hit: 16 ({@dice 2d8+7}) bludgeoning damage. If a creature is hit by this attack twice in the same turn, the target must make a successful DC 19 Constitution saving throw or gain one level of exhaustion."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft. Hit: 20 ({@dice 2d12+7}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft. Hit: 20 ({@dice 2d12+7}) bludgeoning damage."
 					]
 				}
 			],
@@ -19146,7 +19473,7 @@
 				{
 					"name": "Grab",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft., one target. Hit: the target is grappled (escape DC 17)."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft., one target. Hit: the target is grappled (escape DC 17)."
 					]
 				},
 				{
@@ -19171,7 +19498,7 @@
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -19216,6 +19543,9 @@
 				"psychic",
 				"poison"
 			],
+			"conditionImmune": [
+				"poisoned"
+			],
 			"senses": "truesight 90 ft.",
 			"passive": 19,
 			"languages": "Abyssal, Common, Darakhul, Sphinx",
@@ -19250,13 +19580,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 32 ({@dice 6d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 32 ({@dice 6d8+5}) slashing damage."
 					]
 				},
 				{
@@ -19459,7 +19789,7 @@
 				{
 					"name": "Psychic Claw",
 					"entries": [
-						"Ranged Magical Attack: {@hit +10} to hit, range 40 ft., one target. Hit: 32 ({@dice 6d8+5}) psychic damage."
+						"Ranged Magical Attack: {@hit 10} to hit, range 40 ft., one target. Hit: 32 ({@dice 6d8+5}) psychic damage."
 					]
 				}
 			],
@@ -19565,7 +19895,8 @@
 				"piercing"
 			],
 			"immune": [
-				"fire"
+				"fire",
+				"posion"
 			],
 			"conditionImmune": [
 				"exhaustion",
@@ -19614,13 +19945,13 @@
 				{
 					"name": "Engulfing Protoplasm",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 19 ({@dice 2d12+6}) slashing damage and the target must make a successful DC 17 Dexterity saving throw or be grappled by the herald of blood (escape DC 16). While grappled this way, the creature takes 39 ({@dice 6d12}) acid damage at the start of each of the herald's turns. The herald can have any number of creatures grappled this way."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 19 ({@dice 2d12+6}) slashing damage and the target must make a successful DC 17 Dexterity saving throw or be grappled by the herald of blood (escape DC 16). While grappled this way, the creature takes 39 ({@dice 6d12}) acid damage at the start of each of the herald's turns. The herald can have any number of creatures grappled this way."
 					]
 				}
 			],
 			"legendary": [
 				{
-					"name": "Move (1 Action)",
+					"name": "Move",
 					"entries": [
 						"The herald of blood moves up to half its speed."
 					]
@@ -19628,7 +19959,7 @@
 				{
 					"name": "Call of Blood (2 Actions)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., all creatures in reach. Hit: 39 ({@dice 6d12}) necrotic damage and each target must make a successful DC 17 Constitution saving throw or gain 1 level of exhaustion."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., all creatures in reach. Hit: 39 ({@dice 6d12}) necrotic damage and each target must make a successful DC 17 Constitution saving throw or gain 1 level of exhaustion."
 					],
 					"attack": [
 						"Call of Blood|10|6d12"
@@ -19650,7 +19981,7 @@
 			"type": "fiend",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -19693,7 +20024,8 @@
 			"immune": [
 				"cold",
 				"lightning",
-				"necrotic"
+				"necrotic",
+				"poison"
 			],
 			"conditionImmune": [
 				"exhaustion",
@@ -19736,7 +20068,7 @@
 				{
 					"name": "Embrace Darkness",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., all creatures in reach. Hit: 6 ({@dice 1d12}) necrotic damage and targets are paralyzed until the start of the herald's next turn. Making a DC 17 Constitution saving throw negates the paralysis."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., all creatures in reach. Hit: 6 ({@dice 1d12}) necrotic damage and targets are paralyzed until the start of the herald's next turn. Making a DC 17 Constitution saving throw negates the paralysis."
 					]
 				},
 				{
@@ -19748,7 +20080,7 @@
 				{
 					"name": "Shadow Sword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d12+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d12+5}) slashing damage."
 					]
 				}
 			],
@@ -19851,7 +20183,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 39 ({@dice 6d10+6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 39 ({@dice 6d10+6}) bludgeoning damage."
 					]
 				},
 				{
@@ -19930,13 +20262,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) slashing damage. If the bite attack hits a target that's grappled by the horakh, the target must make a successful DC 16 Dexterity saving throw or one of its eyes is bitten out. A creature with just one remaining eye has disadvantage on ranged attack rolls and on Wisdom (Perception) checks that rely on sight. If both (or all) eyes are lost, the target is blinded. The regenerate spell and comparable magic can restore lost eyes. Also see Implant Egg, below."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) slashing damage. If the bite attack hits a target that's grappled by the horakh, the target must make a successful DC 16 Dexterity saving throw or one of its eyes is bitten out. A creature with just one remaining eye has disadvantage on ranged attack rolls and on Wisdom (Perception) checks that rely on sight. If both (or all) eyes are lost, the target is blinded. The regenerate spell and comparable magic can restore lost eyes. Also see Implant Egg, below."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage. If both attacks hit the same Medium or smaller target in a single turn, the target is grappled (escape DC 14)."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage. If both attacks hit the same Medium or smaller target in a single turn, the target is grappled (escape DC 14)."
 					]
 				},
 				{
@@ -20010,7 +20342,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage, and the target must succeed on a DC 15 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage, and the target must succeed on a DC 15 Strength saving throw or be knocked prone."
 					]
 				},
 				{
@@ -20134,19 +20466,19 @@
 				{
 					"name": "Beak (Roc Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 25 ({@dice 4d8+7}) piercing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 25 ({@dice 4d8+7}) piercing damage."
 					]
 				},
 				{
 					"name": "Fist (Giant Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 20 ({@dice 3d8+7}) bludgeoning damage, and the target must succeed on a DC 21 Constitution saving throw or be stunned until the start of Hraesvelgr's next turn."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 20 ({@dice 3d8+7}) bludgeoning damage, and the target must succeed on a DC 21 Constitution saving throw or be stunned until the start of Hraesvelgr's next turn."
 					]
 				},
 				{
 					"name": "Talons (Roc Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 21 ({@dice 4d6+7}) slashing damage, and the target is grappled (escape DC 17). Until this grapple ends, the target is restrained and Hraesvelgr can't use his talons against another target."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 21 ({@dice 4d6+7}) slashing damage, and the target is grappled (escape DC 17). Until this grapple ends, the target is restrained and Hraesvelgr can't use his talons against another target."
 					]
 				},
 				{
@@ -20156,6 +20488,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Hraesvelgr",
 			"legendary": [
 				{
 					"name": "Attack",
@@ -20261,7 +20594,7 @@
 				{
 					"name": "Unleashed Emotion",
 					"entries": [
-						"When a hulking whelp feels threatened—it's touched, intimidationd, cornered, attacked, or even just if a stranger moves adjacent to the whelp—it immediately grows from size Small to Huge as a reaction. If the whelp was attacked, this reaction occurs after the attack is made but before damage is done. Nearby creatures and objects are pushed to the nearest available space and must make a successful DC 15 Strength saving throw or fall prone. Weapons, armor, and other objects worn or carried by the hulking whelp grow (and shrink again) proportionally when it changes size. Overcome by raw emotion, it sets about destroying anything and everything it can see (which isn't much) and reach (which is quite a lot). The transformation lasts until the hulking whelp is unaware of any nearby creatures for 1 round, it drops to 0 hit points, it has 5 levels of exhaustion, or it's affected by a calm emotions spell or comparable magic. The transformation isn't entirely uncontrollable; people or creatures the whelp knows and trusts can be near it without triggering the reaction. Under the wrong conditions, such as in a populated area, a hulking whelp's Unleashed Emotion can last for days."
+						"When a hulking whelp feels threatened—it's touched, intimidated, cornered, attacked, or even just if a stranger moves adjacent to the whelp—it immediately grows from size Small to Huge as a reaction. If the whelp was attacked, this reaction occurs after the attack is made but before damage is done. Nearby creatures and objects are pushed to the nearest available space and must make a successful DC 15 Strength saving throw or fall prone. Weapons, armor, and other objects worn or carried by the hulking whelp grow (and shrink again) proportionally when it changes size. Overcome by raw emotion, it sets about destroying anything and everything it can see (which isn't much) and reach (which is quite a lot). The transformation lasts until the hulking whelp is unaware of any nearby creatures for 1 round, it drops to 0 hit points, it has 5 levels of exhaustion, or it's affected by a calm emotions spell or comparable magic. The transformation isn't entirely uncontrollable; people or creatures the whelp knows and trusts can be near it without triggering the reaction. Under the wrong conditions, such as in a populated area, a hulking whelp's Unleashed Emotion can last for days."
 					]
 				}
 			],
@@ -20275,7 +20608,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 15 ft., one target. Hit: 18 ({@dice 3d8+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 15 ft., one target. Hit: 18 ({@dice 3d8+5}) bludgeoning damage."
 					]
 				}
 			],
@@ -20364,7 +20697,7 @@
 				{
 					"name": "Brainless",
 					"entries": [
-						"Hunduns are immune to all mind-affecting spells and effects. Trying to contact or read a hundun's mind results in the caster becoming confused for 1 round, as per the spell."
+						"Hunduns are immune to any spell or effect that allows an Intelligence, Wisdom, or Charisma saving throw. Trying to contact or read a Hundun's mind confuses the caster as the spell for 1 round."
 					]
 				},
 				{
@@ -20377,8 +20710,8 @@
 					"name": "Enlightening Befuddlement",
 					"entries": [
 						"When a hundun's confusion spell affects a target, it can elect to use the following table rather than the standard one:",
-						"01—10 Inspired: +2 circumstance bonus to skill checks, saving throws, and attack rolls.",
-						"11—20 Distracted: -2 penalty to skill checks, saving throws, and attack rolls.",
+						"01—10 Inspired: Advantage on attack rolls, ability checks, and saving throws.",
+						"11—20 Distracted: Disadvantage on attack rolls, ability checks, and saving throws.",
 						"21—50 Incoherent: The target does nothing but babble or scribble incoherent notes on a new idea.",
 						"51—75 Obsessed: Target is recipient of geas to create a quality magical object.",
 						"76—100 Suggestible: Target receives a suggestion from the hundun."
@@ -20401,7 +20734,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 3d6+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 3d6+5}) bludgeoning damage."
 					]
 				}
 			],
@@ -20444,7 +20777,7 @@
 			"tokenURL": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/ToB%20(3pp)/Hundun.png"
 		},
 		{
-			"name": "Arch-Devil Ia'Affrat the Insatiable",
+			"name": "Ia'Affrat the Insatiable",
 			"size": "L",
 			"type": {
 				"type": "elemental",
@@ -20548,7 +20881,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 0 ft., one creature in the swarm's space. Hit: 21 ({@dice 6d6}) piercing damage plus 14 ({@dice 4d6}) fire damage plus 14 ({@dice 4d6}) poison damage, or 10 ({@dice 3d6}) piercing damage plus 7 ({@dice 2d6}) fire damage plus 7 ({@dice 2d6}) poison damage if Ia'Affrat has half of its hit points or fewer. The target must succeed on a DC 16 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 0 ft., one creature in the swarm's space. Hit: 21 ({@dice 6d6}) piercing damage plus 14 ({@dice 4d6}) fire damage plus 14 ({@dice 4d6}) poison damage, or 10 ({@dice 3d6}) piercing damage plus 7 ({@dice 2d6}) fire damage plus 7 ({@dice 2d6}) poison damage if Ia'Affrat has half of its hit points or fewer. The target must succeed on a DC 16 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -20675,7 +21008,7 @@
 				{
 					"name": "Snow Invisibility",
 					"entries": [
-						"In snowy environments, the ice maiden can turn invisible at will as a bonus action or a reaction."
+						"In snowy environments, the ice maiden can turn invisible as a bonus action."
 					]
 				},
 				{
@@ -20695,7 +21028,7 @@
 				{
 					"name": "Ice Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+3}) piercing damage plus 3 ({@dice 1d6}) cold damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+3}) piercing damage plus 3 ({@dice 1d6}) cold damage."
 					]
 				},
 				{
@@ -20764,7 +21097,7 @@
 			"type": "construct",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -20808,8 +21141,7 @@
 				}
 			],
 			"immune": [
-				"poison",
-				"psychic"
+				"poison"
 			],
 			"conditionImmune": [
 				"charmed",
@@ -20856,7 +21188,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) bludgeoning damage plus 18 ({@dice 4d8}) psychic damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) bludgeoning damage plus 18 ({@dice 4d8}) psychic damage."
 					]
 				},
 				{
@@ -20933,14 +21265,14 @@
 				{
 					"name": "Ceremonial Greatsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one creature. Hit: 10 ({@dice 2d6+3}) slashing damage, and the target must make a successful DC 13 Constitution saving throw or take 5 ({@dice 2d4}) poison damage at the start of each of its turns. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one creature. Hit: 10 ({@dice 2d6+3}) slashing damage, and the target must make a successful DC 13 Constitution saving throw or take 5 ({@dice 2d4}) poison damage at the start of each of its turns. The target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Vomit Swarm (1/Day)",
 					"entries": [
 						"The imy-ut ushabti parts its wrappings voluntarily and releases a swarm of scarab beetles that follow its mental commands. The statistics of this swarm are identical to a swarm of insects, but with the following attack instead of a swarm of insects' standard bite attack:",
-						"Bites: Melee Weapon Attack: {@hit +3} to hit, reach 0 ft., one creature. Hit: 10 ({@dice 4d4}) piercing damage, or 5 ({@dice 2d4}) piercing damage if the swarm has half of its hit points or fewer, and the target must make a successful DC 13 Constitution saving throw or take 5 ({@dice 2d4}) poison damage at the start of each of its turns. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Bites: Melee Weapon Attack: {@hit 3} to hit, reach 0 ft., one creature. Hit: 10 ({@dice 4d4}) piercing damage, or 5 ({@dice 2d4}) piercing damage if the swarm has half of its hit points or fewer, and the target must make a successful DC 13 Constitution saving throw or take 5 ({@dice 2d4}) poison damage at the start of each of its turns. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -21006,7 +21338,7 @@
 			],
 			"senses": "darkvision 120 ft.",
 			"passive": 9,
-			"languages": "Celestial, Common, Draconic, Infernal;",
+			"languages": "Celestial, Common, Draconic, Infernal; telepathy (120 ft.)",
 			"cr": "2",
 			"trait": [
 				{
@@ -21026,13 +21358,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., single target. Hit: 11 ({@dice 2d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., single target. Hit: 11 ({@dice 2d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., single target. Hit: 14 ({@dice 3d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., single target. Hit: 14 ({@dice 3d6+4}) slashing damage."
 					]
 				},
 				{
@@ -21124,7 +21456,7 @@
 				{
 					"name": "Ability Damage/Drain Immunity",
 					"entries": [
-						"The isonade is immune to any effect that would damage or drain it's ability scores.."
+						"The isonade is immune to any effect that would damage or drain it's ability scores."
 					]
 				},
 				{
@@ -21156,13 +21488,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +14} to hit, reach 15 ft., one target. Hit: 42 ({@dice 5d12+10}) piercing damage and the target is grappled (escape DC 20). If the target was already grappled from a previous bite, it's also swallowed whole (see below)."
+						"Melee Weapon Attack: {@hit 14} to hit, reach 15 ft., one target. Hit: 42 ({@dice 5d12+10}) piercing damage and the target is grappled (escape DC 20). If the target was already grappled from a previous bite, it's also swallowed whole (see below)."
 					]
 				},
 				{
 					"name": "Tail Slap",
 					"entries": [
-						"Melee Weapon Attack: {@hit +14} to hit, reach 15 ft., one target. Hit: 31 ({@dice 6d6+10}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 14} to hit, reach 15 ft., one target. Hit: 31 ({@dice 6d6+10}) bludgeoning damage."
 					]
 				},
 				{
@@ -21275,7 +21607,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one creature. Hit: 8 ({@dice 1d10+3}) piercing damage plus 22 ({@dice 5d8}) poison damage, or half as much poison damage with a successful DC 12 Constitution saving throw. A target dropped to 0 hit points by this attack is stable but poisoned and paralyzed for 1 hour, even after regaining hit points."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one creature. Hit: 8 ({@dice 1d10+3}) piercing damage plus 22 ({@dice 5d8}) poison damage, or half as much poison damage with a successful DC 12 Constitution saving throw. A target dropped to 0 hit points by this attack is stable but poisoned and paralyzed for 1 hour, even after regaining hit points."
 					]
 				}
 			],
@@ -21288,7 +21620,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -21352,13 +21684,13 @@
 				{
 					"name": "Jaws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d4+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d4+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+2}) slashing damage."
 					]
 				}
 			],
@@ -21424,7 +21756,7 @@
 				{
 					"name": "Immortality",
 					"entries": [
-						"Jotuns suffer no ill effects from age and are immune to life drain, ability damage, and ability drain."
+						"Jotuns suffer no ill effects from age and are immune to life drain, and effects that reduce ability scores and hit point maximum."
 					]
 				},
 				{
@@ -21456,13 +21788,13 @@
 				{
 					"name": "Greatclub",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 30 ft., one target. Hit: 55 ({@dice 10d8+10}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 30 ft., one target. Hit: 55 ({@dice 10d8+10}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +16} to hit, range 90/240 ft., one target. Hit: 49 ({@dice 6d12+10}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 16} to hit, range 90/240 ft., one target. Hit: 49 ({@dice 6d12+10}) bludgeoning damage."
 					]
 				},
 				{
@@ -21480,6 +21812,7 @@
 					]
 				}
 			],
+			"legendaryActions": 1,
 			"legendary": [
 				{
 					"name": "",
@@ -21537,7 +21870,7 @@
 			"type": "fiend",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -21588,7 +21921,7 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				}
 			],
@@ -21670,7 +22003,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				},
 				{
@@ -21810,13 +22143,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Spear",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage, or 8 ({@dice 1d8+4}) piercing damage if used with two hands to make a melee attack."
+						"Melee or Ranged Weapon Attack: {@hit 7} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage, or 8 ({@dice 1d8+4}) piercing damage if used with two hands to make a melee attack."
 					]
 				}
 			],
@@ -21935,19 +22268,26 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 5 ({@dice 2d4}) poison damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 5 ({@dice 2d4}) poison damage."
 					]
 				},
 				{
 					"name": "Dart",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 5 ({@dice 2d4}) poison damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage plus 5 ({@dice 2d4}) poison damage."
 					]
 				},
 				{
 					"name": "Alchemical Protection (Recharge after a Short or Long Rest)",
 					"entries": [
 						"The kobold chooses up to six allied creatures within 10 feet. It releases alchemical vapors that grant those allies resistance to poison damage for 10 minutes. Instead of poison damage, the kobold can grant resistance to the damage type currently in effect for its Apothecary trait."
+					]
+				},
+				{
+					"name": "Explosive Flask (Recharge 5—6)",
+					"entries":
+					[
+						"The kobold throws a flask of volatile substances at a point within 30 feet. The flask explodes in a 15-foot radius. Creatures in the area take 17 ({@dice 5d6}) poison damage and are poisoned for 1 minute, or take half damage and are not poisoned with a successful DC 13 Dexterity saving throw. A poisoned creature repeats the saving throw at the end of each of its turns, ending the poisoned condition on a success. Instead of poison damage, the kobold can deal the damage type currently in effect for its Apothecary trait."
 					]
 				}
 			],
@@ -22030,13 +22370,13 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 10 ({@dice 3d6}) poison damage and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on a success."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 10 ({@dice 3d6}) poison damage and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on a success."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 10 ({@dice 3d6}) poison damage and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on a success."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 10 ({@dice 3d6}) poison damage and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on a success."
 					]
 				},
 				{
@@ -22123,8 +22463,8 @@
 					"entries": [
 						"The kobold trapsmith excels at setting mechanical traps. Detecting, disarming, avoiding, or mitigating its traps require successful DC 13 checks or saving throws, and the traps have +5 attack bonuses. With thief's tools and basic construction materials, a trapsmith can set up one of the simple but effective traps listed below in 5 minutes. Triggers involve pressure plates, tripwires, small catches in a lock, or other simple mechanisms.",
 						"• Choke Bomb. This small incendiary device burns rapidly and releases choking smoke in a 20-foot sphere. The area is heavily obscured. Any breathing creature that's in the affected area when the cloud is created or that starts its turn in the cloud is poisoned. Once a poisoned creature leaves the cloud, it makes a DC 13 Constitution saving throw at the end of its turns, ending the poisoned condition on a success. The smoke dissipates after 10 minutes, or after 1 round in a strong wind.",
-						"• Poisoned Sliver. A poisoned sliver or needle can be hidden almost anywhere: inside a lock or a box, in a carpeted floor, on the underside of a door handle, in a cup of liquid or a bowl of gems. When someone meets the conditions for being jabbed by the sliver, the trap makes a melee weapon attack with advantage: {@hit +5} to hit, reach 0 ft., one target; Hit: 2 ({@dice 1d4}) piercing damage plus 14 ({@dice 4d6}) poison damage, or one-half poison damage with a successful DC 13 Constitution saving throw.",
-						"• Skullpopper. This trap consists of either a heavy weight, a spike, or a blade, set to fall or swing into a victim. When triggered, a skullpopper makes a melee weapon attack against the first target in its path: {@hit +5} to hit, reach 15 ft., one target; Hit: 11 ({@dice 2d10}) damage. The type of damage depends on how the skullpopper is built: a stone or heavy log does bludgeoning damage, a spiked log does piercing damage, a scything blade does slashing damage, etc.",
+						"• Poisoned Sliver. A poisoned sliver or needle can be hidden almost anywhere: inside a lock or a box, in a carpeted floor, on the underside of a door handle, in a cup of liquid or a bowl of gems. When someone meets the conditions for being jabbed by the sliver, the trap makes a melee weapon attack with advantage: {@hit 5} to hit, reach 0 ft., one target; Hit: 2 ({@dice 1d4}) piercing damage plus 14 ({@dice 4d6}) poison damage, or one-half poison damage with a successful DC 13 Constitution saving throw.",
+						"• Skullpopper. This trap consists of either a heavy weight, a spike, or a blade, set to fall or swing into a victim. When triggered, a skullpopper makes a melee weapon attack against the first target in its path: {@hit 5} to hit, reach 15 ft., one target; Hit: 11 ({@dice 2d10}) damage. The type of damage depends on how the skullpopper is built: a stone or heavy log does bludgeoning damage, a spiked log does piercing damage, a scything blade does slashing damage, etc.",
 						"• Slingsnare. A concealed loop of rope or wire is affixed to a counterweight. When a creature steps into the snare, it must make a successful DC 13 Dexterity saving throw or be yanked into the air and suspended, upside down, 5 feet above the ground. The snared creature is restrained (escape DC 13). The cord is AC 10 and has 5 hit points."
 					]
 				}
@@ -22133,13 +22473,13 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage plus 7 ({@dice 2d6}) poison damage, or one-half poison damage with a successful DC 13 Constitution saving throw."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage plus 7 ({@dice 2d6}) poison damage, or one-half poison damage with a successful DC 13 Constitution saving throw."
 					]
 				},
 				{
@@ -22151,7 +22491,7 @@
 				{
 					"name": "Stunner (1/Day)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) bludgeoning damage, and the target is restrained (escape DC 13). While restrained, the target takes 7 ({@dice 2d6}) lightning damage at the start of its turn and falls prone. The trapsmith has advantage on the attack roll if the target is wearing metal armor. A stunner is a bola made of metal wire, magnets, and static electricity capacitors. A kobold trapsmith can recharge it during a long rest."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. Hit: 5 ({@dice 1d4+3}) bludgeoning damage, and the target is restrained (escape DC 13). While restrained, the target takes 7 ({@dice 2d6}) lightning damage at the start of its turn and falls prone. The trapsmith has advantage on the attack roll if the target is wearing metal armor. A stunner is a bola made of metal wire, magnets, and static electricity capacitors. A kobold trapsmith can recharge it during a long rest."
 					]
 				}
 			],
@@ -22223,13 +22563,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 18 ({@dice 4d6+4}) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 14). Until this grapple ends, the target is restrained and the kongamato can't bite another target. When the kongamato moves, any target it is grappling moves with it."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 18 ({@dice 4d6+4}) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 14). Until this grapple ends, the target is restrained and the kongamato can't bite another target. When the kongamato moves, any target it is grappling moves with it."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage."
 					]
 				}
 			],
@@ -22328,7 +22668,7 @@
 				{
 					"name": "Scythe Limb",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d12+3}) slashing damage, OR a Medium-sized or smaller target can be grappled by the koralk's smaller, vestigial arms instead (no damage, escape DC 13)."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d12+3}) slashing damage, OR a Medium-sized or smaller target can be grappled by the koralk's smaller, vestigial arms instead (no damage, escape DC 13)."
 					]
 				},
 				{
@@ -22340,7 +22680,7 @@
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage and the target must make a successful DC 15 Constitution saving throw or become poisoned. While poisoned this way, the target takes 10 ({@dice 3d6}) poison damage at the start of each of its turns, from liquefaction of its innards. A successful save renders the target immune to the koralk's poison for 24 hours. If a creature dies while poisoned by a koralk, its body bursts open, spewing vile liquid and a newly-formed lemure devil. The lemure is under the command of any higher-order devil nearby. The poison can be neutralized by lesser restoration, protection from poison, or comparable magic. If the lemure is killed, the original creature can be restored to life by resurrection or comparable magic."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage and the target must make a successful DC 15 Constitution saving throw or become poisoned. While poisoned this way, the target takes 10 ({@dice 3d6}) poison damage at the start of each of its turns, from liquefaction of its innards. A successful save renders the target immune to the koralk's poison for 24 hours. If a creature dies while poisoned by a koralk, its body bursts open, spewing vile liquid and a newly-formed lemure devil. The lemure is under the command of any higher-order devil nearby. The poison can be neutralized by lesser restoration, protection from poison, or comparable magic. If the lemure is killed, the original creature can be restored to life by resurrection or comparable magic."
 					]
 				}
 			],
@@ -22353,7 +22693,7 @@
 			"type": "fiend",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -22441,16 +22781,17 @@
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage or 11 ({@dice 1d10+6}) slashing damage if used in two hands plus 14 ({@dice 4d6}) necrotic damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage or 11 ({@dice 1d10+6}) slashing damage if used in two hands plus 14 ({@dice 4d6}) necrotic damage."
 					]
 				},
 				{
 					"name": "Drain Life",
 					"entries": [
-						"Melee Spell Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 20 ({@dice 4d6+6}) necrotic damage. The target must succeed on a DC 19 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken from this attack, and Koschei regains an equal number of hit points."
+						"Melee Spell Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 20 ({@dice 4d6+6}) necrotic damage. The target must succeed on a DC 19 Constitution saving throw or its hit point maximum is reduced by an amount equal to the damage taken from this attack, and Koschei regains an equal number of hit points. This reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
 					]
 				}
 			],
+			"legendaryGroup": "Koschei",
 			"legendary": [
 				{
 					"name": "Attack",
@@ -22476,7 +22817,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"Koschei's innate spellcasting attribute is Charisma (spell save DC 19, {@hit 11} to hit with spell attacks). He can innately cast the following spells, requiring no material components."
+						"Koschei's innate spellcasting attribute is Charisma (spell save DC 19, {@hit 11} to hit with spell attacks). He can innately cast the following spells, requiring no material components:"
 					],
 					"will": [
 						"{@spell detect magic}",
@@ -22556,13 +22897,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage."
 					]
 				},
 				{
@@ -22598,7 +22939,7 @@
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -22666,13 +23007,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft., one target. Hit: 12 ({@dice 1d10+7}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft., one target. Hit: 12 ({@dice 1d10+7}) slashing damage."
 					]
 				},
 				{
 					"name": "Tentacle",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 15 ft., one target. Hit: 10 ({@dice 1d6+7}) necrotic damage. If two tentacle attacks hit the same target in one turn, the target is also grappled (escape DC 17)."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 15 ft., one target. Hit: 10 ({@dice 1d6+7}) necrotic damage. If two tentacle attacks hit the same target in one turn, the target is also grappled (escape DC 17)."
 					]
 				},
 				{
@@ -22783,13 +23124,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage. If the lake troll hits a creature with both claw attacks in the same turn, the target creature must make a successful DC 16 Dexterity saving throw or its weapon (if any) gains a permanent and cumulative -1 penalty to damage rolls. If the penalty reaches -5, the weapon is destroyed. A damaged weapon can be repaired with appropriate artisan's tools during a long rest."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage. If the lake troll hits a creature with both claw attacks in the same turn, the target creature must make a successful DC 16 Dexterity saving throw or its weapon (if any) gains a permanent and cumulative -1 penalty to damage rolls. If the penalty reaches -5, the weapon is destroyed. A damaged weapon can be repaired with appropriate artisan's tools during a long rest."
 					]
 				}
 			],
@@ -22868,7 +23209,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d4+1}) piercing damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d4+1}) piercing damage."
 					]
 				}
 			],
@@ -22947,13 +23288,13 @@
 				{
 					"name": "Kukri Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., 20/60 range, one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., 20/60 range, one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Blowgun",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 25/100 ft., one creature. Hit: 4 ({@dice 1d4+2}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned and unconscious for {@dice 1d4} hours. Another creature can use an action to shake the target awake and end its unconsciousness but not the poisoning."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 25/100 ft., one creature. Hit: 4 ({@dice 1d4+2}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned and unconscious for {@dice 1d4} hours. Another creature can use an action to shake the target awake and end its unconsciousness but not the poisoning."
 					]
 				}
 			],
@@ -23022,13 +23363,13 @@
 				{
 					"name": "Kukri Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., range 20/60, one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., range 20/60, one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Blowgun",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 25/100 ft., one creature. Hit: 5 ({@dice 1d4+3}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned and unconscious for {@dice 1d4} hours. Another creature can use an action to shake the target awake and end its unconsciousness but not the poisoning."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 25/100 ft., one creature. Hit: 5 ({@dice 1d4+3}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or be poisoned and unconscious for {@dice 1d4} hours. Another creature can use an action to shake the target awake and end its unconsciousness but not the poisoning."
 					]
 				}
 			],
@@ -23076,7 +23417,7 @@
 		},
 		{
 			"name": "Leshy",
-			"size": "M",
+			"size": "T",
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
@@ -23144,7 +23485,7 @@
 				{
 					"name": "Club",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) bludgeoning damage."
 					]
 				}
 			],
@@ -23249,7 +23590,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -23309,7 +23650,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d12+4}) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 1d12+4}) piercing damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
 					]
 				},
 				{
@@ -23401,7 +23742,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage."
 					]
 				},
 				{
@@ -23441,7 +23782,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -23516,19 +23857,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage, and the target must succeed on a DC 14 Constitution saving throw or contract lindwurm fever."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage, and the target must succeed on a DC 14 Constitution saving throw or contract lindwurm fever."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 17 ({@dice 3d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 17 ({@dice 3d8+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Constrict",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the lindwurm can constrict only this target."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage, and the target is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the lindwurm can constrict only this target."
 					]
 				}
 			],
@@ -23620,7 +23961,7 @@
 				{
 					"name": "Darkness Vulnerability",
 					"entries": [
-						"Magical darkness is harmful to a liosalfar: They take {@dice 2d10} radiant damage, or half damage with a successful DC 14 Constitution saving throw, each time they start their turn inside magical darkness. Natural darkness is unpleasant to them but not harmful."
+						"Magical darkness is harmful to a liosalfar: They take {@dice 2d10} necrotic damage, or half damage with a successful DC 14 Constitution saving throw, each time they start their turn inside magical darkness. Natural darkness is unpleasant to them but not harmful."
 					]
 				},
 				{
@@ -23652,7 +23993,7 @@
 				{
 					"name": "Disrupting Touch",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 26 ({@dice 4d12}) radiant damage, and the target must succeed on a DC 15 Wisdom saving throw or become stunned for 1 round."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 26 ({@dice 4d12}) radiant damage, and the target must succeed on a DC 15 Wisdom saving throw or become stunned for 1 round."
 					]
 				}
 			],
@@ -23767,7 +24108,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +2} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 2} to hit, reach 5 ft., one target. Hit: 3 ({@dice 1d6}) bludgeoning damage."
 					]
 				},
 				{
@@ -23874,13 +24215,13 @@
 				{
 					"name": "Huntsman's Spear",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +11} to hit, reach 5 ft. or range 60/120 ft., one target. Hit: 12 ({@dice 2d6+5}) piercing damage or 14 ({@dice 2d8+5}) piercing damage if used in two hands, plus 7 ({@dice 2d6}) poison damage. If the target is a creature, it must succeed on a DC 19 Strength saving throw or be knocked prone. As a bonus action, the Lord of the Hunt can cause his spear to magically appear in his hand, even if it is destroyed."
+						"Melee or Ranged Weapon Attack: {@hit 11} to hit, reach 5 ft. or range 60/120 ft., one target. Hit: 12 ({@dice 2d6+5}) piercing damage or 14 ({@dice 2d8+5}) piercing damage if used in two hands, plus 7 ({@dice 2d6}) poison damage. If the target is a creature, it must succeed on a DC 19 Strength saving throw or be knocked prone. As a bonus action, the Lord of the Hunt can cause his spear to magically appear in his hand, even if it is destroyed."
 					]
 				},
 				{
 					"name": "Howling Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +10} to hit, range 150/600 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage plus 7 ({@dice 2d6}) poison damage."
+						"Ranged Weapon Attack: {@hit 10} to hit, range 150/600 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage plus 7 ({@dice 2d6}) poison damage."
 					]
 				}
 			],
@@ -23888,7 +24229,7 @@
 				{
 					"name": "Parry",
 					"entries": [
-						"The Lord of the Hunt adds 3 to his AC against one attack that would hit him. To do so, he must see the attacker and must be wielding a melee weapon."
+						"The Lord of the Hunt adds 6 to his AC against one attack that would hit him. To do so, he must see the attacker and must be wielding a melee weapon."
 					]
 				}
 			],
@@ -23918,7 +24259,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The lord of the hunt's innate spellcasting ability score is Charisma (save DC 16). The Lord of the Hunt can innately cast the following spells, requiring no material components."
+						"The lord of the hunt's innate spellcasting ability score is Charisma (save DC 16). The Lord of the Hunt can innately cast the following spells, requiring no material components:"
 					],
 					"will": [
 						"{@spell druidcraft}",
@@ -24006,7 +24347,7 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage."
 					]
 				},
 				{
@@ -24084,7 +24425,7 @@
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -24132,19 +24473,19 @@
 				{
 					"name": "Maul",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 25 ({@dice 6d6+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 25 ({@dice 6d6+4}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 20 ({@dice 3d10+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 20 ({@dice 3d10+4}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Javelin",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +7} to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 14 ({@dice 3d6+4}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 7} to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 14 ({@dice 3d6+4}) piercing damage."
 					]
 				}
 			],
@@ -24257,25 +24598,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 9 ({@dice 1d8+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 9 ({@dice 1d8+5}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Hurl Moonlight",
 					"entries": [
-						"Ranged Spell Attack: {@hit +7} to hit, range 150 ft., one target. Hit: 19 ({@dice 3d12}) cold damage and the target must succeed on a DC 15 Constitution saving throw or become blinded for 4 rounds."
+						"Ranged Spell Attack: {@hit 7} to hit, range 150 ft., one target. Hit: 19 ({@dice 3d12}) cold damage and the target must succeed on a DC 15 Constitution saving throw or become blinded for 4 rounds."
 					]
 				}
 			],
@@ -24353,8 +24694,13 @@
 				{
 					"name": "Amphibious",
 					"entries": [
-						"The mahoru can breathe air and water.",
-						"Keen Sight and Smell. The mahoru has advantage on Wisdom (Perception) checks that rely on sight or smell."
+						"The mahoru can breathe air and water."
+					]
+				},
+				{
+					"name": "Keen Sight and Smell",
+					"entries": [
+						"The mahoru has advantage on Wisdom (Perception) checks that rely on sight or smell."
 					]
 				},
 				{
@@ -24374,7 +24720,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 20 ({@dice 3d10+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 20 ({@dice 3d10+4}) slashing damage."
 					]
 				},
 				{
@@ -24498,7 +24844,7 @@
 				{
 					"name": "Scorching Blast",
 					"entries": [
-						"Ranged Spell Attack: {@hit +9} to hit, range 120 ft., one target. Hit: 18 ({@dice 3d8+5}) fire damage."
+						"Ranged Spell Attack: {@hit 9} to hit, range 120 ft., one target. Hit: 18 ({@dice 3d8+5}) fire damage."
 					]
 				},
 				{
@@ -24612,7 +24958,7 @@
 				{
 					"name": "Desiccating Touch",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 20 ({@dice 5d6+3}) necrotic damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 20 ({@dice 5d6+3}) necrotic damage."
 					]
 				},
 				{
@@ -24624,7 +24970,7 @@
 				{
 					"name": "Xeric Blast",
 					"entries": [
-						"Ranged Spell Attack: {@hit +7} to hit, range 30/90 ft., one target. Hit: 13 ({@dice 3d6+3}) necrotic damage."
+						"Ranged Spell Attack: {@hit 7} to hit, range 30/90 ft., one target. Hit: 13 ({@dice 3d6+3}) necrotic damage."
 					]
 				}
 			],
@@ -24731,7 +25077,7 @@
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage."
 					]
 				}
 			],
@@ -24763,7 +25109,7 @@
 			"tokenURL": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/ToB%20(3pp)/Malphas%20(Storm%20Crow).png"
 		},
 		{
-			"name": "Arch-Devil Mammon, Archduke of Greed",
+			"name": "Mammon, Archduke of Greed",
 			"size": "H",
 			"type": {
 				"type": "fiend",
@@ -24864,13 +25210,13 @@
 				{
 					"name": "Purse",
 					"entries": [
-						"Melee Weapon Attack: {@hit +14} to hit, reach 10 ft., one target. Hit: 19 ({@dice 3d8+6}) bludgeoning damage plus 18 ({@dice 4d8}) radiant damage."
+						"Melee Weapon Attack: {@hit 14} to hit, reach 10 ft., one target. Hit: 19 ({@dice 3d8+6}) bludgeoning damage plus 18 ({@dice 4d8}) radiant damage."
 					]
 				},
 				{
 					"name": "Molten Coins",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +14} to hit, range 40/120 ft., one target. Hit: 16 ({@dice 3d6+6}) bludgeoning damage plus 18 ({@dice 4d8}) fire damage."
+						"Ranged Weapon Attack: {@hit 14} to hit, range 40/120 ft., one target. Hit: 16 ({@dice 3d6+6}) bludgeoning damage plus 18 ({@dice 4d8}) fire damage."
 					]
 				},
 				{
@@ -24878,17 +25224,9 @@
 					"entries": [
 						"Mammon can use this ability as a bonus action immediately after hitting a creature with his purse attack. The creature must make a DC 24 Constitution saving throw. If the saving throw fails by 5 or more, the creature is instantly petrified by being turned to solid gold. Otherwise, a creature that fails the saving throw is restrained. A restrained creature repeats the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success. The petrification lasts until the creature receives a greater restoration spell or comparable magic."
 					]
-				},
-				{
-					"name": "Lair Actions",
-					"entries": [
-						"On initiative count 20 (losing initiative ties), Mammon takes a lair action to cause one of the following effects; Mammon can't use the same effect two rounds in a row:",
-						"• Mammon infuses a pile of treasure in his lair with life. It becomes an earth elemental made of precious metals and gems. The elemental acts immediately and lasts until destroyed or until Mammon uses this action again.",
-						"• Stacked piles of treasure shift and slide, collapsing onto a creature Mammon can see. The creature is restrained until initiative count 20 on the following round, or until it or an adjacent ally uses an action to make a successful DC 18 Strength check to free it.",
-						"• Mammon magically teleports from one area of treasure to another within 150 feet."
-					]
 				}
 			],
+			"legendaryGroup": "Mammon",
 			"legendary": [
 				{
 					"name": "Attack",
@@ -24954,7 +25292,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -25045,13 +25383,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, range 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage, and the target must succeed on a DC 15 Constitution saving throw or be poisoned for 1 round. The poison duration is cumulative with multiple failed saving throws."
+						"Melee Weapon Attack: {@hit 7} to hit, range 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage, and the target must succeed on a DC 15 Constitution saving throw or be poisoned for 1 round. The poison duration is cumulative with multiple failed saving throws."
 					]
 				},
 				{
 					"name": "Whiptail Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, range 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage, and the target must succeed on a DC 15 Constitution saving throw or take {@dice 1d6} poison damage. If the target is also poisoned by the mamura's claws, it takes another {@dice 1d6} poison damage at the start of each of its turns while the poisoning remains in effect."
+						"Melee Weapon Attack: {@hit 7} to hit, range 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage, and the target must succeed on a DC 15 Constitution saving throw or take {@dice 1d6} poison damage. If the target is also poisoned by the mamura's claws, it takes another {@dice 1d6} poison damage at the start of each of its turns while the poisoning remains in effect."
 					]
 				}
 			],
@@ -25143,7 +25481,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 14 ({@dice 4d6}) piercing damage, or 7 ({@dice 2d6}) piercing damage if the swarm has half of its hit points or fewer. The target must succeed on a DC 15 Dexterity saving throw or one randomly determined magic item in its possession is immediately affected by the Mana Erosion trait. A spellcaster hit by this attack must succeed on a DC 15 Charisma saving throw or one of its lowest-level, unused spell slots is expended."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 14 ({@dice 4d6}) piercing damage, or 7 ({@dice 2d6}) piercing damage if the swarm has half of its hit points or fewer. The target must succeed on a DC 15 Dexterity saving throw or one randomly determined magic item in its possession is immediately affected by the Mana Erosion trait. A spellcaster hit by this attack must succeed on a DC 15 Charisma saving throw or one of its lowest-level, unused spell slots is expended."
 					]
 				}
 			],
@@ -25153,12 +25491,7 @@
 		{
 			"name": "Map Mimic",
 			"size": "T",
-			"type": {
-				"type": "aberration",
-				"tags": [
-					"shapechanger"
-				]
-			},
+			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
 				"N"
@@ -25224,7 +25557,7 @@
 				{
 					"name": "Pseudopod",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) bludgeoning damage. If the mimic is in object form, the target is subjected to its Constrict Face trait."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) bludgeoning damage. If the mimic is in object form, the target is subjected to its Constrict Face trait."
 					]
 				}
 			],
@@ -25237,7 +25570,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -25321,13 +25654,13 @@
 				{
 					"name": "Khopesh of Oblivion",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 19 ({@dice 3d8+6}) slashing damage, and the target must succeed on a DC 17 Wisdom saving throw or some cherished material thing disappears from the universe, and only the target retains any memory of it. This item can be as large as a building, but it can't be a living entity and it can't be on the target's person or within the target's sight."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 19 ({@dice 3d8+6}) slashing damage, and the target must succeed on a DC 17 Wisdom saving throw or some cherished material thing disappears from the universe, and only the target retains any memory of it. This item can be as large as a building, but it can't be a living entity and it can't be on the target's person or within the target's sight."
 					]
 				},
 				{
 					"name": "Enervating Spiked Gauntlet",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d12+6}) bludgeoning damage plus 11 ({@dice 2d10}) necrotic damage, and the target must succeed on a DC 17 Wisdom saving throw or gain 1 level of exhaustion. The target recovers from all exhaustion caused by the enervating spiked gauntlet at the end of its next long rest."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d12+6}) bludgeoning damage plus 11 ({@dice 2d10}) necrotic damage, and the target must succeed on a DC 17 Wisdom saving throw or gain 1 level of exhaustion. The target recovers from all exhaustion caused by the enervating spiked gauntlet at the end of its next long rest."
 					]
 				},
 				{
@@ -25368,12 +25701,7 @@
 		{
 			"name": "Mavka",
 			"size": "M",
-			"type": {
-				"type": "undead",
-				"tags": [
-					"fey"
-				]
-			},
+			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
 				"C",
@@ -25456,7 +25784,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 23 ({@dice 4d8+5}) bludgeoning damage plus 11 ({@dice 2d10}) necrotic damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 23 ({@dice 4d8+5}) bludgeoning damage plus 11 ({@dice 2d10}) necrotic damage."
 					]
 				}
 			],
@@ -25545,7 +25873,7 @@
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 20 ({@dice 3d10+4}) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 20 ({@dice 3d10+4}) bludgeoning damage. If the target is a creature, it must succeed on a DC 14 Strength saving throw or be knocked prone."
 					]
 				}
 			],
@@ -25659,6 +25987,12 @@
 					"entries": [
 						"Every time Mechuiti takes piercing or slashing damage, a spray of caustic blood spurts from the wound toward the attacker. This spray forms a line 10 feet long and 5 feet wide. The first creature in the line must make a successful DC 24 Constitution saving throw against disease or be infected by Mechuiti's Ichor disease. The creature is poisoned until the disease is cured. Every 24 hours that elapse, the target must make a successful DC 24 Constitution saving throw or reduce its hit point maximum by 5 ({@dice 2d4}). The disease is cured on a success. The target dies if the disease reduces its hit point maximum to 0. This reduction to the target's hit point maximum lasts until the disease is cured."
 					]
+				},
+				{
+					"name": "Speak with Apes",
+					"entries": [
+						"Mechuiti can communicate simple concepts to apes."
+					]
 				}
 			],
 			"action": [
@@ -25671,13 +26005,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +17} to hit, reach 10 ft., one target. Hit: 20 ({@dice 2d10+9}) piercing damage plus 5 ({@dice 1d10}) fire damage."
+						"Melee Weapon Attack: {@hit 17} to hit, reach 10 ft., one target. Hit: 20 ({@dice 2d10+9}) piercing damage plus 5 ({@dice 1d10}) fire damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +17} to hit, reach 20 ft., one target. Hit: 20 ({@dice 2d10+9}) slashing damage. If Mechuiti scores a critical hit, it rolls damage dice three times instead of twice."
+						"Melee Weapon Attack: {@hit 17} to hit, reach 20 ft., one target. Hit: 20 ({@dice 2d10+9}) slashing damage. If Mechuiti scores a critical hit, it rolls damage dice three times instead of twice."
 					]
 				},
 				{
@@ -25697,18 +26031,9 @@
 					"entries": [
 						"Each creature of Mechuiti's choice that is within 120 feet of Mechuiti and aware of it must succeed on a DC 24 Wisdom saving throw or become frightened for 1 minute. A frightened creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to Mechuiti's Frightful Presence for the next 24 hours."
 					]
-				},
-				{
-					"name": "Lair Actions",
-					"entries": [
-						"On initiative count 20 (losing initiative ties), Mechuiti takes a lair action to cause one of the following effects. Mechuiti can't use the same effect two rounds in a row.",
-						"• Mechuiti targets one creature it can see within 120 feet of it, and a fissure full of lava opens under the target's feet. The target must succeed on a DC 20 Dexterity saving throw or take 28 ({@dice 8d6}) fire damage.",
-						"• The whole volcano trembles and shakes. Each creature on a solid surface other than a demon must succeed on a DC 20 Dexterity saving throw or be knocked prone. All ground in the volcano becomes difficult terrain for creatures other than a demon until initiative count 20 on the next round.",
-						"• Volcanic gases form a cloud in a 20-foot-radius sphere centered on a point Mechuiti can see within 120 feet of it. The sphere spreads around corners, and its area is lightly obscured. It lasts until initiative count 20 on the next round. Each creature that starts its turn in the cloud must succeed on a DC 15 Constitution saving throw or be poisoned until the end of its next turn. While poisoned in this way, a creature is incapacitated.",
-						"• The pain of all creatures other than demons within 120 feet of Mechuiti is intensified. Until initiative count 20 on the next round, every time a creature affected this way takes damage, he must succeed on a DC 15 Constitution saving throw or be stunned until the end of its next turn."
-					]
 				}
 			],
+			"legendaryGroup": "Mechuiti",
 			"legendary": [
 				{
 					"name": "Move",
@@ -25757,10 +26082,7 @@
 							"{@spell meteor swarm}",
 							"{@spell power word kill}"
 						]
-					},
-					"footerEntries": [
-						"Speak with Apes. Mechuiti can communicate simple concepts to apes."
-					]
+					}
 				}
 			],
 			"isNamedCreature": true,
@@ -25847,7 +26169,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage, and the target is grappled (escape DC 13). If both claw attacks strike the same target in a single turn, the target takes an additional 13 ({@dice 2d12}) psychic damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage, and the target is grappled (escape DC 13). If both claw attacks strike the same target in a single turn, the target takes an additional 13 ({@dice 2d12}) psychic damage."
 					]
 				}
 			],
@@ -25923,7 +26245,7 @@
 				{
 					"name": "Handaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 2 ({@dice 1d4}) poison damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 2 ({@dice 1d4}) poison damage."
 					]
 				}
 			],
@@ -26002,7 +26324,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
 					]
 				},
 				{
@@ -26032,7 +26354,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -26084,7 +26406,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) bludgeoning damage."
 					]
 				},
 				{
@@ -26096,7 +26418,7 @@
 				{
 					"name": "Captivating Dance (Recharges after a Short or Long Rest, Humanoid Form Only)",
 					"entries": [
-						"The mirager performs a sinuously swaying dance. Humanoids within 20 feet that view this dance must make a successful DC 16 Wisdom saving throw or be stunned for {@dice 1d4} rounds and charmed by the mirage for 1 minute. Humanoids of all races and genders have disadvantage on this saving throw, but constructs are immune. A creature that saves successfully is immune to this mirager's dance for the next 24 hours."
+						"The mirager performs a sinuously swaying dance. Humanoids within 20 feet that view this dance must make a successful DC 16 Wisdom saving throw or be stunned for {@dice 1d4} rounds and charmed by the mirager for 1 minute. Humanoids of all races and genders have disadvantage on this saving throw. A creature that saves successfully is immune to this mirager's dance for the next 24 hours."
 					]
 				}
 			],
@@ -26185,13 +26507,13 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
@@ -26278,13 +26600,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 21 ({@dice 4d8+3}) piercing damage, or 39 ({@dice 8d8+3}) piercing damage against a stunned target."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 21 ({@dice 4d8+3}) piercing damage, or 39 ({@dice 8d8+3}) piercing damage against a stunned target."
 					]
 				},
 				{
 					"name": "Quarterstaff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) bludgeoning damage."
 					]
 				},
 				{
@@ -26328,7 +26650,7 @@
 			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -26397,13 +26719,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
 					]
 				}
 			],
@@ -26441,7 +26763,6 @@
 			"cha": 10,
 			"immune": [
 				"poison",
-				"psychic",
 				{
 					"immune": [
 						"bludgeoning",
@@ -26486,13 +26807,13 @@
 				{
 					"name": "Greatsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage plus 11 ({@dice 2d10}) cold or fire damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) slashing damage plus 11 ({@dice 2d10}) cold or fire damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) bludgeoning damage plus 11 ({@dice 2d10}) cold or fire damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) bludgeoning damage plus 11 ({@dice 2d10}) cold or fire damage."
 					]
 				}
 			],
@@ -26530,7 +26851,6 @@
 			"cha": 10,
 			"immune": [
 				"poison",
-				"psychic",
 				{
 					"immune": [
 						"bludgeoning",
@@ -26575,13 +26895,13 @@
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 9 ({@dice 2d8}) cold or fire damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 9 ({@dice 2d8}) cold or fire damage."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage plus 9 ({@dice 2d8}) cold or fire damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) bludgeoning damage plus 9 ({@dice 2d8}) cold or fire damage."
 					]
 				}
 			],
@@ -26682,13 +27002,13 @@
 				{
 					"name": "Crystal Staff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) bludgeoning damage plus 7 ({@dice 2d6}) radiant damage. A target that is struck by the staff two or more times in one turn must make a successful DC 17 Constitution saving throw or be stunned until the end of its next turn."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) bludgeoning damage plus 7 ({@dice 2d6}) radiant damage. A target that is struck by the staff two or more times in one turn must make a successful DC 17 Constitution saving throw or be stunned until the end of its next turn."
 					]
 				},
 				{
 					"name": "Moon Bolt",
 					"entries": [
-						"Ranged Spell Attack: {@hit +11} to hit, range 150/600 ft., one target. Hit: 22 ({@dice 4d10}) radiant damage. If the target is a creature in a form other than its natural form, it takes an additional 22 ({@dice 4d10}) radiant damage and must succeed on a DC 19 Charisma saving throw or revert to its natural form. When the moon bolt hits a target, moonlight glows in a 10-foot radius from that point, creating dim light. The light is stationary and lasts until the end of the Moonlit King's next turn."
+						"Ranged Spell Attack: {@hit 11} to hit, range 150/600 ft., one target. Hit: 22 ({@dice 4d10}) radiant damage. If the target is a creature in a form other than its natural form, it takes an additional 22 ({@dice 4d10}) radiant damage and must succeed on a DC 19 Charisma saving throw or revert to its natural form. When the moon bolt hits a target, moonlight glows in a 10-foot radius from that point, creating dim light. The light is stationary and lasts until the end of the Moonlit King's next turn."
 					]
 				},
 				{
@@ -26738,7 +27058,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The Moonlit King's innate spellcasting ability score is Charisma (save DC 19, {@hit 11} to hit with spell attacks). The Moonlit King can innately cast the following spells, requiring no material components."
+						"The Moonlit King's innate spellcasting ability score is Charisma (save DC 19, {@hit 11} to hit with spell attacks). The Moonlit King can innately cast the following spells, requiring no material components:"
 					],
 					"will": [
 						"{@spell continual flame}",
@@ -26850,19 +27170,19 @@
 				{
 					"name": "Spike",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 20/60 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage plus 3 ({@dice 1d6}) acid damage."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 20/60 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage plus 3 ({@dice 1d6}) acid damage."
 					]
 				},
 				{
 					"name": "Tentacle",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 17 ({@dice 2d10+6}) bludgeoning damage plus 7 ({@dice 2d6}) acid damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 17 ({@dice 2d10+6}) bludgeoning damage plus 7 ({@dice 2d6}) acid damage."
 					]
 				},
 				{
 					"name": "Filaments",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 22 ({@dice 3d10+6}) bludgeoning damage plus 10 ({@dice 3d6}) acid damage, and the target is grappled (escape DC 16) and restrained."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 22 ({@dice 3d10+6}) bludgeoning damage plus 10 ({@dice 3d6}) acid damage, and the target is grappled (escape DC 16) and restrained."
 					]
 				}
 			],
@@ -26872,7 +27192,12 @@
 		{
 			"name": "Morphoi",
 			"size": "M",
-			"type": "plant",
+			"type": {
+				"type": "plant",
+				"tags": [
+					"shapechanger"
+				]
+			},
 			"source": "ToB 3pp",
 			"alignment": [
 				"C",
@@ -26928,19 +27253,19 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Trident",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +2} to hit, reach 5 ft., or {@hit +5} to hit, range 20/60 ft., one target. Hit: 4 ({@dice 1d8}) piercing damage if used with both hands to make a melee attack, or 6 ({@dice 1d6+3}) if thrown."
+						"Melee or Ranged Weapon Attack: {@hit 2} to hit, reach 5 ft., or {@hit 5} to hit, range 20/60 ft., one target. Hit: 4 ({@dice 1d8}) piercing damage if used with both hands to make a melee attack, or 6 ({@dice 1d6+3}) if thrown."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				}
 			],
@@ -27019,7 +27344,7 @@
 				{
 					"name": "Poisoned Gifts",
 					"entries": [
-						"A moss lurker can contaminate wells, potions, meals, or unattended beverages with poisons that induce sleep, nausea, or paralysis. Someone who drinks or eats the contaminated liquid or food must make a successful DC 11 Constitution saving throw to avoid its effect, which can be unconsciousness, poisoning, or paralysis lasting 1 hour. The effect is chosen by the moss lurker at the time the poison is introduced."
+						"A moss lurker can contaminate liquids or food with poison. Someone who consumes the contaminated substance must make a successful DC 11 Constitution saving throw or become poisoned for 1 hour. When the poison is introduced, the moss lurker can choose a poison that also causes the victim to fall unconscious, or to become paralyzed while poisoned in this way. An unconscious creature wakes if it takes damage, or if a creature uses an action to shake it awake."
 					]
 				}
 			],
@@ -27027,25 +27352,25 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage."
 					]
 				},
 				{
 					"name": "Great Sword or Maul",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing or bludgeoning damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing or bludgeoning damage."
 					]
 				},
 				{
 					"name": "Mushroom-Poisoned Javelin",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 30 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus 6 ({@dice 1d12}) poison damage and the target is poisoned until the start of the moss lurker's next turn. A successful DC 11 Constitution save halves the poison damage and prevents poisoning."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 30 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus 6 ({@dice 1d12}) poison damage and the target is poisoned until the start of the moss lurker's next turn. A successful DC 11 Constitution save halves the poison damage and prevents poisoning."
 					]
 				},
 				{
 					"name": "Dropped Boulder",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 100 ft. (vertically), one target. Hit: 10 ({@dice 3d6}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 100 ft. (vertically), one target. Hit: 10 ({@dice 3d6}) bludgeoning damage."
 					]
 				}
 			],
@@ -27121,19 +27446,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d4+2}) piercing damage, and the target is grappled (escape DC 12). If the target was grappled by the myling at the start of the myling's turn, the bite attack hits automatically."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d4+2}) piercing damage, and the target is grappled (escape DC 12). If the target was grappled by the myling at the start of the myling's turn, the bite attack hits automatically."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d6+1}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d6+1}) slashing damage."
 					]
 				},
 				{
 					"name": "Buried Alive",
 					"entries": [
-						"If the myling starts its turn on its chosen burial ground, it sinks into the earth. If it has a creature grappled, that creature sinks with the myling. A Medium or larger creature sinks up to its waist; a Small creature sinks up to its neck. If the myling still has the victim grappled at the start of the myling's next turn, both of them disappear into the earth. While buried this way, a creature is considered stunned. It can free itself with a successful DC 20 Strength (Athletics) check, but only one check is allowed; if it fails, the creature is powerless to aid itself except with magic. The creature must also make a DC 10 Constitution saving throw; if it succeeds, the creature has a lungful of air and can hold its breath for (Constitution modifier+1) minutes before suffocation begins. Otherwise, it begins suffocating immediately. Allies equipped with digging tools can reach it in four minutes divided by the number of diggers; someone using an improvised tool (a sword, a plate, bare hands) counts as only one-half of a digger."
+						"If the myling starts its turn on its chosen burial ground, it sinks into the earth. If it has a creature grappled, that creature sinks with the myling. A Medium or larger creature sinks up to its waist; a Small creature sinks up to its neck. If the myling still has the victim grappled at the start of the myling's next turn, both of them disappear into the earth. While buried this way, a creature is considered stunned. It can free itself with a successful DC 20 Strength (Athletics) check, but only one check is allowed; if it fails, the creature is powerless to aid itself except with magic. The creature must also make a DC 10 Constitution saving throw; if it succeeds, the creature has a lungful of air and can hold its breath for (Constitution modifier + 1) minutes before suffocation begins. Otherwise, it begins suffocating immediately. Allies equipped with digging tools can reach it in four minutes divided by the number of diggers; someone using an improvised tool (a sword, a plate, bare hands) counts as only one-half of a digger."
 					]
 				}
 			],
@@ -27143,7 +27468,12 @@
 		{
 			"name": "Naina",
 			"size": "L",
-			"type": "dragon",
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"shapechanger"
+				]
+			},
 			"source": "ToB 3pp",
 			"alignment": [
 				"L",
@@ -27215,7 +27545,7 @@
 				{
 					"name": "Shapechanger",
 					"entries": [
-						"The naina can use her action to polymorph into one of her two forms: a drake or a female humanoid (Medium fey when in humanoid form). She cannot alter either form's appearance or capabilities (with the exception of her breath weapon) using this ability, and damage sustained in one form transfers to the other form."
+						"The naina can use her action to polymorph into one of her two forms: a drake or a female humanoid. She cannot alter either form's appearance or capabilities (with the exception of her breath weapon) using this ability, and damage sustained in one form transfers to the other form."
 					]
 				}
 			],
@@ -27229,13 +27559,13 @@
 				{
 					"name": "Bite (Drake Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 24 ({@dice 3d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 24 ({@dice 3d12+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw (Drake Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 24 ({@dice 3d12+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 24 ({@dice 3d12+5}) slashing damage."
 					]
 				},
 				{
@@ -27365,7 +27695,13 @@
 				{
 					"name": "Elephants' Bane",
 					"entries": [
-						"The ngobou has advantage on attacks against elephants. It can detect by scent whether an elephant has been within 180 feet of its location anytime in the last 48 hours. Spikes. A creature that grapples an ngobou takes 9 ({@dice 2d8}) piercing damage."
+						"The ngobou has advantage on attacks against elephants. It can detect by scent whether an elephant has been within 180 feet of its location anytime in the last 48 hours."
+					]
+				},
+				{
+					"name": "Spikes",
+					"entries": [
+						"A creature that grapples an ngobou takes 9 ({@dice 2d8}) piercing damage."
 					]
 				}
 			],
@@ -27373,13 +27709,13 @@
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 38 ({@dice 6d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 38 ({@dice 6d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one prone creature. Hit: 18 ({@dice 3d8+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one prone creature. Hit: 18 ({@dice 3d8+5}) bludgeoning damage."
 					]
 				}
 			],
@@ -27392,7 +27728,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -27438,6 +27774,9 @@
 					],
 					"note": "from nonmagical weapons that aren't silvered."
 				}
+			],
+			"immune": [
+				"poison"
 			],
 			"conditionImmune": [
 				"charmed",
@@ -27492,7 +27831,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 17 ({@dice 2d12+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 17 ({@dice 2d12+4}) slashing damage."
 					]
 				}
 			],
@@ -27567,13 +27906,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple one target."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) bludgeoning damage, and the target is grappled (escape DC 12). The scorpion has two claws, each of which can grapple one target."
 					]
 				},
 				{
 					"name": "Sting",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d10+2}) piercing damage, and the target takes 7 ({@dice 2d6}) poison damage and is blinded for {@dice 1d3} hours; a successful DC 12 Constitution saving throw reduces damage by half and prevents blindness. If the target fails the saving throw by 5 or more, the target is also paralyzed while poisoned. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d10+2}) piercing damage, and the target takes 7 ({@dice 2d6}) poison damage and is blinded for {@dice 1d3} hours; a successful DC 12 Constitution saving throw reduces damage by half and prevents blindness. If the target fails the saving throw by 5 or more, the target is also paralyzed while poisoned. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save."
 					]
 				}
 			],
@@ -27663,7 +28002,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 27 ({@dice 4d10+5}) piercing damage, and a Medium or smaller target must succeed on a DC 15 Strength saving throw or be swallowed whole. A swallowed creature is blinded and restrained and has total cover against attacks and other effects outside the nightgarm. It takes 21 ({@dice 6d6}) acid damage at the start of each of the nightgarm's turns. A nightgarm can have only one creature swallowed at a time.",
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 27 ({@dice 4d10+5}) piercing damage, and a Medium or smaller target must succeed on a DC 15 Strength saving throw or be swallowed whole. A swallowed creature is blinded and restrained and has total cover against attacks and other effects outside the nightgarm. It takes 21 ({@dice 6d6}) acid damage at the start of each of the nightgarm's turns. A nightgarm can have only one creature swallowed at a time.",
 						"If the nightgarm takes 25 damage or more on a single turn from the swallowed creature, the nightgarm must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate the creature, which falls prone within 5 feet of the nightgarm. If the nightgarm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 10 feet of movement, exiting prone."
 					]
 				}
@@ -27717,7 +28056,7 @@
 				"swim": 40,
 				"fly": {
 					"number": 40,
-					"condition": " (ethereal only hover)"
+					"condition": " (ethereal only, hover)"
 				}
 			},
 			"str": 21,
@@ -27747,16 +28086,22 @@
 				}
 			],
 			"immune": [
-				"cold",
-				"necrotic",
-				"poison",
 				{
 					"immune": [
-						"piercing"
+						"cold",
+						"necrotic",
+						"poison",
+						{
+							"immune": [
+								"bludgeoning",
+								"piercing",
+								"slashing"
+							],
+							"note": "from nonmagical weapons"
+						}
 					],
-					"note": "and slashing from nonmagical weapons (only when in ethereal form)"
-				},
-				"bludgeoning"
+					"note": "(only when in ethereal form)"
+				}
 			],
 			"conditionImmune": [
 				"charmed",
@@ -27789,7 +28134,7 @@
 				{
 					"name": "Undead Fortitude",
 					"entries": [
-						"If damage reduces the nihileth to 0 hit points, it must make a Constitution saving throw with a DC of 5+the damage taken, unless the damage is radiant or from a critical hit. On a success, the nihileth drops to 1 hit point instead."
+						"If damage reduces the nihileth to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the nihileth drops to 1 hit point instead."
 					]
 				},
 				{
@@ -27821,13 +28166,13 @@
 				{
 					"name": "Tentacle (Material Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage. If the target creature is hit, it must make a successful DC 14 Constitution saving throw or become diseased. The disease has no effect for 1 minute; during that time, it can be removed by lesser restoration or comparable magic. After 1 minute, the diseased creature's skin becomes translucent and slimy. The creature cannot regain hit points unless it is entirely underwater, and the disease can only be removed by heal or comparable magic. Unless the creature is fully submerged or frequently doused with water, it takes 6 ({@dice 1d12}) acid damage every 10 minutes. If a creature dies while diseased, it rises in {@dice 1d6} rounds as a nihilethic zombie. This zombie is permanently dominated by the nihileth."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage. If the target creature is hit, it must make a successful DC 14 Constitution saving throw or become diseased. The disease has no effect for 1 minute; during that time, it can be removed by lesser restoration or comparable magic. After 1 minute, the diseased creature's skin becomes translucent and slimy. The creature cannot regain hit points unless it is entirely underwater, and the disease can only be removed by heal or comparable magic. Unless the creature is fully submerged or frequently doused with water, it takes 6 ({@dice 1d12}) acid damage every 10 minutes. If a creature dies while diseased, it rises in {@dice 1d6} rounds as a nihilethic zombie. This zombie is permanently dominated by the nihileth."
 					]
 				},
 				{
 					"name": "Withering Touch (Ethereal Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one creature. Hit: 14 ({@dice 3d6+4}) necrotic damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one creature. Hit: 14 ({@dice 3d6+4}) necrotic damage."
 					]
 				},
 				{
@@ -27839,20 +28184,13 @@
 				{
 					"name": "Tail (Material Form Only)",
 					"entries": [
-						"As per the aboleth action."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft. one target. Hit: 15 ({@dice 3d6 + 5}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Enslave (3/Day)",
 					"entries": [
 						"As per the aboleth action."
-					]
-				},
-				{
-					"name": "Lair Actions",
-					"entries": [
-						"On initiative count 20 (losing initiative ties), the nihileth can take a lair action to create one of the magical effects as per an aboleth, or the void absorbance action listed below. The nihileth cannot use the same effect two rounds in a row.",
-						"• Void absorbance. A nihileth can pull the life force from those it has converted to nihilethic zombies to replenish its own life. This takes 18 ({@dice 6d6}) hit points from zombies within 30 feet of the nihileth, spread evenly between the zombies, and healing the nihileth. If a zombie reaches 0 hit points from this action, it perishes with no Undead Fortitude saving throw."
 					]
 				}
 			],
@@ -27864,6 +28202,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Nihileth",
 			"legendary": [
 				{
 					"name": "Detect",
@@ -27874,7 +28213,7 @@
 				{
 					"name": "Tail Swipe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 3d6+5}) bludgeoning damage"
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 15 ({@dice 3d6+5}) bludgeoning damage"
 					],
 					"attack": [
 						"Tail Swipe|9|3d6+5"
@@ -27896,7 +28235,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -27935,16 +28274,22 @@
 				}
 			],
 			"immune": [
-				"cold",
-				"necrotic",
-				"poison",
 				{
 					"immune": [
-						"piercing"
+						"cold",
+						"necrotic",
+						"poison",
+						{
+							"immune": [
+								"bludgeoning",
+								"piercing",
+								"slashing"
+							],
+							"note": "from nonmagical weapons"
+						}
 					],
-					"note": "and slashing from nonmagical weapons (only when in ethereal form)"
-				},
-				"bludgeoning"
+					"note": "(only when in ethereal form)"
+				}
 			],
 			"conditionImmune": [
 				"poisoned"
@@ -27971,13 +28316,13 @@
 				{
 					"name": "Slam (Material Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d6+1}) bludgeoning damage and the target must make a successful DC 13 Constitution saving throw or become diseased. The disease has little effect for 1 minute; during that time, it can be removed by bless, lesser restoration, or comparable magic. After 1 minute, the diseased creature's skin becomes translucent and slimy. The creature cannot regain hit points unless it is at least partially underwater, and the disease can only be removed by heal or comparable magic. Unless the creature is either fully submerged or frequently doused with water, it takes 6 ({@dice 1d12}) acid damage every 10 minutes. If a creature dies while diseased, it rises in {@dice 2d6} rounds as a nihilethic zombie. This zombie is permanently dominated by the nihileth that commands the attacking zombie."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d6+1}) bludgeoning damage and the target must make a successful DC 13 Constitution saving throw or become diseased. The disease has little effect for 1 minute; during that time, it can be removed by bless, lesser restoration, or comparable magic. After 1 minute, the diseased creature's skin becomes translucent and slimy. The creature cannot regain hit points unless it is at least partially underwater, and the disease can only be removed by heal or comparable magic. Unless the creature is either fully submerged or frequently doused with water, it takes 6 ({@dice 1d12}) acid damage every 10 minutes. If a creature dies while diseased, it rises in {@dice 2d6} rounds as a nihilethic zombie. This zombie is permanently dominated by the nihileth that commands the attacking zombie."
 					]
 				},
 				{
 					"name": "Withering Touch (Ethereal Form)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d6+1}) necrotic damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d6+1}) necrotic damage."
 					]
 				},
 				{
@@ -27987,18 +28332,20 @@
 					]
 				},
 				{
-					"name": "Void Body",
-					"entries": [
-						"As a reaction, the nihilethic zombie can reduce the damage it takes from a single source by {@dice 1d12} points. This reduction cannot be applied to divine damage."
-					]
-				},
-				{
 					"name": "Sacrifice Life",
 					"entries": [
 						"A nihilethic zombie can sacrifice itself to heal a nihileth within 30 feet of it. All of its remaining hit points transfer to the nihileth in the form of healing. The nihilethic zombie is reduced to 0 hit points and it doesn't make an Undead Fortitude saving throw. A nihileth cannot be healed above its maximum hit points in this manner."
 					]
 				}
 			],
+			"reaction": [
+				{
+					"name": "Void Body",
+					"entries": [
+						"As a reaction, the nihilethic zombie can reduce the damage it takes from a single source by {@dice 1d12} points. This reduction cannot be applied to radiant damage."
+					]
+				}
+		  ],
 			"page": 9,
 			"tokenURL": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/ToB%20(3pp)/Nihilethic%20Zombie.png"
 		},
@@ -28069,19 +28416,19 @@
 				{
 					"name": "Scimitar (Nkosi Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Mambele Throwing Knife (Nkosi Form Only)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				}
 			],
@@ -28167,19 +28514,19 @@
 				{
 					"name": "Scimitar (Nkosi Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Mambele Throwing Knife (Nkosi Form Only)",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage."
 					]
 				},
 				{
@@ -28203,7 +28550,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -28257,7 +28604,7 @@
 				{
 					"name": "Pact Staff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) bludgeoning damage or 8 ({@dice 1d8+4}) bludgeoning damage if used in two hands."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) bludgeoning damage or 8 ({@dice 1d8+4}) bludgeoning damage if used in two hands."
 					]
 				}
 			],
@@ -28306,7 +28653,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -28335,13 +28682,8 @@
 				"stealth": "+7"
 			},
 			"resist": [
-				{
-					"resist": [
-						"slashing"
-					],
-					"note": "from nonmagical weapons"
-				},
 				"bludgeoning",
+				"slashing",
 				"piercing"
 			],
 			"conditionImmune": [
@@ -28467,13 +28809,13 @@
 				{
 					"name": "Greatclub",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Javelin",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +8} to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 12 ({@dice 2d6+5}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 8} to hit, reach 5 ft. or range 30/120 ft., one target. Hit: 12 ({@dice 2d6+5}) piercing damage."
 					]
 				}
 			],
@@ -28563,7 +28905,7 @@
 				{
 					"name": "Waters of Unfathomable Compulsion",
 					"entries": [
-						"Any creature that drinks the water of an oozasis or eats fruit from the plants growing in it has a dream (as the spell, save DC 16) the next time it sleeps. In this dream, the oozasis places a compulsion to carry out some activity as a torrent of images and sensations. When the creature awakens, it is affected by a geas spell (save DC 168, cast as a 7th-level spell) in addition to the effects of dream."
+						"Any creature that drinks the water of an oozasis or eats fruit from the plants growing in it has a dream (as the spell, save DC 16) the next time it sleeps. In this dream, the oozasis places a compulsion to carry out some activity as a torrent of images and sensations. When the creature awakens, it is affected by a geas spell (save DC 16, cast as a 7th-level spell) in addition to the effects of dream."
 					]
 				}
 			],
@@ -28577,7 +28919,7 @@
 				{
 					"name": "Pseudopod",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 15 ft., one creature. Hit: 13 ({@dice 2d8+4}) bludgeoning damage plus 10 ({@dice 3d6}) acid damage, and a target that's Large or smaller is grappled (escape DC 16) and restrained until the grapple ends. The oozasis has two pseudopods, each of which can grapple one target at a time."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 15 ft., one creature. Hit: 13 ({@dice 2d8+4}) bludgeoning damage plus 10 ({@dice 3d6}) acid damage, and a target that's Large or smaller is grappled (escape DC 16) and restrained until the grapple ends. The oozasis has two pseudopods, each of which can grapple one target at a time."
 					]
 				},
 				{
@@ -28703,25 +29045,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d6+8}) piercing damage. The target must succeed on a DC 18 Constitution saving throw or become poisoned. While poisoned in this way, the target can't regain hit points and it takes 14 ({@dice 4d6}) poison damage at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d6+8}) piercing damage. The target must succeed on a DC 18 Constitution saving throw or become poisoned. While poisoned in this way, the target can't regain hit points and it takes 14 ({@dice 4d6}) poison damage at the start of each of its turns. The poisoned target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d6+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d6+8}) slashing damage."
 					]
 				},
 				{
 					"name": "Flail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 17 ({@dice 2d8+8}) bludgeoning damage plus 18 ({@dice 4d8}) acid damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 17 ({@dice 2d8+8}) bludgeoning damage plus 18 ({@dice 4d8}) acid damage."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d6+8}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d6+8}) bludgeoning damage."
 					]
 				}
 			],
@@ -28859,7 +29201,7 @@
 				{
 					"name": "Cacophony Ray",
 					"entries": [
-						"Ranged Spell Attack: {@hit +7} to hit, range 60 ft., one target. Hit: 10 ({@dice 3d6}) thunder damage."
+						"Ranged Spell Attack: {@hit 7} to hit, range 60 ft., one target. Hit: 10 ({@dice 3d6}) thunder damage."
 					]
 				},
 				{
@@ -28872,7 +29214,7 @@
 				{
 					"name": "Voracious Aura (1/Day)",
 					"entries": [
-						"While merged with a humanoid (see Aural Symbiosis), the ostinato feeds on nearby creatures. Up to nine creatures of the ostinato's choice within 60 feet of it can be targeted. Each target must succeed on a DC 13 Charisma saving throw or take 3 ({@dice 1d6}) necrotic damage and have its hit point maximum reduced by the same amount. Victims notice this damage immediately, but not its source."
+						"While merged with a humanoid (see Aural Symbiosis), the ostinato feeds on nearby creatures. Up to nine creatures of the ostinato's choice within 60 feet of it can be targeted. Each target must succeed on a DC 13 Charisma saving throw or take 3 ({@dice 1d6}) necrotic damage and have its hit point maximum reduced by the same amount until it finishes a long rest. The target dies if its maximum hit points are reduced to 0. Victims notice this damage immediately, but not its source."
 					]
 				}
 			],
@@ -28885,7 +29227,7 @@
 			"type": "monstrosity",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -28937,13 +29279,13 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Talons",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage."
 					]
 				},
 				{
@@ -29033,19 +29375,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 13 ({@dice 3d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 13 ({@dice 3d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail (Recharge 5—6)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 16 ({@dice 5d6+3}) slashing damage, and the target must succeed on a DC 13 Constitution saving throw or be incapacitated for 1 round."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 16 ({@dice 5d6+3}) slashing damage, and the target must succeed on a DC 13 Constitution saving throw or be incapacitated for 1 round."
 					]
 				}
 			],
@@ -29127,7 +29469,7 @@
 				{
 					"name": "Fist",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) bludgeoning damage and the target is grappled (escape DC 13)."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) bludgeoning damage and the target is grappled (escape DC 13)."
 					]
 				},
 				{
@@ -29241,7 +29583,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) bludgeoning damage."
 					]
 				}
 			],
@@ -29316,7 +29658,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 10 ({@dice 4d4}) piercing damage, or 5 ({@dice 2d4}) piercing damage if the swarm has half of its hit points or fewer. The target also takes 10 ({@dice 4d4}) poison damage and becomes euphoric for {@dice 1d4} rounds, or takes half as much poison damage and is not euphoric if it makes a successful DC 11 Constitution saving throw. A euphoric creature has disadvantage on saving throws."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 10 ({@dice 4d4}) piercing damage, or 5 ({@dice 2d4}) piercing damage if the swarm has half of its hit points or fewer. The target also takes 10 ({@dice 4d4}) poison damage and becomes euphoric for {@dice 1d4} rounds, or takes half as much poison damage and is not euphoric if it makes a successful DC 11 Constitution saving throw. A euphoric creature has disadvantage on saving throws."
 					]
 				}
 			],
@@ -29410,7 +29752,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 1d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 1d12+5}) piercing damage."
 					]
 				},
 				{
@@ -29444,7 +29786,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -29506,7 +29848,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) bludgeoning damage."
 					]
 				},
 				{
@@ -29628,20 +29970,20 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 10 ft., one target. Hit: 22 ({@dice 2d12+9}) piercing damage. A target creature of Large size or smaller must succeed on a DC 24 Dexterity saving throw or be swallowed by Qorgeth. A swallowed creature is blinded and restrained, and takes 16 ({@dice 3d10}) necrotic damage at the start of each of Qorgeth's turns. Qorgeth can have any number of creatures swallowed at one time.",
+						"Melee Weapon Attack: {@hit 16} to hit, reach 10 ft., one target. Hit: 22 ({@dice 2d12+9}) piercing damage. A target creature of Large size or smaller must succeed on a DC 24 Dexterity saving throw or be swallowed by Qorgeth. A swallowed creature is blinded and restrained, and takes 16 ({@dice 3d10}) necrotic damage at the start of each of Qorgeth's turns. Qorgeth can have any number of creatures swallowed at one time.",
 						"If Qorgeth takes 50 damage or more in a single turn from a creature it has swallowed, it must succeed on a DC 20 Constitution saving throw or regurgitate all swallowed creatures, who land prone within 10 feet of Qorgeth. If Qorgeth dies, a swallowed creature is no longer restrained, and can escape the corpse by spending 30 feet of movement, exiting prone."
 					]
 				},
 				{
 					"name": "Crush",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 10 ft., one target. Hit: 20 ({@dice 2d10+9}) bludgeoning damage. A target creature is also grappled and restrained (escape DC 19) until Qorgeth moves. Qorgeth can grapple up to two creatures at once; at least one of Qorgeth's crush attacks must be directed against each creature it has grappled."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 10 ft., one target. Hit: 20 ({@dice 2d10+9}) bludgeoning damage. A target creature is also grappled and restrained (escape DC 19) until Qorgeth moves. Qorgeth can grapple up to two creatures at once; at least one of Qorgeth's crush attacks must be directed against each creature it has grappled."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +16} to hit, reach 15 ft., one target. Hit: 23 ({@dice 4d6+9}) piercing damage, and the target takes 33 ({@dice 6d10}) poison damage and is poisoned for 1 hour; a successful DC 23 Constitution saving throw reduces poison damage by half and negates the poisoned condition. A creature that fails the save by 10 or more is also paralyzed for as long as the poisoned condition lasts."
+						"Melee Weapon Attack: {@hit 16} to hit, reach 15 ft., one target. Hit: 23 ({@dice 4d6+9}) piercing damage, and the target takes 33 ({@dice 6d10}) poison damage and is poisoned for 1 hour; a successful DC 23 Constitution saving throw reduces poison damage by half and negates the poisoned condition. A creature that fails the save by 10 or more is also paralyzed for as long as the poisoned condition lasts."
 					]
 				},
 				{
@@ -29650,10 +29992,11 @@
 						"On initiative count 20 (losing initiative ties), Qorgeth takes a lair action to cause one of the following effects; Qorgeth can't use the same effect two rounds in a row:",
 						"• Until initiative count 20 on the following round, Qorgeth twists space through the tunnels of its lair. Any creature other than a demon that tries to move must succeed on a DC 15 Charisma saving throw or move half its speed in a random direction before getting its bearings; it can then finish moving as it wants.",
 						"• A section of ceiling in the lair collapses, raining debris onto a 20-foot-radius area. Each creature in the area must make a successful DC 15 Dexterity saving throw or take 18 ({@dice 4d8}) bludgeoning damage and be restrained until the end of its next turn.",
-						"• Thick tangles of demonic worms erupt in the space of up to three creatures Qorgeth can see within 60 feet. Each targeted creature is attacked once by the worms (Melee Weapon Attack: {@hit +7} to hit, reach 0 ft., one target; Hit: 14 ({@dice 4d6}) piercing)."
+						"• Thick tangles of demonic worms erupt in the space of up to three creatures Qorgeth can see within 60 feet. Each targeted creature is attacked once by the worms (Melee Weapon Attack: {@hit 7} to hit, reach 0 ft., one target; Hit: 14 ({@dice 4d6}) piercing)."
 					]
 				}
 			],
+			"legendaryGroup": "Qorgeth",
 			"legendary": [
 				{
 					"name": "Shriek",
@@ -29707,7 +30050,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -29799,19 +30142,19 @@
 				{
 					"name": "Rapier",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage plus 10 ({@dice 3d6}) cold damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage plus 10 ({@dice 3d6}) cold damage."
 					]
 				},
 				{
 					"name": "Shadow Rift (Recharge 5—6)",
 					"entries": [
-						"The Queen of Night and Magic creates a shadowy rift in a 20-foot sphere. Any creature within the rift takes 72 ({@dice 16d8}) cold damage, or half damage with a successful DC 23 Constitution saving throw. Creatures that fail the saving throw are also restrained by icy wisps of shadow. A restrained creature repeats the saving throw at the end of its turn, ending the restrained condition on a success."
+						"The Queen of Night and Magic creates a shadowy rift in a 20-foot sphere centered on a point she can see within 150 feet. Any creature within the rift takes 72 ({@dice 16d8}) cold damage, or half damage with a successful DC 23 Constitution saving throw. Creatures that fail the saving throw are also restrained by icy wisps of shadow. A restrained creature repeats the saving throw at the end of its turn, ending the restrained condition on a success."
 					]
 				},
 				{
 					"name": "Star Strike",
 					"entries": [
-						"Ranged Spell Attack: {@hit +15} to hit, range 120 ft., one target. Hit: 9 ({@dice 2d8}) fire damage plus 9 ({@dice 2d8}) radiant damage."
+						"Ranged Spell Attack: {@hit 15} to hit, range 120 ft., one target. Hit: 9 ({@dice 2d8}) fire damage plus 9 ({@dice 2d8}) radiant damage."
 					]
 				},
 				{
@@ -29823,7 +30166,7 @@
 				{
 					"name": "Unravel",
 					"entries": [
-						"The Queen of Night and Magic targets a creature, object, or magical effect that she can see. For every spell affecting the target, the Queen makes a Charisma check; the DC equals 10+the spell's level. On a success, the spell is dispelled."
+						"The Queen of Night and Magic targets a creature, object, or magical effect that she can see. For every spell affecting the target, the Queen makes a Charisma check; the DC equals 10 + the spell's level. On a success, the spell is dispelled."
 					]
 				}
 			],
@@ -30051,13 +30394,13 @@
 				{
 					"name": "Moonsilver Ring",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) bludgeoning damage plus 10 ({@dice 3d6}) radiant damage. The moonsilver ring is a magical weapon."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) bludgeoning damage plus 10 ({@dice 3d6}) radiant damage. The moonsilver ring is a magical weapon."
 					]
 				},
 				{
 					"name": "Blast",
 					"entries": [
-						"Ranged Spell Attack: {@hit +12} to hit, range 120 ft., one target. Hit: 11 ({@dice 1d10+6}) force damage. A creature hit by a blast must succeed on a DC 19 Strength saving throw or be pushed 10 feet directly away from Nicnevin."
+						"Ranged Spell Attack: {@hit 12} to hit, range 120 ft., one target. Hit: 11 ({@dice 1d10+6}) force damage. A creature hit by a blast must succeed on a DC 19 Strength saving throw or be pushed 10 feet directly away from Nicnevin."
 					]
 				}
 			],
@@ -30124,15 +30467,10 @@
 		{
 			"name": "Qwyllion",
 			"size": "M",
-			"type": {
-				"type": "aberration",
-				"tags": [
-					"fey"
-				]
-			},
+			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -30206,7 +30544,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 24 ({@dice 3d12+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 24 ({@dice 3d12+5}) slashing damage."
 					]
 				},
 				{
@@ -30286,13 +30624,13 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				}
 			],
@@ -30378,7 +30716,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage, and a bitten creature must succeed on a DC 15 Constitution saving throw or be infected with a disease. A diseased creature gains one level of exhaustion immediately. When the creature finishes a long rest, it must repeat the saving throw. On a failure, the creature gains another level of exhaustion. On a success, the disease does not progress. The creature recovers from the disease if its saving throw succeeds after two consecutive long rests or if it receives a lesser restoration spell or comparable magic. The creature then recovers from one level of exhaustion after each long rest."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage, and a bitten creature must succeed on a DC 15 Constitution saving throw or be infected with a disease. A diseased creature gains one level of exhaustion immediately. When the creature finishes a long rest, it must repeat the saving throw. On a failure, the creature gains another level of exhaustion. On a success, the disease does not progress. The creature recovers from the disease if its saving throw succeeds after two consecutive long rests or if it receives a lesser restoration spell or comparable magic. The creature then recovers from one level of exhaustion after each long rest."
 					]
 				},
 				{
@@ -30460,7 +30798,7 @@
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 1 piercing damage plus 14 ({@dice 4d6}) psychic damage and the target must make a successful DC 14 Wisdom saving throw or be charmed for 1 round. While charmed in this way, the creature regards one randomly determined ally as a foe."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 1 piercing damage plus 14 ({@dice 4d6}) psychic damage and the target must make a successful DC 14 Wisdom saving throw or be charmed for 1 round. While charmed in this way, the creature regards one randomly determined ally as a foe."
 					]
 				},
 				{
@@ -30563,13 +30901,13 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 80/320 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
 					]
 				}
 			],
@@ -30649,19 +30987,19 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Rat Dagger Flurry",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., three targets. Hit: 7 ({@dice 1d4+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., three targets. Hit: 7 ({@dice 1d4+3}) piercing damage."
 					]
 				}
 			],
@@ -30740,13 +31078,13 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Bursting Pod",
 					"entries": [
-						"Melee Ranged Attack: {@hit +8} to hit, range 30/120 ft., one target. Hit: 8 ({@dice 1d6+5}) bludgeoning damage, and the target and all creatures within 5 feet of it also take 5 ({@dice 2d4}) piercing damage, or half as much piercing damage with a successful DC 15 Dexterity saving throw."
+						"Melee Ranged Attack: {@hit 8} to hit, range 30/120 ft., one target. Hit: 8 ({@dice 1d6+5}) bludgeoning damage, and the target and all creatures within 5 feet of it also take 5 ({@dice 2d4}) piercing damage, or half as much piercing damage with a successful DC 15 Dexterity saving throw."
 					]
 				},
 				{
@@ -30848,7 +31186,7 @@
 				{
 					"name": "Radiant Runestaff",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d8}) bludgeoning damage plus 4 ({@dice 1d8}) radiant damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d8}) bludgeoning damage plus 4 ({@dice 1d8}) radiant damage."
 					]
 				}
 			],
@@ -30957,19 +31295,19 @@
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 150/600 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 150/600 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Peck",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Rapier",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
 					]
 				}
 			],
@@ -31054,19 +31392,19 @@
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 150/600 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 150/600 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Peck",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Radiant Runespear",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d12+1}) piercing damage plus 2 ({@dice 1d4}) radiant damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d12+1}) piercing damage plus 2 ({@dice 1d4}) radiant damage."
 					]
 				}
 			],
@@ -31087,7 +31425,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -31150,7 +31488,7 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) slashing damage."
 					]
 				},
 				{
@@ -31271,13 +31609,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 3 ({@dice 1d6}) poison damage and be poisoned until the start of the spider's next turn. The target fails the saving throw automatically and takes an extra {@dice 1d6} poison damage if it is bitten by another red-banded line spider while poisoned this way."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must succeed on a DC 10 Constitution saving throw or take 3 ({@dice 1d6}) poison damage and be poisoned until the start of the spider's next turn. The target fails the saving throw automatically and takes an extra {@dice 1d6} poison damage if it is bitten by another red-banded line spider while poisoned this way."
 					]
 				},
 				{
 					"name": "Swingline",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 60 ft., one target. Hit: the spider immediately moves the full length of the webbing (up to 60 feet) to the target and delivers a bite with advantage. This attack can be used only if the spider is higher than its target and at least 10 feet away."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 60 ft., one target. Hit: the spider immediately moves the full length of the webbing (up to 60 feet) to the target and delivers a bite with advantage. This attack can be used only if the spider is higher than its target and at least 10 feet away."
 					]
 				}
 			],
@@ -31290,7 +31628,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -31369,13 +31707,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage and the creature is bleeding profusely. A bleeding creature must make a successful DC 15 Constitution saving throw at the start of its turn or take 10 ({@dice 3d6}) necrotic damage and continue bleeding. On a successful save the creature takes no necrotic damage and the effect ends. A creature takes only 10 necrotic damage per turn from this effect no matter how many times it's been bitten, and a single successful saving throw ends all bleeding. Spending an action to make a successful DC 15 Wisdom (Medicine) check or any amount of magical healing also stops the bleeding. Constructs and undead are immune to the bleeding effect."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage and the creature is bleeding profusely. A bleeding creature must make a successful DC 15 Constitution saving throw at the start of its turn or take 10 ({@dice 3d6}) necrotic damage and continue bleeding. On a successful save the creature takes no necrotic damage and the effect ends. A creature takes only 10 necrotic damage per turn from this effect no matter how many times it's been bitten, and a single successful saving throw ends all bleeding. Spending an action to make a successful DC 15 Wisdom (Medicine) check or any amount of magical healing also stops the bleeding. Constructs and undead are immune to the bleeding effect."
 					]
 				},
 				{
 					"name": "Pike",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d10+5}) piercing damage."
 					]
 				}
 			],
@@ -31431,10 +31769,10 @@
 					"entries": [
 						"50% of rift swine have additional mutant features. Choose or roll {@dice 1d6} on the table below.",
 						"1. Acid boils. A creature that hits the rift swine with a melee attack must make a successful DC 12 Dexterity saving throw or take 3 ({@dice 1d6}) acid damage.",
-						"2. Tentacular Tongue. Instead of using its tusks, the rift swine can attack with its tongue: Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d4+4}) bludgeoning damage. If the target is a creature, it is grappled and restrained as with a tentacle attack (escape DC 14).",
+						"2. Tentacular Tongue. Instead of using its tusks, the rift swine can attack with its tongue: Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d4+4}) bludgeoning damage. If the target is a creature, it is grappled and restrained as with a tentacle attack (escape DC 14).",
 						"3. Covered in Slime. Increase the rift swine's AC by 1.",
 						"4. Acid Saliva. The rift swine's tusk or tongue attack does an additional 3 ({@dice 1d6}) acid damage.",
-						"5. Poison spit. Ranged Weapon Attack: {@hit +3} to hit, range 15 ft., one target. Hit: 6 ({@dice 1d12}) poison damage.",
+						"5. Poison spit. Ranged Weapon Attack: {@hit 3} to hit, range 15 ft., one target. Hit: 6 ({@dice 1d12}) poison damage.",
 						"6. Roll twice."
 					]
 				}
@@ -31449,13 +31787,13 @@
 				{
 					"name": "Tusks",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Tentacle",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 11 ({@dice 2d6+4}) bludgeoning damage. If the target is a creature, it is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the rift swine can't use this tentacle against another target."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 11 ({@dice 2d6+4}) bludgeoning damage. If the target is a creature, it is grappled (escape DC 14). Until this grapple ends, the target is restrained, and the rift swine can't use this tentacle against another target."
 					]
 				}
 			],
@@ -31530,13 +31868,13 @@
 				{
 					"name": "Tendril",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Gnash",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
 					]
 				}
 			],
@@ -31599,7 +31937,7 @@
 				{
 					"name": "Infused Arsenal",
 					"entries": [
-						"As a bonus action, the risen reaver can absorb one unattended weapon into its body. For every weapon it absorbs, it deals +1 damage with its blade attacks."
+						"As a bonus action, the risen reaver can absorb one unattended weapon into its body. For every weapon it absorbs, it deals +1 damage with its blade attacks (maximum of +3)."
 					]
 				},
 				{
@@ -31619,7 +31957,7 @@
 				{
 					"name": "Blade",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one creature. Hit: 15 ({@dice 2d10+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one creature. Hit: 15 ({@dice 2d10+4}) slashing damage."
 					]
 				}
 			],
@@ -31721,13 +32059,13 @@
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage or 10 ({@dice 1d10+5}) slashing damage if used with two hands, plus 10 ({@dice 3d6}) lightning damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) slashing damage or 10 ({@dice 1d10+5}) slashing damage if used with two hands, plus 10 ({@dice 3d6}) lightning damage."
 					]
 				},
 				{
 					"name": "Flood Blast",
 					"entries": [
-						"Ranged Spell Attack: {@hit +8} to hit, range 120 ft., one target. Hit: 18 ({@dice 4d8}) bludgeoning damage. A target creature must succeed on a DC 16 Strength saving throw or be knocked prone and shifted up to 60 feet at the River King's choosing."
+						"Ranged Spell Attack: {@hit 8} to hit, range 120 ft., one target. Hit: 18 ({@dice 4d8}) bludgeoning damage. A target creature must succeed on a DC 16 Strength saving throw or be knocked prone and pushed up to 60 feet at the River King's choosing."
 					]
 				},
 				{
@@ -31771,7 +32109,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The River King's innate spellcasting ability score is Charisma (save DC 16, {@hit 8} to hit with spell attacks). The River King can innately cast the following spells, requiring no material components."
+						"The River King's innate spellcasting ability score is Charisma (save DC 16, {@hit 8} to hit with spell attacks). The River King can innately cast the following spells, requiring no material components:"
 					],
 					"will": [
 						"{@spell create or destroy water}",
@@ -31862,13 +32200,13 @@
 				{
 					"name": "Begrimed Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 7 ({@dice 2d6}) poison damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage plus 7 ({@dice 2d6}) poison damage."
 					]
 				},
 				{
 					"name": "Begrimed Dart",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage plus 7 ({@dice 2d6}) poison damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage plus 7 ({@dice 2d6}) poison damage."
 					]
 				}
 			],
@@ -31940,13 +32278,13 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Dart",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 20/60 ft., one target. Hit: 4 ({@dice 1d4+2}) piercing damage."
 					]
 				}
 			],
@@ -31959,7 +32297,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -32035,7 +32373,7 @@
 				{
 					"name": "Wind of Decay",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 0 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage plus 14 ({@dice 4d6}) necrotic damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or be cursed with tomb rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 ({@dice 3d6}) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies and its body turns to dust. The curse lasts until removed by the remove curse spell or comparable magic."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 0 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage plus 14 ({@dice 4d6}) necrotic damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or be cursed with tomb rot. The cursed target can't regain hit points, and its hit point maximum decreases by 10 ({@dice 3d6}) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies and its body turns to dust. The curse lasts until removed by the remove curse spell or comparable magic."
 					]
 				}
 			],
@@ -32142,13 +32480,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 15 ({@dice 3d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 15 ({@dice 3d6+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) piercing damage and a target creature must succeed on a DC 15 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) piercing damage and a target creature must succeed on a DC 15 Strength saving throw or be knocked prone."
 					]
 				},
 				{
@@ -32238,13 +32576,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, range 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, range 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, range 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, range 5 ft., one target. Hit: 6 ({@dice 1d6+3}) slashing damage."
 					]
 				},
 				{
@@ -32342,7 +32680,7 @@
 				{
 					"name": "Breathless Kiss",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: the target is grappled (escape DC 13) and the rusalka draws all the air from the target's lungs with a kiss. If the rusalka has movement remaining, she drags the grappled creature into deep water, where it begins suffocating."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: the target is grappled (escape DC 13) and the rusalka draws all the air from the target's lungs with a kiss. If the rusalka has movement remaining, she drags the grappled creature into deep water, where it begins suffocating."
 					]
 				},
 				{
@@ -32434,13 +32772,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) piercing damage, and the target must succeed on a DC 16 Constitution save or contract Rust Drake Tetanus."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) piercing damage, and the target must succeed on a DC 16 Constitution save or contract Rust Drake Tetanus."
 					]
 				},
 				{
 					"name": "Tail Swipe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) bludgeoning damage."
 					]
 				},
 				{
@@ -32550,7 +32888,7 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage. If the target is neither undead nor a construct, it also takes 5 ({@dice 1d10}) necrotic damage, or half damage with a successful DC 15 Constitution saving throw. Plants, oozes, and creatures with the Amphibious, Water Breathing, or Water Form traits have disadvantage on this saving throw. If the saving throw fails by 5 or more, the target also gains one level of exhaustion."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage. If the target is neither undead nor a construct, it also takes 5 ({@dice 1d10}) necrotic damage, or half damage with a successful DC 15 Constitution saving throw. Plants, oozes, and creatures with the Amphibious, Water Breathing, or Water Form traits have disadvantage on this saving throw. If the saving throw fails by 5 or more, the target also gains one level of exhaustion."
 					]
 				}
 			],
@@ -32676,7 +33014,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 27 ({@dice 5d8+5}) bludgeoning damage and the target must make a successful DC 17 Constitution saving throw or gain one level of exhaustion."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 27 ({@dice 5d8+5}) bludgeoning damage and the target must make a successful DC 17 Constitution saving throw or gain one level of exhaustion."
 					]
 				}
 			],
@@ -32753,7 +33091,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage. If the target is a creature, it must make a successful DC 12 Constitution saving throw or gain one level of exhaustion."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage. If the target is a creature, it must make a successful DC 12 Constitution saving throw or gain one level of exhaustion."
 					]
 				},
 				{
@@ -32795,7 +33133,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -32886,7 +33224,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) bludgeoning damage. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the sand silhouette engulfs it."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) bludgeoning damage. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 14), and the sand silhouette engulfs it."
 					]
 				},
 				{
@@ -32966,13 +33304,13 @@
 				{
 					"name": "Impaling Leg",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage. If the sand spider scores a critical hit with this attack, it rolls damage dice three times instead of twice. If both impaling leg attacks hit the same target, the second hit does an extra 11 ({@dice 1d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage. If the sand spider scores a critical hit with this attack, it rolls damage dice three times instead of twice. If both impaling leg attacks hit the same target, the second hit does an extra 11 ({@dice 1d12+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one creature. Hit: 16 ({@dice 2d10+5}) piercing damage plus 13 ({@dice 3d8}) poison damage, or half as much poison damage with a successful DC 13 Constitution saving throw."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one creature. Hit: 16 ({@dice 2d10+5}) piercing damage plus 13 ({@dice 3d8}) poison damage, or half as much poison damage with a successful DC 13 Constitution saving throw."
 					]
 				}
 			],
@@ -33074,7 +33412,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				}
 			],
@@ -33162,19 +33500,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 11 ({@dice 1d12+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage plus 24 ({@dice 7d6}) poison damage, or half as much poison damage with a successful DC 15 Constitution saving throw. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned and paralyzed for 1 hour. Regaining hit points doesn't end the poisoning or paralysis."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage plus 24 ({@dice 7d6}) poison damage, or half as much poison damage with a successful DC 15 Constitution saving throw. If the poison damage reduces the target to 0 hit points, the target is stable but poisoned and paralyzed for 1 hour. Regaining hit points doesn't end the poisoning or paralysis."
 					]
 				}
 			],
@@ -33261,7 +33599,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) bludgeoning damage. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 12), and the sap demon uses Soul Sap on it as a bonus action."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) bludgeoning damage. If both attacks hit a Medium or smaller target, the target is grappled (escape DC 12), and the sap demon uses Soul Sap on it as a bonus action."
 					]
 				},
 				{
@@ -33280,7 +33618,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -33344,7 +33682,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) bludgeoning damage plus 14 ({@dice 4d6}) acid damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) bludgeoning damage plus 14 ({@dice 4d6}) acid damage."
 					]
 				},
 				{
@@ -33369,7 +33707,7 @@
 			"type": "elemental",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -33452,7 +33790,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 24 ({@dice 4d8+6}) piercing damage. If the target is a Large or smaller creature, it must succeed on a DC 18 Dexterity saving throw or be swallowed by the sathaq worm. A swallowed creature is blinded and restrained, has total cover against attacks and other effects outside the worm, and takes 7 ({@dice 2d6}) bludgeoning damage plus 7 ({@dice 2d6}) slashing damage plus 7 ({@dice 2d6}) acid damage at the start of each of the sathaq worm's turns. The sathaq worm can have only one creature swallowed at a time. If the sathaq worm takes 20 damage or more on a single turn from a creature inside it, the sathaq worm must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate the swallowed creature, which falls prone in a space within 5 feet of the sathaq worm. If the sathaq worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 10 feet of movement, exiting prone."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 24 ({@dice 4d8+6}) piercing damage. If the target is a Large or smaller creature, it must succeed on a DC 18 Dexterity saving throw or be swallowed by the sathaq worm. A swallowed creature is blinded and restrained, has total cover against attacks and other effects outside the worm, and takes 7 ({@dice 2d6}) bludgeoning damage plus 7 ({@dice 2d6}) slashing damage plus 7 ({@dice 2d6}) acid damage at the start of each of the sathaq worm's turns. The sathaq worm can have only one creature swallowed at a time. If the sathaq worm takes 20 damage or more on a single turn from a creature inside it, the sathaq worm must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate the swallowed creature, which falls prone in a space within 5 feet of the sathaq worm. If the sathaq worm dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 10 feet of movement, exiting prone."
 					]
 				}
 			],
@@ -33465,7 +33803,7 @@
 			"type": "beast",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -33538,13 +33876,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d12+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d12+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 38 ({@dice 5d12+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 38 ({@dice 5d12+6}) slashing damage."
 					]
 				}
 			],
@@ -33611,13 +33949,13 @@
 				{
 					"name": "Heavy Pick",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Hand Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 30/120 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 30/120 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				}
 			],
@@ -33654,7 +33992,10 @@
 							"{@spell dominate person}",
 							"{@spell hold person}"
 						]
-					}
+					},
+					"footerEntries": [
+						"* The scheznyki casts these spells on itself before combat."
+					]
 				}
 			],
 			"tokenURL": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/ToB%20(3pp)/Scheznyki.png"
@@ -33723,13 +34064,13 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage plus 3 ({@dice 1d6}) poison damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage plus 3 ({@dice 1d6}) poison damage."
 					]
 				},
 				{
 					"name": "Sling",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, range 30/120 ft., one target. Hit: 4 ({@dice 1d4+2}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 4} to hit, range 30/120 ft., one target. Hit: 4 ({@dice 1d4+2}) bludgeoning damage."
 					]
 				}
 			],
@@ -33742,7 +34083,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -33789,7 +34130,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d10+3}) piercing damage plus 3 ({@dice 1d6}) cold damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d10+3}) piercing damage plus 3 ({@dice 1d6}) cold damage."
 					]
 				},
 				{
@@ -33869,19 +34210,19 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d4+4}) piercing damage, plus sleep poison."
+						"Melee or Ranged Weapon Attack: {@hit 6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d4+4}) piercing damage, plus sleep poison."
 					]
 				},
 				{
 					"name": "Short Bow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 80/320, one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus sleep poison."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 80/320, one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus sleep poison."
 					]
 				},
 				{
 					"name": "Sleep Poison",
 					"entries": [
-						"Dark satyrs coat their weapons with a sleep poison made from the brain fluids of dorreqi. Any creature not immune to poison injured by a selang blade or arrow must succeed on a DC 14 Constitution saving throw or fall asleep for {@dice 2d6} rounds."
+						"An injured creature must succeed on a DC 14 Constitution saving throw or be poisoned for {@dice 2d6} ` rounds. A creature poisoned in this way is unconscious. An unconscious creature wakes if it takes damage, or if a creature uses its action to shake it awake."
 					]
 				},
 				{
@@ -33975,13 +34316,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 10 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 10 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
 					]
 				},
 				{
@@ -34083,7 +34424,7 @@
 				{
 					"name": "Nabboot",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d4+5}) bludgeoning damage plus 7 ({@dice 2d6}) necrotic damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or be cursed with tomb taint. The cursed target's speed is reduced to half, and its hit point maximum decreases by 3 ({@dice 1d6}) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies and its body turns to dust. The curse lasts until removed by the remove curse spell or comparable magic."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d4+5}) bludgeoning damage plus 7 ({@dice 2d6}) necrotic damage. If the target is a creature, it must succeed on a DC 15 Constitution saving throw or be cursed with tomb taint. The cursed target's speed is reduced to half, and its hit point maximum decreases by 3 ({@dice 1d6}) for every 24 hours that elapse. If the curse reduces the target's hit point maximum to 0, the target dies and its body turns to dust. The curse lasts until removed by the remove curse spell or comparable magic."
 					]
 				},
 				{
@@ -34162,13 +34503,13 @@
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Hooves",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 12 ({@dice 3d6+2}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 12 ({@dice 3d6+2}) bludgeoning damage."
 					]
 				}
 			],
@@ -34251,9 +34592,9 @@
 					]
 				},
 				{
-					"name": "Sunlight Powerlessness",
+					"name": "Sunlight Sensitivity",
 					"entries": [
-						"The shadow beast is utterly powerless in bright light or natural sunlight and flees from it. A shadow beast caught in such light cannot attack and can take only a single move action."
+						"While in sunlight, the shadow beast has disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight."
 					]
 				}
 			],
@@ -34267,13 +34608,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d8+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d10+5}) slashing damage."
 					]
 				},
 				{
@@ -34367,13 +34708,13 @@
 				{
 					"name": "Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 80/320 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage."
 					]
 				}
 			],
@@ -34382,7 +34723,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components."
+						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components:"
 					],
 					"daily": {
 						"1": [
@@ -34474,13 +34815,13 @@
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +8} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage, and a target creature must succeed on a DC 15 Constitution saving throw or become poisoned for 1 minute. A poisoned creature repeats the save at the end of each of its turns, ending the effect on a success."
+						"Melee or Ranged Weapon Attack: {@hit 8} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d4+5}) piercing damage, and a target creature must succeed on a DC 15 Constitution saving throw or become poisoned for 1 minute. A poisoned creature repeats the save at the end of each of its turns, ending the effect on a success."
 					]
 				},
 				{
 					"name": "Rapier",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage plus 7 ({@dice 2d6}) poison damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d8+5}) piercing damage plus 7 ({@dice 2d6}) poison damage."
 					]
 				}
 			],
@@ -34497,7 +34838,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components."
+						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components:"
 					],
 					"daily": {
 						"3": [
@@ -34589,7 +34930,7 @@
 				{
 					"name": "Rapier",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage plus 17 ({@dice 5d6}) psychic damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage plus 17 ({@dice 5d6}) psychic damage."
 					]
 				},
 				{
@@ -34601,7 +34942,7 @@
 				{
 					"name": "Leadership (Recharges after a Short or Long Rest)",
 					"entries": [
-						"The enchantress can utter a special command or warning to a creature she can see within 30 feet of her. The creature must not be hostile to the enchantress and it must be able to hear (the command is inaudible to all but the target creature). For 1 minute, the creature adds a d4 to its attack rolls and saving throws. A creature can benefit from only one enchantress's Leadership at a time. This effect ends if the enchantress is incapacitated."
+						"The enchantress can utter a special command or warning to a creature she can see within 30 feet of her. The creature must not be hostile to the enchantress and it must be able to hear (the command is inaudible to all but the target creature). For 1 minute, the creature adds {@dice 1d4} to its attack rolls and saving throws. A creature can benefit from only one enchantress's Leadership at a time. This effect ends if the enchantress is incapacitated."
 					]
 				}
 			],
@@ -34610,7 +34951,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The shadow fey's innate spellcasting ability is Charisma. She can cast the following spells innately, requiring no material components."
+						"The shadow fey's innate spellcasting ability is Charisma. She can cast the following spells innately, requiring no material components:"
 					],
 					"daily": {
 						"4": [
@@ -34762,13 +35103,13 @@
 				{
 					"name": "Rapier",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +7} to hit, range 150/600 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage plus 7 ({@dice 2d6}) poison damage."
+						"Ranged Weapon Attack: {@hit 7} to hit, range 150/600 ft., one target. Hit: 8 ({@dice 1d8+4}) piercing damage plus 7 ({@dice 2d6}) poison damage."
 					]
 				}
 			],
@@ -34777,7 +35118,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components."
+						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components:"
 					],
 					"daily": {
 						"3": [
@@ -34799,7 +35140,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -34875,13 +35216,13 @@
 				{
 					"name": "Pike",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d10+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Javelin",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 30/120 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 30/120 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage."
 					]
 				}
 			],
@@ -34898,7 +35239,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components."
+						"The shadow fey's innate spellcasting ability is Charisma. It can cast the following spells innately, requiring no material components:"
 					],
 					"daily": {
 						"1": [
@@ -34956,7 +35297,7 @@
 			"vulnerable": [
 				"bludgeoning"
 			],
-			"senses": "darkvision 60 ft., blindsense 30 ft.",
+			"senses": "darkvision 60 ft., blindsight 30 ft.",
 			"passive": 11,
 			"languages": "understands the languages of its creator but can't speak",
 			"cr": "1",
@@ -34970,13 +35311,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the sharkjaw skeleton can bite only the grappled creature and has advantage on attack rolls to do so."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage. If the target is a Large or smaller creature, it is grappled (escape DC 13). Until this grapple ends, the sharkjaw skeleton can bite only the grappled creature and has advantage on attack rolls to do so."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
 					]
 				}
 			],
@@ -34989,7 +35330,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -35056,13 +35397,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 15 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage and the target is grappled (escape DC 13), restrained, and poisoned (DC 13 Strength saving throw negates, lasts while grappled and 1 round after). The shellycoat can shift the position of a grappled creature by up to 15 feet as a bonus action. While it has a creature grappled, the shellycoat can use its claws attack only against the grappled creature."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 15 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage and the target is grappled (escape DC 13), restrained, and poisoned (DC 13 Strength saving throw negates, lasts while grappled and 1 round after). The shellycoat can shift the position of a grappled creature by up to 15 feet as a bonus action. While it has a creature grappled, the shellycoat can use its claws attack only against the grappled creature."
 					]
 				}
 			],
@@ -35126,6 +35467,18 @@
 				"bludgeoning",
 				"piercing"
 			],
+			"immune": [
+				"cold",
+				"thunder",
+				"slashing"
+			],
+			"conditionImmune": [
+				"blinded",
+				"deafened",
+				"prone",
+				"stunned",
+				"unconscious"
+			],
 			"senses": "darkvision 120 ft., tremorsense 60 ft.",
 			"passive": 19,
 			"languages": "Void Speech",
@@ -35178,7 +35531,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +14} to hit, reach 15 ft., one target. Hit: 30 ({@dice 4d10+8}) bludgeoning damage, and the target is grappled (escape DC 18) and restrained. The shoggoth can grapple any number of creatures simultaneously, and this has no effect on its number of attacks."
+						"Melee Weapon Attack: {@hit 14} to hit, reach 15 ft., one target. Hit: 30 ({@dice 4d10+8}) bludgeoning damage, and the target is grappled (escape DC 18) and restrained. The shoggoth can grapple any number of creatures simultaneously, and this has no effect on its number of attacks."
 					]
 				}
 			],
@@ -35191,7 +35544,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -35288,7 +35641,7 @@
 				{
 					"name": "Strength Drain",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one creature. Hit: 3 ({@dice 1d4+1}) necrotic damage, and the target's Strength score is reduced by one-half that amount. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest. If a non-evil humanoid dies from this attack, a new shadow rises from the corpse {@dice 1d4} hours later."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one creature. Hit: 3 ({@dice 1d4+1}) necrotic damage, and the target's Strength score is reduced by one-half that amount. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest. If a non-evil humanoid dies from this attack, a new shadow rises from the corpse {@dice 1d4} hours later."
 					]
 				}
 			],
@@ -35383,7 +35736,7 @@
 				{
 					"name": "Inexorable Threads",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 30 ft., one target. Hit: 27 ({@dice 5d8+5}) radiant damage, and the target is \"one step closer to death.\" If the target is reduced to 0 hit points, it's treated as if it's already failed one death saving throw. This effect is cumulative; each inexorable threads hit adds one unsuccessful death saving throw. If a character who's been hit three or more times by inexorable threads is reduced to 0 hit points, he or she dies immediately. This effect lasts until the character completes a long rest."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 30 ft., one target. Hit: 27 ({@dice 5d8+5}) radiant damage, and the target is \"one step closer to death.\" If the target is reduced to 0 hit points, it's treated as if it's already failed one death saving throw. This effect is cumulative; each inexorable threads hit adds one unsuccessful death saving throw. If a character who's been hit three or more times by inexorable threads is reduced to 0 hit points, he or she dies immediately. This effect lasts until the character completes a long rest."
 					]
 				},
 				{
@@ -35408,7 +35761,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -35457,7 +35810,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage and the target must make a successful DC 10 Constitution saving throw or be paralyzed for {@dice 1d4} rounds. In addition, the skin bat attaches itself to the target. The skin bat can't bite a different creature while it's attached, and its bite attack automatically hits a creature the skin bat is attached to. Removing a skin bat requires a successful DC 11 Strength check and inflicts 5 ({@dice 1d4+3}) slashing damage to the creature the bat is being removed from. A successful save renders the target immune to skin bat poison for 24 hours."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage and the target must make a successful DC 10 Constitution saving throw or be paralyzed for {@dice 1d4} rounds. In addition, the skin bat attaches itself to the target. The skin bat can't bite a different creature while it's attached, and its bite attack automatically hits a creature the skin bat is attached to. Removing a skin bat requires a successful DC 11 Strength check and inflicts 5 ({@dice 1d4+3}) slashing damage to the creature the bat is being removed from. A successful save renders the target immune to skin bat poison for 24 hours."
 					]
 				}
 			],
@@ -35531,13 +35884,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) slashing damage plus 5 ({@dice 1d10}) acid damage, and the target is grappled (escape DC 12). The skitterhaunt has two claws, each of which can grapple one target."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) slashing damage plus 5 ({@dice 1d10}) acid damage, and the target is grappled (escape DC 12). The skitterhaunt has two claws, each of which can grapple one target."
 					]
 				},
 				{
 					"name": "Sting",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d10+2}) piercing damage plus 5 ({@dice 1d10}) acid damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d10+2}) piercing damage plus 5 ({@dice 1d10}) acid damage."
 					]
 				},
 				{
@@ -35616,7 +35969,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 15 ft., one target. Hit: 31 ({@dice 4d12+5}) bludgeoning damage plus 9 ({@dice 2d8}) piercing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 15 ft., one target. Hit: 31 ({@dice 4d12+5}) bludgeoning damage plus 9 ({@dice 2d8}) piercing damage."
 					]
 				},
 				{
@@ -35723,7 +36076,7 @@
 				{
 					"name": "Chilling Touch",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 28 ({@dice 8d6}) cold damage or 14 ({@dice 4d6}) cold damage if the swarm has half of its hit points or fewer. The target must make a successful DC 13 Constitution saving throw or be unable to regain hit points. An affected creature repeats the saving throw at the end of its turns, ending the effect on itself with a successful save. The effect can also be ended with a greater restoration spell or comparable magic."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 28 ({@dice 8d6}) cold damage or 14 ({@dice 4d6}) cold damage if the swarm has half of its hit points or fewer. The target must make a successful DC 13 Constitution saving throw or be unable to regain hit points. An affected creature repeats the saving throw at the end of its turns, ending the effect on itself with a successful save. The effect can also be ended with a greater restoration spell or comparable magic."
 					]
 				}
 			],
@@ -35805,7 +36158,7 @@
 				{
 					"name": "Absorb Magic",
 					"entries": [
-						"As a bonus action, the golem targets any creature, object, or magical effect within 10 feet of it. The golem chooses a spell already cast on the target. If the spell is of 3rd level or lower, the golem absorbs the spell and it ends. If the spell is of 4th level or higher, the golem must make a check with a +9 modifier. The DC equals 10+the spell's level. On a successful check, the golem absorbs the spell and it ends. The golem's body glows when it absorbs a spell, as if under the effect of a light spell. A smaragdine golem can only hold one absorbed spell at a time."
+						"As a bonus action, the golem targets any creature, object, or magical effect within 10 feet of it. The golem chooses a spell already cast on the target. If the spell is of 3rd level or lower, the golem absorbs the spell and it ends. If the spell is of 4th level or higher, the golem must make a check with a +9 modifier. The DC equals 10 + the spell's level. On a successful check, the golem absorbs the spell and it ends. The golem's body glows when it absorbs a spell, as if under the effect of a light spell. A smaragdine golem can only hold one absorbed spell at a time."
 					]
 				}
 			],
@@ -35819,7 +36172,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 25 ({@dice 4d8+7}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 25 ({@dice 4d8+7}) bludgeoning damage."
 					]
 				},
 				{
@@ -35838,7 +36191,7 @@
 			"type": "fey",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -35923,13 +36276,13 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 7 ({@dice 2d6}) cold damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage plus 7 ({@dice 2d6}) cold damage."
 					]
 				},
 				{
 					"name": "Ice Crown",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +9} to hit, range 80/320ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage plus 7 ({@dice 2d6}) cold damage. The target's speed is reduced by 10 feet until the end of its next turn."
+						"Ranged Weapon Attack: {@hit 9} to hit, range 80/320ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage plus 7 ({@dice 2d6}) cold damage. The target's speed is reduced by 10 feet until the end of its next turn."
 					]
 				},
 				{
@@ -35973,7 +36326,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The Snow Queen's innate spellcasting ability score is Charisma (save DC 17, {@hit 9} to hit with spell attacks). The Snow Queen can innately cast the following spells, requiring no material components."
+						"The Snow Queen's innate spellcasting ability score is Charisma (save DC 17, {@hit 9} to hit with spell attacks). The Snow Queen can innately cast the following spells, requiring no material components:"
 					],
 					"will": [
 						"{@spell fog cloud}",
@@ -36096,13 +36449,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d10+8}) piercing damage plus 5 ({@dice 1d10}) poison damage, and the target is grappled (escape DC 18). If the target was already grappled, it is swallowed instead. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects from outside the son of Fenris, and it takes 28 ({@dice 8d6}) acid damage at the start of each of the son of Fenris's turns. It can swallow only one creature at a time. If it takes 45 damage or more on a single turn from the swallowed creature, it must succeed on a DC 17 Constitution saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 feet of the son of Fenris. If the son of Fenris dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 feet of movement, exiting prone."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d10+8}) piercing damage plus 5 ({@dice 1d10}) poison damage, and the target is grappled (escape DC 18). If the target was already grappled, it is swallowed instead. While swallowed, the target is blinded and restrained, it has total cover against attacks and other effects from outside the son of Fenris, and it takes 28 ({@dice 8d6}) acid damage at the start of each of the son of Fenris's turns. It can swallow only one creature at a time. If it takes 45 damage or more on a single turn from the swallowed creature, it must succeed on a DC 17 Constitution saving throw at the end of that turn or regurgitate the creature, which falls prone in a space within 10 feet of the son of Fenris. If the son of Fenris dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 15 feet of movement, exiting prone."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 15 ft., one target. Hit: 19 ({@dice 2d10+8}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 15 ft., one target. Hit: 19 ({@dice 2d10+8}) bludgeoning damage."
 					]
 				},
 				{
@@ -36198,7 +36551,7 @@
 			"type": "fiend",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -36275,7 +36628,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage plus 7 ({@dice 2d6}) psychic damage, or half as much psychic damage with a successful DC 15 Constitution saving throw."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage plus 7 ({@dice 2d6}) psychic damage, or half as much psychic damage with a successful DC 15 Constitution saving throw."
 					]
 				},
 				{
@@ -36359,7 +36712,7 @@
 				{
 					"name": "Inhabit",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: The target must succeed on a DC 14 Charisma saving throw or become dominated by the spark, as the dominate person spell. The spark instantly enters the target's space and merges into the target's physical form. While inhabiting a creature, a spark takes no damage from physical attacks. The target creature receives a +4 bonus to its Dexterity and Charisma scores while it's inhabited. The speech and actions of an inhabited creature are noticeably jerky and erratic to any creature with passive Perception 14 or higher.",
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: The target must succeed on a DC 14 Charisma saving throw or become dominated by the spark, as the dominate person spell. The spark instantly enters the target's space and merges into the target's physical form. While inhabiting a creature, a spark takes no damage from physical attacks. The target creature receives a +4 bonus to its Dexterity and Charisma scores while it's inhabited. The speech and actions of an inhabited creature are noticeably jerky and erratic to any creature with passive Perception 14 or higher.",
 						"Each time the spark uses innate spellcasting, the host can attempt another DC 14 Charisma saving throw. A successful save expels the spark, which appears in an unoccupied space within 5 feet of the former host.",
 						"The inhabiting spark slowly burns out its host's nervous system. The inhabited creature must make a successful DC 15 Constitution saving throw at the end of each 24 hour-period or take {@dice 2d6} lightning damage and have its maximum hit points reduced by the same amount. The creature dies if this damage reduces its hit point maximum to 0. The reduction lasts until the inhabited creature completes a long rest after the spark is expelled."
 					]
@@ -36460,13 +36813,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d10+2}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d10+2}) piercing damage."
 					]
 				},
 				{
 					"name": "Sting",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) piercing damage plus 5 ({@dice 1d10}) poison damage, and the target must succeed on a DC 15 Constitution saving throw or become poisoned for {@dice 1d6} rounds."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d8+2}) piercing damage plus 5 ({@dice 1d10}) poison damage, and the target must succeed on a DC 15 Constitution saving throw or become poisoned for {@dice 1d6} rounds."
 					]
 				}
 			],
@@ -36476,7 +36829,12 @@
 		{
 			"name": "Spawn of Arbeyach",
 			"size": "M",
-			"type": "aberration",
+			"type": {
+				"type": "fiend",
+				"tags": [
+					"devil"
+				]
+			},
 			"source": "ToB 3pp",
 			"alignment": [
 				"L",
@@ -36545,13 +36903,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage plus 4 ({@dice 1d8}) poison damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) piercing damage plus 4 ({@dice 1d8}) poison damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage plus 9 ({@dice 2d8}) poison damage. If the target is a creature, it must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage plus 9 ({@dice 2d8}) poison damage. If the target is a creature, it must succeed on a DC 13 Constitution saving throw or be poisoned for 1 minute. A poisoned creature repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -36577,7 +36935,7 @@
 			"type": "undead",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -36668,7 +37026,7 @@
 				{
 					"name": "Spectral Rend",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) necrotic damage. If the target is a creature, it must succeed on a DC 14 Wisdom saving throw or be frightened and have its speed reduced to 0; both effects last until the end of its next turn."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) necrotic damage. If the target is a creature, it must succeed on a DC 14 Wisdom saving throw or be frightened and have its speed reduced to 0; both effects last until the end of its next turn."
 					]
 				}
 			],
@@ -36758,19 +37116,19 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage plus 4 ({@dice 1d8}) poison damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage plus 4 ({@dice 1d8}) poison damage."
 					]
 				},
 				{
 					"name": "Spit Venom",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 60 ft., one target. Hit: 16 ({@dice 3d8+3}) poison damage, and the target must make a successful DC 14 Constitution saving throw or be poisoned and blinded until the end of its next turn."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 60 ft., one target. Hit: 16 ({@dice 3d8+3}) poison damage, and the target must make a successful DC 14 Constitution saving throw or be poisoned and blinded until the end of its next turn."
 					]
 				},
 				{
 					"name": "Staff of Leng",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) bludgeoning damage plus 13 ({@dice 2d12}) psychic damage, and the target must make a successful DC 15 Wisdom saving throw or be stunned until the start of the spider's next turn."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) bludgeoning damage plus 13 ({@dice 2d12}) psychic damage, and the target must make a successful DC 15 Wisdom saving throw or be stunned until the start of the spider's next turn."
 					]
 				}
 			],
@@ -36892,13 +37250,13 @@
 				{
 					"name": "Sickle Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d8+1}) slashing damage."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d8+1}) slashing damage."
 					]
 				},
 				{
 					"name": "Razor Line (Recharge 5—6)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +3} to hit, reach 15 ft., one target. Hit: 3 ({@dice 1d4+1}) slashing damage, and the target is grappled (escape DC 10). Instead of moving, the spider thief can retract the razor line and pull itself onto the grappled creature (the spider thief enters and remains in the target's space). The spider thief's sickle claw attacks have advantage against a grappled creature in the same space. If the grappled creature escapes, the spider thief immediately displaces into an unoccupied space within 5 feet."
+						"Melee Weapon Attack: {@hit 3} to hit, reach 15 ft., one target. Hit: 3 ({@dice 1d4+1}) slashing damage, and the target is grappled (escape DC 10). Instead of moving, the spider thief can retract the razor line and pull itself onto the grappled creature (the spider thief enters and remains in the target's space). The spider thief's sickle claw attacks have advantage against a grappled creature in the same space. If the grappled creature escapes, the spider thief immediately displaces into an unoccupied space within 5 feet."
 					]
 				}
 			],
@@ -36964,19 +37322,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 34 ({@dice 4d12+8}) piercing damage. If the target is a Large or smaller creature, it is grappled (escape DC 18). When the spinosaurus moves, the grappled creature moves with it. Until this grapple ends, the target is restrained and the spinosaurus can't bite another target."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 34 ({@dice 4d12+8}) piercing damage. If the target is a Large or smaller creature, it is grappled (escape DC 18). When the spinosaurus moves, the grappled creature moves with it. Until this grapple ends, the target is restrained and the spinosaurus can't bite another target."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 22 ({@dice 4d6+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 22 ({@dice 4d6+8}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 20 ft., one target. Hit: 21 ({@dice 3d8+8}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 20 ft., one target. Hit: 21 ({@dice 3d8+8}) bludgeoning damage."
 					]
 				},
 				{
@@ -37075,7 +37433,7 @@
 				{
 					"name": "Lightning Dart",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 20/60 ft., one target. Hit: 1 piercing damage plus 9 ({@dice 2d8}) lightning damage. If the attack misses, the target still takes 4 ({@dice 1d8}) lightning damage. Whether the attack hits or misses its intended target, every other creature within 10 feet of the target takes 9 ({@dice 2d8}) lightning damage, or half damage with a successful DC 14 Dexterity saving throw."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 20/60 ft., one target. Hit: 1 piercing damage plus 9 ({@dice 2d8}) lightning damage. If the attack misses, the target still takes 4 ({@dice 1d8}) lightning damage. Whether the attack hits or misses its intended target, every other creature within 10 feet of the target takes 9 ({@dice 2d8}) lightning damage, or half damage with a successful DC 14 Dexterity saving throw."
 					]
 				}
 			],
@@ -37188,6 +37546,12 @@
 					"entries": [
 						"The drake's weapon attacks are magical."
 					]
+				},
+				{
+					"name": "Nimbus of Stars",
+					"entries": [
+						"The drake is surrounded by a whirling nimbus of tiny motes of starlight. A sighted creature that starts its turn within 10 feet of the drake must make a successful DC 18 Constitution saving throw or become incapacitated. At the start of a character's turn, a character can choose to avert its eyes and gain immunity against this effect until the start of its next turn, but it must treat the drake as invisible while the character's eyes are averted."
+					]
 				}
 			],
 			"action": [
@@ -37200,13 +37564,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 15 ({@dice 3d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 15 ({@dice 3d6+5}) slashing damage."
 					]
 				},
 				{
@@ -37216,15 +37580,9 @@
 					]
 				},
 				{
-					"name": "Nimbus of Stars",
-					"entries": [
-						"The drake is surrounded by a whirling nimbus of tiny motes of starlight. A sighted creature that starts its turn within 10 feet of the drake must make a successful DC 18 Constitution saving throw or become incapacitated. At the start of a character's turn, a character can choose to avert its eyes and gain immunity against this effect until the start of its next turn, but it must treat the drake as invisible while the character's eyes are averted."
-					]
-				},
-				{
 					"name": "Searing Star (1/Day)",
 					"entries": [
-						"Ranged Spell Attack: {@hit +12} to hit, range 120 ft., one target. Hit: 65 ({@dice 10d12}) force damage, and the target must succeed on a DC 18 Constitution saving throw or be permanently blinded."
+						"Ranged Spell Attack: {@hit 12} to hit, range 120 ft., one target. Hit: 65 ({@dice 10d12}) force damage, and the target must succeed on a DC 18 Constitution saving throw or be permanently blinded."
 					]
 				}
 			],
@@ -37323,6 +37681,7 @@
 				"cold",
 				"fire",
 				"lightning",
+				"poison",
 				"psychic"
 			],
 			"conditionImmune": [
@@ -37366,19 +37725,19 @@
 				{
 					"name": "Crushing Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 10 ft., one target. Hit: 20 ({@dice 2d12+7}) bludgeoning damage plus 13 ({@dice 3d8}) necrotic damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 10 ft., one target. Hit: 20 ({@dice 2d12+7}) bludgeoning damage plus 13 ({@dice 3d8}) necrotic damage."
 					]
 				},
 				{
 					"name": "Disintegrating Gaze (Recharge 5—6)",
 					"entries": [
-						"Ranged Spell Attack: {@hit +15} to hit, range 60 ft., one target in line of sight. Hit: 32 ({@dice 5d12}) necrotic damage, and the target must make a successful DC 20 Constitution saving throw or dissipate into vapor as if affected by a gaseous form spell. An affected creature repeats the saving throw at the end of each of its turns; on a success, the effect ends on that creature, but on a failure, the creature takes another 32 ({@dice 5d12}) necrotic damage and remains gaseous. A creature reduced to 0 hit points by this necrotic damage is permanently disintegrated and can be restored only by a wish or comparable magic that doesn't require some portion of a corpse to work."
+						"Ranged Spell Attack: {@hit 15} to hit, range 60 ft., one target in line of sight. Hit: 32 ({@dice 5d12}) necrotic damage, and the target must make a successful DC 20 Constitution saving throw or dissipate into vapor as if affected by a gaseous form spell. An affected creature repeats the saving throw at the end of each of its turns; on a success, the effect ends on that creature, but on a failure, the creature takes another 32 ({@dice 5d12}) necrotic damage and remains gaseous. A creature reduced to 0 hit points by this necrotic damage is permanently disintegrated and can be restored only by a wish or comparable magic that doesn't require some portion of a corpse to work."
 					]
 				},
 				{
 					"name": "Dimensional Stomp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d20+7}) bludgeoning damage, and the target must make a successful DC 15 Dexterity saving throw or be teleported to a new location as if affected by the dimension door spell. The destination is chosen by the star spawn, but it cannot be in the same space as another object or creature."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 18 ({@dice 2d20+7}) bludgeoning damage, and the target must make a successful DC 15 Dexterity saving throw or be teleported to a new location as if affected by the dimension door spell. The destination is chosen by the star spawn, but it cannot be in the same space as another object or creature."
 					]
 				}
 			],
@@ -37481,13 +37840,13 @@
 				{
 					"name": "Ax Arm",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d6+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d6+8}) slashing damage."
 					]
 				},
 				{
 					"name": "Long Axe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 40 ({@dice 5d12+8}) slashing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 40 ({@dice 5d12+8}) slashing damage."
 					]
 				},
 				{
@@ -37559,13 +37918,20 @@
 					"entries": [
 						"The stryx has advantage on Wisdom (Perception) checks that rely on hearing or sight."
 					]
+				},
+				{
+					"name": "Familiar Bond",
+					"entries": [
+						"A stryx can serve another creature as a familiar, forming a telepathic bond with its willing master. While the two are within 100 feet of each other, they can communicate telepathically, and as an action the master can use the familiar's senses for one round. During this time the master is blinded and deafened to his or her own surroundings. Additionally, as long as the stryx is within 10 feet of its master, the master can benefit from its comprehend languages innate spell.",
+						"A stryx is a normal (if odd) living creature, however, not a magically-summoned celestial, fey, or fiend, so it has significant limitations as a familiar. It can't be dismissed to a pocket dimension or magically summoned only when it's wanted. The stryx can't deliver touch-range spells. When it is more than 100 feet from its master, the two can't communicate except by prearranged signals (a hand wave or a whistle, for example). It rolls its own initiative and it can attack in combat, but if the stryx is killed, it's dead and that's that."
+					]
 				}
 			],
 			"action": [
 				{
 					"name": "Talons",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 1 slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 1 slashing damage."
 					]
 				}
 			],
@@ -37591,7 +37957,7 @@
 			"type": "fiend",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -37677,13 +38043,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 20 ({@dice 4d6+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 20 ({@dice 4d6+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 29 ({@dice 5d8+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 29 ({@dice 5d8+6}) slashing damage."
 					]
 				},
 				{
@@ -37739,13 +38105,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 1 bludgeoning damage."
 					]
 				},
 				{
 					"name": "Sting",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 1 piercing damage, plus 21 ({@dice 6d6}) poison damage and the target is poisoned until it completes a short or long rest. A successful DC 10 Constitution saving throw reduces the poison damage to half and prevents the poisoned condition. If the target fails this saving throw while already poisoned, it gains one level of exhaustion in addition to the other effects."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 1 piercing damage, plus 21 ({@dice 6d6}) poison damage and the target is poisoned until it completes a short or long rest. A successful DC 10 Constitution saving throw reduces the poison damage to half and prevents the poisoned condition. If the target fails this saving throw while already poisoned, it gains one level of exhaustion in addition to the other effects."
 					]
 				}
 			],
@@ -37826,19 +38192,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one creature. Hit: 11 ({@dice 2d6+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one creature. Hit: 11 ({@dice 2d6+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 22 ({@dice 4d8+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Thrash",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d10}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d10}) slashing damage."
 					]
 				}
 			],
@@ -37897,7 +38263,7 @@
 				{
 					"name": "Sew",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the suturefly sews the target's mouth, nose, or eye closed. With supernatural speed, the suturefly repeatedly pierces the target's face, each time threading a loop of the target's own skin through the previous hole. These skin loops rapidly blacken, shrink, and draw the orifice tightly closed. It takes two actions and a sharp blade to sever the loops and reopen the orifice, and the process causes intense pain and 2 slashing damage. A victim whose mouth and nose have been sewn shut begins suffocating at the start of his or her next turn."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the suturefly sews the target's mouth, nose, or eye closed. With supernatural speed, the suturefly repeatedly pierces the target's face, each time threading a loop of the target's own skin through the previous hole. These skin loops rapidly blacken, shrink, and draw the orifice tightly closed. It takes two actions and a sharp blade to sever the loops and reopen the orifice, and the process causes intense pain and 2 slashing damage. A victim whose mouth and nose have been sewn shut begins suffocating at the start of his or her next turn."
 					]
 				}
 			],
@@ -37943,7 +38309,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must make a successful DC 11 saving throw or become poisoned. While poisoned this way, the target is paralyzed and takes 3({@dice 1d6}) poison damage at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself with a success."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 1 piercing damage, and the target must make a successful DC 11 saving throw or become poisoned. While poisoned this way, the target is paralyzed and takes 3({@dice 1d6}) poison damage at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself with a success."
 					]
 				}
 			],
@@ -38029,13 +38395,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage plus 9 ({@dice 2d4+4}) bludgeoning damage, and the target is grappled (escape DC 14). The target must also make a successful DC 15 Constitution saving throw or be stunned until the end of its next turn."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage plus 9 ({@dice 2d4+4}) bludgeoning damage, and the target is grappled (escape DC 14). The target must also make a successful DC 15 Constitution saving throw or be stunned until the end of its next turn."
 					]
 				},
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) bludgeoning damage, and the target must succeed on a DC 15 Strength saving throw or be knocked prone and pushed 5 feet. The temple dog can immediately enter the position the target was pushed out of, if it chooses to."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 14 ({@dice 3d6+4}) bludgeoning damage, and the target must succeed on a DC 15 Strength saving throw or be knocked prone and pushed 5 feet. The temple dog can immediately enter the position the target was pushed out of, if it chooses to."
 					]
 				}
 			],
@@ -38112,13 +38478,13 @@
 				{
 					"name": "Assegai",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage, or 7 ({@dice 1d8+3}) piercing damage if used with two hands to make a melee attack."
+						"Melee or Ranged Weapon Attack: {@hit 5} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage, or 7 ({@dice 1d8+3}) piercing damage if used with two hands to make a melee attack."
 					]
 				},
 				{
 					"name": "Hurl Thorns",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 20/60 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage, and the thorn explodes in a 10-foot-radius sphere centered on the target. Every creature in the affected area other than the original target takes 4 ({@dice 1d8}) piercing damage, or half damage with a successful DC 13 Dexterity saving throw."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 20/60 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage, and the thorn explodes in a 10-foot-radius sphere centered on the target. Every creature in the affected area other than the original target takes 4 ({@dice 1d8}) piercing damage, or half damage with a successful DC 13 Dexterity saving throw."
 					]
 				}
 			],
@@ -38218,7 +38584,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) slashing damage plus 26 ({@dice 4d12}) cold damage. If the target is wearing metal armor, it must make a successful DC 17 Constitution saving throw or gain one level of exhaustion."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 15 ({@dice 2d8+6}) slashing damage plus 26 ({@dice 4d12}) cold damage. If the target is wearing metal armor, it must make a successful DC 17 Constitution saving throw or gain one level of exhaustion."
 					]
 				},
 				{
@@ -38239,7 +38605,7 @@
 						"A thuellai's howl can cause creatures to temporarily lose their minds and even to attack themselves or their companions. Each target within 100 feet of the theullai and able to hear the howl must make a successful DC 14 Wisdom saving throw or roll {@dice 1d8} and consult the table below at the start of its next turn. An affected creature repeats the saving throw at the end of each of its turns; a success ends the effect on itself, but a failure means it must roll again on the table below at the start of its next turn.",
 						"1: Act normally",
 						"2-4: Do nothing but babble incoherently",
-						"5-6: Do {@dice 1d8} damage+Str modifier to self with item in hand",
+						"5-6: Do {@dice 1d8} damage + Str modifier to self with item in hand",
 						"7-8: Attack nearest target; select randomly if more than one"
 					]
 				},
@@ -38312,12 +38678,6 @@
 					"entries": [
 						"The giant can consume half of its weight in food without ill effect, and it has advantage against anything that would give it the poisoned condition. Poisonous and spoiled foodstuffs are common in a thursir lair."
 					]
-				},
-				{
-					"name": "Runic Blood",
-					"entries": [
-						"Thursir giants have a natural connection to the thurs rune and can use an action to inscribe a weapon with the rune three times per day. A creature struck a blow from such a weapon takes 4 ({@dice 1d8}) lightning damage in addition to the weapon damage suffered, and the target can't take reactions until the start of its next turn. The thurs rune lasts for one hour, or until three successful strikes, whichever comes first."
-					]
 				}
 			],
 			"action": [
@@ -38330,13 +38690,19 @@
 				{
 					"name": "Warhammer",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 40/160 ft., one target. Hit: 15 ({@dice 2d10+4}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 40/160 ft., one target. Hit: 15 ({@dice 2d10+4}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Runic Blood (3/Day)",
+					"entries": [
+						"Thursir giants can inscribe the thurs rune on a weapon. A creature hit by the weapon takes an additional {@dice 1d8} lightning damage, and the target can't take reactions until the start of its next turn. The thurs rune lasts for one hour, or for three hits, whichever comes first."
 					]
 				}
 			],
@@ -38408,13 +38774,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d8+8}) piercing damage. If the target is a Huge or smaller creature, it must succeed on a DC 18 Dexterity saving throw or be swallowed by the titanoboa. A swallowed creature is blinded and restrained, has total cover against attacks and other effects outside the snake, and takes 21 ({@dice 6d6}) acid damage at the start of each of the titanoboa's turns. If the titanoboa takes 30 damage or more on a single turn from a creature inside it, the titanoboa must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the titanoboa. If the titanoboa dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 21 ({@dice 3d8+8}) piercing damage. If the target is a Huge or smaller creature, it must succeed on a DC 18 Dexterity saving throw or be swallowed by the titanoboa. A swallowed creature is blinded and restrained, has total cover against attacks and other effects outside the snake, and takes 21 ({@dice 6d6}) acid damage at the start of each of the titanoboa's turns. If the titanoboa takes 30 damage or more on a single turn from a creature inside it, the titanoboa must succeed on a DC 15 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 10 feet of the titanoboa. If the titanoboa dies, a swallowed creature is no longer restrained by it and can escape from the corpse by using 20 feet of movement, exiting prone."
 					]
 				},
 				{
 					"name": "Constrict",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 15 ft., one target. Hit: 27 ({@dice 3d12+8}) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained, and the titanoboa can't constrict another target."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 15 ft., one target. Hit: 27 ({@dice 3d12+8}) bludgeoning damage, and the target is grappled (escape DC 18). Until this grapple ends, the target is restrained, and the titanoboa can't constrict another target."
 					]
 				}
 			],
@@ -38427,7 +38793,7 @@
 			"type": "construct",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -38464,7 +38830,8 @@
 			],
 			"immune": [
 				"fire",
-				"cold"
+				"cold",
+				"poison"
 			],
 			"conditionImmune": [
 				"exhaustion",
@@ -38501,7 +38868,7 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 5 ft., one target. Hit: 12 ({@dice 1d10+7}) bludgeoning damage. The target is also knocked inside the tophet's burning belly if the attack scores a critical hit."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 5 ft., one target. Hit: 12 ({@dice 1d10+7}) bludgeoning damage. The target is also knocked inside the tophet's burning belly if the attack scores a critical hit."
 					]
 				},
 				{
@@ -38561,13 +38928,13 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) slashing damage."
 					]
 				},
 				{
 					"name": "Light Crossbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 80/320 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage."
 					]
 				}
 			],
@@ -38654,13 +39021,13 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +7} to hit, range 150/600 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage."
+						"Ranged Weapon Attack: {@hit 7} to hit, range 150/600 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage."
 					]
 				}
 			],
@@ -38737,13 +39104,13 @@
 				{
 					"name": "Scimitar",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d6+7}) slashing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +12} to hit, reach 5 ft., one creature. Hit: 10 ({@dice 1d6+7}) piercing damage, and the target must succeed on a DC 18 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 12} to hit, reach 5 ft., one creature. Hit: 10 ({@dice 1d6+7}) piercing damage, and the target must succeed on a DC 18 Constitution saving throw or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
@@ -38759,6 +39126,7 @@
 					]
 				}
 			],
+			"legendaryGroup": "Tosculi Hive-Queen",
 			"legendary": [
 				{
 					"name": "Flight",
@@ -38830,25 +39198,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d4+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d4+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d4+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d4+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d4+5}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw against poison or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one creature. Hit: 7 ({@dice 1d4+5}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw against poison or be paralyzed for 1 minute. A paralyzed target repeats the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Prepare Host",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one paralyzed creature. Hit: 10 ({@dice 2d4+5}) piercing damage, and the target is paralyzed for 8 hours. The paralysis can be ended with a successful DC 20 Wisdom (Medicine) check or by a spell or magical effect that cures disease. (Because only paralyzed creatures can be targeted, a hit by this attack is automatically a critical hit; bonus damage is included in the damage listing.)"
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one paralyzed creature. Hit: 10 ({@dice 2d4+5}) piercing damage, and the target is paralyzed for 8 hours. The paralysis can be ended with a successful DC 20 Wisdom (Medicine) check or by a spell or magical effect that cures disease. (Because only paralyzed creatures can be targeted, a hit by this attack is automatically a critical hit; bonus damage is included in the damage listing.)"
 					]
 				}
 			],
@@ -38856,7 +39224,7 @@
 			"tokenURL": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/ToB%20(3pp)/Tosculi%20Warrior.png"
 		},
 		{
-			"name": "Arch-Devil Totivillus, Scribe of Hell",
+			"name": "Totivillus, Scribe of Hell",
 			"size": "M",
 			"type": {
 				"type": "fiend",
@@ -38960,7 +39328,7 @@
 				{
 					"name": "Trust Aura",
 					"entries": [
-						"Totivillus projects a 25-foot-radius trust aura. As long as Totivillus is talking, creatures in that area find his utterances so fascinating and compelling that they're affected as if by a sanctuary spell (affected creatures must make a DC 23 Wisdom saving throw at the start of each of their turns; if the saving throw fails, they can't attack Totivillus directly until the start of their next turn). This effect ends immediately and can't be renewed for 1 minute if Totivillus attacks physically. Devils are not immune to this aura."
+						"Totivillus projects a 25-foot-radius trust aura. As long as Totivillus is talking, creatures in that area find his utterances so fascinating and compelling that they must make a DC 23 Wisdom saving throw at the start of each of their turns; if the saving throw fails, they can't attack Totivillus directly until the start of their next turn. This effect ends immediately and can't be renewed for 1 minute if Totivillus attacks physically. Devils are not immune to this aura."
 					]
 				}
 			],
@@ -38974,13 +39342,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 30 ({@dice 4d12+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 30 ({@dice 4d12+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Hellfire Bolt (Recharge 5—6)",
 					"entries": [
-						"Ranged Spell Attack: {@hit +15} to hit, range 120 ft., one target. Hit: 65 ({@dice 10d12}) force damage plus 33 ({@dice 6d10}) thunder damage; a successful DC 20 Dexterity saving throw halves thunder damage."
+						"Ranged Spell Attack: {@hit 15} to hit, range 120 ft., one target. Hit: 65 ({@dice 10d12}) force damage plus 33 ({@dice 6d10}) thunder damage; a successful DC 20 Dexterity saving throw halves thunder damage."
 					]
 				}
 			],
@@ -38994,7 +39362,7 @@
 				{
 					"name": "Devil's Mark",
 					"entries": [
-						"Totivillus sprays magical ink from his fingertips at a single target within 30 feet. The target must make a successful DC 23 Dexterity saving throw or receive a devil's mark: a tattoo in the shape of Totivillus's personal seal. All devils have advantage when they make spell or spell-like attacks against the devil-marked creature, and the creature has disadvantage on saving throws against such attacks. The mark can be removed by remove curse if the caster also makes a successful DC 23 spellcasting check. The mark reveals itself as desecrated to detect evil and good. It often shifts its position on the body, especially when it's concealed (and usually at the most inconvenient moment). Because such marks are sometimes placed on those who've made pacts with devils, NPC paladins and clerics might assume that any character bearing a devil's mark is in league with evil forces."
+						"Totivillus sprays magical ink from his fingertips at a single target within 30 feet. The target must make a successful DC 23 Dexterity saving throw or receive a devil's mark: a tattoo in the shape of Totivillus's personal seal. All devils have advantage on spell attacks made against the devil-marked creature, and the creature has disadvantage on saving throws made against spells and abilities used by devils. The mark can be removed by remove curse if the caster also makes a successful DC 23 spellcasting check. The mark reveals itself as desecrated to detect evil and good. It often shifts its position on the body, especially when it's concealed (and usually at the most inconvenient moment). Because such marks are sometimes placed on those who've made pacts with devils, NPC paladins and clerics might assume that any character bearing a devil's mark is in league with evil forces."
 					]
 				},
 				{
@@ -39238,25 +39606,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Battleaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage or 9 ({@dice 1d10+4}) slashing damage if used with two hands. Using the battleaxe two-handed prevents using the handaxe."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage or 9 ({@dice 1d10+4}) slashing damage if used with two hands. Using the battleaxe two-handed prevents using the handaxe."
 					]
 				},
 				{
 					"name": "Handaxe",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
+						"Melee or Ranged Weapon Attack: {@hit 6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) slashing damage."
 					]
 				},
 				{
@@ -39327,13 +39695,13 @@
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Tentacles",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 10 ft., one creature. Hit: 13 ({@dice 3d6+3}) bludgeoning damage plus 10 ({@dice 3d6}) lightning damage. The target is also grappled (escape DC 13). Until this grapple ends, the target is restrained. While grappling the target, the tusked skyfish can't use this attack against other targets. When the tusked skyfish moves, a Medium or smaller target it is grappling moves with it."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 10 ft., one creature. Hit: 13 ({@dice 3d6+3}) bludgeoning damage plus 10 ({@dice 3d6}) lightning damage. The target is also grappled (escape DC 13). Until this grapple ends, the target is restrained. While grappling the target, the tusked skyfish can't use this attack against other targets. When the tusked skyfish moves, a Medium or smaller target it is grappling moves with it."
 					]
 				},
 				{
@@ -39445,7 +39813,7 @@
 				{
 					"name": "Umbral Grasp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 18 ({@dice 4d6+4}) cold damage and the target's Strength score is reduced by {@dice 1d6}. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest. If a non-evil humanoid dies from this attack, a shadow rises from the corpse {@dice 1d4} hours later."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 18 ({@dice 4d6+4}) cold damage and the target's Strength score is reduced by {@dice 1d6}. The target dies if this reduces its Strength to 0. Otherwise, the reduction lasts until the target finishes a short or long rest. If a non-evil humanoid dies from this attack, a shadow rises from the corpse {@dice 1d4} hours later."
 					]
 				}
 			],
@@ -39543,7 +39911,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus 9 ({@dice 2d8}) poison damage, and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target takes 9 ({@dice 2d8}) fire damage at the start of its turn. A poisoned creature repeats the saving throw at the end of its turn, ending the effect on a success."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) piercing damage plus 9 ({@dice 2d8}) poison damage, and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the target takes 9 ({@dice 2d8}) fire damage at the start of its turn. A poisoned creature repeats the saving throw at the end of its turn, ending the effect on a success."
 					]
 				},
 				{
@@ -39657,7 +40025,7 @@
 				{
 					"name": "Tentacle",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 20 ft., one target. Hit: 20 ({@dice 3d8+7}) bludgeoning damage, and the target is grappled (escape DC 17). Until this grapple ends, the target is restrained. Each of its four tentacles can grapple one target."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 20 ft., one target. Hit: 20 ({@dice 3d8+7}) bludgeoning damage, and the target is grappled (escape DC 17). Until this grapple ends, the target is restrained. Each of its four tentacles can grapple one target."
 					]
 				},
 				{
@@ -39753,7 +40121,6 @@
 			},
 			"immune": [
 				"poison",
-				"psychic",
 				{
 					"immune": [
 						"bludgeoning",
@@ -39817,13 +40184,13 @@
 				{
 					"name": "Medjai's Scepter",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage plus 10 ({@dice 3d6}) poison damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) bludgeoning damage plus 10 ({@dice 3d6}) poison damage."
 					]
 				},
 				{
 					"name": "Khopesh",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				}
 			],
@@ -39909,13 +40276,13 @@
 				{
 					"name": "Greataxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) slashing damage plus 3 ({@dice 1d6}) necrotic damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 11 ({@dice 1d12+5}) slashing damage plus 3 ({@dice 1d6}) necrotic damage."
 					]
 				},
 				{
 					"name": "Longbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +4} to hit, range 150/600 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
+						"Ranged Weapon Attack: {@hit 4} to hit, range 150/600 ft., one target. Hit: 6 ({@dice 1d8+2}) piercing damage."
 					]
 				},
 				{
@@ -40055,13 +40422,13 @@
 				{
 					"name": "Longsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage or 9 ({@dice 1d10+4}) slashing damage if used with two hands, plus 11 ({@dice 2d10}) radiant damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage or 9 ({@dice 1d10+4}) slashing damage if used with two hands, plus 11 ({@dice 2d10}) radiant damage."
 					]
 				},
 				{
 					"name": "Spear",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +8} to hit, reach 10 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage or 8 ({@dice 1d8+4}) piercing damage if used with two hands to make a melee attack, plus 11 ({@dice 2d10}) radiant damage."
+						"Melee or Ranged Weapon Attack: {@hit 8} to hit, reach 10 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage or 8 ({@dice 1d8+4}) piercing damage if used with two hands to make a melee attack, plus 11 ({@dice 2d10}) radiant damage."
 					]
 				}
 			],
@@ -40081,7 +40448,7 @@
 				{
 					"name": "Harvest the Fallen (Costs 2 Actions)",
 					"entries": [
-						"A valkyrie can take the soul of a newly dead body and bind it into a weapon or shield. Only one soul can be bound to any object. Individuals whose souls are bound can't be raised by any means short of a wish or comparable magic. A valkyrie can likewise release any soul that has been bound by another valkyrie, or transfer a bound soul from one object to another. Once bound, the soul grants the item a +1 bonus for every 4 character levels of the soul, and this replaces any other magic on the item. At the DM's discretion, part of this bonus can become an appropriate special quality (a fire giant's soul might create a flaming weapon, for example)."
+						"A valkyrie can take the soul of a newly dead body and bind it into a weapon or shield. Only one soul can be bound to any object. Individuals whose souls are bound can't be raised by any means short of a wish or comparable magic. A valkyrie can likewise release any soul that has been bound by another valkyrie, or transfer a bound soul from one object to another. Once bound, the soul grants the item a +1 bonus for every 4 character levels of the soul (maximum of +3), and this replaces any other magic on the item. At the DM's discretion, part of this bonus can become an appropriate special quality (a fire giant's soul might create a flaming weapon, for example)."
 					]
 				}
 			],
@@ -40235,13 +40602,13 @@
 				{
 					"name": "Unarmed Strike (Vampire Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one creature. Hit: 8 ({@dice 1d8+4}) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18)."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one creature. Hit: 8 ({@dice 1d8+4}) bludgeoning damage. Instead of dealing damage, the vampire can grapple the target (escape DC 18)."
 					]
 				},
 				{
 					"name": "Bite (Bat or Vampire Form Only)",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 ({@dice 1d6+4}) piercing damage plus 10 ({@dice 3d6}) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one willing creature, or a creature that is grappled by the vampire, incapacitated, or restrained. Hit: 7 ({@dice 1d6+4}) piercing damage plus 10 ({@dice 3d6}) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the vampire regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0. A humanoid slain in this way and then buried in the ground rises the following night as a vampire spawn under the vampire's control."
 					]
 				},
 				{
@@ -40253,7 +40620,7 @@
 				{
 					"name": "Call the Blood",
 					"entries": [
-						"The vampire warlock targets one humanoid it can see within 60 feet. The target must be injured (has fewer than its normal maximum hit points). The target's blood is drawn out of the body and streams through the air to the vampire warlock. The target takes 25 ({@dice 6d6+4}) necrotic damage and its hit point maximum is reduced by an equal amount until the target finishes a long rest; a successful DC 17 Constitution saving throw prevents both effects. The vampire warlock regains hit points equal to half the damage dealt."
+						"The vampire warlock targets one humanoid it can see within 60 feet. The target must be injured (has fewer than its normal maximum hit points). The target's blood is drawn out of the body and streams through the air to the vampire warlock. The target takes 25 ({@dice 6d6+4}) necrotic damage and its hit point maximum is reduced by an equal amount until the target finishes a long rest; a successful DC 17 Constitution saving throw prevents both effects. The vampire warlock regains hit points equal to half the damage dealt. The target dies if this effect reduces its hit point maximum to 0."
 					]
 				},
 				{
@@ -40294,7 +40661,7 @@
 				{
 					"name": "Innate Spellcasting",
 					"headerEntries": [
-						"The vampire's spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components."
+						"The vampire's spellcasting ability is Charisma (spell save DC 17). It can innately cast the following spells, requiring no material components:"
 					],
 					"will": [
 						"{@spell darkness}",
@@ -40372,13 +40739,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 17 ({@dice 3d8+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d8+4}) slashing damage."
 					]
 				},
 				{
@@ -40483,7 +40850,7 @@
 				{
 					"name": "Venomous Fist",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw or be affected by the Selket's venom curse (see above)."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage. If the target is a creature, it must succeed on a DC 12 Constitution saving throw or be affected by the Selket's venom curse (see above)."
 					]
 				}
 			],
@@ -40675,13 +41042,13 @@
 				{
 					"name": "+1 Shortsword",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d6+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d6+6}) piercing damage."
 					]
 				},
 				{
 					"name": "+1 Shortbow",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +9} to hit, range 80/320 ft., one target. Hit: 9 ({@dice 1d6+6}) piercing damage."
+						"Ranged Weapon Attack: {@hit 9} to hit, range 80/320 ft., one target. Hit: 9 ({@dice 1d6+6}) piercing damage."
 					]
 				},
 				{
@@ -40765,7 +41132,7 @@
 			"conditionImmune": [
 				"frightened"
 			],
-			"senses": "60 ft.",
+			"senses": "darkvision 60 ft.",
 			"passive": 9,
 			"languages": "Common, Goblin, Sylvan",
 			"cr": "2",
@@ -40817,13 +41184,13 @@
 				{
 					"name": "Straight Razor",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d4+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Unclean Cut",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one creature that is grappled by the vile barber, incapacitated, or restrained. Hit: 6 ({@dice 1d4+4}) slashing damage plus 7 ({@dice 2d6}) necrotic damage. The creature and all its allies who see this attack must make successful DC 15 Wisdom saving throws or become frightened for {@dice 1d4} rounds."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one creature that is grappled by the vile barber, incapacitated, or restrained. Hit: 6 ({@dice 1d4+4}) slashing damage plus 7 ({@dice 2d6}) necrotic damage. The creature and all its allies who see this attack must make successful DC 15 Wisdom saving throws or become frightened for {@dice 1d4} rounds."
 					]
 				}
 			],
@@ -40918,13 +41285,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d6+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Tendril",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d4+5}) slashing damage plus 3 ({@dice 1d6}) poison damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 7 ({@dice 1d4+5}) slashing damage plus 3 ({@dice 1d6}) poison damage."
 					]
 				},
 				{
@@ -41008,13 +41375,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 21 ({@dice 3d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 18 ({@dice 3d8+5}) slashing damage."
 					]
 				}
 			],
@@ -41090,7 +41457,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d10+3}) piercing damage plus 3 ({@dice 1d6}) cold damage."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d10+3}) piercing damage plus 3 ({@dice 1d6}) cold damage."
 					]
 				},
 				{
@@ -41212,7 +41579,7 @@
 				{
 					"name": "Tendril",
 					"entries": [
-						"Melee Weapon Attack: {@hit +10} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage plus 11 ({@dice 2d10}) necrotic damage."
+						"Melee Weapon Attack: {@hit 10} to hit, reach 10 ft., one target. Hit: 10 ({@dice 1d8+6}) slashing damage plus 11 ({@dice 2d10}) necrotic damage."
 					]
 				},
 				{
@@ -41301,7 +41668,7 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage."
 					]
 				},
 				{
@@ -41381,7 +41748,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) bludgeoning damage."
 					]
 				}
 			],
@@ -41446,7 +41813,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained and the water leaper can't bite another target."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage and the target is grappled (escape DC 13). Until this grapple ends, the target is restrained and the water leaper can't bite another target."
 					]
 				},
 				{
@@ -41458,7 +41825,7 @@
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the creature takes 7 ({@dice 2d6}) poison damage at the start of its turn. A poisoned creature repeats the saving throw at the end of its turn, ending the effect on a success."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d6+3}) piercing damage and the target must make a successful DC 12 Constitution saving throw or be poisoned for 1 minute. While poisoned in this way, the creature takes 7 ({@dice 2d6}) poison damage at the start of its turn. A poisoned creature repeats the saving throw at the end of its turn, ending the effect on a success."
 					]
 				},
 				{
@@ -41502,8 +41869,7 @@
 			"wis": 8,
 			"cha": 8,
 			"immune": [
-				"poison",
-				"psychic"
+				"poison"
 			],
 			"conditionImmune": [
 				"blinded",
@@ -41542,19 +41908,19 @@
 				{
 					"name": "Trimming Blade",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage and possible unmaking."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) slashing damage and possible unmaking."
 					]
 				},
 				{
 					"name": "Poisoned Needle Shuttle",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +5} to hit, range 30 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or become paralyzed. The target repeats the saving throw at the end of each of its turns, ending the effect on itself with a success."
+						"Ranged Weapon Attack: {@hit 5} to hit, range 30 ft., one target. Hit: 7 ({@dice 1d8+3}) piercing damage, and the target must succeed on a DC 13 Constitution saving throw or become paralyzed. The target repeats the saving throw at the end of each of its turns, ending the effect on itself with a success."
 					]
 				},
 				{
 					"name": "Unmaking",
 					"entries": [
-						"The clockwork weaving spider's speed and its slim, sharp blade can slice cloth, leather, and paper into scraps very quickly. Whenever a clockwork weaving spider's trimming blade attack roll exceeds the target's armor class by 5 or more, the target must succeed on a DC 13 Dexterity saving throw or one of their possessions, chosen randomly from the list below, becomes unusable or damaged until repaired."
+						"The clockwork weaving spider's speed and its slim, sharp blade can slice cloth, leather, and paper into scraps very quickly. Whenever a clockwork weaving spider's trimming blade attack roll exceeds the target's armor class by 5 or more, the target must succeed on a DC 13 Dexterity saving throw or one of their possessions becomes unusable or damaged until repaired (DM's choice)."
 					]
 				}
 			],
@@ -41636,13 +42002,13 @@
 				{
 					"name": "Slam",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., single target. Hit: 15 ({@dice 3d6+5}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., single target. Hit: 15 ({@dice 3d6+5}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Rock",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +8} to hit, range 60/180 ft., one target. Hit: 21 ({@dice 3d10+5}) bludgeoning damage."
+						"Ranged Weapon Attack: {@hit 8} to hit, range 60/180 ft., one target. Hit: 21 ({@dice 3d10+5}) bludgeoning damage."
 					]
 				}
 			],
@@ -41686,7 +42052,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage, and the target is grappled (escape DC 10). Until this grapple ends, the wharfling can't use its bite on another target. While the target is grappled, the wharfling's bite attack hits it automatically."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d4+3}) piercing damage, and the target is grappled (escape DC 10). Until this grapple ends, the wharfling can't use its bite on another target. While the target is grappled, the wharfling's bite attack hits it automatically."
 					]
 				},
 				{
@@ -41766,7 +42132,7 @@
 				{
 					"name": "Bites",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 21 ({@dice 6d6}) piercing damage, or 10 ({@dice 3d6}) piercing damage if the swarm has half of its hit points or fewer."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 0 ft., one creature in the swarm's space. Hit: 21 ({@dice 6d6}) piercing damage, or 10 ({@dice 3d6}) piercing damage if the swarm has half of its hit points or fewer."
 					]
 				},
 				{
@@ -41830,7 +42196,7 @@
 				{
 					"name": "Hatred for Spellcasters",
 					"entries": [
-						"The white ape does one extra die of damage (d8 or d10, respectively) per attack against an enemy it has seen cast a spell."
+						"The white ape does one extra die of damage ({@dice 1d8} or {@dice 1d10}, respectively) per attack against an enemy it has seen cast a spell."
 					]
 				}
 			],
@@ -41844,13 +42210,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage, and the target must succeed on a DC 14 Constitution saving throw or contract the arcane wasting disease."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage, and the target must succeed on a DC 14 Constitution saving throw or contract the arcane wasting disease."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 7} to hit, reach 5 ft., one target. Hit: 15 ({@dice 2d10+4}) slashing damage."
 					]
 				},
 				{
@@ -41912,7 +42278,8 @@
 			"conditionImmune": [
 				"charmed",
 				"exhaustion",
-				"paralyzed"
+				"paralyzed",
+				"restrained"
 			],
 			"senses": "blindsight 10 ft., darkvision 60 ft.",
 			"passive": 14,
@@ -41922,7 +42289,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d10+4}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 9 ({@dice 1d10+4}) piercing damage."
 					]
 				},
 				{
@@ -41964,7 +42331,6 @@
 			},
 			"immune": [
 				"poison",
-				"psychic",
 				"radiant"
 			],
 			"conditionImmune": [
@@ -42003,7 +42369,7 @@
 				{
 					"name": "Light Ray",
 					"entries": [
-						"Ranged Weapon Attack: {@hit +6} to hit, range 30 ft., one target. Hit: 6 ({@dice 1d4+4}) radiant damage."
+						"Ranged Weapon Attack: {@hit 6} to hit, range 30 ft., one target. Hit: 6 ({@dice 1d4+4}) radiant damage."
 					]
 				},
 				{
@@ -42098,19 +42464,19 @@
 				{
 					"name": "Battleaxe",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 8 ({@dice 1d8+4}) slashing damage."
 					]
 				},
 				{
 					"name": "Dagger",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d4+4}) piercing damage."
+						"Melee or Ranged Weapon Attack: {@hit 6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 6 ({@dice 1d4+4}) piercing damage."
 					]
 				},
 				{
 					"name": "Spear",
 					"entries": [
-						"Melee or Ranged Weapon Attack: {@hit +6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage, or 8 ({@dice 1d8+4}) piercing damage if used with two hands to make a melee attack."
+						"Melee or Ranged Weapon Attack: {@hit 6} to hit, reach 5 ft. or range 20/60 ft., one target. Hit: 7 ({@dice 1d6+4}) piercing damage, or 8 ({@dice 1d8+4}) piercing damage if used with two hands to make a melee attack."
 					]
 				}
 			],
@@ -42126,7 +42492,7 @@
 			},
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -42206,7 +42572,7 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) piercing damage plus 3 ({@dice 1d6}) cold damage. The target is also knocked prone if the attack scored a critical hit."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 8 ({@dice 2d4+3}) piercing damage plus 3 ({@dice 1d6}) cold damage. The target is also knocked prone if the attack scored a critical hit."
 					]
 				},
 				{
@@ -42276,7 +42642,7 @@
 				{
 					"name": "Helminth Infestation",
 					"entries": [
-						"Melee Weapon Attack: {@hit +5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d6}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw or be afflicted with a helminth infestation (parasitic worms). An afflicted creature can't regain hit points and its hit point maximum decreases by 10 ({@dice 3d6}) for every 24 hours that elapse. If the affliction reduces the target's hit point maximum to 0, the victim dies. The affliction lasts until removed by any magic that cures disease."
+						"Melee Weapon Attack: {@hit 5} to hit, reach 5 ft., one target. Hit: 7 ({@dice 2d6}) bludgeoning damage plus 10 ({@dice 3d6}) necrotic damage. If the target is a creature, it must succeed on a DC 14 Constitution saving throw or be afflicted with a helminth infestation (parasitic worms). An afflicted creature can't regain hit points and its hit point maximum decreases by 10 ({@dice 3d6}) for every 24 hours that elapse. If the affliction reduces the target's hit point maximum to 0, the victim dies. The affliction lasts until removed by any magic that cures disease."
 					]
 				}
 			],
@@ -42373,7 +42739,7 @@
 				{
 					"name": "Absorb",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) force damage, and the xanka regains hit points equal to the damage caused by its attack. In addition, a living creature hit by this attack must make a successful DC 12 Dexterity saving throw or suffer a gaping wound that causes 2 ({@dice 1d4}) necrotic damage at the end of each of the creature's turns until the wound is treated with magical healing or with a successful DC 10 Intelligence (Medicine) check. If a creature who fails this saving throw is wearing armor or using a shield, the creature can choose to prevent the necrotic damage by permanently reducing the AC of its armor or shield by 1 instead."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 6 ({@dice 1d8+2}) force damage, and the xanka regains hit points equal to the damage caused by its attack. In addition, a living creature hit by this attack must make a successful DC 12 Dexterity saving throw or suffer a gaping wound that causes 2 ({@dice 1d4}) necrotic damage at the end of each of the creature's turns until the wound is treated with magical healing or with a successful DC 10 Intelligence (Medicine) check. If a creature who fails this saving throw is wearing armor or using a shield, the creature can choose to prevent the necrotic damage by permanently reducing the AC of its armor or shield by 1 instead."
 					]
 				}
 			],
@@ -42386,7 +42752,7 @@
 			"type": "aberration",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -42433,13 +42799,13 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
 					"name": "Stinger",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage, and the target must succeed on a DC 15 Charisma saving throw or have its fate corrupted. A creature with corrupted fate has disadvantage on Charisma checks and Charisma saving throws, and it is immune to divination spells and to effects that sense emotions or read thoughts. The target's fate can be restored by a dispel evil and good spell or comparable magic."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one creature. Hit: 12 ({@dice 2d6+5}) piercing damage, and the target must succeed on a DC 15 Charisma saving throw or have its fate corrupted. A creature with corrupted fate has disadvantage on Charisma checks and Charisma saving throws, and it is immune to divination spells and to effects that sense emotions or read thoughts. The target's fate can be restored by a dispel evil and good spell or comparable magic."
 					]
 				},
 				{
@@ -42525,13 +42891,13 @@
 				{
 					"name": "Gore",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 27 ({@dice 4d8+9}) piercing damage."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 27 ({@dice 4d8+9}) piercing damage."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"Melee Weapon Attack: {@hit +13} to hit, reach 10 ft., one target. Hit: 31 ({@dice 4d10+9}) bludgeoning damage. If the target is a creature, it must succeed on a DC 21 Strength saving throw or be knocked prone."
+						"Melee Weapon Attack: {@hit 13} to hit, reach 10 ft., one target. Hit: 31 ({@dice 4d10+9}) bludgeoning damage. If the target is a creature, it must succeed on a DC 21 Strength saving throw or be knocked prone."
 					]
 				},
 				{
@@ -42550,7 +42916,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -42588,7 +42954,11 @@
 			},
 			"immune": [
 				"acid",
-				"thunder"
+				"thunder",
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
 			],
 			"senses": "blindsight 120 ft.",
 			"passive": 14,
@@ -42618,13 +42988,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d6+6}) piercing damage plus 3 ({@dice 1d6}) poison damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d6+6}) piercing damage plus 3 ({@dice 1d6}) poison damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage."
 					]
 				},
 				{
@@ -42725,13 +43095,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d10+2}) piercing damage plus 3 ({@dice 1d6}) fire damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 10 ft., one target. Hit: 13 ({@dice 2d10+2}) piercing damage plus 3 ({@dice 1d6}) fire damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 9 ({@dice 2d6+2}) slashing damage."
 					]
 				},
 				{
@@ -42807,13 +43177,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 10 ({@dice 2d6+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage, and the target loses 3 hit point from bleeding at the start of each of its turns for six rounds unless it receives magical healing. Bleeding damage is cumulative; the target loses 3 hp per round for each bleeding wound it has taken from a mithral dragon's claws."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 14 ({@dice 2d10+3}) slashing damage, and the target loses 3 hit point from bleeding at the start of each of its turns for six rounds unless it receives magical healing. Bleeding damage is cumulative; the target loses 3 hp per round for each bleeding wound it has taken from a mithral dragon's claws."
 					]
 				},
 				{
@@ -42848,7 +43218,7 @@
 			"type": "dragon",
 			"source": "ToB 3pp",
 			"alignment": [
-				"L",
+				"N",
 				"E"
 			],
 			"ac": [
@@ -42915,13 +43285,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 5 ({@dice 1d10}) cold damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 5 ({@dice 1d10}) cold damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
@@ -42987,13 +43357,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10ft., one target. Hit: 25 ({@dice 3d12+6}) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained and the spinosaurus can't bite another target."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10ft., one target. Hit: 25 ({@dice 3d12+6}) piercing damage. If the target is a Medium or smaller creature, it is grappled (escape DC 16). Until this grapple ends, the target is restrained and the spinosaurus can't bite another target."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d6+6}) slashing damage."
 					]
 				}
 			],
@@ -43082,13 +43452,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 3 ({@dice 1d6}) cold damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage plus 3 ({@dice 1d6}) cold damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 9} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
@@ -43118,7 +43488,7 @@
 				{
 					"name": "Void Twist",
 					"entries": [
-						"When the dragon is hit by a ranged attack it can create a small rift in space to increase its AC by 2 against that attack. If the attack misses because of this increase the dragon can choose a creature within 30 feet to become the new target for that attack. Use the original attack roll to determine if the attack hits the new target."
+						"When the dragon is hit by a ranged attack it can create a small rift in space to increase its AC by 4 against that attack. If the attack misses because of this increase the dragon can choose a creature within 30 feet to become the new target for that attack. Use the original attack roll to determine if the attack hits the new target."
 					]
 				}
 			],
@@ -43172,7 +43542,8 @@
 			"conditionImmune": [
 				"charmed",
 				"exhaustion",
-				"paralyzed"
+				"paralyzed",
+				"restrained"
 			],
 			"senses": "blindsight 10 ft., darkvision 60 ft.",
 			"passive": 17,
@@ -43202,13 +43573,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 10 ft., one target. Hit: 16 ({@dice 2d10+5}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
+						"Melee Weapon Attack: {@hit 8} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d6+5}) slashing damage."
 					]
 				},
 				{
@@ -43374,13 +43745,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +18} to hit, reach 10 ft., one target. Hit: 26 ({@dice 3d10+10}) piercing damage and the target is grappled (escape DC 20). Until the grapple ends, the target is restrained and the zaratan can't bite another target."
+						"Melee Weapon Attack: {@hit 18} to hit, reach 10 ft., one target. Hit: 26 ({@dice 3d10+10}) piercing damage and the target is grappled (escape DC 20). Until the grapple ends, the target is restrained and the zaratan can't bite another target."
 					]
 				},
 				{
 					"name": "Flipper",
 					"entries": [
-						"Melee Weapon Attack: {@hit +18} to hit, reach 15 ft., one target. Hit: 19 ({@dice 2d8+10}) bludgeoning damage and the target must succeed on a DC 26 Strength saving throw or be pushed 10 feet away from the zaratan."
+						"Melee Weapon Attack: {@hit 18} to hit, reach 15 ft., one target. Hit: 19 ({@dice 2d8+10}) bludgeoning damage and the target must succeed on a DC 26 Strength saving throw or be pushed 10 feet away from the zaratan."
 					]
 				},
 				{
@@ -43460,13 +43831,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage. If the target is a Medium or smaller creature grappled by the zimwi, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the zimwi, and it takes 14 ({@dice 4d6}) acid damage at the start of each of the zimwi's turns. If the zimwi's stomach takes 20 damage or more on a single turn from a creature inside it, the zimwi must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 5 feet of the zimwi. Damage done to a zimwi's stomach does not harm the zimwi. The zimwi's stomach is larger on the inside than the outside. It can have two Medium creatures or four Small or smaller creatures swallowed at one time. If the zimwi dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 13 ({@dice 2d8+4}) piercing damage. If the target is a Medium or smaller creature grappled by the zimwi, that creature is swallowed, and the grapple ends. While swallowed, the creature is blinded and restrained, it has total cover against attacks and other effects outside the zimwi, and it takes 14 ({@dice 4d6}) acid damage at the start of each of the zimwi's turns. If the zimwi's stomach takes 20 damage or more on a single turn from a creature inside it, the zimwi must succeed on a DC 14 Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall prone in a space within 5 feet of the zimwi. Damage done to a zimwi's stomach does not harm the zimwi. The zimwi's stomach is larger on the inside than the outside. It can have two Medium creatures or four Small or smaller creatures swallowed at one time. If the zimwi dies, a swallowed creature is no longer restrained by it and can escape from the corpse using 5 feet of movement, exiting prone."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage, and if the target is a Medium or smaller creature and the zimwi isn't already grappling a creature, it is grappled (escape DC 11)."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 11 ({@dice 2d6+4}) slashing damage, and if the target is a Medium or smaller creature and the zimwi isn't already grappling a creature, it is grappled (escape DC 11)."
 					]
 				}
 			],
@@ -43573,19 +43944,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 10 ft., one target. Hit: 19 ({@dice 2d12+6}) piercing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 10 ft., one target. Hit: 19 ({@dice 2d12+6}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d12+6}) slashing damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 5 ft., one target. Hit: 19 ({@dice 2d12+6}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"Melee Weapon Attack: {@hit +11} to hit, reach 20 ft., one target. Hit: 15 ({@dice 2d8+6}) bludgeoning damage."
+						"Melee Weapon Attack: {@hit 11} to hit, reach 20 ft., one target. Hit: 15 ({@dice 2d8+6}) bludgeoning damage."
 					]
 				},
 				{
@@ -43686,13 +44057,13 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d12+3}) piercing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 16 ({@dice 2d12+3}) piercing damage."
 					]
 				},
 				{
 					"name": "Claws",
 					"entries": [
-						"Melee Weapon Attack: {@hit +6} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
+						"Melee Weapon Attack: {@hit 6} to hit, reach 5 ft., one target. Hit: 12 ({@dice 2d8+3}) slashing damage."
 					]
 				},
 				{
@@ -43757,7 +44128,7 @@
 				{
 					"name": "Whip-claw",
 					"entries": [
-						"Melee Weapon Attack: {@hit +4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage, and the target is grappled (escape DC 8). While grappled, the target cannot speak or cast spells with verbal components."
+						"Melee Weapon Attack: {@hit 4} to hit, reach 5 ft., one target. Hit: 5 ({@dice 1d6+2}) slashing damage, and the target is grappled (escape DC 8). While grappled, the target cannot speak or cast spells with verbal components."
 					]
 				}
 			],


### PR DESCRIPTION
Ok, sorry about this, it's a bit of a beast, but you can blame Kobold Press for a lot of that - Tome of Beasts had a truly staggering amount of errata (and they still haven't caught all the bugs - in fact the errata themselves have mistakes, sigh). The other person you can blame is... probably me. I'm guessing that your original data came from the Shaped Script data files perhaps? I made the ToB data file by scraping the PDF but, wow, that was ugly. Not least because Kobold are horrifically inconsistent in both formatting and language. I'm sure I haven't caught all the errors but I think this should fix a big chunk!