### PR TITLE
Add Encyclopedia Magica

### DIFF
--- a/item/Faolyn; Encyclopedia Magica.json
+++ b/item/Faolyn; Encyclopedia Magica.json
@@ -1,0 +1,11972 @@
+{
+	"monster": [
+		{
+			"name": "Coral dragon",
+			"size": "S",
+			"type": "dragon",
+			"source": "EnMa",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"ac": 12,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 28,
+				"formula": "8d6"
+			},
+			"speed": {
+				"walk": 30,
+				"fly": 60,
+				"swim": 30
+			},
+			"str": 8,
+			"dex": 15,
+			"con": 10,
+			"int": 15,
+			"wis": 15,
+			"cha": 15,
+			"skill": {
+				"arcana": "+6",
+				"history": "+6",
+				"nature": "+6",
+				"religion": "+6"
+			},
+			"immune": [
+				"force"
+			],
+			"senses": "darkvision 60 ft.",
+			"passive": 12,
+			"languages": "Common, Draconic",
+			"cr": "1",
+			"trait": [
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The coral dragon has advantage on saving throws versus spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"Melee Weapon Attack: {@hit 1} to hit, reach 5 ft., one target. Hit: 1 ({@dice 1d4-1}) piercing damage."
+					]
+				},
+				{
+					"name": "Forceful Breath (Recharge 5–6)",
+					"entries": [
+						"The dragon exhales magical force in a 20 foot line that is 5 feet wide. Each creature in that line must make a DC 10 Dexterity saving throw, taking 11 (2d10) force damage on a failed saving throw, or half as much on a successful one."
+					]
+				}
+			],
+			"traitTags": [
+				"Magic Resistance"
+			]
+		},
+		{
+			"name": "Giant Sea Turtle",
+			"size": "H",
+			"type": "beast",
+			"source": "EnMa",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 17,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 85,
+				"formula": "10d12+20"
+			},
+			"speed": {
+				"walk": 10,
+				"swim": 90
+			},
+			"str": 20,
+			"dex": 7,
+			"con": 15,
+			"int": 2,
+			"wis": 12,
+			"cha": 7,
+			"passive": 11,
+			"cr": "4",
+			"trait": [
+				{
+					"name": "Hold Breath",
+					"entries": [
+						"The giant sea turtle can hold its breath for 1 hour."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"Melee Weapon Attack: {@hit 7} to hit, reach 10 ft., one target. Hit: 18 ({@dice 2d12+5}) piercing damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Hold Breath"
+			]
+		},
+		{
+			"name": "Guardian Tail (Animal Form)",
+			"size": "S",
+			"type": "construct",
+			"source": "EnMa",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 13,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 10,
+				"formula": "3d6"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 7,
+			"dex": 12,
+			"con": 10,
+			"int": 2,
+			"wis": 8,
+			"cha": 5,
+			"skill": {
+				"perception": "+1"
+			},
+			"immune": [
+				"poison",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"petrified",
+				"poisoned"
+			],
+			"senses": "darkvision 60 ft.",
+			"passive": 11,
+			"cr": "1/8",
+			"trait": [
+				{
+					"name": "Immutable Form",
+					"entries": [
+						"The guardian tail is immune to any spell or effect that would alter its form."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite or Claw",
+					"entries": [
+						"Melee Weapon Attack: {@hit 3} to hit, reach 5 ft., one target. Hit: 2 ({@dice 1d4}) piercing or slashing damage."
+					]
+				}
+			],
+			"traitTags": [
+				"Immutable Form"
+			]
+		},
+		{
+			"name": "Rabbit",
+			"size": "T",
+			"type": "beast",
+			"source": "EnMa",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 1,
+				"formula": "1d4-1"
+			},
+			"speed": {
+				"walk": 40,
+				"burrow": 5
+			},
+			"str": 2,
+			"dex": 15,
+			"con": 8,
+			"int": 2,
+			"wis": 12,
+			"cha": 6,
+			"skill": {
+				"perception": "+3"
+			},
+			"passive": 13,
+			"cr": "0",
+			"trait": [
+				{
+					"name": "Keen Hearing and Smell",
+					"entries": [
+						"The rabbit has advantage on Wisdom (Perception) checks that rely on hearing or smell."
+					]
+				},
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The rabbit’s long jump is up to 10 feet and its high jump is up to 5 feet, with or without a running start."
+					]
+				}
+			],
+			"traitTags": [
+				"Keen Senses"
+			]
+		}
+	],
+	"item": [
+		{
+			"name": "Abacus of Calculation",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "1",
+			"entries": [
+				"You speak the mathematical equation you wish to calculate, and the abacus will shift the beads by itself. If you command it to, it will speak the answer aloud."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Absinth Oil",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This cursed item appears to be a beneficial oil, such as oil of armor. When applied to the skin, you will take double damage from all weapon attacks for 24 hours. Once on, it cannot be washed off for 24 hours, unless {@i remove curse} is cast first."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Air Mask",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"entries": [
+				"This mask produces a constant stream of fresh air when worn, allowing you to breathe normally underwater, in a thin atmosphere, or in an airless void."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Airboat",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"entries": [
+				"Airboats appear as normal boats or ships of one sort or another, but as their name implies, they can fly. The spellcaster who commands the boat can issue the boat a mental command, causing it to rise or sink; in order to move forward, however, the boat must be rowed, use sails, or otherwise be propelled as a normal boat. While in the air, its speed is doubled.",
+				"The spellcaster must remain on the boat, at or within 10 feet of the helm. If forced to move, the airboat will stop all forward motion. It will hover in place for 10 minutes before gently descending to ground level.",
+				"The airboat can also be used in the water. Without oars, sails, or another form of propulsion, the spellcaster can direct it to move at half-speed. Using normal propulsion methods increases the sailing airboat's movement to 1 1/2 times its normal speed.",
+				"The DM may roll a d6 to randomly determine the type of boat:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d6",
+						"Vehicle"
+					],
+					"rows": [
+						[
+							"1",
+							"Galley"
+						],
+						[
+							"2",
+							"Keelboat"
+						],
+						[
+							"3",
+							"Longship"
+						],
+						[
+							"4",
+							"Rowboat"
+						],
+						[
+							"5",
+							"Sailing ship"
+						],
+						[
+							"6",
+							"Warship"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of Charming",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"If you cast a spell that inflict the charmed condition on a target that is within 15 feet of you while you are wearing this amulet, that target has disadvantage on its saving throw to resist."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of Cheetah Speed",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"While wearing this amulet, your speed increases by 5 feet. In addition, you can use an action to increase your speed by 10 feet for one minute, and to use the Dash action as a bonus action. This only functions if you are wearing no armor or light armor. Once you use this ability, you cannot use it again until you have taken a short or long rest."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of Communication",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.1",
+			"entries": [
+				"This amulet has 7 charges. You may use your action to expend a charge and cast {@i comprehend languages}.",
+				"This amulet regains 1d6+1 expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of Hunting",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"Typically made of horn or antler and sinew, this amulet grants you advantage on all Animal Handling, Perception, and Survival ability checks made while hunting beasts and monstrosities."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of Magic Resistance",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"While wearing this amulet, you have advantage on saving throws against magical spells and effects."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of Perpetual Youth",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"While wearing this amulet, you are immune to magical aging. In addition, it absorbs 30 years of natural aging—you simply don't get any older. At the end of this time, the amulet cracks and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of the Beast",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This amulet comes in two varieties, silver and ivory.",
+				{
+					"items": [
+						{
+							"name": "Silver Amulet",
+							"entries": [
+								"If you are a lycanthrope—either infected or born as one—you can't change your shape while wearing this amulet. This has no effect on you if you're not a lycanthrope, even if you're a different type of shapechanger or are able to shapechange through other means."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Ivory Amulet",
+							"entries": [
+								"While wearing this amulet, you are infected with lycanthropy and will turn into a werewolf (or more rarely, a different type of werebeast) on the next full moon and every full moon afterwards. The ivory amulet is cursed. You can't take it off and you can't be cured of your lycanthropy or otherwise have your lycanthropy suppressed while wearing this amulet."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Amulet of the Spirit",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"While wearing this item, you gain advantage on saving throws against spells and effects that would remove your soul or spirit from your body, or that would allow something else to possess your body."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ankh of Life",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a cleric or paladin",
+			"weight": "0.1",
+			"entries": [
+				"You hold this ankh up and use your action to channel you divine power through it, which emanates outward from the ankh in a 30-foot cone. All undead in this area take 70 points of radiant damage. Once you use this ability, you can't use it again until the next dawn.",
+				"In addition, this amulet has 6 charges. It regains 1d6 expended charges daily at dawn. When you hold the amulet, you may expend one or more charges and cast the following spells: {@i lesser restoration} (1 charge); {@i heal} (2 charges); {@i greater restoration} or {@i regeneration} (4 charges); or {@i resurrection} (6 charges)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Anklet of Hobbling",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"While wearing this item, your speed is reduced to 10 feet. A command word needs to be spoken before the anklet is removed.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"Some, but not all, of these anklets are cursed. Once you don this cursed item, you can't take it off unless you are targeted by the {@i remove curse} spell or similar magic."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Antidote Potion, Abberations & Fey",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you use your action to drink this potion, you immediately lose the poisoned condition and heal 1d6 hit points. This potion is a pale, translucent yellow or brown.",
+				"This will cure a toxin delivered by an aberration or fey.",
+				"This restriction only applies to natural weapon attacks of these creatures, poisons applied by wielded weapons can always be cured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Antidote Potion, Common",
+			"tier": "Major",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you use your action to drink this potion, you immediately lose the poisoned condition and heal 1d6 hit points. This potion is a pale, translucent yellow or brown.",
+				"This will cure a toxin delivered by a beast, dragon, giant, humanoid, or monstrosity.",
+				"This restriction only applies to natural weapon attacks of these creatures, poisons applied by wielded weapons can always be cured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Antidote Potion, Mystical",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you use your action to drink this potion, you immediately lose the poisoned condition and heal 1d6 hit points. This potion is a pale, translucent yellow or brown.",
+				"This will cure a toxin delivered by a celestial, elemental, or fiend.",
+				"This restriction only applies to natural weapon attacks of these creatures, poisons applied by wielded weapons can always be cured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Antidote Potion, Plants & Oozes",
+			"tier": "Major",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you use your action to drink this potion, you immediately lose the poisoned condition and heal 1d6 hit points. This potion is a pale, translucent yellow or brown.",
+				"This will cure a toxin delivered by an ooze or plant.",
+				"This restriction only applies to natural weapon attacks of these creatures, poisons applied by wielded weapons can always be cured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Antidote Potion, Undead",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you use your action to drink this potion, you immediately lose the poisoned condition and heal 1d6 hit points. This potion is a pale, translucent yellow or brown.",
+				"This will cure a toxin delivered by an undead.",
+				"This restriction only applies to natural weapon attacks of these creatures, poisons applied by wielded weapons can always be cured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Anvil of the Dwarfs",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"reqAttune": "by a dwarf or by a cleric of the forge domain",
+			"weight": "300",
+			"entries": [
+				"If you have proficiency with Smith's tools, this anvil allows you to double your normal proficiency bonus when using them. In addition, the maximum gp value of the items you can create increases to 50 gp per day. Finally, when constructing a weapon or suit of armor using this anvil, roll a d20. On a roll of 20, the weapon or armor is enchanted with a +1 bonus.",
+				"If you don't have proficiency with Smith's tools, you are treated as if you do while using this anvil, using your normal proficiency level. You get none of the other benefits of using this anvil, however."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arcane Shot",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "2",
+			"type": "A",
+			"entries": [
+				"This enchanted ammunition must be fired from a siege weapon to be used. There are several different types of {@i arcane shot}, and {@i arcane shot} that misses its target is destroyed and dissipates harmlessly.",
+				{
+					"items": [
+						{
+							"name": "Dust Shot",
+							"entries": [
+								"This shot explodes in midair into a mist of fine white, nonflammable particles that fills a 50-foot-tall cylinder with a 40-foot radius. It hangs in the air for 10 minutes. The area is lightly obscured. A moderate or stronger wind (at least 10 miles per hour) will disperse the dust in 1 minute."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Ring Shot",
+							"entries": [
+								"All metallic objects within 100 feet of the target begin ringing loudly enough to be heard up to 500 feet away and drowning out all other sounds in that area. The ringing lasts for 1 minute. A creature within 50 feet of the point of impact must make a DC 15 Constitution saving throw or be deafened for 1 minute."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Scatter Shot",
+							"entries": [
+								"This shot breaks into deadly magical shrapnel on impact. All creatures within 30 feet of the impact point must make a DC 15 Dexterity saving throw, taking 4d10 force damage on a failed saving throw, or half as much on a successful one."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Skunk Shot",
+							"entries": [
+								"This shot breaks on impact and releases a greenish, foul-smelling vapor, similar to that produced by the {@i stinking cloud} spell. This gas hangs in the air for 1 minute before dissipating, and the area is lightly obscured. All creatures within 30 feet of the point of impact must make a DC 15 Constitution saving throw each time they end their turn in that area or take 2d8 poison damage and spend its next action that turn retching and reeling. Creatures that don't need to breathe or are immune to poison automatically succeed on this saving throw. A moderate or stronger wind (at least 10 miles per hour) will disperse the dust in 1 minute."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Snow Shot",
+							"entries": [
+								"This shot explodes in mid air and causes a violent snowstorm to spring up in a 50-foot-tall cylinder with a 40-foot radius, similar to that produced by the {@i sleet storm} spell. The area is heavily obscured, and exposed flames in the area are doused. The snowstorm persists for 10 minutes before dissipating."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Termite Shot",
+							"entries": [
+								"This shot breaks on impact and releases a brown, molasses-like goo, which bubbles forth and spreads out at a rate of 20 feet each round for 1 minute before melting away. This substance causes 2d6 acid damage each round to all wooden objects in that area."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Armor of Absorption, Type Ⅰ",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"armor": true,
+			"type": "GV",
+			"entries": [
+				"While wearing this armor, if you are hit by an attack that reduces your hit point maximum or one of your attributes, the armor will instead absorb the negative energy that caused the reduction; while you will still take damage from the attack, you won't suffer from the reduction. Each time this armor absorbs a draining attack, roll a d20. On a roll of 1, the armor absorbs the negative energy and becomes a nonmagical suit of armor.",
+				"While wearing this armor, you have resistance to necrotic damage. If the armor loses its absorption ability and becomes nonmagical, it no longer provides resistance.",
+				{
+					"type": "entries",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"any armor"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Armor of Absorption, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"armor": true,
+			"type": "GV",
+			"entries": [
+				"While wearing this armor, if you are hit by an attack that reduces your hit point maximum or one of your attributes, the armor will instead absorb the negative energy that caused the reduction; while you will still take damage from the attack, you won't suffer from the reduction. Each time this armor absorbs a draining attack, roll a d20. On a roll of 1, the armor absorbs the negative energy and becomes a nonmagical suit of armor.",
+				"While wearing this armor, you are immune to necrotic damage. If the armor loses its absorption ability, it doesn't become entirely nonmagical and continues to provide resistance to necrotic damage, as if it were {@i armor of resistance}.",
+				{
+					"type": "entries",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"any armor"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Armor of Command",
+			"type": "HA",
+			"armor": true,
+			"rarity": "Legendary",
+			"weight": "65",
+			"ac": 18,
+			"strength": "15",
+			"stealth": true,
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"You have a +1 bonus to AC while wearing this expensive-looking armor, and you have advantage on all Charisma ability checks. In addition, you may also cast the {@i command}, {@i mass suggestion} and {@i suggestion} spells (spell save DC 17). Once you cast a spell, you can't cast that spell again until the next dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Armor of Fear",
+			"type": "HA",
+			"armor": true,
+			"rarity": "Very Rare",
+			"weight": "65",
+			"ac": 18,
+			"strength": "15",
+			"stealth": true,
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"While wearing this demonic-looking armor, you gain a +1 bonus to AC. In addition, this armor has 3 charges. While wearing the armor, you may expend a charge to cast the {@i fear} spell (save DC 15). The armor regains 1d3 expended charges at dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Armor-Piercing Dagger",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Legendary",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This dagger, whether wielded in melee combat or used as a throwing weapon, ignores non-magical armor. If the target is wearing magical armor, it only counts the bonuses the armor grants. For instance, {@i chainmail +1} would increase the wearer's AC by 1. Magical armor that doesn't grant bonuses is treated as giving a +1 bonus for the purpose of being struck by this dagger."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Aroma of Dreams",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This is a small crystal container holding 2d4+2 applications of a thin salve that has a heady scent. A creature that is within 10 feet of you for a full round must make a DC 15 Constitution saving throw or fall asleep; on a success, that creature is immune to this salve for 24 hours. An application of perfume remains active for 10 minutes before becoming inert."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Aromatic Pipe",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.1",
+			"entries": [
+				"This smoking pipe produces any non-harmful scent you wish when you use it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Biting",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"Once fired from a bow, the {@i arrow of biting} transforms into a flying snake and attacks your target. Roll initiative for the flying snake, which has its own turns. It will continue to attack that target for one minute or until the target dies or moves outside of your bow's long range (320 feet for a shortbow or 600 feet for a longbow). At that time, the flying snake turns back into a nonmagical arrow."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Blinding",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"When this arrow hits your target, it explodes in a brilliant flash of light. All creatures within 30 feet of the point of impact must make a DC 13 Constitution saving throw or be blinded for 1 minute. A creature may reroll at the end of each of its turns, ending this effect on a success. Once it releases the burst of light, it becomes a nonmagical arrow."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Bow-Breaking",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Rare",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"This arrow usually appears to be a perfectly normal arrow, although some appear to be {@i arrows of slaying}. The arrow retains its enchantment whether it hits or misses.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This arrow is cursed. When fired from a nonmagical bow, roll a d6. On a 1-3, the bowstring breaks; on a 4-5, the bow itself breaks, and on a 6, the arrow fires normally. When fired from a magical bow, roll a d6. On a 1-5, the bowstring breaks, and on a 6, the arrow fires normally."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Direction",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Minor",
+			"reqAttune": true,
+			"entries": [
+				"This arrow has 3 charges. You may use your action to throw the arrow in the air and spend a charge while imagining an object or place, or the closest object of a particular kind. When the arrow lands, it is pointing in the object's direction. The {@i arrow of direction} can't find living creatures.",
+				"If shot from a bow, roll a d6 whether it hits or misses. On a 1, the arrow breaks and becomes useless. You don't need to be attuned to the arrow to shoot it.",
+				"The arrow regains all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Extended Range, Type Ⅰ",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Common",
+			"weight": "0.05",
+			"tier": "Minor",
+			"entries": [
+				"When fired from a bow or crossbow, these arrows and quarrels have double the range of normal ammunition.",
+				"Whether the ammunition hits or misses, roll a d6; on a 1, the arrow or quarrel breaks. Otherwise, it retains its magic and can be reused.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Bow Type",
+						"Range"
+					],
+					"rows": [
+						[
+							"Shortbow or light crossbow",
+							"160/640 ft."
+						],
+						[
+							"Longbow",
+							"300/1,200 ft."
+						],
+						[
+							"Hand crossbow",
+							"60/240 ft."
+						],
+						[
+							"Heavy crossbow",
+							"200/800 ft."
+						]
+					],
+					"colStyles": [
+						"col-xs-6",
+						"col-xs-6 text-align-center"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Extended Range, Type Ⅱ",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Minor",
+			"entries": [
+				"When fired from a bow or crossbow, these arrows and quarrels have triple the range of normal ammunition.",
+				"Whether the ammunition hits or misses, roll a d6; on a 1, the arrow or quarrel breaks. Otherwise, it retains its magic and can be reused.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Bow Type",
+						"Range"
+					],
+					"rows": [
+						[
+							"Shortbow or light crossbow",
+							"240/960 ft."
+						],
+						[
+							"Longbow",
+							"420/1,800 ft."
+						],
+						[
+							"Hand crossbow",
+							"90/360 ft."
+						],
+						[
+							"Heavy crossbow",
+							"300/1,200 ft."
+						]
+					],
+					"colStyles": [
+						"col-xs-6",
+						"col-xs-6 text-align-center"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Harm",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"Much more common than the {@i arrow of slaying}, the {@i arrow of harm} does an extra die of damage to a particular type of creature. Once it deals its extra damage to a creature, it becomes a nonmagical arrow."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Holding",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"When the {@i arrow of holding} hits a creature, that creature must make a DC 13 saving throw or be paralyzed for 1 minute. A creature may reroll at the end of each of its turns, ending this effect on a success. Upon hitting the target, the arrow becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Arrow of Returning",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Uncommon",
+			"weight": "0.05",
+			"tier": "Minor",
+			"entries": [
+				"If you fail to hit your target when firing an arrow of returning, it will reappear in your quiver at the beginning of your next turn. If it hits the target but is recovered, it can be reused."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Backbiter",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "3",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "P",
+			"property": [
+				"T",
+				"V"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"You gain a +1 bonus to attack and damage rolls made with this magic weapon.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This weapon is cursed and attuning to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the spear, keeping it on your person at all times. While attuned to this weapon, you have disadvantage on attack rolls made with weapons other than this one."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"If you roll a 1 on the attack roll, the spear twists around and stabs you. The DM will roll the damage dice two times to determine how much damage you take."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Badge of Freedom",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"As long as you are wearing this metal broach, you have advantage on saving throws to resist being grappled, paralyzed, petrified, or restrained, and to all Dexterity ability checks when attempting to free yourself from ropes, shackles, cages, spider webs, and other such bonds."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Beans (Variant)",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"This is an extended (and quite powerful) variant of the bag of beans presented in the {@i Dungeon Master's Guide}. It includes the results from the DMG.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d100",
+						"Effect"
+					],
+					"rows": [
+						[
+							"01",
+							"5d4 toadstools sprout. If a creature eats a toadstool, roll a die. On an odd roll, the eater must succeed on a DC 15 Constitution saving throw or be poisoned for 1 hour and take 5d6 poison damage. On an evil roll, the eater gains 5d6 temporary hit points for 1 hour."
+						],
+						[
+							"02",
+							"A geyser erupts, shooting 30 feet into the air for 1d12 rounds, producing a thousand gallons of liquid each round. It spews one of the following (DM's choice): cold water, boiling hot water, tepid water, mediocre beer, berry juice, tea, vinegar, wine, rock oil, or vegetable oil. The liquid can be collected into bottles or buckets; otherwise, it evaporates within an hour."
+						],
+						[
+							"03",
+							"A {@creature treant|mm} sprouts, reaching full height and growth in 1d6 rounds. There is a 50 percent chance that the treant is chaotic evil and immediately attacks."
+						],
+						[
+							"04",
+							"An animate, immobile stone statue in your likeness rises. It makes verbal threats against you. If you leave it and others come near, it describes you as the most heinous of villains and directs the newcomers to find and attack you. If you are on the same plane of existence as the statue, it knows where you are. The statue becomes inanimate after 24 hours."
+						],
+						[
+							"05",
+							"A campfire with blue flames springs forth and burns for 24 hours (or until it is extinguished)"
+						],
+						[
+							"06",
+							"1d6+6 {@creature shrieker|mm|shriekers} sprout."
+						],
+						[
+							"07",
+							"1d4+8 bright pink toads crawl forth. Whenever a toad is touched, it transforms into a Large or smaller monster of the DM's choice. The monster remains for 1 minute, then disappears in a puff of bright pink smoke"
+						],
+						[
+							"08",
+							"A hungry {@creature bulette|mm} burrows up and attacks."
+						],
+						[
+							"09",
+							"A fruit tree grows. It has 1d10+20 fruit, 1d8 of which act as randomly determined magic potions, while one acts as an ingested poison of the DM's choice. The tree vanishes after 1 hour. Picked fruit remains, retaining any magic for 30 days."
+						],
+						[
+							"10",
+							"A nest of1d4+3 eggs springs up. Any creature that eats an egg must make a DC 20 Constitution saving throw. On a successful save, a creature permanently increases its lowest ability score by 1, randomly choosing among equally low scores. On a failed save, the creature takes 10d6 force damage from an internal magical explosion."
+						],
+						[
+							"11",
+							"A pyramid with a 60-foot-square base bursts upwards. Inside is a sarcophagus containing a {@creature mummy lord|mm}. The pyramid is the mummy lord's lair, and its sarcophagus contains a treasure of the DM's choice."
+						],
+						[
+							"12",
+							"A giant beanstalk sprouts, growing to a height of the DM's choice. The top leads where the DM chooses, such as to a great view, a cloud giant's castle, or a different plane of existence."
+						],
+						[
+							"13",
+							"A great whirlwind, 30 feet tall with a 5-foot radius, appears out of nowhere. All creatures within 10 feet of it must make a DC 15 Strength saving throw or be restrained by it (escape DC 15). The whirlwind moves erratically (speed 40 ft.) for one minute before dying down. A creature who touches or is touched by the whirlwind, or is restrained by it, takes 2d10 bludgeoning damage at the end of each of its turns."
+						],
+						[
+							"14",
+							"A sphere of utter darkness with a 60-foot radius, impervious to darkvision, appears. It is centered on the bean. The darkness remains for 24 hours before dissipating."
+						],
+						[
+							"15",
+							"A pheasant leaps out of the ground and attempts to fly away (speed 30 ft., fly 50 ft.). 1d4 of its feathers are actually {@i Quall's feather tokens}."
+						],
+						[
+							"16",
+							"A spring bubbles up. The first creature who drinks from it has its age reduced by 1d12 years. Subsequent drinks age the drinker by 10d6 years."
+						],
+						[
+							"17",
+							"A number of {@creature zombie|mm|zombies} equal to three times the number of PCs present claw their way up from the ground and attack. These zombies have the maximum, not the average, number of hit points."
+						],
+						[
+							"18",
+							"A pool of molten lava rises to the surface and expands 10 feet each round to a maximum radius of 60 feet. Anyone caught in the lava receives 10d8 fire damage each time they end their round in the pool. The lava cools down and solidifies into slag over a period of 24 hours."
+						],
+						[
+							"19",
+							{
+								"entries": [
+									"Weirdly colored gasses rise from the ground and fill a sphere 60 feet in diameter. A creature that ends its turn in the gas must make a DC 15 Constitution saving throw or suffer one of the following effects (roll a d4):",
+									"{@b 1.} The creature's hit point maximum is permanently increased by 1d8.",
+									"{@b 2.} The creature's hit point maximum is permanently reduced by 1d4.",
+									"{@b 3.} The creature contracts {@b wererat} lycanthropy.",
+									"{@b 4.} The creature contracts sewer rot."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"20",
+							{
+								"entries": [
+									"3d6 beasts of CR 1 or lower rise from the earth at a rate of 1 per round. Each beast behaves in a random manner (roll a d4):",
+									"{@b 1.} The beast runs away at top speed.",
+									"{@b 2.} The beast follows your directions for 24 hours, then wanders off.",
+									"{@b 3.} The beast attacks the nearest creature.",
+									"{@b 4.} The beast acts normally for a creature of its species."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"21",
+							"A cloud of nearly-invisible, almost odorless gas flows up from the ground, forming a 40-foot sphere and remaining for 1 hour before dissipating. A strong wind (at least 20 miles per hour) will disperse the gas in one minute. If any spells are cast while in the cloud, it explodes into multicolored flames. Any creature in that area must make a DC 15 Dexterity saving throw, taking 1d6 fire damage per level of the spell (a cantrip inflicts 1d4 fire damage) on a failed save, or half as much on a successful one."
+						],
+						[
+							"22",
+							"Two {@i Bigby's hands} appear, one a Clenched Fist and the other a Grasping Hand. They attack the nearest creature that is within 90 feet of them. They otherwise don't move more than 10 feet from their location and remain until they are destroyed or 10 minutes have passed."
+						],
+						[
+							"23",
+							"Fast-growing tendrils of a weird, rubbery material reach up from the ground in a 30-foot radius. All creatures in that area must make a DC 15 Dexterity saving throw or be restrained by the tendrils (escape DC 15). The tendrils remain in place for 24 hours, then wither away."
+						],
+						[
+							"24",
+							"A pit 20 feet in diameter and 10d10 feet deep suddenly appears directly under you. All creatures in that area fall in, taking normal falling damage."
+						],
+						[
+							"25",
+							{
+								"entries": [
+									"A duplicate of you will emerge from the ground. It is identical to you in any way, including alignment and general outlook on life. If allowed, it will remain with you for anywhere from a few hours to a month, and then will leave to establish its own life",
+									"    The DM should roll a d10. On a roll of 1-8, the duplicate will fade away after 1d4+1 months. On a 9-10, it continues to exist and will age normally."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"26",
+							"A magical earthquake shakes the ground, centered on the place the bean was planted and traveling outwards to a 500-foot radius. This effect is otherwise identical to the {@i earthquake} spell."
+						],
+						[
+							"27",
+							"An (or perhaps {@i the}) {@i apparatus of Kwalish} digs its way out of the ground. It's operated by a slightly confused, unarmed {@creature hobgoblin|mm}."
+						],
+						[
+							"28",
+							"A 20-foot-tall tree grows over the course of 1 minute. It bears 3d8 obviously magical fruits of various types. If a fruit is cut, crushed, or bitten into, it produces a random object worth 50 gp or less. The DM can choose the item or roll on the table presented for the {@i robe of useful items}. After 24 hours or whenever all the fruits have been picked (whichever comes first), the tree becomes a normal, non-fruit-bearing tree such as an oak or aspen."
+						],
+						[
+							"29",
+							"A powerful hailstorm strikes the area to a radius of 100 feet. Each round that a creature ends its turn in that area, it must make a DC 15 Dexterity saving throw, taking 7 (2d6) bludgeoning damage and 3 (1d6) cold damage on a failed save, or half as much on a successful one."
+						],
+						[
+							"30",
+							"1d6 intelligent holly bushes (use {@creature awakened shrub|mm} statistics) grow out of the ground in 1 round and attack. 4d6 of their berries are red garnets (worth 100 gp each) and 6d6 are worthless, garnet-colored glass."
+						],
+						[
+							"31",
+							"A hole 30 feet wide and 40 feet deep appears in front of you. In it is a purple worm and a {@i ring of three wishes}."
+						],
+						[
+							"32",
+							"Dark, choking smoke billows up from the ground and covers a spherical area that has a radius of 60 feet. The area is heavily obscured. A creature in that area must hold its breath or begin to suffocate."
+						],
+						[
+							"33",
+							"An obviously magical {@creature wyvern|mm} leaps out of the ground and attacks. It is identical to a normal wyvern, save that the to-hit bonus for its stinger attack is +10."
+						],
+						[
+							"34",
+							"A {@i sphere of annihilation} rises from the ground. If you attempt to control it and fail, it will move towards you at a speed of 20 feet. It will continue to follow you for 1 hour, no matter how you try to escape it. At the end of this time, the {@i sphere} becomes stationary."
+						],
+						[
+							"35",
+							"A 30-foot-diameter pool of crystal-clear, sweet-tasting water bubbles up from the ground. If you touch the water, you may choose to cast {@i commune} without using a spell slot. The DM will roll a d6. On a roll of 1-4, the powers that be will answer all questions. On a roll of 5-6, you will have two questions answered, but upon asking the third question, you will be attacked by three {@creature water weird|mm|water weirds} instead."
+						],
+						[
+							"36",
+							"An arm holding a sword erupts from the ground. The sword is magical and of a type determined by the DM."
+						],
+						[
+							"37",
+							"Nothing will appear to happen, but five rounds later, a meteor will crash into the ground (you will be forewarned by a quickly-growing shadow on the ground). All creatures within 30 feet of the bean must make a DC 15 Dexterity saving throw. A creature within 5 feet of it takes 10d10 bludgeoning damage and 5d10 fire damage on a failed save, or half as much on a successful one. A creature within 5-30 feet takes 5d10 bludgeoning damage on a failed save, or half as much on a successful one."
+						],
+						[
+							"38",
+							"A spectral, scythe-wielding grim reaper appears (use the statistics for the {@creature avatar of death|dmg} from the Skull entry of the {@i deck of many things}.) It targets you, and no other creature can affect the avatar in any way."
+						],
+						[
+							"39",
+							"1d6 intelligent holly (use {@creature awakened shrub|mm} statistics) grow out of the ground in 1 round and attack. 3d6 of their berries are explosive; if thrown (range 20/50), they explode, one or more creatures within 5 feet of the point of impact must make a Dexterity saving throw (DC equal to 10 + the thrower's proficiency bonus), taking 10 (3d6) fire damage on a failed save, or half as much on a successful one."
+						],
+						[
+							"40",
+							"A {@i wall of thorns} springs up around the bean, forming a circular wall 30 feet in radius, 10 feet high, and 5 feet thick. It remains for 24 hours, then withers away."
+						],
+						[
+							"41",
+							"A beautiful, silvery gray horse appears. It is capable of speech and is very well-spoken; it is proficient in all Charisma-based skills, and will offer you a ride to any destination. The horse is actually a {@creature nightmare|mm} in disguise and will take the rider to Oinos, the first layer of the Gray Waste of Hades."
+						],
+						[
+							"42",
+							"An iron golem rises from the ground and attacks. In its forehead are three gemstones: a {@i gem of brightness}, a {@i gem of seeing}, and a diamond worth 5,000 gp."
+						],
+						[
+							"43",
+							{
+								"entries": [
+									"A powerful ancestral spirit coalesces and questions you about your actions (especially events that have taken place within the last half-year or so). If the spirit feels that you have been true to your ideals, vows, oaths, and alignment (whatever your alignment may be), it will award you with 5,000 XP. Otherwise, it will remove 5,000 XP from you. If this would bring you to a lower level, you lose enough XP to have exactly enough to be at your current level.",
+									"    The spirit doesn't attack and can't be harmed by any attacks. It vanishes after it awards or drains XP."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"44",
+							{
+								"entries": [
+									"A huge fountain, exquisitely carved yet still quite gaudy, grows out of the earth. It is 20 feet high, made from expensive marble, and is decorated with leaping dolphins and nymphs with water jars. It spurts pure water, and 2d6 copper coins can be easily found in the fountain's basin. The fountain continues to produce water for 2d6 hours before it runs dry, but the fountain itself is permanent. It's far too heavy to be moved, but if hooked up to some plumbing or otherwise provided with sufficient water, it can continue to be used as a fountain. ",
+									"    Optionally, the DM can roll on the table for the {@i magic fountain} (q.v.)."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"45",
+							"10d6 {@creature swarm of insects|mm|swarms of insects} crawl out of the ground and buzz around. They only attack if disturbed or harassed, and will settle down and disperse in an hour."
+						],
+						[
+							"46",
+							"The ground cracks open and steam hisses upwards, and an extradimensional creature steps out. Roll on the table under the entry for the {@i iron flask} to determine the type of creature. There is a 10 percent chance that the creature is hostile."
+						],
+						[
+							"47",
+							"The area around the bean turns into a {@i well of many worlds}. It can be picked up and taken."
+						],
+						[
+							"48",
+							"A hostile {@creature earth elemental|mm} appears—and the elemental's mind and your mind are switched. If either you or it is slain, the switch becomes permanent. Otherwise, it lasts for 24 hours, after which you are returned to normal. A {@i dispel evil and good} will restore your minds before that."
+						],
+						[
+							"49",
+							"A clockwork {@creature wyvern|mm} springs out of the ground. It has the attributes and abilities of a normal wyvern, but with the following changes: its AC is 17, it can breathe a 30-foot cone of frost (recharge 5-6; a creature in that area must make a DC 15 Dexterity saving throw, taking 6d4 cold damage on a failed save, or half as much on a successful one), and its gemstone eyes give it {@i true seeing} to 30 feet. If slain, its eyes retain those properties and can be worn over the eyes (in the same way items such as {@i eyes of minute seeing} can be worn) to grant the wearer truesight to 30 feet. Both of these eyes must be worn as a set for this to function."
+						],
+						[
+							"50",
+							"Sixteen {@creature vine blight|mm|vine blights} crawl out of the ground and attack."
+						],
+						[
+							"51",
+							{
+								"entries": [
+									"Brilliantly colored, fantastically shaped flowers grow in the area within 300 feet of the bean. One minute after growing, they emit a magical pollen: all creatures in that area must make a DC 20 Constitution saving throw or fall asleep; a creature immune to unconsciousness, that doesn't need to sleep, or who has the Fey Ancestry trait isn't affected. The sleep lasts for 1 hour, and a sleeping creature will be awakened by if it takes damage. This sleep counts as a long rest. ",
+									"    Sleeping creatures dream vividly. Each player should describe their sleeping PC's dreams. The DM will roll a die for each sleeping PC. On an even roll, the character will discover upon awakening that it has been granted a {@i wish} based on its dream; the level of detail and type of dream that was had determine what form the wish takes."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"52",
+							"A {@creature young red dragon|mm} claws its way out of the ground and attacks. If slain and its body butchered, a fist-sized red ruby can be found in place of its heart. This ruby acts exactly like a {@i wand of fireballs}."
+						],
+						[
+							"53",
+							{
+								"entries": [
+									"A magical trebuchet appears. A character who attunes to it can command it to shrink to a height of 1 inch or back into its normal size. It aims itself automatically, takes only a single action to load, has a range of 500/1,500 feet, and a +7 to hit.",
+									"    It can also be commanded to throw a {@i delayed blast fireball} that does 42 (12d6) fire damage. Once it has done so, it can't do so again until the following dawn."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"54",
+							"A hemispherical chunk of earth 500 feet in diameter rises out of the ground. It will slowly rise into the air at a rate of 10 feet per round, to a maximum height of 300 feet. It will remain in the air indefinitely and will slowly float on the winds."
+						],
+						[
+							"55",
+							"Nothing seems to happen. If the bean is dug up again, it will be proven to have turned into a gold nugget worth 50 gp. Further investigation will reveal that the site can be turned into a successful gold mine."
+						],
+						[
+							"56",
+							"Nothing appears to happen, but two {@creature invisible stalker|mm|invisible stalkers} have appeared and will follow you. They will attempt to steal the {@i bag of beans} and upon doing so, will peacefully leave. If you resist, however, they will attack."
+						],
+						[
+							"57",
+							"A small house appears. Inside are 2d6 {@creature troll|mm|trolls} who have taken up residence and dislike trespassers. If the house is carefully searched, a DC 15 Intelligence (Investigation) will reveal a trapdoor that leads to an extradimensional dungeon of the DM's design."
+						],
+						[
+							"58",
+							"A fortress like the one create by {@i Daern's instant fortress} appears suddenly. Each creature in the area where the fortress appears must make a DC 15 Dexterity saving throw, taking 10d10 bludgeoning damage on a failed save, or half as much on a successful one. You can command the fortress' entrance to open or close, but the fortress can never be moved or shrunk to its cube form."
+						],
+						[
+							"59",
+							{
+								"entries": [
+									"A large tent, covering a 30-foot-square section of ground and reaching 10 feet tall, appears, enclosing all creatures in the area inside. The tent is lavishly furnished with velvet pillows, golden lamps, porcelain vases, exotic tapestries, expensive incense, bottles of fine wine, bowls of rare, ripe fruit, etc. All creatures inside the tent when it appears must make a DC 15 Wisdom saving throw or be affected by the Sympathy part of the {@i antipathy/sympathy} spell. ",
+									"    Anything removed from the tent turns into scraps of paper 1d4 hours later."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"60",
+							{
+								"entries": [
+									"4d6 laughing, bat-winged skulls spring from the ground and surround you. They don't attack but are extremely bothersome—their constant laughter interrupts sleep and is distracting; you must succeed on a DC 10 Constitution saving throw each time you attempt to cast a spell or perform any action that requires concentration. ",
+									"    Each skull has AC 13, 10 hit points, and is immune to all but one type of damage, which is different for each skull, and not immediately obvious. After 2d4 days, the skulls fly away."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"61",
+							"An unhatched dragon's egg appears. It will hatch in 2d6 days if kept warm. The type of dragon it becomes is completely random, and the infant dragon will see you as its mother—at least at first."
+						],
+						[
+							"62",
+							"A wishing well appears. The first person who throws a coin in gets a wish. The next person who throws in 1,000 gp worth of coins and treasure gets a wish as well. Afterwards, the well disappears."
+						],
+						[
+							"63",
+							"A fissure, 2d10×5 feet long, 2d4×5 feet wide, and 1d4+1 miles deep appears. Unless the DM decides otherwise, there is absolutely nothing at the bottom. The fissure closes up again in 5d4 days."
+						],
+						[
+							"64",
+							{
+								"entries": [
+									"Mist rises from the ground. Over the course of a minute, it coalesces into the form of a dragon. It breathes a blast of scalding steam in a 40-foot cone. All creatures in that area must make a Dexterity saving throw, taking 6d6 fire damage on a failed save, or half as much on a successful one. After it breathes, it dissipates. ",
+									"    The dragon is immune to all forms of damage except for lightning damage. If injured with lightning—even for just a single point of damage, it vanishes. It will reappear behind you 1d4 hours later."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"65",
+							"A rope grows out of the ground and winds its way upwards to a height of 30 feet. It acts as a {@i rope trick} spell, except that it has a duration of 6 hours. At the end of that time, the rope collapses and turns into a {@i rope of climbing}."
+						],
+						[
+							"66",
+							"A {@creature basilisk|mm} appears. However, instead of turning creatures into stone, it ages them 5d10 years. After a minute, if it's still alive, the basilisk will wander away."
+						],
+						[
+							"67",
+							"An {@creature umber hulk|mm} digs its way out of the ground. After a minute, if it's still alive, it will dig a new tunnel and leave. If reduced to 0 hit points, its eyes will change color and it will utter a prophecy in Common. This prophecy will come true."
+						],
+						[
+							"68",
+							"A tavern appear. Although it appears seedy, it's staffed by {@i unseen servants} and all the food is a {@i hero's feast}. The tavern vanishes in the middle of the night, 3d4 days later."
+						],
+						[
+							"69",
+							"An insane {@creature gynosphinx|mm} appears. She will ask a simple children's riddle and will attempt to devour anyone who can't answer it."
+						],
+						[
+							"70",
+							"A pumpkin patch instantly grows, covering a 100-square-foot patch. The pumpkins ripen, then over-ripen in the space of 1 round. The next round, all but 1d6 of them burst open, releasing a cloud of noxious gasses. A creature that starts its turn inside the cloud must make a DC 15 Constitution saving throw or spend its action retching and reeling (creatures that don't need to breathe or that are immune to poison or the poisoned condition are immune to this effect). One round later, the pumpkins that didn't explode grow into hostile {@creature scarecrow|mm|scarecrows} and attack."
+						],
+						[
+							"71",
+							"The weather for 5 miles around becomes chaotic, changing rapidly and often dangerously over the next 24 hours."
+						],
+						[
+							"72",
+							"A squirrel (or other small, harmless animal appropriate to the environment) scampers along, digs the bean up, and eats it. Then it address you in your native language, offers hints as to the location of a magical treasure, and answers questions as if it had the skills Arcana, History, Nature, and Religion with a +10 proficiency bonus. An hour later, it becomes a perfectly normal squirrel, but will follow you around everywhere. If the squirrel is later questioned (using {@i speak with animals} or a similar effect), it will have none of its previous knowledge."
+						],
+						[
+							"73",
+							"A sexy {@creature vampire|mm} appears in the next night (its sex and appearance depends on your interests). It carries a {@i vorpal sword} and a {@i rope of entanglement}. It isn't bound to a coffin or requires grave dirt, but it is otherwise a normal vampire. It will stalk you, then attempt to kill you and turn you into its spawn."
+						],
+						[
+							"74",
+							{
+								"entries": [
+									"Nothing appears to happen, but if the bean is dug up, it will be found to have been replaced by an ornate puzzle box with 5,000 gp. If opened (a feat that requires a DC 18 Intelligence ability check), monsters begin pouring out. Each creature will constitute an Easy or Medium encounter for your party, but a new monster will appear at the rate of one each round for 10d10 rounds. The monsters are either unaligned, neutral, or evil in alignment, but won't immediately attack unless provoked (or one gets hungry). The only way to stop it is to close the puzzle box, but doing so requires both a DC 15 Intelligence saving throw {@i and} a DC 15 Strength ability check. ",
+									"    If you allow all the monsters to leave the box unharmed, the last monster out is far more powerful than the others and will grant you a wish. The wish can't undo the effects of the puzzle box."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"75",
+							"Immediately after the bean is planted, a rumbling in the earth will be heard, quickly getting louder and louder. Within 1d6 rounds, a herd (3d10) of albino {@creature mammoth|mm|mammoths} will appear. They will trample anything in their path before running away but will only engage in combat if attacked."
+						],
+						[
+							"76",
+							"An immovable, cage-like throne appears. A humanoid that sits in the throne may choose to be transported to either the Ethereal or Astral plane. It's a one-way trip, however. The throne can be used 10 times and then disappears."
+						],
+						[
+							"77",
+							"A friend but kleptomaniacal halfling thief appears. It can be easily talked into joining the party (and can even be used as a PC, if desired). Otherwise, it will wander off to have an adventure on its own—having first stolen several items from the PCs."
+						],
+						[
+							"78",
+							"The ground in a 60-foot radius turns into a bubbling, sticking, smelly tar-like substance. The area is difficult terrain."
+						],
+						[
+							"79",
+							"A giant oak tree grows, reaching its full height in a minute. It has 10d10 large acorns, each of which is filled with a different nonmagical substance that is worth less than 100 gp and weighs an ounce or less. The substance can be anything: dough, chocolate, amber, water, a live bee, etc. Once it runs out of these acorns, it will only grow normal acorns."
+						],
+						[
+							"80",
+							"A glowing silver harp appears in midair and begins to play. All creatures within 60 feet of the harp that can hear it must make a DC 20 Constitution saving throw or fall asleep; a creature immune to unconsciousness, that doesn't need to sleep, or who has the Fey Ancestry trait isn't affected. The sleep lasts for 1 hour, and a sleeping creature will be awakened by if it takes damage. This sleep counts as a long rest."
+						],
+						[
+							"81",
+							{
+								"entries": [
+									"A disembodied, fanged maw appears in the air, hovering 4 feet above the ground. Inside is a small extradimensional space. A creature that reaches inside must make a DC 15 Dexterity (Sleight of Hand) saving throw. On a success, the creature is able to snatch an item that is hidden inside: a bag of gems, a small magical item, etc. On a failure, the mouth snaps shut, inflicting 3d8 piercing damage to that creature's arm. ",
+									"    Nonliving objects that are thrust into the maw are automatically bitten and take damage; if a {@i mage hand} or similar effect is used, the caster must make a concentration check, using the amount of damage the mouth would have inflicted to determine the DC. ",
+									"    The mouth vanishes in 1 minute."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"82",
+							"A tombstone rises from the ground. It has your name on it, along with your birthdate and a date of death for a month in the future. Until that date passes, you have disadvantages on saving throws to avoid being frightened, and on that date, you have disadvantage on all death saving throws."
+						],
+						[
+							"83",
+							"You vanish into thin air. Magical attempts to find you will reveal that you are trapped inside the bean, as if caught by the minimum containment version of the spell {@i imprisonment}. You can be freed in the same way as that spell, although a {@i dispel magic} cast with a 7th level or higher spell slot will free you."
+						],
+						[
+							"84",
+							"The bean transforms into a ball of soft, pastel light, which will float serenely towards you (fly speed of 10 feet). If it touches you, you must make a DC 15 Charisma saving throw. On a success, nothing happens. On a failure, any item you are wearing or carrying, even magical items, turns into glass. However, your lowest ability score is permanently increased by 1."
+						],
+						[
+							"85",
+							{
+								"entries": [
+									"An area 30 yards in radius around the bean turns into a sand put. All creatures must make a DC 15 Dexterity saving throw or be pulled down into its center. The DM should roll a d6 to determine what lies in wait:",
+									"{@b 1-2.} A hungry adult blue dragon.",
+									"{@b 3-4.} The entrance to an underground cavern.",
+									"{@b 5-6.} A portal to another plane of existence. This portal remains open for 24 hours."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"86",
+							"Poisonous gas seeps out of the ground and hangs in the air for 10 minutes. A moderate (10 miles per hour) or greater wind will disperse the gas in 1 minute. A creature that ends its turn within 30 feet of the bean must make a DC 15 Constitution saving throw or take 11 (2d10) poison damage and be poisoned for 1 hour. The dirt around the bean's location becomes 2d4 doses of {@i dust of sneezing and choking}."
+						],
+						[
+							"87",
+							"The DM's favorite {@b dinosaur} emerges from the ground and wreaks havoc."
+						],
+						[
+							"88",
+							{
+								"entries": [
+									"A huge eyeball, 1 foot in diameter, rises from the ground and floats 6 feet in the air. Any creature that can see the eye and starts its turn within 30 feet of it must make a DC 15 Constitution saving throw. If the saving throw fails by 5 or more, the creature is instantly petrified. Otherwise, a creature that fails the save begins to turn into a statue and is restrained. The restrained creature must repeat the saving throw at the end of its next turn, becoming petrified on a failure or ending the effect on a success.",
+									"    The affected creature doesn't turn into stone. Instead, the DM should roll a d8 to determine the substance:",
+									"{@b 1.} Glass",
+									"{@b 2.} Lead",
+									"{@b 3.} Gold",
+									"{@b 4.} Salt",
+									"{@b 5.} Ice",
+									"{@b 6.} Wax",
+									"{@b 7.} Iron",
+									"{@b 8.} Wood"
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"89",
+							{
+								"entries": [
+									"The bean transforms into a deeply purple gemstone which then shoots up from the ground and imbeds itself in the middle of your forehead (causing 1 point of bludgeoning damage while doing so). Thereafter, whenever you are injured, the gemstone will glow and one charge will be drained from a magic item within 30 feet of you. Each charge drained heals you of 1d12 damage. Each round for as long as you are injured, it will continue to drain charges and heal you. If there are no charged magical items nearby, the gemstone still glows but you aren't healed. You have no control over this effect. ",
+									"    If a charged item says that, when depleted of all charges, you must roll a d20 and on a 1, the item is destroyed, the item is instead destroyed on a roll of 1-2. ",
+									"    A {@i dispel evil and good} will end this effect."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"90",
+							"Eye-watering smoke billows up from the ground in a 60-foot-radius sphere. A creature that starts its turn in the smoke cloud or enters the cloud for the first time must make a DC 15 Constitution saving throw or be blinded for as long as they remain in the cloud, and for 1 round afterwards."
+						],
+						[
+							"91",
+							"Absolutely nothing happens. Nothing at all."
+						],
+						[
+							"92",
+							"The bean violently explodes after a minute. All creatures within 30 feet of the bean must make a DC 15 Dexterity saving throw. A creature takes 14 (4d6) bludgeoning damage, 14 (4d6) thunder damage, and 14 (4d6) fire damage on a failed save, or half as much on a successful one."
+						],
+						[
+							"93",
+							"A {@i wall of stone} appears—1,000 feet in the air. It hits the ground in 1d4 rounds. All creatures directly underneath it must make a DC 15 Dexterity saving throw. A creature takes 10d12 bludgeoning damage on a failed saving throw, but none on a successful one."
+						],
+						[
+							"94",
+							"A stone pillar 30 feet in diameter erupts from the ground and quickly rises to 100 feet tall, taking all creatures that were in the area with it. The pillar abruptly vanishes 1 hour later, dumping anyone still on it to the ground."
+						],
+						[
+							"95",
+							"A shrine, covered in horrible fiendish images and idols, slowly rises from the ground. The shrine demands sacrifice. If someone offers it money, goods, or blood, it will cause a magical weapon to appear at that creature's feet. If a magical item is offered, it will grant that creature a {@i wish}. If nothing is offered, it drains two points from your highest attribute. A {@i greater restoration} will restore the lost attributes, one point per casting."
+						],
+						[
+							"96",
+							"1d6 creatures within 60 feet are struck by the {@i enlarge/reduce} spell; a creature may make a DC 15 Wisdom saving throw to resist. An affected creature must roll a die: on an even roll, the creature is enlarged; on an odd roll, the creature is reduced. This change is permanent until the creature is targeted by a {@i remove curse} or similar spell."
+						],
+						[
+							"97",
+							"A perfectly ordinary {@creature warhorse|mm} trots up. It will allow you (and only you) to ride it."
+						],
+						[
+							"98",
+							"a storm made of sheets of roaring flame appears in a 30-foot cube centered on the bean and lasts for one round. All creatures in that area must make a DC 15 Dexterity saving throw. A creature takes 39 (7d10) fire damage on a failed save, or half as much on a successful one. The fire damages objects in the area and ignites flammable objects that aren't being worn or carried."
+						],
+						[
+							"99",
+							"A rolled-up tapestry appears. Its intricate weaving reveals a fairly accurate map to an ancient, undiscovered dungeon, temple, or castle, as well as a partial map of that place. The dungeon is guaranteed to have a great deal of treasure, although it will also have many guardians."
+						],
+						[
+							"100",
+							"A hostile {@creature oni|mm} appears. It wields a powerful magical glaive, and it has a unique ability—if it fails a saving throw against a spell, it suffers the effects of that spell, but as a reaction can then cast that spell itself."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Bones, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This bag contains a number of tiny bones.",
+				"If the bones are scattered on a battlefield (100 or more combatants) in the heat of battle, and the command word is spoken, eighty skeletons grow out of the bones. These skeletons have maximum hit points. The skeletons are loyal to you and follow your commands. The skeletons remain until either dusk (if they were released during the day) or dawn (if they were released at night), and then crumble into dust. Once you use this item, it can't be used again."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Bones, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This bag contains a number of tiny bones.",
+				"If the bones are scattered on a battlefield (100 or more combatants) in the heat of battle, and the command word is spoken, eighty skeletons grow out of the bones. These skeletons have maximum hit points. The skeletons are loyal to you and follow your commands. The skeletons remain until either dusk (if they were released during the day) or dawn (if they were released at night), and then crumble into dust. Once you use this item, it can't be used again.",
+				"Once you have used this bag, if you put a bone back into the bag, it will restock its supply of bones again in 7 days."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Many Bags",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"entries": [
+				"This appears to be a normal cloth sack and functions as such; most of these bags are large enough to hold 40 pounds worth of goods, although some hold as few as 20 or as many as 100 pounds. On command, it can change into any other sort of container you wish, such as a backpack, chest, bucket, vial, belt pouch, and so on. It's carrying capacity and size don't change."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Misplacing",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "2",
+			"entries": [
+				"This item isn't so much cursed as it is unlucky. Anything put in it is likely to be misplaced. When searching for something in the bag, roll a die. On an even roll, you find it. Otherwise, you pull out something else entirely, which may or may not be useful. In addition, you can't find {@i anything} in the bag until you have put something in it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Returning",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This small bag contains one copper, silver, electrum, gold, and platinum piece. Whenever one of these coins is spent, it returns to the bag the next dawn. This bag will only return that particular coin, no matter how many other coins are placed inside and spent."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Seeds",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": "by a druid or nature domain cleric",
+			"weight": "0.5",
+			"entries": [
+				"You may reach into this small green leather bag and withdraw a seed. If you plant the seed, it grows into a mature tree, shrub, or vine in the space of a minute. You may draw out a number of seeds equal to 6 plus your Wisdom modifier, then you can't draw out any more seeds until 1 month has passed.",
+				"Half the time, the plant has edible parts: a fruit or nut tree, a berry bush, grape vine, etc. The rest of the time, it's a plant that isn't edible, but may be useful in other ways, such as in medicinal properties.",
+				"You have no control over what sort of plant is produced. If it's not suited for the environment in which it was grown, it will slowly die over the course of several weeks to months unless carefully tended."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bag of Wind",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"You may use your action to open this drawstring bag. By doing so, you release the wind trapped within. Once that ability has been used, the bag can't be used again until the following dawn.",
+				"There are four types of bags:",
+				{
+					"items": [
+						{
+							"name": "Bag of Boreas",
+							"entries": [
+								"This bag releases a blast of freezing wind in a line 30 feet long and 5 feet wide. All creatures in that area must make a DC 17 Strength saving throw or be knocked prone and take 14 (4d6) cold damage."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Bag of Euros",
+							"entries": [
+								"This bag releases a puff of warm air in a 30-foot-radius sphere. Each creature in that area must make a DC 17 Constitution saving throw or have its speed reduced by 10 feet and have disadvantage to all saving throws to avoid being charmed. This lasts for 1 minute."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Bag of Notus",
+							"entries": [
+								"This bag releases a blast of burning wind in a line 30 feet long and 5 feet wide. All creatures in that area must make a DC 17 Strength saving throw or be knocked prone and take 14 (4d6) fire damage."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Bag of Zephynrus",
+							"entries": [
+								"A gentle breeze wafts forth in a 30-foor-radius sphere. Each creature in that area gains 2d8 temporary hit points, and for 1 minute, its speed increases by 10 feet."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bagpipes of Confusion",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a bard",
+			"weight": "6",
+			"entries": [
+				"When you play these bagpipes, all creatures within 60 feet of you who can hear you must make a DC 15 Wisdom saving throw or become confused, as per the {@i confusion} spell, for as long as you continue to play and for 1 minute afterwards. A creature may make a new saving throw at the end of each of its turns, ending the effect on itself on a success.",
+				"Once you use this ability, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bagpipes of Fear",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a bard",
+			"weight": "6",
+			"entries": [
+				"When you play these bagpipes, all creatures within 100 feet of you must make a DC 15 Wisdom saving throw or be frightened of you for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Balances of Conversion",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"entries": [
+				"This set of scales will convert any coins placed in its left-hand tray into a gem of equivalent value, which appears in its right hand tray, and any gemstone placed in its right-hand tray will be converted into coins, which appear in its left-hand scale. The tray can hold up to 100 coins at a time."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Balances of Power",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "1",
+			"entries": [
+				"If you place a gemstone worth at least 1,000 gp in the right-hand tray of these scales, it will disappear and one of your attributes is raised by +2, and its maximum is raised by 2 as well. You may choose which attribute you wish to raise; if you don't, one attribute will be chosen at random. The attribute returns to normal in 24 hours, but you don't get your gemstone back."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ball of Endless String",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.2",
+			"entries": [
+				"This is a 4-inch-diameter ball of variegated woolen yarn. No matter how much is used, it never runs out."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bands of the Beast",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"These metal bands are worn around the wrists or ankles. While wearing the bands, you have advantage on saving throws against poison. You get an additional effect, depending on the type of band:",
+				{
+					"items": [
+						{
+							"name": "Bands of the Serpent",
+							"entries": [
+								"You can communicate with snakes as if you shared a language, and you can understand and speak Draconic, if you couldn't already. You can cast {@i animal friendship} at will, but only on snakes."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"In addition, you can use your action to transform into a {@creature giant constrictor snake|mm}; your game statistics are replaced by that of the snake's but you retain your mental characteristics. Once you use this ability, you can't use it again until the following dawn.",
+				{
+					"items": [
+						{
+							"name": "Bands of the Arachnid",
+							"entries": [
+								"You can communicate with spiders as if you shared a language, and you can understand and speak Drow, if you couldn't already. You can cast {@i animal friendship} at will, but only on spiders."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"In addition, you can use your action to transform into a {@creature giant spider|mm}; your game statistics are replaced by that of the spider's but you retain your mental characteristics. Once you use this ability, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Barding +1",
+			"tier": "Major",
+			"rarity": "Rare",
+			"type": "TAH",
+			"entries": [
+				"Much like armor made for humanoids, horses (and horse-like creatures) can use this magical armor. This armor gives a +1 bonus to AC while wearing it."
+			],
+			"source": "EnMa",
+			"weight": "x3"
+		},
+		{
+			"name": "Barding +2",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"type": "TAH",
+			"entries": [
+				"Much like armor made for humanoids, horses (and horse-like creatures) can use this magical armor. This armor gives a +2 bonus to AC while wearing it."
+			],
+			"source": "EnMa",
+			"weight": "x3"
+		},
+		{
+			"name": "Barding +3",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"type": "TAH",
+			"entries": [
+				"Much like armor made for humanoids, horses (and horse-like creatures) can use this magical armor. This armor gives a +3 bonus to AC while wearing it."
+			],
+			"source": "EnMa",
+			"weight": "x3"
+		},
+		{
+			"name": "Barding of Easy Travel, Type Ⅰ",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"type": "TAH",
+			"entries": [
+				"This is a miniature suit of horse barding.",
+				"When placed on the ground and the command word spoken, it turns into a riding horse, complete with tack (but not with armored barding), for a maximum of 8 hours. Once you use this ability, you can't use it again until the following dawn. If the horse is slain, you can't summon it again for 1 week."
+			],
+			"source": "EnMa",
+			"weight": "x3"
+		},
+		{
+			"name": "Barding of Easy Travel, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"type": "TAH",
+			"entries": [
+				"This is a miniature suit of horse barding.",
+				"When placed on the ground and the command word spoken, it turns into a non-horse creature. It will allow you (and only you) to ride it, and it will obey your spoken commands (no action required by you). It will remain in this form for a maximum of 8 hours. Once you use this ability, you can't use it again until the following dawn. If the creature is slain, you can't summon it for 1 week.",
+				"Roll a d20 to determine what sort of creature it becomes:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d20",
+						"Creature"
+					],
+					"rows": [
+						[
+							"1",
+							"Cave bear"
+						],
+						[
+							"2",
+							"Chimera"
+						],
+						[
+							"3",
+							"Elephant"
+						],
+						[
+							"4",
+							"Giant boar"
+						],
+						[
+							"5",
+							"Giant eagle"
+						],
+						[
+							"6",
+							"Giant goat"
+						],
+						[
+							"7",
+							"Giant scorpion"
+						],
+						[
+							"8",
+							"Giant spider"
+						],
+						[
+							"9",
+							"Gorgon"
+						],
+						[
+							"10",
+							"Griffon"
+						],
+						[
+							"11",
+							"Hippogriff"
+						],
+						[
+							"12",
+							"Mammoth"
+						],
+						[
+							"13",
+							"Manticore"
+						],
+						[
+							"14",
+							"Owlbear"
+						],
+						[
+							"15",
+							"Pegasus"
+						],
+						[
+							"16",
+							"Triceratops"
+						],
+						[
+							"17",
+							"Unicorn"
+						],
+						[
+							"18",
+							"Winter wolf"
+						],
+						[
+							"19",
+							"Worg"
+						],
+						[
+							"20",
+							"Wyvern"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa",
+			"weight": "x3"
+		},
+		{
+			"name": "Barding of Flight",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"type": "TAH",
+			"entries": [
+				"When worn by a horse or other equine, this leather barding transforms into a pair of bat-like wings. It grants the mount a flying speed of 60 and can be used for a maximum of 6 hours. Once that ability has been used, it cannot be used again until the following dawn. For every two hours of continuous flight, the horse takes 1 level of exhaustion; a ten minute rest between stretches of flight will prevent this."
+			],
+			"source": "EnMa",
+			"weight": "x3"
+		},
+		{
+			"name": "Basin of the Angel",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "2200",
+			"entries": [
+				"This bowl is made from silver and inscribed with hundreds of interwoven holy symbols. Rising from the center is a golden statuette of an angel, with back and wings arched and arms held high, holding a crystal vial from which water endlessly pours but never fully fills the {@i basin}. The bowl has a diameter of 5 feet, is 2 feet high, and weighs over a ton.",
+				"If the {@i basin} is properly installed in a temple dedicated to good-aligned gods and then blessed by a priest of that god, all good-aligned creatures who are within 30 feet of the {@i basin} gain advantage on all saving throws. If one of those creature drinks from the {@i basin}, it water heals 3d6 hit points and removes one condition from which that creature is suffering, as if {@i greater restoration} had been cast on it, and if the water is used to anoint a creature, that creature gains the benefit of a {@i bless} spell. A creature can only benefit from the {@i basin}'s water once per month, and the water loses its power if it's bottled.",
+				"While installed, the {@i basin} radiates {@i protection from evil and good} to a radius of 30 feet. This protects against fiends and undead. An evil creature of CR 5 or lower who sees the {@i basin} must make a DC 19 Wisdom saving throw or be frightened for 1 minute. On each of its turns, the frightened creature must take the Dash action and move away from the {@i basin} by the safest and shortest available route, unless there is nowhere to move. If the target moves to a place at least 60 feet away from the {@i basin} where it can no longer see it, this effect ends. In an evil creature of higher CR who touches the {@i basin} must make a DC 19 Wisdom saving throw or take 3d10 radiant damage and be teleported three miles away to a random location. The {@i basin} has no effect on neutral or unaligned creatures.",
+				"Finally, should the temple ever be in truly great danger and need, a solar will appear and defend the temple with its life. Once a solar has been summoned, whether it lives or dies, neither it nor a different solar can be summoned by the basic until 100 years have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Battle Cloak",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this cloak, you can use your reaction to parry one melee weapon attack. You may roll 1d6 + your Dexterity modifier and subtract that amount from the damage you take. In addition, if you rolled a critical hit when you attack a foe, your cloak has entangled your opponent's melee weapon (if it has one) and snatched it out of its hands. This trait doesn't work on opponents using unarmed melee attacks or if you attacked with a ranged weapon.",
+				"When you are holding (but not wearing) the cloak, you may also speak a command word. This transforms the cloak into a magical cudgel made of force for 1 minute. It inflicts 1d8 bludgeoning damage. Once you use this ability, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Battle Star",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d8}",
+			"dmgType": "P",
+			"tier": "Major",
+			"reqAttune": "by a dwarf",
+			"entries": [
+				"This large morningstar inflicts an additional 1d4 radiant damage to constructs, and while wielding this weapon, you are immune to being restrained, and you have advantage on all saving throws against being charmed or frightened.",
+				"When you strike an opponent that isn't a construct, the {@i battlestar} creates a bright flash of “starfire.” The target must make a DC13 Constitution saving throw or be blinded until the end of its next turn, and all magical items, magical symbols, marks, wards, or glyphs that are within 10 feet of the target will glow for as long as the target is blinded."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Beady Eye",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This large bead turns into an {@i arcane eye} on command, and will last for up to 1 hour a day. You may activate and deactivate it at will; its time activated is measured in increments of 5 minutes. Once it has been activated for a full hour, it will become inert and can't be activated again until a full day has passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bell of Freedom",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"This bell has 7 charges. When rung, all nonmagical locks within 20 feet of it open. Magical locks like {@i arcane locks} are suppressed for 10 minutes.",
+				"The bell regains 1d6+1 expended charges each day at dawn"
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bell of Protection",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This is a very large temple bell, weighing over a ton. When rung by a member of the temple's clergy, it produces a loud, echoing tone that creates a barrier to unnatural creatures, and continues to ring for 1 minute. An undead or fiend can't come closer than 300 feet away from the bell unless it succeeds on a DC 19 Charisma saving throw. On a success, it is able to move through the barrier and approach, but it takes 2d10 psychic damage in the process.",
+				"Once the bell has been rung, it can't be rung again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Belt of Many Pouches",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This belt has eight small pouches, each of which contains eight additional small pouches, each right behind the others. Despite their small size, each pouch can carry up to 10 pounds worth of materials. The materials can't weigh more than 20 pounds each or be longer than 3 feet on a side. No matter how much the belt carries, it never weighs more than 10 pounds."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Belt of the Lions",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"While wearing this belt, you may speak to any sort of feline as though you shared a language, you take half-damage from falls, and you gain darkvision out to 60 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Black Candle",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"The candle's magic is activated when the candle is lit, which requires an action. After burning for 4 hours, the candle is consumed. You can snuff it out early for use at a later time; its time activated is measured in increments of 5 minutes.",
+				"By letting the candle burn for 10 minutes, you can cast {@i bestow curse} (spell save DC 15, 8 hour duration). If you burn a lock of the creature's hair (or one of its teeth, or some of its blood, etc.) in the flame, you can curse the creature no matter where it is, as long as it's on the same plane with you. Otherwise, the creature must be within 1 mile of you the entire time you burn the candle."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Black Pearl",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "0.5",
+			"entries": [
+				"This large black pearl grants you 6 additional spell slots to use each day. You may decide if you want to be able to cast one additional 6th-level spell, one 4th-level and one 2nd-level, or so on."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Black Scythe",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"type": "GV",
+			"entries": [
+				"You gain +1 to attack and damage rolls made with this magic weapon. If you use this weapon to attack a plant, it inflicts an additional 3 (1d6) necrotic damage to that plant. In addition, if you score a critical hit when attacking a plant, the plant is frightened of you for 1 minute. On each of its turns, the frightened creature must take the Dash action and move away from you by the safest and shortest available route, unless there is nowhere to move. If the target moves to a place at least 60 feet away from you where it can no longer see you, this effect ends.",
+				"You may use your action to cause the scythe to create a wave of necrotic energy that automatically kills any mundane plant of Large size or smaller in a 30-foot-radius sphere. Once you use this ability, you can't use it again until the following dusk.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item scythe|EnMa}",
+								"{@item sickle|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Blackflame Dagger",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"If you thrust the blade of this dagger into any fire of Medium size or smaller, it will instantly extinguish that fire, absorbing the flames into the blade itself. If you thrust it into a larger flame, then a medium-sized area of fire will be extinguished, but will quickly reignite. While holding this dagger, you are resistant to nonmagical fire. This has no special affect on fire elementals and other creatures made of fire.",
+				"You may channel the absorbed flame into a gout of fire, which forms a 30-foot line. All creatures in that area must make a 13 Dexterity saving throw. A creature takes 6d6 fire damage on a failed saving throw, or half as much on a successful one. Once you use this ability, you can't use it again until you use the blade to extinguish a fire."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bolas",
+			"rarity": "None",
+			"value": "1gp",
+			"weight": "1",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"type": "R",
+			"property": [
+				"S",
+				"T",
+				"L"
+			],
+			"entries": [
+				"Bards, druids, rangers, and rogues are proficient in bolas.",
+				"{@b Special.} A large or smaller creature hit by bolas has its legs restrained until its free. A bola has no effect on creatures that are immune to the grappled or restrained conditions or are Huge or larger. A creature that is caught in the bolas may attempt to escape by breaking or cutting the leather cords (DC 11 Strength ability check to break the cords; the cords have AC 11, 5 hp, and are immune to bludgeoning, poison, and psychic damage). When you use an action, bonus action, or reaction to attack with a bola, you can make only one attack regardless of the number of attacks you can normally make."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bolas of Sunlight",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"type": "R",
+			"property": [
+				"S",
+				"T",
+				"L"
+			],
+			"entries": [
+				"If these bolas are thrown and hit their target, they produce a brilliant burst of light. The target takes 7 (2d6) radiant damage and must make a DC 13 Constitution saving throw or be blinded for 1 minute. A creature may make a new saving throw at the beginning of each of its turns, ending the effect on a success.",
+				"{@b Special.} A large or smaller creature hit by bolas has its legs restrained until its free. A bola has no effect on creatures that are immune to the grappled or restrained conditions or are Huge or larger. A creature that is caught in the bolas may attempt to escape by breaking or cutting the leather cords (DC 11 Strength ability check to break the cords; the cords have AC 11, 5 hp, and are immune to bludgeoning, poison, and psychic damage). When you use an action, bonus action, or reaction to attack with a bola, you can make only one attack regardless of the number of attacks you can normally make."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bone of Animation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.2",
+			"entries": [
+				"When you say the command word, this small, human bone turns into a skeleton with 36 hp and armor class 15, but otherwise identical to a normal animated skeleton. It will follow simple commands you issue it. If you give it a weapon, it can fight for you. After one hour, or if turned, slain, or on your command, it reverts back into bone form. Once it reverts back, the {@i bone of animation} cannot be used again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bone Ring",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"Carved from human bone, this ring provides immunity to hit point and attribute reduction, and resistance to necrotic damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bonewand",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a cleric, sorcerer, warlock, or wizard",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 7 charges. You may use your action to expend a charge and fire a 60-foot cone of razor-sharp bone shards. All creatures in that area must make a DC 17 Dexterity saving throw. A creature takes 10 (3d6) piercing damage and 10 (3d6) necrotic damage on a failed saving throw, and half as much on a successful one.",
+				"If a creature dies from the damage inflicted by this wand, it rises 1d4 rounds later as a wight. This wight is charmed by you for 24 hours. If, before that time is up, you touch the wight with the wand and expend 5 charges, it will remain charmed by you indefinitely. However, if you or your allies harm it, it may make a DC 13 Wisdom saving throw to break free of the charm; at that point, it will turn on you.",
+				"The wand regains 1d4+3 expended charges daily at dusk. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Boots of Attraction",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "2",
+			"entries": [
+				"These boots act in all ways as {@i boots of tracks} (q.v.).",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"These boots are cursed. Once you are attuned to them, you cannot remove them until a {@i remove curse} spell has been cast on them. If the DM uses random monster encounters, the chances of an encountering happening to you are doubled (for instance, if an encounter normally happens on a roll of 1 on a d10, then it would now happen on a roll of 1-2). Monsters in planned encounters will attack you first."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Boots of Balance",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "2",
+			"entries": [
+				"While wearing these boots, you have advantage on all Dexterity (Acrobatics) rolls."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Boots of Cloudwalking",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "2",
+			"entries": [
+				"While wearing these boots, your walking speed is increased to 50 feet.",
+				"In addition, if there is a storm or other very dense cloud cover, you may activate this item and make a tremendous leap, jumping on top of the clouds; the range for this leap is effectively in the miles. You may then walk across the clouds at a speed of 100 feet for up to 3 hours. You will be warned when your time is about to end, and will be able to make another tremendous leap to the ground. Once you use this ability, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Boots of Tracks",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "2",
+			"entries": [
+				"While wearing these boots, you can command them to leave tracks identical to those left by any other creature. You may choose which creature you will emulate; it must be no more than one size larger or smaller than you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bottle of Fireflies",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.2",
+			"entries": [
+				"This glass bottle appears empty. If you pour a serving of wine into it (quality doesn't matter), the wine is immediately consumed and numerous tiny lights begin to glow, winking in and out as if they were fireflies. You can control the brightness of the light in five-foot increments: the bottle will she bright light in a radius of 5 feet to 30 feet, and dim light for an equal distance. For each serving of wine you pour in, the bottle will glow for 1 hour."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bottle of Trapping",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"While holding this bottle, you may cast {@i imprisonment} (minimus containment version), targeting one creature of Large size or smaller that you can see within 30 feet of you. That creature must make a DC 19 Strength saving throw or be sucked into the bottle. Only one creature may be trapped in the bottle at a time, but you can release the creature at any time by using a bonus action.",
+				"From the outside, the bottle is as breakable as any other glass bottle, but it can't be broken from the inside. Breaking the bottle releases the imprisoned creature."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Box of Delightful Transports, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "4",
+			"entries": [
+				"These 6-inch-cube boxes come in pairs. Each box in the pair has 3 charges. If any non-living, non-magical item or items are placed inside one of the boxes and the command word spoken, the item will instantly teleport to the other box, regardless of distance, although both boxes must be on the same plane. Teleporting an object from box to box only takes 1 charge.",
+				"For each item placed, the DM should roll a d20. On a 1, the teleportation went wrong and the object wound up in a random location up to 100 miles from the intended destination. If both boxes are placed inside linked {@i teleportation circles}, however, there is no chance of failure.",
+				"The boxes regain all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Box of Delightful Transports, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "8",
+			"entries": [
+				"These 1-foot-cube boxes come in pairs. Each box in the pair has 3 charges. If any non-living, non-magical item or items are placed inside one of the boxes and the command word spoken, the item will instantly teleport to the other box, regardless of distance, although both boxes must be on the same plane. Teleporting an object from box to box only takes 1 charge.",
+				"For each item placed, the DM should roll a d20. On a 1, the teleportation went wrong and the object wound up in a random location up to 100 miles from the intended destination. If both boxes are placed inside linked {@i teleportation circles}, however, there is no chance of failure.",
+				"The boxes regain all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Box of Delightful Transports, Type Ⅲ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "32",
+			"entries": [
+				"These 3-foot-cube boxes come in pairs. Each box in the pair has 3 charges. If any non-living, non-magical item or items are placed inside one of the boxes and the command word spoken, the item will instantly teleport to the other box, regardless of distance, although both boxes must be on the same plane. Teleporting an object from box to box only takes 1 charge.",
+				"For each item placed, the DM should roll a d20. On a 1, the teleportation went wrong and the object wound up in a random location up to 100 miles from the intended destination. If both boxes are placed inside linked {@i teleportation circles}, however, there is no chance of failure.",
+				"The boxes regain all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Box of Preservation, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "2",
+			"entries": [
+				"Anything placed inside the box is magically preserved in exactly the same condition as when it was placed inside it, indefinitely.",
+				"These boxes are the size of a breadbox (1 foot × 6 inches × 6 inches). An object placed in the box must be non-living and inanimate."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Box of Preservation, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "15",
+			"entries": [
+				"Anything placed inside the box is magically preserved in exactly the same condition as when it was placed inside it, indefinitely.",
+				"These boxes are 4 feet × 2 feet × 2 feet. An object placed in the box must be non-living and inanimate."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Box of Preservation, Type Ⅲ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "40",
+			"entries": [
+				"Anything placed inside the box is magically preserved in exactly the same condition as when it was placed inside it, indefinitely.",
+				"These boxes are 8 feet × 4 feet × 3 feet. A living creature may be placed in the box; it's treated as if being under the effects of a {@i feign death} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bracelet of Beastly Command",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This is a cuff bracelet adorned with an image of a particular type of animal, usually portrayed in a stylized manner. While wearing this bracelet, you can cast {@i dominate beast} on the type of animal with which the bracelet is decorated.",
+				"To determine the type of creature the bracelet can affect, roll a d6:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d6",
+						"Creature Type",
+						"Examples"
+					],
+					"rows": [
+						[
+							"1",
+							"Reptilian/saurian",
+							"giant lizard, triceratops"
+						],
+						[
+							"2",
+							"Avian",
+							"eagle, giant vulture"
+						],
+						[
+							"3",
+							"Arthropod",
+							"giant centipede, giant wolf spider"
+						],
+						[
+							"4",
+							"Amphibian",
+							"frog, giant frog"
+						],
+						[
+							"5",
+							"Mammalian",
+							"giant bat, wolf"
+						],
+						[
+							"6",
+							"Piscine",
+							"hunter shark, quipper"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4",
+						"col-xs-4"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bracelet of Charms",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"reqAttune": "by a fighter, paladin, or ranger",
+			"weight": "0.1",
+			"entries": [
+				"You can slide this gold chain bracelet around a hand-held weapon of any sort, including a magical weapon, and speak a command word. The weapon then turns into a small golden charm that dangles from the chain. A missile weapon and ammunition pouch or quiver counts as a single weapon. The bracelet can hold four weapons. At any time, you can use a bonus action to command the bracelet to turn a charm back into a weapon. The weapon will then appear in your hands.",
+				"A weapon may be turned into a charm, retrieved, and returned to charm form once each day; it can't be retrieved a second time until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bracers of Attraction",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"These bracers give you +2 to your AC.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"These bracers are cursed. Becoming attuned to it extends the curse to you. As long as you remain cursed, you cannot remove the bracers until a {@i remove curse} is cast on them."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"When you wear these bracers during a time when using your hands is of utmost importance (such as during combat), your wrists clamp together as if the bracers were very strong magnets. At the beginning of each of your turns, you may attempt to make a DC 18 Strength saving throw to wrest your arms apart. If successful, you may use your arms normally for 1d4 rounds, after which they will clamp together again. Any task that isn't straight-out impossible with your wrists clamped together will be at disadvantage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bracers of Brachiating",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"While wearing these wrist bands, you have a climbing speed of 30 feet, and may move through trees and by using vines and ropes as if they were normal terrain."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bracers of Defenselessness",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"These appear to be, and act as, {@i bracers of defense}. As with those items, you gain a +2 bonus to AC if you are wearing no armor and using no shield.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"These bracers are cursed. Becoming attuned to it extends the curse to you. As long as you remain cursed, you cannot remove the bracers until a {@i remove curse} is cast on them."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"When in combat with a dangerous enemy—a creature that constitutes a Medium or harder encounter difficulty—the bracer's curse takes effect and your AC becomes 6 + your Dexterity modifier for 1 hour.",
+				"After 1 hour, your armor class returns to normal."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bracers of the Merfolk",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"While wearing these bracers, you gain a swim speed of 30 feet and can breathe water as easily as air."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Brazen Bottle",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This bronze bottle is shaped like a Klein bottle. When uncorked and the command word open, you are granted the ability to compel a celestial, elemental, or fiend inside, by making a Charisma check against the target creature's Wisdom. You may use double your proficiency bonus when making this check. If you're successful, the creature enters the bottle and is trapped. Opening the bottle a second time allows the trapped creature to escape.",
+				"Any given found {@i brazen bottle} has a 50 percent chance of being occupied. A {@i detect evil and good} spell will reveal the nature of the creature trapped inside, as will a {@i legend lore} spell. If the bottle was occupied and the trapped creature escapes, it might be so relieved to be freed that it might offer you its services, or it might be so enraged it attacks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bridle of Calm",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"While wearing this bridle, the animal is immune to any magical or mundane attempt to frighten or charm it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Bridle of Plane Shifting",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"Each one of these bridles is linked to a particular plane, and the bridles often have emblems or designs reminiscent of that plane on them. When placed on a horse (or similar riding creature), the command word spoken, and the horse spurred into a gallop, the bridle will transport you to a specific location on that layer (this is usually, but not always, the top-most layer or in or near the domain of a powerful creature native to that plane).",
+				"The GM should roll on the following table or choose the bridle's destination.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d100",
+						"Plane"
+					],
+					"rows": [
+						[
+							"01-04",
+							"The Infinite Layers of the Abyss"
+						],
+						[
+							"05-08",
+							"The Infinite Battlefield of Acheron"
+						],
+						[
+							"09-12",
+							"The Olympic Glades of Arborea"
+						],
+						[
+							"13-16",
+							"The Peaceable Kingdoms of Arcadia"
+						],
+						[
+							"17-20",
+							"The Astral Plane"
+						],
+						[
+							"21-24",
+							"The Twin Paradise of Bytopia"
+						],
+						[
+							"25-28",
+							"The Tarterian Depths of Carceri"
+						],
+						[
+							"29-32",
+							"The Blessed Fields of Elysium"
+						],
+						[
+							"33-36",
+							"The Ethereal Plane"
+						],
+						[
+							"37-40",
+							"The Far Realms"
+						],
+						[
+							"41-44",
+							"The Feywild"
+						],
+						[
+							"45-48",
+							"The Bleak Eternity of Gehenna"
+						],
+						[
+							"49-52",
+							"The Gray Waste of Hades"
+						],
+						[
+							"53-56",
+							"The Ever-Changing Chaos of Limbo"
+						],
+						[
+							"57-60",
+							"The Clockwork Nirvana of Mechanus"
+						],
+						[
+							"61-64",
+							"The Seven Heavens of Mount Celestia"
+						],
+						[
+							"65-68",
+							"The Nine Hells of Baator"
+						],
+						[
+							"69-72",
+							"The Outlands"
+						],
+						[
+							"73-76",
+							"the Windswept Depths of Pandemonium"
+						],
+						[
+							"77-80",
+							"The Plane of Air"
+						],
+						[
+							"81-84",
+							"The Plane of Earth"
+						],
+						[
+							"85-88",
+							"The Plane of Fire"
+						],
+						[
+							"89-92",
+							"The Plane of Water"
+						],
+						[
+							"93-96",
+							"The Shadowfell"
+						],
+						[
+							"97-100",
+							"The Heroic Domains of Ysgard"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Buckle of Lockpicks",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": "by a rogue",
+			"weight": "0.1",
+			"entries": [
+				"When attached to a belt, this buckle can hold a set of thieves' tools. These tools can't be found by nonmagical means unless you wish them to be found. In addition, while wearing this buckle, you have a +5 bonus when using those tools."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Buckle of Weaponry",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"While this buckle is attached to a belt, you can say a command word and one weapon you are holding shrinks to no more than two inches long and can be stored in a magically hidden compartment in the buckle. Up to five shrunken weapons may be stored in the buckle.",
+				"A weapon may be shrunken, enlarged, and shrunk again once each day; it can't be enlarged a second time until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Caduceus Staff",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"You must have proficiency in the Medicine skill or in the Healer's Kit to use this item. This staff, which has carvings of feathered lines and coiling serpents, has 7 charges. You may use your action to expend a charge and cast {@i cure wounds} at 1st level. For 1 charge, you cast the 1st-level version of the spell. You can increase the spell slot level by one for each additional charge you expend.",
+				"In addition, while attuned to this staff, you may use double your proficiency bonus when using the Medicine skill or Healer's Kit.",
+				"The staff regains 1d6+1 charges each day at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Camouflaging Tent",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "20",
+			"entries": [
+				"This tent automatically changes its colors to blend in with its surroundings. A creature looking for it has disadvantage on any roll to do so."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Candle of Everburning",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"entries": [
+				"Once lit, this votive candle burns continuously for 24 hours until you command it to be extinguished. Nothing else, including full immersion in water, will extinguish the flame. These candles often come in sets of 12."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Candle of Exploding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"When lit, this candle burns normally for 1 minute, and then explodes. All creatures within 20 feet must make a DC 13 Dexterity saving throw. A creature takes 10 (3d6) fire damage on a failed saving throw, or half as much on a successful one."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Candle of Protection",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"The candle's magic is activated when the candle is lit, which requires an action. After burning for 4 hours, the candle is destroyed. You can snuff it out early for use at a later time; its time activated is measured in increments of 5 minutes.",
+				"While lit, every creature within 10 feet of the candle is under the effects of the {@i protection from evil and good} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cane of Armament",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"dmg1": "{@dice 2d6}",
+			"dmgType": "S",
+			"property": [
+				"H",
+				"2H"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This item looks like a normal cane, but when a command word is spoken, it turns into a {@i greatsword +1}. A second command can turn it back into a cane."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Canteen of Coolness",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"entries": [
+				"This item holds one quart of any liquid at 40° Fahrenheit (4° Celsius)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cape of Shadows",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"While you wear this cape, you may cast {@i dimension door}, although your starting and destination locations must both be in shadows cast by a Small or larger object. Once you have done so, you can't do so again until the following dusk.",
+				"In addition, while you are in dim light or darkness, you gain proficiency in the Stealth skill, if you don't already know it, and you double your proficiency bonus on checks made with that skill. You also can take the Hide action as a bonus action while in dim light or darkness."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Casket of the Wind Spy",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"This is a small crystal casket with golden hinges and lock, inside of which is trapped a minor air elemental. Upon speaking the command word and unlocking the casket, the elemental will be released. It is loyal to you and will obey your commands. It uses the statistics for the {@creature invisible stalker|mm}, but it has the Investigation skill at +6 and can speak Common. It won't fight, even in self-defense, and will flee if attacked. Speaking the command word a second time while the elemental is within 60 feet of the casket will cause it to return to its casket. It must rest inside for at least 24 hours before it can be released again.",
+				"If you choose, you can release the elemental from your service at any time; it will immediately flee back to the Plane of Air and the casket will become nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cat's Eye Ring",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you have darkvision to 60 feet. If you already have darkvision, it adds an additional 30 feet to its range."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Catalogue of Outer Planer Artifacts",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "2",
+			"entries": [
+				"This tome contains sixteen thick pages, each one illustrated with a symbol of one of the Outer Planes and the image of a strange mechanical device or a form of transport, and each page is bordered by images of gemstones. If a gemstone worth 1,000 gp or more is placed on the border, the gemstones will vanish, and the item will appear within in an open space within 10 feet of you.",
+				"The object can be used to transport you and up to seven companions who are touching you or the object to a particular Outer Plane. If you are familiar with the Plane, you may attempt a DC 18 Intelligence (Arcana) ability check to go to a particular location on that Plane. Otherwise, you go to a random location on the topmost layer. Once you use the device, you can't use it again until the following dawn.",
+				"Each time you use the object, you must roll a d20. On a 1, you go to the correct place, but the device immediately vanishes.",
+				{
+					"items": [
+						{
+							"name": "The Abyss",
+							"entries": [
+								"This is a black circle of cloth that looks much like a {@i well of many worlds}, except that it only takes you to the layer of Pazunia, somewhere along the banks of the Styx. The cloth itself stays behind. Removing the cloth from the book requires cinnabar."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Acheron",
+							"entries": [
+								"This is a puzzle of 43 pieces of onyx that comes in a small black bag. The puzzle must be put together first (a process that takes an hour) and forms the shape of a 2-inch cube. Once assembled, you are transported to Avalas, Acheron's top layer. The cube then disappears and reappears, in pieces, in its bag (wherever the bag might be). Removing the puzzle from the book requires garnets."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Arborea",
+							"entries": [
+								"This large chariot is made of electrum and is sculpted in the form of vines and leaves. It must be hitched to four horses. If you speak the command word while the chariot is moving, it and everyone riding it in are transported to the first layer of Arborea, between the realms of Olympus and Arvandor. Removing the chariot from the book requires amber."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Arcadia",
+							"entries": [
+								"This is a palm-sized metal sculpture made of silver rods connected to one another to form the outline of a cube. If the rods are rearranged to form a pyramid and held in your hand, you (and the pyramid) are transported to Abellio, the first layer of Arcadia. Removing the sculpture from the book requires diamonds."
+							],
+							"type": "item"
+						},
+						{
+							"name": "The Beastlands",
+							"entries": [
+								"This is a leaf; the veins are made of exquisitely detailed gold and the leaf itself is made of paper-thin slivers of green glass. If you hold the leaf while speaking the command word, a brisk, cold wind will momentarily blow; when the wind dies down, you will find yourself in Krigala, the Beastland's first layer. Removing the leaf from the book requires peridot."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Bytopia",
+							"entries": [
+								"This appears to be a featureless silver cube, but careful reveals that there are actually four buttons. If pressed in the correct order, they cause the box to break into two halves. If you hold each half in your hands and say the command word, you are transported to Dothion, which is often considered to be Bytopia's top layer. Removing the cube from the book requires citrines."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Carceri",
+							"entries": [
+								"This is a necklace of dull red pearls. When you speak the command word while wearing this necklace, you are transported to Orthrys, the first and outermost layer of the Plane. Removing the necklace from the book requires black pearls."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Elysium",
+							"entries": [
+								"This is a coracle, a form of rowboat made from stretched hides. If you place it on a river and begin to row it, it any anyone riding in it will be transported to the river Oceanus where it flows through the layer of Amoria. Removing the boat from the book requires sardonyx."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Gehenna",
+							"entries": [
+								"This is a small silver and bronze brazier. If you burn fresh, aromatic herbs and cinnamon while in a small, closed room, it will produce a great deal of thick, cloying smoke and fill the room. 1d4 rounds later, the smoke will clear and you will find yourself and everyone else in that room, as well as the brazier, in Khala, Gehenna's top layer. Removing the brazier from the book requires fire agates."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Hades",
+							"entries": [
+								"This is a keelboat made of iron. If you place it on a river and begin to row it, it and anyone riding in it will be transported to the river Styx where it flows through the layer of Oinos. Removing the boat from the book requires moonstones."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Limbo",
+							"entries": [
+								"This is a magical mirror. While your reflection is normal, the background shows utter chaos. If the command word is spoken while you look at your reflection, the mirror turns into a portal leading to a completely random place on that Plane. The portal remains open for 1 minute, but the mirror remains where it was. Removing the mirror from the book requires opals."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Mechanus",
+							"entries": [
+								"This is a golden pocket watch with an attached fob; the watch keeps perfect time. The watch has a fourth hand, and if that hand is wound all the way around the clock while the command word is spoken, the watch opens up into a clockwork portal that takes you to a cog exactly one mile outside of Regulus, then folds back up into a watch again. Removing the watch from the book requires quartz crystals."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Mount Celestia",
+							"entries": [
+								"This is a small, golden sphere that constantly emits a faint glow. If you pour pure water over it while speaking the command word, you are transported to Lunia, the first of Celestia's layers and the one at its base. Removing the sphere from the book requires blue sapphires."
+							],
+							"type": "item"
+						},
+						{
+							"name": "The Nine Hells",
+							"entries": [
+								"This is a dark red, heart-shaped coal that pulses warmly when held and smells of old blood. If dropped into an open flame, it explodes into a dark-flamed fireball. The fireball does no harm, but when the smoke clears, you're in Avernus and the coal has been consumed. Removing the coal from the book requires bloodstone."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Pandemonium",
+							"entries": [
+								"This is a jar of pitch, but the lid is securely latched on with a metal ring puzzle that may take a minute or two to figure out. If the jar is opened, its entire supply of pitch painted on a wall, the jar closed and secured again, and the command word spoken, it becomes a portal that leads to the layer of Pandesmos. The pitch will evaporate off the wall a minute later and the jar will refill itself. Removing the jar requires black tourmaline."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Ysgard",
+							"entries": [
+								"This is a prism. It must be placed on the ground with bright, magical light shining through it. It forms an arching rainbow, and if you step on the rainbow while saying the command word, you are whisked away to the topmost layer, Asgard. Removing the prism from the book requires iolite."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cauldron of Creatures",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "10",
+			"entries": [
+				"You can spend 1 hour brewing a potion in this cauldrom, including a biological sample (such as a tuft of fur) from a beast. The potion's drinker can then {@i shapechange} into that creature. When making the potion, you can choose its duration, anywhere from an hour to a week. While in the form of the beast, you use its statistics but retain your own Intelligence, Wisdom, or Charisma. Once you brew a potion in the {@i cauldron of creatures}, you can't do so again for 7 days."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cauldron of Doom",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "20",
+			"entries": [
+				"By placing a corpse inside of this cauldron and letting it simmer for a length of time, you can cause it to rise again as an undead under your command, as if it had cast {@i animate dead} on it. If you let the corpse remain in the cauldron for 3 hours, it will rise as a zombie. If you let it remain for 6 hours, it will rise as a ghoul. You can't create any other sort of undead with the {@i cauldron of doom}, nor can you use it to reassert control over a creature you have created with the cauldron or through a spell. Once you reanimate a corpse in the cauldron, you can't do so again for 7 days.",
+				"An undead you create with the {@i cauldron of doom} remains under your control for 7 days. If you cast {@i animate dead} or {@i create undead} on an undead you create with the cauldron, you reassert control for 7 days, not just 24 hours."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cauldron of Potion-Brewing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "10",
+			"entries": [
+				"You must have proficiency in the Arcana skill to use this cauldron. If you fill it up with alcohol (of any type) and succeed on an Intelligence (Arcana) skill check, you can produce a single dose of any potion with which you are familiar. If you are proficient in Alchemist's Tools, you make this check with advantage. If you fail the check by 5 or more, it turns into a {@i potion of poison}. Once you create a potion in the cauldron, you can't do so again for 3 days.",
+				"The difficulty of brewing a potion, and the time it takes to do so, are as follows:",
+				{
+					"type": "table",
+					"colLabels": [
+						"Potion Rarity",
+						"Check DC",
+						"Time Needed"
+					],
+					"rows": [
+						[
+							"Common",
+							"DC 13",
+							"30 minutes"
+						],
+						[
+							"Uncommon",
+							"DC 15",
+							"1 hour"
+						],
+						[
+							"Rare",
+							"DC 17",
+							"3 hours"
+						],
+						[
+							"Very Rare",
+							"DC 19",
+							"8 hours"
+						]
+					],
+					"colStyles": [
+						"col-xs-4",
+						"col-xs-4 text-align-center",
+						"col-xs-4 text-align-center"
+					]
+				},
+				"You can't create Legendary potions with the {@i cauldron}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Censer of Thaumaturgy",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"entries": [
+				"When you fill this censer with incense (which must be of high quality and worth at least 100 gp) and burn, it releases a cloud of faint, richly-scented smoke that fills the sphere with a 60 foot radius. The smoke doesn't hinder vision in any way. The censer burns for 10 minutes unless deliberately extinguished earlier; if you extinguish the incense early, you can't re-use it later on.",
+				"If you cast a spell in the smoke-filled area, and the spell allows you to cast it at higher levels, you can cast the spell up to four levels higher (to a maximum of 8th level) while only expending the lowest-level spell slot."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chair of Insomnia",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "8",
+			"entries": [
+				"While sitting in this chair, you cannot fall asleep, even though magical means. This does not prevent fatigue or taking levels of exhaustion through lack of sleep. The chair isn't cursed; you can get up at any time you like and go to sleep."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chair of the Ancestors",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "20",
+			"entries": [
+				"While you sit in this chair, you may cast either {@i commune} or {@i spirit guardians}. Once you cast either of these spells, you can't cast that spell again until the following dawn.",
+				"Instead of contacting a deity, you instead summon a shade of your ancestral spirits and speak with them."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chalice of Identification",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"If you pour a potion into this chalice, it will identify the potion for you. After one minute, the potion's name will appear in misty letters of condensation on the side. {@i Potions of poison} will identify as a {@i potion of healing}. Other baleful potions will appear to be of a helpful type. Once identified, the potion can be poured back into its original container or into another container."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chalice of Liquid Bread",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"If you an alcoholic beverage into this chalice and say the command word, it will transform that liquid into a thick, non-alcoholic liquid food that is tasty, nutritious, and very filling and serves as a single meal. The quality of the original alcohol doesn't matter; the cheapest grog and the finest wines produce the same {@i liquid bread}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chalice of Planer Travel",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This silver goblet has five runes carved into the rim. The runes are the symbols of the Material Plane, the Ethereal Plane, the Astral Plane, and two other Outer Planes of the DM's choice.",
+				"If you fill this chalice with fine wine, say the command word, and drink from the edge of the chalice that has the rune of the plane you wish to go to, you are instantly transported to that plane. If you can picture your destination clearly, you will be transported to that place; otherwise, you will go to a random place on that plane. Once you have used the chalice in this manner, it can't be used again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Changeling Cloak",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"When you wear this cloak, you may use your action to cast {@i disguise self} at will."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chariot of Flames",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "100",
+			"entries": [
+				"This appears to be a normal, two-wheeled chariot made of iron and highly polished wood. When you stand in the chariot and speak the command word, two fiery horses appear, hitched to the chariot. The chariot's speed on the ground is 100 feet, and it has a fly speed of 120 feet. The horses' hoofbeats, even when flying, create a thunderous noise, and it trails a thick cloud of smoke behind it. All creatures other than you and up to two others that you designate take 7 (2d6) fire damage when they touch either the chariot or the horses. When you travel, a creature other than you and those you designate that is within 20 feet of the chariot must make a DC 19 Constitution saving throw or be blinded by the smoke and deafened by the thunder until the beginning of its next turn.",
+				"The horses use the same attributes as {@creature warhorse|mm|warhorses}, save that they are immune to fire, lightning, radiant, and thunder damage, but are vulnerable to cold damage and take 1 point of cold damage for every gallon of water splashed on them or for every 5 feet they must move through water. Each of their attacks inflicts an additional 4 (1d8) fire damage.",
+				"The chariot's AC is 17 and it is immune to fire, lightning, poison, psychic, radiant, and thunder damage, and has 50 hit points, but is vulnerable to cold damage and takes 1 point of cold damage for every gallon of water splashed on it or for every 5 feet it must move through water."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Charm of Distraction",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This serpent-shaped charm grants you several benefits if attached to a bracelet. The charm improves your AC by +1 and gives you advantage on saving throws against being charmed. If you already have advantage on such saving throws (such as through the Fey Ancestry racial ability), you become immune to being charmed. Finally, you may use your action to cast {@i hold monster} (spell save DC 17). Once you have cast this spell, you can't do so again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chime of Time",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.2",
+			"entries": [
+				"This small hollow stick made of silvery metal chimes every hour. Although not particularly loud, it can be heard clearly up to 100 feet away."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Chimes of Interruption",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.2",
+			"entries": [
+				"This chime has 3 charges and regain 1d3 expended charges each day at dawn. When you strike the chime, it resonates extremely loudly for three full rounds. No normal conversation can be had, and no spell with a verbal component can be cast, within 30 feet of you during this time."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Claw of Spell-Stealing",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring looks like a claw. If you strike a spellcasting opponent with this claw, your opponent must make a DC 17 saving throw using its spellcasting attribute.",
+				"If the target fails, you have stolen one of its spells. Roll 1d6-1 to determine the level of the spell (on a 0, you have stolen a cantrip). You then may cast that spell without using any material components or expending a spell slot one time; the memory of the spell then fades from your mind. If you don't cast the spell within 24 hours, or if you use this item again before casting the spell, you lose the ability to cast that spell. In addition, the target won't be able to cast that spell until it has taken a short or long rest."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Claw of the Bear",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"When you wear these leather gauntlets and use your action to say the command word, long metal claws emerge. You are proficient in their use. They are magical weapon that inflict 1d8 slashing damage. You also have advantage on Strength (Athletics) checks when climbing."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Charming",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this swirling, multicolored cloak, any creature you attempt to charm via spell or other magical ability is at disadvantage to its saving throw."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Flame",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"When you wear this cloak, you have immunity to cold damage and resistance to fire damage.",
+				"In addition, when you cast a spell that inflicts fire damage that allows you to cast it at higher levels to increase the amount of damage it inflicts, you may choose to cast that spell at one slot level higher while only expending the lower level spell slot."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Lordliness",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this fine, regal cloak, you have advantage on all Charisma (Persuasion) and Charisma (Deception) checks. In addition, you may use your action to cast {@i mass suggestion}. Once you cast the spell, you cannot use that ability again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Many Colors",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This cloak is made of patches of different colors that seem to shift color and pattern when not being watched. While wearing this cloak, you have resistance to radiant damage and are immune to being blinded. You also have advantage on saving throws to disbelieve illusions and to avoid being taking damage or being hindered by spells of 5th level and lower that rely on color to produce their effect, such as {@i color spray} and {@i hypnotic pattern}.",
+				"In addition, this cloak has 6 charges. You can use your action to expend 1 or more charges to cast {@i color spray} (1 charge), {@i daylight} (3 charges), or {@i hypnotic pattern} (3 charges). The cloak regains 1d4+2 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Stars, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This cloak is made of dark, fine cloth, with twelve silver stars embroidered on it. The cloak is enchanted with four different spells, {@i clone, feeblemind, teleport, wish}, each of which can be cast three times. Touching a star and speaking the command word casts the spell and causes the star to vanish. When all the stars are gone, the cloak becomes nonmagical. Any given cloak may be missing 1d6 stars already. The cloak's spell save DC is 19."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Stars, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This cloak is made of dark, fine cloth, with twelve silver stars embroidered on it. The cloak is enchanted with four different spells, {@i antimagic field, antipathy/sympathy, reverse gravity, imprisonment}, each of which can be cast three times. Touching a star and speaking the command word casts the spell and causes the star to vanish. When all the stars are gone, the cloak becomes nonmagical. Any given cloak may be missing 1d6 stars already. The cloak's spell save DC is 19."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Stars, Type Ⅲ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This cloak is made of dark, fine cloth, with twelve silver stars embroidered on it. The cloak is enchanted with four different spells, {@i finger of death, legend lore, shapechange, time stop}, each of which can be cast three times. Touching a star and speaking the command word casts the spell and causes the star to vanish. When all the stars are gone, the cloak becomes nonmagical. Any given cloak may be missing 1d6 stars already. The cloak's spell save DC is 19."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of Survival",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this cloak, you have advantage on saving throws against poison and on all Wisdom (Survival) ability checks and Strength (Athletics) checks made to swim or stay afloat if thrown overboard. You are also immune to standard travel-induced maladies, such as seasickness and stomach upsets caused by unfamiliar water supplies.",
+				"In addition, if you end up in an airless environment (such as being underwater or thrown into the vacuum of space), the cloak magically creates a bubble of air big enough to allow you to breathe for 10 minutes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of the Clouds",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This gossamer, lacy cloak has 7 charges. While wearing this cloak, you have resistance to lightning and thunder damage.",
+				"While wearing this cloak, you can cast the {@i gust} cantrip. You may use your action to expend one or more charges to cast the following spells: {@i control weather} (6 charges), {@i feather fall} (1 charge), {@i fly} (2 charges), {@i fog cloud} (1 charge), {@i gust of wind} (2 charges), and {@i lightning bolt} (3 charges). The spells use your spellcasting ability and spell save DC.",
+				"The cloak regains 1d6+1 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cloak of the Rogue",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a rogue",
+			"weight": "1",
+			"entries": [
+				"When you wear this cloak, you gain several benefits: You get a +1 to your armor class, as long as you are wearing no armor or light armor, and you have advantage on Stealth and Sleight of Hand checks, and when using Thieves' Tools. In addition, there are four {@i bags of holding} (of the type described in the {@i Dungeon Master's Guide}) sewn into the lining of the cloak."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Coffin of Creation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a wizard",
+			"weight": "20",
+			"entries": [
+				"If you place a humanoid corpse inside this coffin and close the lid for 24 hours, the corpse will rise as a particular form of undead; each coffin creates only one type of undead. If the undead normally has an Intelligence of less than 10, it becomes 10. Once you use the coffin to create an undead, you can't do so again for 7 days.",
+				"The undead is charmed by you for 30 days or until you and your companions do anything harmful to it. Before the charmed condition ends, you can renew it for 1 week by casting {@i animate dead} or {@i create undead} on it, provided that it is a type of undead that can be affected by either of those spells. Otherwise, the undead will choose whether to remain friendly to you, based on how you treated it while it was charmed.",
+				"The DM should roll a d12 or pick from the following table to determine the type of undead the coffin creates.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d12",
+						"Undead Type"
+					],
+					"rows": [
+						[
+							"1",
+							"A flameskull and two crawling claws"
+						],
+						[
+							"2",
+							"Ghost"
+						],
+						[
+							"3",
+							"Ghast"
+						],
+						[
+							"4",
+							"Ghoul"
+						],
+						[
+							"5",
+							"Mummy"
+						],
+						[
+							"6",
+							"Shadow"
+						],
+						[
+							"7",
+							"Skeleton"
+						],
+						[
+							"8",
+							"Specter"
+						],
+						[
+							"9",
+							"Vampire Spawn"
+						],
+						[
+							"10",
+							"Wight"
+						],
+						[
+							"11",
+							"Wraith"
+						],
+						[
+							"12",
+							"Zombie"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Coin of Alms",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"entries": [
+				"This appears to be a platinum coin of ancient design and clearly worth more than a typical platinum piece.",
+				"{@b Curse.} This coin is cursed. If you take the coin and don't give it away to someone else within 10 minutes, you must make a DC 18 Wisdom saving throw or be cursed. While cursed, you refuse to part with the coin, but being separated from it fails to end the curse.",
+				"While cursed, you gain the following ideal: {@i I must be charitable and philanthropic; it would be terrible of me to be greedy and keep money for myself.} You can't keep more than 100 gp worth of goods and money on you at a time (not counting this coin). Any additional goods and money you have, you will need to give to someone in need: a poor laborer or farmer, an orphanage, a beggar, etc. If an ally can prove that it is truly in need of a particular item or money, you may donate to that person.",
+				"However, you won't give to someone, no matter who they are, who is merely pretending to need an object or money, or would immediately spend the money on something that you would normally consider frivolous or evil (for instance, if you yourself are not a hard drinker, you wouldn't give money to an ally who was, even if they were dead broke at the time, unless you can guarantee the money won't be spent on alcohol; likewise, if you are not normally fond of magic, you wouldn't give your money to the party's wizard so she could write a new spell into her book).",
+				"You don't feel compelled to give away magic items, heirlooms or other items with sentimental value, spellbooks or spell foci, or favored weapons or armor, unless you are completely certain that the individual would have a much better use for them than you would. The {@i coin of alms} can't compel you to give away cursed items or artifacts."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Collar of Change",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "0.5",
+			"entries": [
+				"While wearing this studded leather collar, you may use your action to cast {@i polymorph} on yourself. You retain your own alignment and Intelligence, but otherwise use the statistics of the creature you change into. Once you have done so, you can't do so again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Companion Guardian Tail",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This is a tail that came from a fox, raccoon, or other such animal, with leather straps, beads, and a pin at one end. It is designed to be attached to a backpack, quiver, chest, or other container as a decorative toggle. Once attached, the tail protects the container's contents. You may designate any number of creatures besides yourself who are allowed to touch or open the container. If any other creature does so, the entire container will shapechange into a the form of an animal of the type from which the tail came.",
+				"The animal will then flee until you call for it; if you don't call for it within an hour, it will seek you out and get your attention. Once you touch it again, it turns back into the container. It will only attack if absolutely necessary.",
+				"If the animal is killed, the container reverts to its normal form. Depending on the type and amount of damage inflicted on it, the container may be damaged or destroyed, as may some of its contents. The tail will become nonmagical then.",
+				"Regardless of the type of animal the tail came from, the {@creature Guardian Tail (Animal Form)|EnMa|guardian tail} uses the same {@creature Guardian Tail (Animal Form)|EnMa|statistics}",
+				"If you use an action to speak the command word, these tails change between animal and container form, allowing to act as a companion of sorts when not being used. None of the objects it holds in container form are accessable while its in animal form."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Copper Lance",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"dmg1": "{@dice 1d12}",
+			"dmgType": "P",
+			"property": [
+				"R",
+				"S"
+			],
+			"entries": [
+				"This gleaming lance grants you a +1 bonus to attack and damage rolls. In addition, the lance has 3 charges.You may use your action to expend a charge. For 1 minute, if the lance strikes a target, it will blaze like the sun. All creatures within 60 feet of you who can see the lance must make a DC 15 Constitution saving throw or be blinded for 1 minute. A creature may make a new saving throw at the end of each of its turns, and whenever it takes damage, ending the effect on a success.",
+				"The {@i copper lance} regains 1d3 expended charges each day at dawn.",
+				"If you are attuned to both this item and the {@i copper shield}, all creatures have disadvantage on their saving throws against being blinded, and you regain all expended charges each day."
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"source": "EnMa"
+		},
+		{
+			"name": "Copper Shield",
+			"type": "S",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"ac": 2,
+			"tier": "Major",
+			"reqAttune": true,
+			"armor": true,
+			"entries": [
+				"This shining shield grants you a +1 bonus to your armor class. In addition, the shield has 3 charges. You may use your action to expend a charge and command the shield to blaze like the sun. All creatures within 60 feet of you who can see the shield must make a DC 15 Constitution saving throw or be blinded for 1 minute. A creature may make a new saving throw at the end of each of its turns, and whenever it takes damage, ending the effect on a success.",
+				"The {@i copper shield} regains 1d3 expended charges each day at dawn.",
+				"If you are attuned to both this item and the {@i copper lance}, all creatures have disadvantage on their saving throws against being blinded, and you regain {@i all} expended charges each day."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Cord of Binding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"If you use this cord to tie up a creature, any attempt to escape it is at disadvantage.",
+				"You can also command it to animate and tie up any creature that is currently grappled, restrained, paralyzed, prone, or unconscious.",
+				"The cord has AC 11, 50 hp, and is immune to poison and psychic damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Coronet of Communication",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This crown has 7 charges. You may use your action to expend one or more charges to cast the following spells: {@i dream} (5 charges), {@i detect thoughts} (2 charges), {@i mass suggestion} (5 charges), {@i telepathy} (6 charges), and {@i suggestion} (2 charges). The spells use your spellcasting ability and spell save DC.",
+				"The coronet regains 1d6+1 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Courier Key",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"entries": [
+				"This is a pair of matching keys, although each key can be used without the other and there is a 50 percent chance that only one key will be found.",
+				"If you hold the key up to a humanoid's forehead and whisper a message of no more than 100 words in length, then turn the key as if in a lock, the message is “locked” into that creature's mind. The message can then by “unlocked” by holding the same key or its pairing key up to the creature's forehead and turning it the other direction.",
+				"The creature forgets the contents of the message, but remembers that it heard a message and that it has been locked away by magical means. However, no magic short of a {@i wish} can unlock it without using one of those two keys."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Crown of Leadership",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this jeweled crown, your Charisma is 19, unless it was already higher. In addition, you are immune to being frightened while wearing the crown. You also can cast the {@i guidance} cantrip while wearing it. If you can speak positively to an individual or a crowd for a full round, you can cast {@i calm emotions}, using your spell save DC. If you can speak positively to an individual for a full minute, you can cast {@i bless} on that creature."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Crown of Stars",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This appears to be a plain silver circlet. When worn, however, the circlet disappears and a halo of twinkling, immaterial gemstones appear and orbit closely around your head, shedding dim light to a distance of 10 feet. In this form, the circlet closely resembles {@i ioun stones}, but they can't be grabbed away from you.",
+				"The crown has 7 charges. You may use your action to expend a charge and cast one of the following spells, with a spell save DC of 19: {@i arcane eye} (4 charges), {@i dispel magic} (as if cast with a 9th-level spell slot; 6 charges), {@i Evard's black tentacles} (4 charges), {@i finger of death} (6 charges), {@i lightning bolt} (inflicts 11d6 lightning damage, 6 charges), {@i Melf's minute meteors} (3 charges), or {@i unseen servant} (1 charge).",
+				"The crown regains 1d6+1 expended charges each day at dusk"
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Crystal Coffin",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "20",
+			"entries": [
+				"Any humanoid forced into this coffin must make a DC 19 Wisdom saving throw or suffer the Slumber variant of the {@i imprisonment} spell. If the command word is spoken when the lid is opened, the creature will awaken."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Crystal Mirror",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"When held, this silvery gemstone gives you advantage on saving throws against being charmed, frightened, paralyzed, stunned, or unconsciousness."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dagger of Concealment, Type Ⅰ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Minor",
+			"entries": [
+				"This dagger has gilt filigree along the hilt and blade.",
+				"When you say the command word, the dagger changes into a plain gold ring or back again."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dagger of Concealment, Type Ⅱ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Legendary",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"This dagger has gilt filigree along the hilt and blade.",
+				"This is a {@i dagger +1} in its dagger form and a {@i ring of protection} in its ring form. You don't get the benefits of the ring's protection when it's in dagger form."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dagger of Throwing, Type Ⅰ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This dagger's range is doubled, to 40/120 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dagger of Throwing, Type Ⅱ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This dagger gives you advantage on your attack roll when throwing it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dagger of Throwing, Type Ⅲ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This dagger returns to your hand immediately after being throw, whether it hits or misses the target."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dark Crown",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This is a circlet of black metal set with human teeth. While wearing this crown, you have darkvision to 120 feet, are immune to being frightened, paralyzed, or petrified, can't be possessed, can't be aged by ghosts, and are resistant to necrotic damage. In addition, you can see through any sort of illusory disguise worn by an undead in an attempt to appear either alive or fully dead.",
+				"You may use your action to channel a powerful blast of energy at one undead within 30 feet. It may make a DC 19 Constitution saving throw to resist, taking 33 (6d10) radiant damage on a failed saving throw, or half as much on a successful one. Once you use this ability, you can't use it again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart of Branding",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"These darts, which are usually found in bundles of 1d4+1, have a mystical symbol burned into their barrels. When a dart is thrown and hits a target, it bursts into brilliant flame for a moment, then die out, turning the dart into ash in the process. The target takes an additional 5 (2d4) fire damage and must make a DC 13 Constitution saving throw or be blinded for 1 minute. It may make a new saving throw at the beginning of each of its turns, ending the effect on itself on a success.",
+				"In addition, the dart leaves behind a brand of the same symbol it has burned into it. This brand will eventually fade over the course of several months."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart of Light",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"These darts, which glow faintly in the dark, are normally found in bundles of 1d4+1. When a dart is thrown and hits a target, it explodes in a burst of bright light, destroying the dart. All creatures within 10 feet of the target must make a DC 13 Constitution saving throw or be blinded until the beginning of its next turn. The target creature is outlined by a bright glow, similar to that produced by the {@i faerie fire} spell, and sheds dim light in a 10-foot radius for 1 minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart of Stunning",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"These darts are usually found in bundles of 1d4+1. When a dart is thrown and hits a target, the target must make a DC 13 Constitution saving throw or be stunned for 1 minute. A creature may attempt a new saving throw at the end of each of its turns, and whenever it takes damage, ending the effect on a success. Hitting the target causes the dart to be destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart of the Hornet's Nest, Type Ⅰ",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Uncommon",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"These darts are usually found in bundles of 1d4+1. You have advantage when attacking with this dart. When you throw it, it transforms into numerous tiny, silvery hornets, which buzz and sting the target for a round, then fall lifeless to the ground. There are three types of {@i darts of the hornet's nest}.",
+				"This dart inflicts 2d4 piercing damage and 1d4 poison damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart of the Hornet's Nest, Type Ⅱ",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"These darts are usually found in bundles of 1d4+1. You have advantage when attacking with this dart. When you throw it, it transforms into numerous tiny, silvery hornets, which buzz and sting the target for a round, then fall lifeless to the ground. There are three types of {@i darts of the hornet's nest}.",
+				"This dart inflicts 3d4 piercing damage and 2d4 poison damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart of the Hornet's Nest, Type Ⅲ",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"These darts are usually found in bundles of 1d4+1. You have advantage when attacking with this dart. When you throw it, it transforms into numerous tiny, silvery hornets, which buzz and sting the target for a round, then fall lifeless to the ground. There are three types of {@i darts of the hornet's nest}.",
+				"This dart inflicts 5d4 piercing damage and 3d4 poison damage, and the target must make a DC 13 Constitution saving throw or be paralyzed until the end of its next turn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dart Ring",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 9 charges. You may use your action to expend a charge and fire a thorn-like dart from the ring. This dart has a range of 15/30 feet. On a hit, the it inflicts 1 point of piercing damage but injects a long-lasting toxin; the target must make a DC 15 Constitution saving throw or be poisoned for 24 hours. At the beginning of the creature's next turn, and at the end of every hour, the target must make another saving throw or take an additional 3 (1d6) poison damage. Both the poisoned effect and poison damage end on a successful saving throw.",
+				"The ring regains 1d8+1 expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dead Box",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"entries": [
+				"These boxes range in size from 1 foot to 10 feet on a side and are constructed of a strange, heavy, almost unbreakable stone. The box is immune to all non-magical damage and resistant to magical damage, has an AC of 20, and 200 hit points.",
+				"When properly sealed, the box is magically locked and can't be opened without the command word. it is completely impossible to determine the contents of a box, even with the use of a {@i wish}. Anything inside the box is perfectly preserved, although the box doesn't have its own air or food supply."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Deathstriker Axe",
+			"type": "M",
+			"weapon": true,
+			"axe": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "7",
+			"dmg1": "{@dice 1d12}",
+			"dmgType": "S",
+			"property": [
+				"H",
+				"2H"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This weapon constantly crackles with electrical energy, and on a successful hit, it inflicts an additional 1d10 lightning damage.",
+				"The {@i deathstriker axe} has 3 charges. You may use an action and expend a charge to shoot a bolt of lightning at a target within 60 feet. The creature must make a DC 19 Dexterity saving throw, taking 21 (6d6) lightning damage on a failed saving throw, or half as much on successful one.",
+				"The axe regains all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Deceptor's Boots",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "2",
+			"entries": [
+				"While attuned to these boots, you may use your action to cast {@i etherealness}, {@i invisibility}, or {@i spider climb}. Once you cast one of these spells, you can't cast that spell again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Deck of Chance",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"These decks of cards alter fate itself by improving—or worsening—some of your rolls. The effects last until the following dawn. You may draw one card; additional cards drawn before the next dawn have no effect.",
+				"If you draw a red card, the affected rolls are rolled at disadvantage. If you draw a black card, the affected rolls are rolled at advantage.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Card",
+						"",
+						"Effect"
+					],
+					"rows": [
+						[
+							"Ace",
+							"",
+							"Drawing an ace alters your ability checks, attack rolls, and saving throws."
+						],
+						[
+							"Two",
+							"",
+							"Drawing a two alters your ability checks."
+						],
+						[
+							"Three through Nine",
+							"",
+							"Drawing one of these cards alters your ability checks:"
+						],
+						[
+							"Ten",
+							"",
+							"Drawing a ten alters your attack rolls"
+						],
+						[
+							"Jack, Queen, or King",
+							"",
+							"Drawing a face card"
+						],
+						[
+							"Face card",
+							"",
+							"This alters your armor class: -2 penalty if a red card is drawn; +2 bonus if a black card is drawn."
+						]
+					],
+					"colStyles": [
+						"col-xs-4",
+						"col-xs-4 text-align-center",
+						"col-xs-4"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Defender's Harp",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a bard",
+			"weight": "2",
+			"entries": [
+				"This harp has 5 charges. When you use an action to expend a charge and pluck a string, it causes a painfully loud ringing, resonating outwards and centered on you. All creatures other than yourself and up to 7 other creatures of your choice must make a DC 15 Constitution saving throw. A creature takes 9 (2d8) thunder damage on a failed saving throw, or half as much damage on a successful one. In addition, a creature that failed its save is deafened until the end of its next turn.",
+				"Buildings and inanimate objects take 18 (4d8) thunder damage, and inanimate objects made of glass or crystal take double damage.",
+				"The harp regains 1d4+1 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Diadem of Doom",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This jeweled crown can be commanded to take the form of any other form of headgear. While wearing it, you get a +1 bonus to your armor class and are immune to the frightened condition. You also have advantage on Charisma ability checks when dealing with fiends and undead.",
+				"In addition, the {@i diadem} has 9 charges. You can use your action to expend one or more charges to cast the following spells: {@i animate dead} (3 charges), {@i bestow curse} (3 charges), {@i dispel magic} (3 charges), {@i fear} (3 charges), {@i flame strike} (5 charges), {@i passwall} (5 charges), or {@i speak with dead} (3 charges).",
+				"The diadem regains 1d8+1 expended charges each day at dusk.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This item is cursed, and attuning to it extends the curse to you. As long as you are cursed, you are unwilling to remove the diadem and wear it at all times. Over the course of the following weeks or months, your alignment will shift to evil. If you are still cursed by this item after a full year has passed, you will become a lycanthrope of a type chosen by the DM."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Disintegration Chamber",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"entries": [
+				"These glass and metal boxes range in size from 1 foot to 10 feet on a side. It has three charges. You may expend a charge to cast {@i disintegrate}, inflicting 10d6+40 force damage on everything inside the box. A living creature may make a DC 17 Constitution saving throw to resist.",
+				"The chamber regains all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dove's Harp",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a bard",
+			"weight": "2",
+			"entries": [
+				"When played, this harp glows gently, shedding dim light to 10 feet. If you use your action to play the harp, then all creatures within 30 feet who can hear it must make a DC 13 Wisdom saving throw or fall under the effects of a {@i calm emotions} spell.",
+				"If you play the harp for a full minute, all creatures within 10 feet of you are subject to a {@i lesser restoration} and regain 2d6 hit points.",
+				"Once you use either of these abilities, you can't use that ability again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dowsing Key",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"entries": [
+				"If you place the tip of this key in the ground and turn it, the key “unlocks” any underground water present at that location, turning it into a spring. The amount of water provided depends on its location and the conditions of the area. Once the {@i key of dousing} has been used, it can't be used again until 10 days have passed.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Area",
+						"Spring's Output"
+					],
+					"rows": [
+						[
+							"Very dry",
+							"1 pint per minute; the spring has a 50 percent chance of drying up at the end of every day"
+						],
+						[
+							"Dry",
+							"1 gallon per minute; the spring has a 50 percent chance of drying up at the end of every week"
+						],
+						[
+							"Average",
+							"10 gallons per minute; the spring has a 50 percent chance of drying up at the end of each month"
+						],
+						[
+							"Damp or marshy area",
+							"1,000 gallons per minute; the spring has a 50 percent chance of drying up at the end of each year"
+						],
+						[
+							"Local aquifer or very wet ground",
+							"10,000 gallons per minute; the spring is permanent"
+						]
+					],
+					"colStyles": [
+						"col-xs-6",
+						"col-xs-6"
+					]
+				},
+				{
+					"type": "table",
+					"colLabels": [
+						"d10",
+						"Water Type"
+					],
+					"rows": [
+						[
+							"1-5",
+							"freshwater"
+						],
+						[
+							"6-7",
+							"potable mineral water"
+						],
+						[
+							"8",
+							"saltwater"
+						],
+						[
+							"10",
+							"hot spring"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragon Bones, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"These are bones which are carved with mystic runes and occult images and stained with blue and green dyes. To use the bones, you must spend 1 minute throwing them and interpreting the results.",
+				"After throwing the bones, you may cast {@i augury}. Once you have done so, you can't do so again until the following dawn. You can use these bones as the material component for casting {@i augury} normally, and if you do so, you can cast that spell twice before you begin to suffer from the cumulative 25 percent chance of a random reading.",
+				"You may also use these bones as the material components for the {@i find the path} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragon Bones, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"These are bones which are carved with mystic runes and occult images and stained with blue and green dyes. To use the bones, you must spend 1 minute throwing them and interpreting the results.",
+				"After throwing the bones, you may cast either {@i augury}, {@i divination} or {@i legend lore}. Once you have cast a spell in this way, you can't cast that spell again until the following dawn.",
+				"You can use these bones as the material component for casting {@i augury} normally, and if you do so, you can cast that spell twice before you begin to suffer from the cumulative 25 percent chance of a random reading.",
+				"You can use these bones as the material component for casting {@i divination} normally, and if you do so, you can cast that spell twice before you begin to suffer from the cumulative 25 percent chance of a random reading",
+				"You may also use these bones as the material components for the {@i find the path} spell, and, if you do so, you don't need to concentrate on that spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragon Eye",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"If this small, glittering opal is thrown into the air while the command word is spoken, it will crack open and a {@b young dragon} will emerge. This dragon will see you as an ally to be heeded and trusted and it will follow your requests to the best of its ability. However, it will also act according to its species; a chromatic dragon will in a rapacious and violent manner, for instance, while a metallic dragon may prefer to use its debilitating breath weapon or engage in conversation. After 1d4 hours, the dragon will vanish.",
+				"Roll a d10 to determine what sort of dragon emerges:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d10",
+						"Dragon Type"
+					],
+					"rows": [
+						[
+							"1",
+							"{@creature young Black dragon|mm|Black}"
+						],
+						[
+							"2",
+							"{@creature young Blue dragon|mm|Blue}"
+						],
+						[
+							"3",
+							"{@creature young Brass dragon|mm|Brass}"
+						],
+						[
+							"4",
+							"{@creature young Bronze dragon|mm|Bronze}"
+						],
+						[
+							"5",
+							"{@creature young Copper dragon|mm|Copper}"
+						],
+						[
+							"6",
+							"{@creature young Gold dragon|mm|Gold}"
+						],
+						[
+							"7",
+							"{@creature young Green dragon|mm|Green}"
+						],
+						[
+							"8",
+							"{@creature young Red dragon|mm|Red}"
+						],
+						[
+							"9",
+							"{@creature young Silver dragon|mm|Silver}"
+						],
+						[
+							"10",
+							"{@creature young White dragon|mm|White}"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragon Scale Shield",
+			"type": "S",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"ac": 2,
+			"tier": "Major",
+			"reqAttune": true,
+			"armor": true,
+			"entries": [
+				"Made from the scales of a dragon, this {@i shield +1} gives you resistance to one damage type that is determined by the kind of dragon that provided the scales.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Dragon",
+						"Resistance"
+					],
+					"rows": [
+						[
+							"Black, copper",
+							"Acid"
+						],
+						[
+							"Blue, bronze",
+							"Lightning"
+						],
+						[
+							"Brass, gold, red",
+							"Fire"
+						],
+						[
+							"Bronze",
+							"Lightning"
+						],
+						[
+							"Green",
+							"Poison"
+						],
+						[
+							"Silver, white",
+							"Cold"
+						]
+					],
+					"colStyles": [
+						"col-xs-6",
+						"col-xs-6"
+					]
+				},
+				"If you wear both this and {@i dragon scale mail} or a {@i dragonhide cloak} (q.v.) of the same type, you gain immunity to that damage type. There is no additional benefit if you wear all three items."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragon Slippers",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"You can command these green silk slippers to cast {@i seeming} on you, making you appear to be a Large dragon with gold and green scales and a barbed tail. This illusion lasts for 1 hour or until you dismiss it, but otherwise is identical to the {@i seeming} spell.",
+				"In addition, you also gain a fly speed equal to your walking speed. You don't get any other draconic abilities."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragonhelm",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a barbarian, cleric bard, fighter, paladin",
+			"weight": "4",
+			"entries": [
+				"This {@i helmet +2} appears to be a normal, slightly worn metal helmet until it is attuned to and worn. At that point, it reveals its true form: it's gleaming and unblemished, adorned with precious metals and gemstones and sculpted to look like scales.",
+				"While wearing the helmet, you have darkvision to 100 feet and truesight to 30 feet. In addition, you can use the helmet to cast {@i fear}. Once you have done so, you can't do so again until the following dawn.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This helmet is cursed and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the helmet, keeping it on your person at all times and wearing it at least once each day, if only for a few minutes."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"While cursed, you will become increasingly greedy and megalomaniacal, refusing to heed the advice of others, lashing out at the slightest perceived insult, and hording your valuables and refusing to spend any unless absolutely necessary. You won't necessarily change your alignment, but you will definitely act in an antisocial and rather draconic manner."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragonhide Cloak",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"Made from the hide of a dragon, this cloak gives you +2 AC while you wear it, and resistance to one damage type that is determined by the kind of dragon that provided the hide:",
+				{
+					"type": "table",
+					"colLabels": [
+						"Dragon",
+						"Resistance"
+					],
+					"rows": [
+						[
+							"Black, copper",
+							"Acid"
+						],
+						[
+							"Blue, bronze",
+							"Lightning"
+						],
+						[
+							"Brass, gold, red",
+							"Fire"
+						],
+						[
+							"Bronze",
+							"Lightning"
+						],
+						[
+							"Green",
+							"Poison"
+						],
+						[
+							"Silver, white",
+							"Cold"
+						]
+					],
+					"colStyles": [
+						"col-xs-6",
+						"col-xs-6"
+					]
+				},
+				"If you wear both this and dragon scale mail or a dragon scale shield (q.v.) of the same type, you gain immunity to that damage type. There is no additional benefit if you wear all three items."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragonlance, Type Ⅰ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Rare",
+			"weight": "6",
+			"dmg1": "{@dice 1d12}",
+			"dmgType": "P",
+			"property": [
+				"R",
+				"S"
+			],
+			"entries": [
+				"This very long, silvery lance has a reach of 15 feet.",
+				"This {@i lance +1} inflicts an additional 1d8 force damage when it strikes a dragon."
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"source": "EnMa"
+		},
+		{
+			"name": "Dragonlance, Type Ⅱ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "6",
+			"dmg1": "{@dice 1d12}",
+			"dmgType": "P",
+			"property": [
+				"R",
+				"S"
+			],
+			"entries": [
+				"This very long, silvery lance has a reach of 15 feet.",
+				"This {@i lance +3} inflicts an additional 2d8 force damage when it strikes a dragon. In addition, if you are wielding this lance while mounted on a dragon, you inflict additional damage: +1d12 if you are riding a young dragon, +2d12 if you are riding an adult dragon, and +4d12 if you are riding an ancient dragon."
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"source": "EnMa"
+		},
+		{
+			"name": "Dramatic Mask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"These masks are made in the traditional comedy and tragedy style. Each mask has 3 charges. When you wear one of them, you can use your action to expend a charge to affect all creatures within 30 feet of you who can see you, unless it first makes a DC 17 Wisdom saving throw. A creature may make a new save at the end of each of its turns, ending the effect on itself on a success.",
+				{
+					"items": [
+						{
+							"name": "Mask of Comedy",
+							"entries": [
+								"A creature who fails its save is affected by {@i Tasha's hideous laughter} for 1 minute."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Mask of Tragedy",
+							"entries": [
+								"A creature who fails its save is affected by despair, as per the Hopelessness option of the {@i symbol} spell, for 1 minute."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"The mask regains all expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dream Stone",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"These small agates, which have been carved with lunar symbols, are usually found in bundles of 1d4+1 stones. If you sleep with one of these stones under your head, you will receive a cryptic dream that reveals an event that will happen in the near future or provides a solution to a problem that has been stymieing you. Once you use a dream stone, a crack bisects the carved symbol and the stone becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dress of Amazement",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "2",
+			"entries": [
+				"This outfit can take on any form, style, or color you wish for any gender or race and refits itself for a Small to Large wearer. No matter the outfit's appearance, it always seems opulent and very stylish. In its natural form, it resembles plain but otherwise decent clothing."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Drums of Thunder",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a bard",
+			"weight": "4",
+			"entries": [
+				"This is a pair of kettledrums, lashed together with leather thongs. The two drums only work when together; if they are ever separated, they become nonmagical. You can use your action to strike one or both of the drums. When struck, the {@i drums of thunder} produce a loud, rumbling boom.",
+				"The {@i drums of thunder} have 7 charges and regain 1d4 expended charges each day at dawn. While attuned to the drums, you can cast the {@i thunderclap} cantrip. You may use your action to strike the drums and expend 1 or more charges to cast the following spells: {@i cause fear} (1 charge), {@i control weather} (6 charges), {@i jump} (1 charge), {@i lightning bolt} (3 charges), or {@i thunder step} (3 charges)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dungeon Chains",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "20",
+			"entries": [
+				"These chains and shackles are incredibly heavy and obviously meant to restrain a creature rather than be used for any other purpose. They enlarge and shrink to fit creatures between Small and Huge size. While chained by them, the prisoner can't shapechange, use any form of teleportation or extradimensional travel, can't turn gaseous, ethereal, or misty, its walking speed is reduced by 10 feet, and all other speeds are halved."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Appearance",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles very fine sand. A packet usually contains 1d4 pinches. When you use an action to throw a pinch of dust into the air, each creature within 10 feet of you that is invisible will become visible, and it will also reveal an illusion's true nature and negate displacement effects. In addition, any attempt to hide while the dust is active will be at disadvantage. The dust remains effective for 10 minutes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Blandness",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this power resembles an unidentified spice. A packet usually contains 2d10+4 pinches.",
+				"This dust makes food utterly bland. It can be used to mask the taste of poisons, rotted or burnt food, or food with a strong odor."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Dullness",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles glistening sand. A packet usually contains 1d4 pinches. You may use your action to throw the dust in the air. Each creature within 10 feet of you must make a DC 13 Constitution saving throw. On a failure, one of a creature's senses is partially damaged for 10 minutes. A creature may make a new saving throw once each minute, ending the effect on itself on a success. A {@i lesser restoration} will end the effect as well.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d10",
+						"Effect"
+					],
+					"rows": [
+						[
+							"1-2",
+							"{@b Vision.} The target's vision is blurred. It is at disadvantage on attack rolls, as well as on Wisdom (Perception) checks that rely on sight. In addition, if the target moves at faster than half-speed, it must make a DC 10 Dexterity ability check at the beginning o each of its turns, or it trips and falls."
+						],
+						[
+							"3-4",
+							"{@b Hearing.} The target's hearing is muted have disadvantage on Wisdom (Perception) checks that rely on hearing, and can't hear spoken language unless it is shouted from no farther away than 10 feet. In addition, if the target attempts to cast a spell that has a verbal component, it must make a DC 10 Intelligence ability check to make sure that it's speaking the words correctly."
+						],
+						[
+							"5",
+							"{@b Touch.} The target becomes numb. It has disadvantage on Dexterity (Sleight of Hand) checks and on Dexterity saving throws. In addition, the target will be unaware of how much damage it takes from an attack until the effect ends."
+						],
+						[
+							"6",
+							"{@b Sixth Sense.} You can't receive, transmit, use, or interpret any sort of magical or mundane ability relating to telepathy, divining, communing, or seeing through magical means, such as with an {@i arcane eye}. In addition, if you are subjected to such an effect and that effect allows a saving throw, you have disadvantage on that roll."
+						],
+						[
+							"7-8",
+							"{@b Dulled Senses.} All of yours physical senses are dulled. You have disadvantage on all Wisdom (Perception) checks."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Green Sleeping",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles very fine green sand. There is enough of it for 1d6 uses. When you use an action to throw the dust into the air, each creature within 10 feet of you must make a DC 13 Wisdom saving throw or fall asleep for 1 hour, or until the sleeper takes damage or someone uses an action to shake or slap the sleeper awake."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Illusion",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles powdered graphite. . A packet usually contains 1d4 pinches. You may use your action to sprinkle a pinch over a Small to Large creature, while at the same time thinking of an image. The creature will then be covered by an illusion of that image, as if you had cast {@i seeming} on it. The illusion must be of the same size and shape as the creature on which you are using the dust; for instance, you can make a human look like a gnoll or an elf, but not like a manticore or a horse.",
+				"The illusion lasts for 1 hour or until blown away by a strong wind of at least 20 miles per hour."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Images",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles very fine, multicolored, twinkling sand. A packet usually contains 1d6+4 pinches. If a pinch is thrown into a fire while you concentrate on a recent misfortune, the dust will form a puff of dense, colorful smoke that obscures vision in a 5-foot cube.",
+				"The smoke takes on the image of either the culprit or the events that caused the misfortune. If there is no culprit (i.e., if the misfortune was the result of just bad luck), the smoke will roil for moment and then dissipate. The smoke dissipates in one round."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Magic Detection",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles very fine, multicolored, twinkling sand. A packet usually contains 1d6+4 pinches. If a pinch is thrown into the air, it will become a 20-foot-radius cloud, too faint to obscure vision. Anything magical in that area will spark and flash in a rainbow of colors. The cloud dissipates in one round."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Piquantness",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this power resembles an unidentified spice. A packet usually contains 2d10+4 pinches.",
+				"This dust enhances flavor. If sprinkled on good food, it makes that food delicious. It also makes poisons, rot, and badly-cooked food unmistakably bad."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of the Black Arts",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles fine coal dust. A packet usually contains 1 pinch of dust. When you draw a line of this dust on the ground, and another creatures walks over it, that creature must make a DC 17 Constitution saving throw. It takes 12d10 necrotic damage on a failed saving throw, or half as much on a successful one. Once spread out, the dust lasts for 24 hours."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of the Black Veil",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles black sand. A packet usually contains 1d6+2 pinches. You may use your action to throw the dust in the air, where it will become a 20-foot-radius sphere of {@i darkness}, as per the spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Dust of Tracelessness",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Found in a small packet, this powder resembles gray dust. A packet usually contains 1d6+4 pinches. If you use your action to throw a pinch of it into the air, it will cause a 20-foot cube to appear as dusty, dirty, and cobweb-laden as if it had been completely unused for a decade or more."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ebon Skull",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "2",
+			"entries": [
+				"This slightly stylized skull is carved of pure black stone of an unknown type and has rubies for eyes. It has 7 charges. You can spend your action to expend a charge and cast {@i animate dead} (1 charge), {@i cloudkill} (3 charges), or {@i create undead} (4 charges).",
+				"While attuned to the skull, you are immune to hit point reduction, exhaustion, and attempts to possess you or remove your soul from your body. In addition, you gain darkvision to 60 feet, resistance against necrotic damage, and have advantage on saving throws against illusions.",
+				"The skull regains 1d4 charges each day at dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Egg of Adult Dragon's Breath",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"Made from magically altered and hardened dragon's eggs that have been shrunk down to the size of a large hen's egg, these items are magical grenades. When you throw the egg to the ground (range 30/60 feet), it explodes, releasing a burst of energy. Creatures within the area must make a DC 15 saving throw, taking full damage on a failed save or half as much on a successful one.",
+				"The amount of damage inflicted, and the radius of the energy released, depends on the age of the dragon that laid the egg, and the type of damage inflicted depends on the type of dragon that laid the egg:",
+				"This egg came from an adult dragon and deals 16d8 damage in a 60-foot radius sphere around the point of impact.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d6",
+						"Dragon",
+						"Damage Type"
+					],
+					"rows": [
+						[
+							"1",
+							"Black or copper",
+							"Acid damage"
+						],
+						[
+							"2",
+							"Blue or bronze",
+							"Lightning damage"
+						],
+						[
+							"3-4",
+							"Brass, gold, or red",
+							"Fire damage"
+						],
+						[
+							"5",
+							"Green",
+							"Poison damage"
+						],
+						[
+							"6",
+							"Silver or white",
+							"Cold damage"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4",
+						"col-xs-4 text-align-center"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Egg of Ancient Dragon's Breath",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"Made from magically altered and hardened dragon's eggs that have been shrunk down to the size of a large hen's egg, these items are magical grenades. When you throw the egg to the ground (range 30/60 feet), it explodes, releasing a burst of energy. Creatures within the area must make a DC 15 saving throw, taking full damage on a failed save or half as much on a successful one.",
+				"The amount of damage inflicted, and the radius of the energy released, depends on the age of the dragon that laid the egg, and the type of damage inflicted depends on the type of dragon that laid the egg:",
+				"This egg came from an ancient dragon and deals 18d12 damage in a 90-foot radius sphere around the point of impact.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d6",
+						"Dragon",
+						"Damage Type"
+					],
+					"rows": [
+						[
+							"1",
+							"Black or copper",
+							"Acid damage"
+						],
+						[
+							"2",
+							"Blue or bronze",
+							"Lightning damage"
+						],
+						[
+							"3-4",
+							"Brass, gold, or red",
+							"Fire damage"
+						],
+						[
+							"5",
+							"Green",
+							"Poison damage"
+						],
+						[
+							"6",
+							"Silver or white",
+							"Cold damage"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4",
+						"col-xs-4 text-align-center"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Egg of Cloudkill",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"When you throw this egg to the ground (range 30/60 feet), it cracks open and releases a cloud of thick, toxic clouds in a 20-foot-radius sphere that spreads around corners. The area is heavily obscured. A creature that enters the area for the first time or starts its turn in it must make a DC 13 Constitution saving throw, taking 23 (5d8) poison damage on a failed save or half as much on a successful one."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Egg of Wonder",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"When you break open one of these eggs, a fey spirit in the form of an animal emerges. It uses the attributes of the beast it appears to be, although its Intelligence increases by +2. The creature will be friendly to you and your companions and will remain with you indefinitely, although it will vanish forever if slain or if a {@i dispel evil or good} or {@i dispel magic} is cast on it.",
+				"Roll a d20 to determine what creature emerges.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d20",
+						"Creature"
+					],
+					"rows": [
+						[
+							"1",
+							"Ape"
+						],
+						[
+							"2",
+							"Axe beak"
+						],
+						[
+							"3",
+							"Black bear"
+						],
+						[
+							"4",
+							"Boar"
+						],
+						[
+							"5",
+							"Brown bear"
+						],
+						[
+							"6",
+							"Constrictor snake"
+						],
+						[
+							"7",
+							"Crocodile"
+						],
+						[
+							"8",
+							"Dire wolf"
+						],
+						[
+							"9",
+							"Elk"
+						],
+						[
+							"10",
+							"Giant badger"
+						],
+						[
+							"11",
+							"Giant eagle"
+						],
+						[
+							"12",
+							"Giant frog"
+						],
+						[
+							"13",
+							"Giant lizard"
+						],
+						[
+							"14",
+							"Giant owl"
+						],
+						[
+							"15",
+							"Giant scorpion"
+						],
+						[
+							"16",
+							"Giant wolf spider"
+						],
+						[
+							"17",
+							"Lion"
+						],
+						[
+							"18",
+							"Panther"
+						],
+						[
+							"19",
+							"Tiger"
+						],
+						[
+							"20",
+							"Wolf"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Elf-Cleaver",
+			"type": "M",
+			"weapon": true,
+			"axe": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "7",
+			"dmg1": "{@dice 1d12}",
+			"dmgType": "S",
+			"property": [
+				"H",
+				"2H"
+			],
+			"tier": "Major",
+			"reqAttune": "by a dwarf, goblinoid, or orc",
+			"entries": [
+				"This is a {@i greataxe +1}. While attuned to this weapon, you automatically detect the presence of an elf or fey within 100 feet. If you strike an elf or fey with this weapon, you inflict an additional 1d12 slashing damage.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This weapon is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the axe, keeping it within reach at all times. While attuned to this weapon, you have disadvantage on attack rolls made with weapons other than this one. You also have disadvantage on any roll designed to assist or gain a positive reaction from an elf or a fey."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"If you see an elf or fey you must make a DC 15 Wisdom saving throw or fall into a berserk rage. While raging, you have advantage on all attack rolls, but all attack rolls made against you are also made at advantage. You can't end this rage early. In addition, while you are raging, you will see all humanoids within 60 feet of you as elves, even your closest allies.",
+				"The rage will last until there are no humanoids or fey within 60 feet of you or you have been restrained for a minute or rendered unconscious."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Elixir of Life, Type Ⅰ",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If poured into the mouth of a creature who has died no more than 1 hour ago, it must make a DC 10 Constitution saving throw. On a success, it comes back to life an hour later with 1 hit point"
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Elixir of Life, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If poured into the mouth of a creature who has died no more than 1 hour ago, it automatically comes back to life an hour later with 1/2 its normal hit points."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Elixir of Madness",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This appears to be a beneficial elixir, such as an {@i elixir of health}. However, when you drink it, you must make a DC 17 Wisdom saving throw or go insane. The DM will choose the form your insanity takes or roll on the Indefinite Madness table in the {@i Dungeon Master's Guide}, Chapter 8: Running the Game. You will remain insane until you are subjected to a {@i greater restoration} or similar spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Essence of Darkness",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion turns your entire body—skin, hair, teeth, tongue, and sclera—a dull matte black for 8 hours. When you are in dim light or darkness, you have advantage on Stealth rolls and can take the Hide action as a bonus action. You can't end this effect early, unless you are targeted by a {@i lesser restoration}.",
+				"You can also dilute the potion in a gallon of water, turning it into a pure black, indelible dye that will never fade."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Everbountiful Soup Kettle",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "5",
+			"entries": [
+				"If you fill this two-gallon iron kettle with water, juice, ale, or oil, and then say the command word, the liquid is transformed into a piping-hot, delicious vegetable soup, sufficient to provide six filling meals. If you also place a pound of raw vegetables in the liquid before saying the command word, the kettle will create twelve meals instead.",
+				"You can use the kettle three times, then you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Everclean Towel",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"entries": [
+				"This 1-foot-square towel cannot be stained or dirtied in any way, no matter how much it's used to clean."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Everfull Cask",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "5",
+			"entries": [
+				"Each day at dawn, this cask fills itself with up to 5 gallons of fresh water. If the cask is damaged or its cover is lost, no water is created."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Everfull Inkwell, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"This is a small glass inkwell with a stopper. It weighs around 1/2 pound. When the stopper is in, it never leaks.",
+				"This inkwell never runs dry. It is of good enough quality to be used to record magic spells and scrolls."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Everfull Inkwell, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"This is a small glass inkwell with a stopper. It weighs around 1/2 pound. When the stopper is in, it never leaks.",
+				"This inkwell never runs dry. It is of good enough quality to be used to record magic spells and scrolls. You can also command it to change color and opacity."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Everfull Purse",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"If you place a coin inside this bag and let it remain undisturbed for 8 hours, it will produce 1d10+5 copies of that coin.",
+				"Each {@i everfull} purse only duplicates one kind of coin. Roll a d20 to determine the type of coin the purse will duplicate:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d20",
+						"Type of Coin Duplicated"
+					],
+					"rows": [
+						[
+							"1-8",
+							"Copper coins"
+						],
+						[
+							"9-14",
+							"Silver coins"
+						],
+						[
+							"15-19",
+							"Gold coins"
+						],
+						[
+							"20",
+							"Platinum coins"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				},
+				"If you empty the purse completely and allow it to remain completely empty of any kind of coin for 24 hours, it loses its enchantment altogether and becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Eye of Accuracy",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This is a piece of polished bone carved into the shape of an eye. If its touched to a nonmagical weapon, it disappears and the symbol of the eye glows on the weapon's blade or striking head for 1 minute. During this time, the weapon becomes magical and gets a +2 bonus to both to-hit and damage rolls. The {@i eye of accuracy} can only be used one time."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Eyes of Sight",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"These crystal lenses fit over the eyes. While wearing them, you have darkvision to 60 feet, truesight to 30 feet, are immune to being blinded, and you can't be charmed by visual means, such as by meeting a vampire's gaze or through the {@i hypnotic pattern} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Eyes of the Arcanist",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"These crystal lenses fit over the eyes. They have 3 charges. While wearing them, you can expend 1 charge as an action to cast either {@i comprehend languages} (written languages only) or {@i true seeing}. The lenses regain all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Faerie Flute, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"If you play this flute for one minute while outside, you summon fey to your side; the fey will serve you faithfully for 8 hours, then depart. Once you use this ability, you can't use it again until the following dawn.",
+				"You can cast {@i conjure woodland beings}.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"Some, but not all, of these flutes are cursed, and when you have used the flute once, the curse will extend to you. You will not be able to rid yourself of the flute until {@i remove curse} is cast; if you try to get rid of it or destroy it, the flute will merely reappear, whole and unharmed, among your belongings."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"Fey you deliberately summon will serve you but will either pervert your orders in order to cause harm to you, your allies, and your loved ones, or they will outright attack you. Other fey will stalk you and attempt to steal your belongings, and some will demand that you play the flute for them and summon their friends for them, and will terrorize you if you don't play. Casting {@i protection evil and good} will prevent the fey from harassing you for as long as the spell is active, and {@i dispel evil and good} will banish the fey to the Feywild for 24 hours, but after that it will return."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Faerie Flute, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"If you play this flute for one minute while outside, you summon fey to your side; the fey will serve you faithfully for 8 hours, then depart. Once you use this ability, you can't use it again until the following dawn.",
+				"You can cast either {@i conjure woodland beings} or {@i conjure fey}.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"Some, but not all, of these flutes are cursed, and when you have used the flute once, the curse will extend to you. You will not be able to rid yourself of the flute until {@i remove curse} is cast; if you try to get rid of it or destroy it, the flute will merely reappear, whole and unharmed, among your belongings."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"Fey you deliberately summon will serve you but will either pervert your orders in order to cause harm to you, your allies, and your loved ones, or they will outright attack you. Other fey will stalk you and attempt to steal your belongings, and some will demand that you play the flute for them and summon their friends for them, and will terrorize you if you don't play. Casting {@i protection evil and good} will prevent the fey from harassing you for as long as the spell is active, and {@i dispel evil and good} will banish the fey to the Feywild for 24 hours, but after that it will return."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Fang Dagger, Type Ⅰ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"When drawn, this thinly-bladed dagger becomes infused with poison.",
+				"This dagger inflicts an additional 3 (1d6) poison damage on a successful hit."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Fang Dagger, Type Ⅱ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"When drawn, this thinly-bladed dagger becomes infused with poison.",
+				"This dagger inflicts an additional 7 (2d6) poison damage, and the target must make a DC 15 Constitution saving throw or be poisoned for 1 minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Fanged Mask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This half-mask is lined with vicious-looking fangs. While wearing it, you are proficient in attacking with your bite, and you inflict 3 (1d6) piercing damage plus your Strength modifier. This is considered to be a magical attack. In addition, a creature you might must make a Constitution saving throw or be stunned until the beginning of its next turn. The save DC is equal to 8 + your Strength modifier + your proficiency bonus."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Amber Monkeys",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"These amber statues of monkeys are always created in sets of three, and are carved in the three wise monkeys poses (“see no evil; hear no evil; speak no evil”). Each monkey can be used separately from the others and has two command words. Speaking the first command word causes the statuette to become a very large real monkey (use {@creature ape|mm} statistics, except it has 30 hit points) for up to 8 hours. Once it has been used in this manner, it can't be used again until 7 days have passed.",
+				"Each {@i amber monkey} has a secondary use as well. If this command word is spoken, the monkey teleports to the shoulders of one target you choose within 60 feet of you. It will then wrap its limbs and tail around the target's torso. The target is grappled (escape DC 13), and suffers an additional effect, depending on the type of monkey:",
+				{
+					"type": "list",
+					"items": [
+						"The {@i see no evil} monkey covers its target's eyes. For as long as the target creature is grappled, it is blinded. If the monkey is removed, the target is blinded for 1 minute afterwards, but may make a DC 17 Constitution saving throw at the beginning of each of its turns, ending the effect on a success.",
+						"The {@i hear no evil} monkey covers its target's ears. For as long as the target creature is grappled, it is deafened. If the monkey is removed, the target is deafened for 1 minute afterwards, but may make a DC 17 Constitution saving throw at the beginning of each of its turns, ending the effect on a success.",
+						"The {@i speak no evil} monkey covers its target's mouth. For as long as the target creature is grappled, it is mute and can't cast spells with verbal components. If the monkey is removed, the target is mute for 1 minute afterwards, but may make a DC 17 Constitution saving throw at the beginning of each of its turns, ending the effect on a success."
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Coral Dragon",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This is a delicate carving of a serpentine dragon about 8 inches long. It can become a 3-foot-long, wingless dragon for up to 24 hours. Once used, it can't be used again until 7 days have passed. The coral dragon is knowledgeable about many things and eager to answer questions or cast its spells on your behalf. See {@creature Coral Dragon|EnMa} for the dragon's statistics."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Emerald Frog",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"This is a 1-inch-long frog carved out of emerald. When activated, it becomes a normal frog (use {@creature frog|mm} statistics, except that it is immune to poison damage and the poisoned condition). It can remain in this form for up to 24 hours, and once it has been used, it can't be used again until 7 days have passed.",
+				"While in frog form, the figurine allows you to cast {@i beast sense} on it. In addition, the frog can be used to attack insect- or spider-like creatures, including giant versions of normal insects and spiders as well as monstrous creatures such as ankhegs, driders, ettercaps, and thri-kreen. It can't target swarms. When facing a creature such as that, the frog has the attacks listed on the next page.",
+				{
+					"type": "inset",
+					"entries": [
+						{
+							"items": [
+								{
+									"name": "Tongue",
+									"entries": [
+										"The frog targets one Large or smaller creature that it can see within 20 feet of it. The target must make a DC 15 Strength saving throw. On a failed save, the target is pulled into an unoccupied space within 5 feet of the frog, and the frog can make a bite attack against it as a bonus action."
+									],
+									"type": "item"
+								},
+								{
+									"name": "Bite",
+									"entries": [
+										"{@i Melee Weapon Attack:} +3 to hit, reach 5 feet, one target. {@i Hit:} 1 piercing damage, and the creature is grappled (escape DC 15). Until this grapple ends, the target is restrained and the frog can't bite another target."
+									],
+									"type": "item"
+								},
+								{
+									"name": "Swallow",
+									"entries": [
+										"The frog makes one bite attack against a Large or smaller target it is grappling. If the attack hits, the target is magically shrunk to the size of a normal insect, swallowed, and the grapple ends. The swallowed target is blinded and restrained, it has total cover against attacks and other effects outside the frog, and it takes 10 (3d6) acid damage at the start of each of the frog's turns. The frog can have only one target swallowed at a time. If the frog dies, a swallowed creature will reappear in its normal size, prone in a space within 5 feet of the frog. If the frog is reverted back to its figurine form, the swallowed creature must make a DC 15 Constitution saving throw. On a success, it will reappear prone as above. Otherwise, it is killed and can only be brought back by a {@i true resurrection} or {@i wish} spell."
+									],
+									"type": "item"
+								}
+							],
+							"type": "list",
+							"style": "list-hang-notitle"
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Jade Snakes",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"These jade figurines are always created in pairs, one made of green jade (the {@i snake of striking}) and the other of white jade (the {@i snake of soothing}). When activated, they the figurines become {@creature giant constrictor snake|mm|giant constrictor snakes}. You can use one figurine at a time; if you activate both at the same time, the {@i snake of striking} will immediately attack the {@i snake of soothing}, which won't fight back. If one of the pair is destroyed, the other crumbles to dust.",
+				{
+					"type": "list",
+					"items": [
+						"The {@i snake of striking} has AC 14 and 104 hit points. It can be activated for up to 8 hours, after which it cannot be used again for another 2 days. This snake can only be healed while activated; damage not healed when it reverts to statuette form will remain until it is activated again.",
+						"The {@i snake of soothing} will gently coil around a willing, injured creature. You can use it to cast {@i cure wounds} (healing 5d8 damage) and {@i lesser restoration} twice each. It may be activated for 1 hour, after which it can't be used for another 2 days. It has statistics of a normal giant constrictor snake, but won't attack, even in defense."
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Moonstone Rabbit",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This pale blue-white statuette transforms into a normal sized, blue {@creature rabbit|EnMa}. It has a burrowing speed of 20 feet, and when it digs, it produces a hole 5 feet in diameter. The rabbit can be activated for up to 1 hour, after which it can't be used again until 2 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Opal Cats",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"These figurines are always made in sets of three: a {@i mother cat} made from black opal, a {@i kitten of contemplation} made of white opal carved sitting in a loaf, and a {@i kitten of caterwauling} made of fire opal, sitting up with its mouth open in a yowl. Each can be used for up to 8 hours, and once a cat has been used, it can't be used until 7 days have passed. Their properties are as follows:",
+				{
+					"type": "list",
+					"items": [
+						"The {@i mother cat} can be commanded to transform into a Large, shimmering black feline that uses the attributes of a {@creature tiger|mm}.",
+						"The {@i kitten of caterwauling} becomes a red tabby {@creature cat|mm} and can be commanded to guard an area. You may designate any number of creatures to be allowed within 30 feet of it. If anyone else approaches, the kitten will emit a wail clearly audible up to 300 feet away. It will continue to cry until the creature moves out of range, and for 1 minute afterwards. The kitten can also be commanded to attack, screaming out a 60 foot cone of deafeningly loud sound. All creatures in that area must make a DC 15 Constitution saving throw, taking 14 (3d8) thunder damage on a failed saving throw, or half as much on a successful one. In addition, a creature that fails its save is deafened for 1 minute, and may attempt a new save at the end of each of its turns, ending the effect on itself on a success.",
+						"The {@i kitten of contemplation} becomes a cream-colored tabby {@creature cat|mm} and will sit on or next to you and purr soothingly. After 10 minutes, it will remove the incapacitated and stunned conditions, will remove one level of exhaustion, and if you are under the effects of mental confusion or magically-caused madness that allowed for an initial saving throw to resist, you may make a new saving throw. In addition, if the kitten stays next to you while you sleep, it will prevent you from having nightmares, even those caused by the {@i dream} spell or a night hag's {@i nightmare haunting}. Finally, if you are a wizard and the kitten sits on your lap, it will take half as long as normal to inscribe a spell into your spellbook. (This stacks with the reduced time for inscribing a spell of your chosen school; spells of that school will take only one half-hour per level to inscribe."
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Silver Carp",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This 4-inch-long carp is cast out of silver. When activated, it grows to a length of 2 feet and is covered with beautiful, scintillating scales. It can remain in this form for 24 hours, and once it has been used, it can't be used again until 5 days have passed. If placed in water, it will purify up to 10 gallons of water per minute. If held in the air, it will spout fresh water out at the rate of one gallon per minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Figurine of Wondrous Power, Tourmaline Turtle",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"When this 6-inch-long statuette is placed in water and the command word spoken, it transforms into a 30-foot-long {@creature giant sea turtle|EnMa}. It can carry as many as 12 Medium-sized creatures on its back and swim along the surface of the water. It has 24 charges, and each hour or portion thereof it spends in beast form costs 1 charge. While it has charges, it can be used as often as you wish. When it runs out of charges, it reverts to a figurine and can't be used again until 7 days have passed, when it regains all its charges.",
+				"In addition, it can be commanded to dive and take its riders with it. In this case, you may expend a second charge and it will create a bubble of air adequate for itself and its passengers for 1 hour."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Fingernails of Rending",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"This is a set of five 3-inch-long, metallic fingernail-rings. Often, two sets, one for each hand, are found together. If you place one of these rings on each finger of one hand, they bind themselves forever to you. Technically, this is not a curse. However, only amputation, {@i greater restoration}, a {@i wish}, or your death will allow you to be rid of them.",
+				"These fingernail-rings don't get in the way of wearing other magical rings, nor do they hamper your movements or manual dexterity in any way.",
+				"When the {@i fingernails} initially bind to you, they cause extreme pain and feelings of horror and revulsion; you must make a DC 17 Wisdom saving throw or fail unconscious for 1d10+10 minutes. Although the pain and horrified feelings subside after you wake up, they never truly fade away completely. After wearing the fingernails for a week, your hand will wither and blacken, as if you were dead and rotting.",
+				"For as long as you wear even one of these {@i fingernails}, your unarmed melee attacks are magical and inflict an additional 4 (1d8) necrotic damage. In addition, if you roll a natural 20 when you attack with them, and your opponent is wearing nonmagical armor, you rend that armor, causing it a permanent and cumulative -1 to the AC it offers. Armor reduced to an AC of 10 that drops to a +0 bonus is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Fire Gem",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"This fist-sized fire opal has 3 charges. You may use your turn to expend 1 charge and cause the gem to expel a gout of fire 90 feet long and 5 feet wide. All creatures in that area must make a 17 Dexterity saving throw, taking 33 (6d10) fire damage on a failed saving throw or half as much on a successful one.",
+				"The gem regains 1d3 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Firebow",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"Any nonmagical arrow that you fire from this bow immediately bursts into flame, inflicting an additional 4 (1d8) fire damage on a successful hit."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flask of Curses",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"When opened, this flask releases a cloud of pale smoke that fills a sphere with a 10-foot radius that spreads around corners. Its area is heavily obscured and lasts for 1 minute or until a moderate wind disperses it.",
+				"Any creature that enters the area or starts its turn there and must breathe must make a DC 17 Wisdom saving throw or be cursed. While cursed, the creature has disadvantage on ability checks and saving throws made with one of Intelligence, Wisdom, or Charisma, chosen by the DM. This curse is lasts for 24 hours or until a {@i remove curse} or similar spell is cast upon an affected creature."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flint of Fire",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.1",
+			"entries": [
+				"This fire is used to start magical fires.",
+				{
+					"items": [
+						{
+							"name": "Flint of Cold Fire",
+							"entries": [
+								"If this flint is used to start a fire, the resulting fire will be cool to the touch. In addition, the flames can't spread more than one foot away from where you started the fire and won't light combustibles. It sheds light as normal, but as it is cool, it provides no heat and can't be used to cook anything."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Flint of Dark Fire",
+							"entries": [
+								"If this flint is used to start a fire, the fire will be a dark, flickering magenta that sheds dim light out to 5 feet, and in dim light or darkness, it can't be seen from farther away than that. It produces as much heat as a normal fire and can be used to light combustibles. If used to set combustibles on fire, it produces more dark fire."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flute of Courage",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"You must be proficient in wind instruments to use this flute. When you play this instrument for at least 1 fill round, all allies within 60 feet have advantage on saving throws to avoid being frightened. The advantage lasts for as long as you continue to play, plus one minute afterwards."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flute of Dismissing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"entries": [
+				"You must be proficient with wind instruments to use this flute. These pipes have three charges. By using your action to play this pipe you can expend a charge and banish one conjured or summoned creature you can see within 60 feet of you back to its home plane. The creature may make a Charisma saving throw to resist, using your spell save DC. If the creature succeeds, it is paralyzed until the end of its next turn.",
+				"THe flut regains 1d3 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flute of Peace",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"You must be proficient with wind instruments to use this flute. This flute has 5 charges. While playing this flute, you may use your action to expend 1 or more charges to cast one of the following spells: {@i calm emotions} (2 charges), {@i protection from evil and good} (1 charge), {@i sanctuary} (1 charge), or {@i spirit guardians} (3 charges).",
+				"The flute regains 1d4+1 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flute of Puppies",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"You must be proficient with wind instruments to use this flut. When you play this flute, you may choose up to three creatures within 30 feet of you that you can see. Those creatures must make a DC 15 Constitution saving throw. On a failure, the creature is magically transformed into a puppy. Shapechangers automatically succeed on their saving throw. The creature's statistics, including its mental characteristics, become that of a puppy, and its alignment becomes unaligned. It will be quite intelligent (Int 4) and fairly long-lived for a canine, but will otherwise be a normal beast without any knowledge of its former life. Once you use this ability, you can't use it again until the following dawn.",
+				"A {@i dispel magic} cast with a 9th-level spell slot, or a {@i wish}, will reverse the effect. Otherwise, the change is permanent, although the puppy will eventually grow up to be a dog.",
+				"There is rumored to be a version of this flute that creates kittens instead."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Flute of Wind Dancing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"You must be proficient with wind instruments to use this flute. This flute has 7 charges. While playing this flute, you may use your action to cast the {@i gust} cantrip or to expend 1 or more charges to cast one of the following spells: {@i control winds} (5 charges), {@i dust devil} (2 charges), {@i gust of wind} (2 charges), or {@i wind wall} (3 charges).",
+				"The flute regains 1d6+1 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Folding Moat",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"entries": [
+				"This is a large loop of cloth, over 10 feet in diameter. When placed on the ground and the command word spoken, it expands to become a 30-foot-wide, 10-foot deep trench that encloses an area with a 300 foot radius. A second command word will cause the moat to fill up with water. A third command word causes the water to vanish and the moat to turn back into cloth."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Food Pouch",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "1",
+			"entries": [
+				"Each day at dawn, this bag magically produces two meals' worth of granola-type food. The food is kind of bland but nutritious and filling. It won't produce any new food until the food it already has produced has been eaten."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Frostreaver",
+			"type": "M",
+			"axe": true,
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "S",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This axe is made of magical ice and will melt if left in temperatures above 50° F for more than an hour.",
+				"You gain +1 to hit and damage with this weapon, and it inflicts an additional 11 (2d10) cold damage to its target."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gargoyle Cloak",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this gray, rough-textured cloak , you change your shape into that of a {@creature gargoyle|mm} for up to 1 hour. You gain the statistics of a gargoyle, but you keep your own Intelligence, Wisdom, Charisma, and alignment. Once you have used this ability, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gauntlets of Dexterity",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"These gloves raise your Dexterity to 19 while you wear them. If your Dexterity is higher than 19, these gloves have no effect."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gauntlets of Heat",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"These gauntlets have 5 charges and regain 1d4+1 charges each day at dawn. While wearing them, you can use your action to cast the {@i produce flame} cantrip, or to expend a charge to cast {@i burning hands} (1 charge) or {@i heat metal}). In addition, if you hold a combustible item for a round, you can set it on fire. You can't cause damage directly this way."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gauntlets of Holding",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"entries": [
+				"While you wear these gloves, you gain a +5 bonus to Strength (Athletics) when attempting to grapple, restrain, or otherwise hold onto a creature or object."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gauntlets of Specialization",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"When you wear these gauntlets, you gain proficiency with one specific type of two-handed weapon. If you already have proficiency in that weapon, you score a critical hit with that weapon on a 18-20.",
+				"Roll on the following table to determine the type of weapon these gauntlets are used with:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"Weapon"
+					],
+					"rows": [
+						[
+							"1",
+							"Battleaxe"
+						],
+						[
+							"2",
+							"Greatclub"
+						],
+						[
+							"3",
+							"Longsword"
+						],
+						[
+							"4",
+							"Maul"
+						],
+						[
+							"5",
+							"Quarterstaff"
+						],
+						[
+							"6",
+							"Spear"
+						],
+						[
+							"7",
+							"Trident"
+						],
+						[
+							"8",
+							"Warhammer"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gauze of Appearance",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This thin, flimsy cloth is so finely woven as to be almost invisible. In bright light, it takes a DC 20 Wisdom (Perception) or Intelligence (Investigation) to find it; in dim light or darkness, the DC rises to 25.",
+				"Any invisible creature that touches the gauze will be rendered visible and the invisibility will be canceled, and any illusion that touches it will automatically be dispelled."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gem of Income",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"This is a small, egg-shaped soapstone carved with tree motifs. If planted in fertile soil in full sunlight, along with a gold coin, and then watered, it will grow into a literal money tree in one week. The tree will reach the height of 10 feet. Its bark will have a distinctly golden tinge to its bark and its leaves, which never fall off, will be reddish-gold in color. Each week throughout the late spring to late autumn, the tree will grow 2d10 coins. They will start out as copper coins, turn into silver coins two days later, and then into gold coins two days after that; afterwards, they will fall off the tree and a new batch will grow.",
+				"Any attempt, mundane or magical, to shape, improve, duplicate, splice, enchant, or otherwise alter the tree will instantly kill it. It will also die if it takes more than 5 hit points of fire or lightning damage in a single round or is exposed to below-freezing temperatures for more than 4 hours."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gembow",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Legendary",
+			"weight": "2",
+			"dmg1": "{@dice 1d6}",
+			"dmgType": "P",
+			"property": [
+				"A",
+				"2H"
+			],
+			"range": "80/320",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This {@i shortbow +1} has a small indentation located just above the grip. If a gemstone is placed in that indentation, then when a nonmagical arrow is fired from the bow, it will become engulfed in magical energy and will inflict an additional 11 (2d10) damage of a specific type. There's a 50 percent chance that the bow already has a gemstone in place.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"Gemstone",
+						"Damage Type"
+					],
+					"rows": [
+						[
+							"1",
+							"Black opal",
+							"Thunder"
+						],
+						[
+							"2",
+							"Black sapphire",
+							"Necrotic"
+						],
+						[
+							"3",
+							"Diamond",
+							"Lightning"
+						],
+						[
+							"4",
+							"Jacinth",
+							"Acid"
+						],
+						[
+							"5",
+							"Opal",
+							"Radiant"
+						],
+						[
+							"6",
+							"Ruby",
+							"Fire"
+						],
+						[
+							"7",
+							"Star sapphire",
+							"Cold"
+						],
+						[
+							"8",
+							"Yellow sapphire",
+							"Poison"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4 text-align-center",
+						"col-xs-4 text-align-center"
+					]
+				},
+				"If you roll a 1 when attacking with this bow, the DM will roll a d4. On a 1, the gemstone cracks and the bow will no longer inflict additional damage until a new gem is inserted."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gemstone of Musing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a wizard",
+			"weight": "0.1",
+			"entries": [
+				"You can use this gemstone as an arcane focus. In addition, when you use your Arcane Recovery, you may regain an additional number of spell slots equal to half your Intelligence modifier, rounded up."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gemstone of Retaliation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"If worn, this gemstone grants you advantage on saving throws against evocation spells. In addition, if an evocation spell is cast on you and you successfully save against it, you may attempt a Charisma ability check (DC equal to the caster's spell save DC). If successful, you capture some of the spell energy, and may use your reaction to turn it into a {@i magic missile} and send it back to the creature that cast that spell on you. This automatically hits and inflicts 1d4+1 force damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gemstone of Shielding",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This pale, translucent white gemstone must be pressed against your forehead, where it will meld seamlessly and invisibly into your skin. You may remove the gemstone at any time. While attuned to the gemstone and it is in your head, you have resistance to psychic damage and advantage on saving throws against psionic attacks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ghostly Palace",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"This item takes the form of an ornate, obviously valuable key. Once each night, you can use the key to summon a doorway to a magical palace which resides on the Ethereal Plane. You may stay in the palace as long as you wish; as long as you are in it, it is visible to the outside world as a faintly shining outline of a palace. You and any creature you designate when you turn the key can enter the palace for as long as you are inside.",
+				"The palace is beautifully appointed and is identical to {@i Mordenkainen's magnificent mansion}, save that it consists of one hundred 10-foot cubes, and it renews its supply of food after every 24 full hours you remain inside.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This item is cursed, and becoming attuned to it extends the curse to you. As long as you remain cursed, you will be unwilling to sleep outside of the palace, finding all other places to be far inferior. You aren't compelled to remain inside, but you will always want to return to it, and you will be unwilling to part with the key."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"After you have stayed in the palace for a total of 7 days (it doesn't matter whether this is all at once or in shorter periods over a longer span of time), an {@creature invisible stalker|mm} will appear. If you aren't in the palace, or if you are in it but alone, it will locate you and immediately attack in an attempt to kill you; if you are in the palace but have companions, it will attack and kill your companions first, then you. The invisible stalker's goal is to reclaim the key and return it to the resting place of its master, the palace's original owner. If the invisible stalker is slain, a new one will take its place after 7 days, regardless of the length of time you stay in the palace in the meantime."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Girdle of Femininity and Masculinity",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This is a broad leather belt. As soon as you put it on, you are transformed into a member of the opposite sex.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This girdle is cursed, and taking it off does not remove the curse. Only {@i remove curse}, {@i wish}, or dying will reverse the change. If you don't want to return back to your original gender, then you are no longer cursed and only a {@i wish} will change you back, and further uses of this girdle or a different {@i girdle of femininity and masculinity} won't have an effect on you."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Globe of Serenity",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"This small glass orb emits a continuous, almost inaudible tone. All creatures who start their turn within 60 feet of it must make a DC 17 Wisdom saving throw or be affected with the {@i calm emotions} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gloves of Lightning",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"These ornate gloves have 3 charges and regain 1d3 expended charges each day at dawn. You may use your action to expend a charge and shoot a bolt of lightning from the gloves to one creature within 100 feet. That creature must make a DC 15 Dexterity saving throw, taking 28 (8d6) lightning damage on a failed save, or half as much on a successful one."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gloves of the Octopus",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"You may command these gloves to grow into five 15-foot-long tentacles. You may use your action to have tentacles to attack up to five targets that are within 10 feet of each other, although you only make a single Dexterity-based attack roll; you are considered to have proficiency with the tentacles. On a successful hit, a target is grappled (escape DC 8 + your proficiency bonus + your Strength modifier), provided it is no more than one size category larger than you. If two tentacles successfully grapple an opponent, that creature is restrained.",
+				"At the start of each of your turns, you can constrict any creature you have grappled or restrained inflict 1d4 + your Strength modifier in bludgeoning damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Goblet of Potions, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"There are three types of goblets. When any sort of alcohol is poured into the goblet and allowed to sit undisturbed for 1 minute, the liquid is transformed into a type of poison; it still smells and tastes like the type of alcohol that was used. The drinker must make a DC 15 Constitution saving throw or be affected by the poison.",
+				"This creates a sleeping poison. The drinker falls unconscious for 1d4 days. The creature can’t be awakened except through magic. It also won’t need to eat or drink during this time, although it will wake up very hungry and thirsty.",
+				"Once you use the goblet, you can't use it again until the following dawn. The poison can be bottled but spoils after 24 hours. A creature that can't be poisoned automatically succeeds on its saving throw."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Goblet of Potions, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"There are three types of goblets. When any sort of alcohol is poured into the goblet and allowed to sit undisturbed for 1 minute, the liquid is transformed into a type of poison; it still smells and tastes like the type of alcohol that was used. The drinker must make a DC 15 Constitution saving throw or be affected by the poison.",
+				"This creates a deadly poison. The drinker takes 33 (6d10) poison damage on a failed saving throw, or half as much on a successful one.",
+				"Once you use the goblet, you can't use it again until the following dawn. The poison can be bottled but spoils after 24 hours. A creature that can't be poisoned automatically succeeds on its saving throw."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Goblet of Potions, Type Ⅲ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"There are three types of goblets. When any sort of alcohol is poured into the goblet and allowed to sit undisturbed for 1 minute, the liquid is transformed into a type of poison; it still smells and tastes like the type of alcohol that was used. The drinker must make a DC 15 Constitution saving throw or be affected by the poison.",
+				"This creates a paralytic poison. If the drinker fails its saving throw, it will become paralyzed for 1d4 days. It will continue to need to eat and drink during this time. A creature that is immune to being paralyzed automatically succeeds on its saving throw.",
+				"Once you use the goblet, you can't use it again until the following dawn. The poison can be bottled but spoils after 24 hours. A creature that can't be poisoned automatically succeeds on its saving throw."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Golden Sickle",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"type": "GV",
+			"entries": [
+				"You gain +1 to attack and damage rolls made with this magic weapon. While holding it, you may cast {@i pass without trace} and {@i tree stride}. Once you cast one of those spells, you can't cast that spell again until the following dawn.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item Scythe|EnMa}",
+								"{@item Sickle|PHB}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gong of Dispelling",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "1",
+			"entries": [
+				"This item has 50 charges. You may use your action to expend a charge and ring the gong. This casts {@i dispel evil and good} in a 30-foot radius centered on the gong. Choose whether you are using the Break Enchantment or Dismissal version of this spell. An affected creature may make a Charisma saving throw (save DC equal to your spell save DC; if you don't have one, the save DC is 8 + your proficiency bonus + your Charisma modifier) to resist.",
+				"If you spend two actions to ring the bell twice and expend two charges, then creatures have disadvantage on their saving throw.",
+				"If you use the Break Enchantment version, it affects all creatures in that area. Creatures that are charmed or frightened are automatically affected. A possessing creature may make a Charisma saving throw to avoid being exorcised.",
+				"If you use the Dismissal version, you may affect a number of celestials, elementals, fey, fiends, or undead equal to your Charisma modifier. A creature may make a Charisma saving throw to avoid being banished.",
+				"The gong becomes nonmagical when you use the last charge."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gong of Earthquakes",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This tiny gong is only 3 inches in diameter. You can use an action to strike the gong and use it to cast {@i earthquake}. Once you have done so, you can't do so again until 7 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Gong of the Whirlwind",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This tiny gong is only 3 inches in diameter. You can use an action to strike the gong and use it to cast {@i whirlwind}. Once you have done so, you can't do so again until 7 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Greenmask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by an elf or half-elf",
+			"weight": "0.5",
+			"entries": [
+				"This mask is made of magically living wood and is carved to resemble an elf's face. The eye holes are covered with transparent crystals and there are no mouth or nose holes.",
+				"While wearing this mask, you have a +1 bonus to your armor class and resistance to poison damage. You also have advantage on saving throws against gaze attacks and to avoid being blinded. Finally, your darkvision's range increases by 30 feet, and you have advantage on all Wisdom (Perception) rolls that rely on sight."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Guardian Egg",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "20",
+			"entries": [
+				"When you say the command word, this large (20 pound) brass egg transforms into a metallic construct that is humanoid but blank-faced. It serves you faithfully for 24 hours, then transforms back into an egg. It also transforms back into an egg if slain. After transforming back, it can't be used again for 7 days.",
+				"The construct is roughly the same size and shape as a {@creature hill giant|mm}, and uses its statistics except that its type is construct, its alignment is neutral, its armor class is 18, and it doesn't need to breathe, drink, eat, or sleep.",
+				"If you put the ground on the egg when you say the command word, the construct's speed is 60 feet. If you throw the egg in the air, the construct has wings; its walking speed is 30 feet and its fly speed is 60 feet. If you place the egg in water, the construct has a fish-like tail; its walking speed is 0 feet and its swim speed is 60 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Guardian Tail",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This is a tail that came from a fox, raccoon, or other such animal, with leather straps, beads, and a pin at one end. It is designed to be attached to a backpack, quiver, chest, or other container as a decorative toggle. Once attached, the tail protects the container's contents. You may designate any number of creatures besides yourself who are allowed to touch or open the container. If any other creature does so, the entire container will shapechange into a the form of an animal of the type from which the tail came.",
+				"The animal will then flee until you call for it; if you don't call for it within an hour, it will seek you out and get your attention. Once you touch it again, it turns back into the container. It will only attack if absolutely necessary.",
+				"If the animal is killed, the container reverts to its normal form. Depending on the type and amount of damage inflicted on it, the container may be damaged or destroyed, as may some of its contents. The tail will become nonmagical then.",
+				"Regardless of the type of animal the tail came from, the {@creature Guardian Tail (Animal Form)|EnMa|guardian tail} uses the same {@creature Guardian Tail (Animal Form)|EnMa|statistics}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Hammer of Silence",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"This hammer makes no noise when it is used, no matter what it struck against.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item light hammer|phb}",
+								"{@item warhammer|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Hand of Remote Action",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"These gloves come either singly or in pairs. If you are attuned to one glove, you don't need to use a second attunement slot to use a second glove.",
+				"While wearing these gloves, you can cast the {@i mage hand} cantrip. You can feel through these hands as if they were your won, but your own hands are numb. You can also use the {@i mage hands} to open and close containers, manipulate objects, and to attack. All attack rolls and skill checks you make are rolled at disadvantage, however.",
+				"In addition, you can also use your action to use the gloves to cast {@i Bigby's hand}. Once you have done so, you can't do so again until the following dawn.",
+				"You can create one {@i mage hand} or {@i Bigby's hand} per glove that you're wearing, and you can concentrate on and use both {@i hands} at the same time."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Hands of the Healing Spirit",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This amulet, which takes the form of hands clasped in prayer, has 7 charges. It grants you the following abilities:",
+				{
+					"items": [
+						{
+							"name": "Healthy Aura",
+							"entries": [
+								"Whenever you roll Hit Dice to regain hit points, you regain an extra two dice."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Spells",
+							"entries": [
+								"While attuned to this amulet, you can cast the {@i light} cantrip. You may use your action to expend one or more charges and cast the following spells: {@i cure wounds} (1 charge, heals 2d8 hit points), {@i lesser restoration} (2 charges), {@i heal} (6 charges), {@i healing word} (1 charge), {@i mass cure wounds} (5 charges), or {@i protection from evil and good} (1 charge)."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Spirit of Healing and Harmony",
+							"entries": [
+								"You may spend 1 charge to gain advantage on saving throws against poison, on Wisdom (Medicine) skill checks and proficiency checks made with Healer's Kits, or on Charisma (Persuasion) checks. This lasts for 1 hour."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"The amulet regains 1d6+1 expended charges each day at dawn. If you expend the amulet's last charge, roll a d20. On a 1, the amulet crumbles into ashes and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Harp of Gold",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a bard",
+			"weight": "90",
+			"entries": [
+				"When you play this large (90 lbs) pedal harp for an hour, all copper, silver, and platinum coins within 10 feet of it turn to gold, permanently. This doesn't change the coin's appearance, only its metal. The hour you spend playing can be used as a short rest.",
+				"Once you use this ability, you can't use it again until 3 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Harp of Healing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a bard",
+			"weight": "70",
+			"entries": [
+				"This harp has 3 charges. If you expend a charge and spend 10 minutes playing this harp, all creatures within 30 feet of you who can hear you heal a number of hit points equal to 2d6 + your Charisma modifier (if you are proficient in harps, you may also add your proficiency bonus).",
+				"The harp regains all expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Hasp of Locking",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.1",
+			"entries": [
+				"When placed on any door or lid, this hasp locks with an {@i arcane lock}. It unlocks when you speak the command word."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Hat of Holding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"Similar to a {@i bag of holding}, this hat can hold up to 50 pounds of objects in an extradimensional space. An item can't be longer than 4 feet on a side. Objects can only be retrieved when the hat is held so that its opening faces upwards; nothing will fall out when you place the hat on your head.",
+				"As this employs extradimensional space, placing it inside a {@i bag of holding} or similar object causes both items to be destroyed and a rift to the Astral Plane to be opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Heart of Bravery",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This is a small piece of golden jewelry, usually designed to go on a charm bracelet or a necklace. There are two varieties of this item. While wearing it, you have advantage on all saving throws to avoid being frightened.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"Some {@i hearts of bravery} are actually {@i hearts of cowardice} and are cursed; attuning to this charm extends the curse to you. Removing the charm doesn't negate the curse.",
+								"While cursed, you have disadvantage on all saving throws to avoid being frightened."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Helm of Creation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "4",
+			"entries": [
+				"This helm has 7 charges. While wearing this helm, you may use your action to expend 1 or more charges to cast one of the following spells: {@i hallucinatory terrain} (4 charges), {@i illusory script} (1 charge), {@i major image} (3 charges), or {@i programmed illusion} (5 charges).",
+				"The helm regains 1d4 expended charges each day at dawn. If you expend the helm's last charge, roll a d20. On a 1, the helm becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Helmet of Sensory Protection",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "2",
+			"entries": [
+				"While wearing this helmet, you have advantage on saving throws to avoid being blinded or deafened, from being poisoned by gaseous poisons (such as a {@i cloudkill} or a green dragon's breath), and when saving against gaze attacks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Holy Shield",
+			"type": "S",
+			"rarity": "Legendary",
+			"weight": "6",
+			"ac": 2,
+			"tier": "Major",
+			"reqAttune": "by a cleric or paladin, a divine soul sorcerer, or a pact of the celestial warlock",
+			"armor": true,
+			"entries": [
+				"Upon attuning to this {@i shield +2}, its face changes so that an image of your holy symbol appears on it. While wielding the shield, you are under the effects of a {@i protection from evil and good} spell that protects you from fiends and undead (if your holy symbol is that of a good or neutral deity) or celestials (if your holy symbol is that of an evil deity)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Horn Bonnet",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"Made from the hide of a horned animal and decorated with feathers, this hood grants you advantage on initiative rolls and on Wisdom (Perception) checks. In addition, you may use your action and speak its command word, and your Strength will increase to 22 (+6) for 10 minutes. Once you use this ability, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Horn of Dolphins",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "2",
+			"entries": [
+				"This is a large conch shell which can be blown as a horn. If you use your action to blow through it while in or on the water, or on the shore, it produces a deep thrum that can be heard for 10 miles. Within 10 minutes, 3d12+10 dolphins will appear. They are friendly to you and your companions, can understand simple commands and questions you pose to them, and will attempt to do what you ask of them as long as it's not dangerous.",
+				"Once this ability has been used, it can't be used again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Horn of Hades",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "2",
+			"entries": [
+				"If you use your action to blow through this horn, you summon yugoloths to you. The yugoloths will be friendly towards you and your companions, and will perform a single task you require of it. If the task is difficult, dangerous, or inconvenient, it will demand payment, however. If you or your companions are hostile towards it, it will immediately attack. Once it has finished its task, it is free to do as it pleases and doesn't have to return to the Gray Waste.",
+				"Roll on the following table to determine the type of yugoloth you summon:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d12",
+						"Yugoloth Type"
+					],
+					"rows": [
+						[
+							"1-3",
+							"2d4 mezzoloths"
+						],
+						[
+							"4-5",
+							"1d4 nycaloths"
+						],
+						[
+							"6-7",
+							"1d3-1 (minimum 1) arcanaloths"
+						],
+						[
+							"8",
+							"1 ultraloth"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				},
+				"If you summon mezzoloths or nycaloths with this horn, you can't use the horn again until 7 days have passed. If you summon arcanaloths, you can't use the horn again until a year has passed. If you summon an ultraloth, you can't use the horn again until a century has passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Hornblade",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "2",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "S",
+			"property": [
+				"L"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This {@i sickle +1} has a curved blade that appears to have been carved out of horn or bone, but is as hard as steel. On command, its blade and hilt lengthen into a {@i scythe +1}"
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Horned Mask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a druid or ranger",
+			"weight": "0.5",
+			"entries": [
+				"This mask has a bestial face and two curving horns. While wearing it, you have darkvision to 120 feet, your vision isn't hindered by lightly obscured areas, and can't be blinded, charmed, or stunned. In addition, you have advantage on Wisdom (Survival) ability checks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Horseshoes of Hades",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "2",
+			"entries": [
+				"These iron horseshoes come in sets of four and appear to be {@i horseshoes of a zephyr}. When all four shoes are affixed to the hooves of a horse or similar creature, it immediately turns into a {@creature nightmare|mm} and attacks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Incense of Meditation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "2",
+			"entries": [
+				"This incense comes in sets of 2d4 blocks and breathing a block produces a pearly smoke and a unique, heady scent. A spellcaster who spends eight hours meditating while breathing in the smoke gains several benefits, which last for 24 hours:",
+				{
+					"type": "list",
+					"items": [
+						"If a spell you cast requires you to roll dice to determine damage, you may reroll a number of dice equal to your spellcasting ability modifier.",
+						"If a spell you cast has a duration of 1 minute or longer, you can choose to double its duration, to a maximum duration of 24 hours.",
+						"If a spell you cast has a range of 5 feet or greater, you can double the range of that spell.",
+						"If a spell you cast requires you to make a spell attack roll, you have advantage on that roll. If the spell requires your target to make a saving throw to avoid taking damage or suffering a deleterious effect, the target has disadvantage on that roll."
+					]
+				},
+				"You may use as many or as few of those options on any spell you cast while the incense remains in effect."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Incubalum",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This is a foot long, rock-hard egg, similar in appearance and texture to a geode. The egg has AC 18, 20 hit points, is immune to poison and psychic damage and resistant to all other types of damage. If the {@i inculabum} is broken, a fully adult specimen of a terrestrial creature will emerge.",
+				"The creature has the abilities and intellect of an adult of its species, along with its base instincts. It will have no memories and no real understanding of the world around it. At this point, its alignment is neutral. Whether it becomes good or evil is dependent on a combination of its species' primary alignment and the way that it is treated.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d20",
+						"Creature"
+					],
+					"rows": [
+						[
+							"1-3",
+							"Aarakocra"
+						],
+						[
+							"4-5",
+							"Bullywug"
+						],
+						[
+							"6",
+							{
+								"entries": [
+									"Dragon (Adult age category; roll a d12 to determine the type:",
+									"{@b 1:} Black.",
+									"{@b 2:} Blue.",
+									"{@b 3:} Brass.",
+									"{@b 4:} Bronze.",
+									"{@b 5:} Copper.",
+									"{@b 6:} Gold.",
+									"{@b 7:} Green.",
+									"{@b 8:} Red.",
+									"{@b 9:} Silver.",
+									"{@b 10:} White.",
+									"{@b 11:} Faerie dragon (blue).",
+									"{@b 12:} Roll again, ignoring further rolls of 12."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"7-9",
+							"Kenku"
+						],
+						[
+							"11-13",
+							"Kobold"
+						],
+						[
+							"14-16",
+							"Lizardfolk"
+						],
+						[
+							"17-18",
+							"Thri-kreen"
+						],
+						[
+							"19",
+							"Umber hulk"
+						],
+						[
+							"20",
+							{
+								"entries": [
+									"Yuan-ti (roll a d6 to determine the type:",
+									"{@b 1-2:} Abomination.",
+									"{@b 3-4:} Malison.",
+									"{@b 5-6:} Pureblood.)"
+								],
+								"type": "entries"
+							}
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Infinite Rope",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "10",
+			"entries": [
+				"This is a loop of rope that grows to one mile in length when you speak a command word; initially 50 feet long, it will grow at a rate of 10 feet each round. A second command rate will cause it to shorten, also at 10 feet each round. It cannot be used to compress or crush anyone and will simply stop shrinking or growing if it meets any resistance."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Inkwell of Scrollmaking",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"If you place a gemstone of any sort worth at least 25 gp inside this inkwell, it will convert that gem into magical ink, suitable for inscribing spells into your spellbook. For every 25 gp worth of gemstone, you can inscribe one spell level worth; thus, to inscribe a 6th-level spell, you would need to use 150 gp worth of gemstones.",
+				"If you are inscribing a spell of the school of your arcane tradition, you can inscribe two spell levels for every 25 gp the gemstone is worth."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Airy Water",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"While you are underwater, this blue-green spindle makes the water within a 10-foot radius around you breathable by you and other surface-dwellers. It doesn't turn the water into air, however, and it remains breathable by aquatic creatures as well."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Darksight",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"For as long as this pure black sphere orbits you, you have darkvision to 60 feet, and magical darkness doesn't hinder your vision."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Empowerment",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"This clear prism has 50 charges. You can expend one or more charges to raise the slot level of a spell you cast, at the rate of one slot level per charge spent. For instance, if you wish to cast {@i fireball} with a 5th-level spell slot, you can use a 3rd-level slot and expend two charges from this stone. Once you have used all 50 charges, the stone burns out and turns a dull gray, losing its magic."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Free Action",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"While this cerulean rhomboid circles your head, you are unaffected by difficult terrain and have advantage on ability checks made to escape being grappled or restrained."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Greater Light",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"This brilliant golden sphere glows with bright light to a radius of 20 feet and dim light for a further 20 feet. This light is sunlight and affects creatures with Sunlight Sensitivity or Sunlight Hypersensitivity."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Greater Protection",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"You have immunity to a type of damage while this stone orbits your head.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"Stone's Appearance",
+						"Immunity To:"
+					],
+					"rows": [
+						[
+							"1",
+							"Bright white rectangle",
+							"Acid damage"
+						],
+						[
+							"2",
+							"Mottled white hexagon",
+							"Cold damage"
+						],
+						[
+							"3",
+							"Pulsing red star",
+							"Fire damage"
+						],
+						[
+							"4",
+							"Silver rod",
+							"Lightning damage"
+						],
+						[
+							"5",
+							"Mottled black rectangle",
+							"Necrotic damage"
+						],
+						[
+							"6",
+							"Mottled green sphere",
+							"Poison damage"
+						],
+						[
+							"7",
+							"Orange cube",
+							"Psychic damage"
+						],
+						[
+							"8",
+							"Deep purple prism",
+							"Radiant damage"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4",
+						"col-xs-4 text-align-center"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Magic Resistance",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"While this clear sphere orbits your head, you have advantage on saving throws against spells and other magical effects."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Mental Acuity",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"As long as this puce cube orbits your head, you can cast the {@i message} cantrip and the {@i detect thoughts} spell at will."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Might",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"At the end of each short and long rest, you gain 15 temporary hit points."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Mirroring",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"While this mirrored cube orbits your head, you have advantage on saving throws versus gaze attacks and other attacks that require eye contact."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Protection",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"You have resistance to a type of damage while this stone orbits your head.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"Stone's Appearance",
+						"Resistance To:"
+					],
+					"rows": [
+						[
+							"1",
+							"Mottled yellow and white rectangle",
+							"Acid damage"
+						],
+						[
+							"2",
+							"Blue and white hexagon",
+							"Cold damage"
+						],
+						[
+							"3",
+							"Red and orange star",
+							"Fire damage"
+						],
+						[
+							"4",
+							"Iron-gray rod",
+							"Lightning damage"
+						],
+						[
+							"5",
+							"Mottled gray rectangle",
+							"Necrotic damage"
+						],
+						[
+							"6",
+							"Yellow-green sphere",
+							"Poison damage"
+						],
+						[
+							"7",
+							"Yellow-orange cube",
+							"Psychic damage"
+						],
+						[
+							"8",
+							"Light purple prism",
+							"Radiant damage"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4",
+						"col-xs-4 text-align-center"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Protection from Weapons",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"You have resistance to bludgeoning, piercing, and slashing from nonmagical weapons while this maroon star orbits your head."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Spirit Storage",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"If you die due to violence, your soul enters this clear pink sphere. A {@i greater restoration} spell will return your soul to your body, as long as it is cast within a year of the death and the stone is intact. It doesn't matter if the spell is cast on your body or on the stone, as long as both are on the same plane. Upon being restored, Your body will revert to its pre-death condition. You will have 0 hit points but will be stable and unconscious for 1 hour, even after regaining hit points."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ioun Stone, Translation",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.2",
+			"entries": [
+				"While this light blue prism orbits your head, you can understand and speak all spoken languages. This stone doesn't give you any special ability to understand written languages."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Iron Bow",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "2",
+			"dmg1": "{@dice 1d8}",
+			"dmgType": "P",
+			"property": [
+				"A",
+				"H",
+				"2H"
+			],
+			"range": "150/600",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This {@i longbow +2} is made of magically flexible iron. It creates its own arrows when you pull back the string. In addition, you can command the bow to fire a bolt of lightning at a target you can see within 300 feet. Once you use this ability, you can't use it again until the following dawn.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This bow is cursed. Becoming attuned to it extends the curse to you. As long as you remain cursed, you are unwilling to part with the bow, keeping it on your person at all times. While attuned to this weapon, you have disadvantage on attack rolls made with weapons other than this one."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"Over a period of weeks or months, your alignment will shift to chaotic good. In addition, you will be unable to refuse any heroic deed presented to you, no matter how dangerous or impossible it seems. You will be generally unwilling to allow others to help you on these quests, but can, with difficulty, be persuaded."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ironstar Mace",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d6}",
+			"dmgType": "B",
+			"tier": "Major",
+			"reqAttune": "by a dwarf",
+			"entries": [
+				"This is a {@i mace +1}. It is remarkably light but also unbreakable. It has 5 charges. When attacking, you may declare that you want to spend a charge to make a shattering strike. If you hit, you may roll an additional damage die and the target must make a DC 17 Constitution saving throw or be stunned for 1 minute. A creature may attempt a new save at the beginning of each of its turns, ending the effect on a success. In addition, if the target is wearing a nonmagical breastplate, half-plate, or plate armor, the DM must roll a d6. On a roll of 1 or 2, the armor is shattered and rendered useless.",
+				"The mace regains 1d3 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ivy Bracelet",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a druid",
+			"weight": "0.1",
+			"entries": [
+				"This fragile-seeming bracelet is made of living ivy. While wearing it, you can communicate with plants as if you shared a language.",
+				"This bracelet has 5 charges. You may use your action to expend a charge to cast one of the following spells: {@i entangle} (1 charge), {@i plant growth} (3 charges), or {@i transport via plants} (5 charges).",
+				"The bracelet regains 1d4+1 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Jade Scepter of Defending",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This white-jade rod functions as a {@i mace +2}. It constantly glows while being held, shedding bright light in a 5-foot radius and dim light for an additional 5 feet. If you hold the scepter and concentrate on it (as if concentrating on a spell), performing no other actions, you are immune to bludgeoning, piercing, and slashing damage from nonmagical attacks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Javelin of Distance",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "2",
+			"dmg1": "{@dice 1d6}",
+			"dmgType": "P",
+			"property": [
+				"T"
+			],
+			"range": "30/120",
+			"tier": "Major",
+			"entries": [
+				"This {@i javelin +1} has a range of 90/130 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Jewelry of Equus",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This piece of jewelry can take nearly any form; earrings, bracelets, and pendants are the most common type. On command, you can order the jewelry to assume the form of a beast of burden, or turn it back into its jewelry form. There is no limit to the length of time it may remain in either form.",
+				"In its animal form, it is identical to a normal creature of its type, except that it is a construct and its Intelligence is 2 (-4). If the animal takes damage, it can only heal in animal form, and if it's slain, it reverts back to jewelry form, the jewelry becomes nonmagical, and the beast can't be summoned again.",
+				"Roll a d8 to determine creature type.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"Creature"
+					],
+					"rows": [
+						[
+							"1",
+							"Camel"
+						],
+						[
+							"2",
+							"Draft horse"
+						],
+						[
+							"3",
+							"Giant lizard"
+						],
+						[
+							"4",
+							"Mastiff"
+						],
+						[
+							"5",
+							"Mule"
+						],
+						[
+							"6",
+							"Ox"
+						],
+						[
+							"7",
+							"Pony"
+						],
+						[
+							"8",
+							"Riding horse"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Key of Entrance",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"When you place this key against any locked door, lid, or hatch and say the command word, the lock opens. The key counters and dispels {@i arcane locks}. This key will also nullify any traps that are inside or part of the lock itself, but will also automatically trigger any traps that are on the door or hinges that haven't already been disarmed.",
+				"Once you use this ability, you can't use it again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Key of Inquiry",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"This key is used to “unlock” truths a creature is keeping hidden. The creature may attempt a DC 17 Wisdom saving throw. On a failure, the creature must answer three questions truthfully, fully, and plainly, to the best of its ability."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Key of Reunion",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"These keys come in pairs. If one key is held flat in the hand, it will invariably point to the other key, as long as they are on the same plane of existence."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Key of Silence",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"When you use your action to point this key at a target within 60 feet and turn it, that target must make a DC 17 Charisma saving throw or lose all ability to speak as you lock its voice. The creature may attempt a new saving throw at the end of each of its turns, ending the effect on a success. If it doesn't succeed after one minute, the creature is mute for 24 hours. You can choose to unlock its voice at any time by using an action to turn the key in the other direction. A {@i lesser restoration} will also end this condition.",
+				"Once you lock a target's voice, you cannot use this key again until the following day."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Key of Storage",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"When held and turned, this key reveals a thin door that extradimensional “storage locker” that has a volume of 100 cubic feet inside. When you unlock this space, you can choose if you want the door to open upwards (as if opening a box that was resting on the floor) or outwards (as if opening a cabinet). Unlike a {@i bag of holding}, there is no weight limit; it can hold anything that can fit in that space. Like a {@i bag of holding}, however, breathing creatures inside the bag can survive up to a number of minutes equal to 10 divided by the number of creatures (minimum 1 minute), after which time they begin to suffocate.",
+				"As this employs extradimensional space, placing it inside a {@i bag of holding} or similar object causes both items to be destroyed and a rift to the Astral Plane to be opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mace of Crushing",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"This {@i mace +1} deals double damage to objects and structures.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item mace|phb}",
+								"{@item maul|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mace of Pain",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"This heavy mace has a +2 bonus to attack and damage rolls, and each of its blows causes incredible pain. On a successful attack, the target's hit point maximum is reduced by an amount equal to half the damage the mace inflicts, rounded down. Constructs, elementals, fiends, undead, and creatures that can't feel pain are immune to this drain.",
+				"In addition, whenever you roll a critical hit when using this weapon, or your total roll is higher than 20 (even if it wasn't a critical hit), the target is in so much pain that it is stunned until the end of its next turn.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item mace|phb}",
+								"{@item maul|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mage Wine",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If you are capable of casting spells from the wizard's spell list, then when you drink this rich red potion, you will instantly regain one spell slot that you cast earlier in the day. Roll a d4 to determine the slot level. If you haven't used any slots of that level, you regain the lowest level slot you have used."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Magical Chess Set, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"entries": [
+				"This chess set is made of rare inlaid woods and has delicately carved pieces.",
+				"This one-player version plays against you and provides an acceptable game. It is capable of slowly learning from you and will eventually become a stronger opponent.",
+				"If its actual statistics are needed, the chess set starts with a proficiency bonus of -2, but this increases by 1 for every two games it wins, with no upper limits. If nobody plays it for a year, it resets to a bonus of +0."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Magical Chess Set, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "1",
+			"entries": [
+				"This chess set is made of rare inlaid woods and has delicately carved pieces.",
+				"This type of {@i magical chess set} comes in pairs. If both sets are properly set up with all their pieces, then a move made on one board is mirrored on the other set, as long as the two sets are on the same plane. You can command the set to chime when the other player makes a move."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Magical Fountain",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"entries": [
+				"This is a large, ornate water fountain, usually made of granite or marble and typically carved with statues of nymphs spilling water from urns, leaping dolphins spouting water from their blowholes, fabulous beasts spitting out plumes of water, imps or little boys peeing, and so on. These fountains are usually discovered in unexpected places, such as in the center of a strangely large room inside a forgotten dungeon or deep within a monster-haunted badlands.",
+				"The water consumed from these fountains is magical, although not necessarily beneficial. Each fountain produces 1d20 drinks before it “dries up,” although it continues to produce non-magical water. After a set period of time—typically a month, a year and a day, or a century, it regains its magical ability.",
+				"Magical fountains aren't hooked up to any obvious plumbing. Any attempt to move the fountain, take it apart to locate the source of the water, or hook up pipes to it to divert the water causes the fountain to irrevocably break. Water taken from fountain loses its potency after 1 hour.",
+				"Each magical fountain produces only a single effect (if the fountain's description tells you to roll a die to determine the results, then each drinker has to roll a die), unless the DM chooses to have a fountain have multiple effects. Unless otherwise specified, the effects last for 2d8+10 hours, which {@i doesn't} include time taken for short or long rests.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d100",
+						"Fountain of…"
+					],
+					"rows": [
+						[
+							"01-03",
+							"{@b Fountain of Age.} You become quite old. Your Strength, Dexterity, and Constitution are reduced by 1d4 each, and you have disadvantage on Wisdom (Perception) checks that rely on hearing."
+						],
+						[
+							"04-06",
+							{
+								"entries": [
+									"{@b Fountain of Altered Attributes.} Roll a die. On an odd number, one of your attributes increases by 1d4. On an even number, it's reduced by that amount. Roll a d6 to determine which attribute is altered:",
+									"{@b 1:} Strength. ",
+									"{@b 2:} Dexterity. ",
+									"{@b 3:} Constitution. ",
+									"{@b 4:} Intelligence. ",
+									"{@b 5:} Wisdom. ",
+									"{@b 6:} Charisma."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"07-09",
+							"{@b Fountain of Amnesia.} You lose all your memories for the duration. You don't actually lose any of your racial or class abilities, and your allies can attempt to explain to you how they work. Each time you try to use one of your abilities for the first time, you will need to make a DC 11 Intelligence check (if it's a racial ability), DC 13 (if it's a class feature), or DC 15 (if it's an archetype feature) to figure it out."
+						],
+						[
+							"10-12",
+							"{@b Fountain of Bravery and Cowardice.} Roll a die. On an odd number, you can roll saving throws against being frightened at advantage for as long as the effects last. On an even number, you roll such saving throws at disadvantage. If the dice falls off the table, you gain a cripplingly severe phobia of something mundane and harmless for the duration."
+						],
+						[
+							"13-15",
+							{
+								"entries": [
+									"{@b Fountain of Detection.} You gain the ability to detect the presence of certain things. The effects are identical to the spell of the same name and only requires you to concentrate on it when you are actively using the ability. Roll a d4 to determine what you can detect:",
+									"{@b 1:} {@i Detect evil and good}.",
+									"{@b 2:} {@i Detect magic}.",
+									"{@b 3:} {@i Detect poison and disease}.",
+									"{@b 4:} {@i Detect thoughts}."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"16-19",
+							"{@b Fountain of Disbelief.} The next monster you see, and all monsters of that particular species, will suddenly cease to exist for you. You simply will refuse to believe that it exists. If one of those creatures is pointed out to you, you will either see nothing or see a creature of a similar type. The monster can still see you and attack; you will believe you were harmed by something else, by an invisible creature, or by an ally."
+						],
+						[
+							"19-21",
+							{
+								"entries": [
+									"{@b Fountain of Disease.} You develop an unpleasant and unsightly, but not fatal disease. While diseased, you have disadvantage on a type of roll. A {@i lesser restoration} will end the disease. Roll a d6 to determine what you have disadvantage on: ",
+									"{@b 1:} Saving throws using a physical attribute.",
+									"{@b 2:} Saving throws using a mental attribute.",
+									"{@b 3:} Ability checks using a physical attribute.",
+									"{@b 4:} Ability checks using a mental attribute.",
+									"{@b 5:} Strength-based attack rolls.",
+									"{@b 6:} Dexterity-based attack rolls."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"22-24",
+							"{@b Fountain of Enchantment.} Roll a die. On an odd number, you fall madly in love with the first person you see. On an even number, you develop a seething hatred for the first person you see. If the die falls off the table, you become completely indifferent to that person; no matter what that person does, you won't care either way."
+						],
+						[
+							"25-27",
+							"{@b Fountain of Flight.} You gain the ability to fly at a speed of 60 feet. However, you can't go higher than 30 feet, nor can you go lower than 1 foot off the ground; while this ability is in effect, you can't touch the ground."
+						],
+						[
+							"28-30",
+							"{@b Fountain of Geases.} A spirit trapped within the fountain's waters puts a {@i geas} on you, unless you succeed on a DC 17 Wisdom saving throw. You are fully aware of the terms of the geas."
+						],
+						[
+							"31-33",
+							"{@b Fountain of Ghostliness.} Roll a die. On an odd number, you turn invisible. You remain solid and can still be heard, touched, and smelled. On an even number, you become incorporeal, as do your clothes and armor. Your other belongings, including backpacks, fall to the ground. While incorporeal, you can move through creatures and objects as if they were difficult terrain, and you take 5 (1d10) force damage if you end your turn inside an object. You can cast spells that don't require material components or use other abilities that don't require interacting with a physical object."
+						],
+						[
+							"34-36",
+							{
+								"entries": [
+									"{@b Fountain of Greed.} You become obsessed with collecting a certain type of object. Roll a d6 to determine what it is:",
+									"{@b 1:} Coins, no matter how many, how heavy, or the denomination. ",
+									"{@b 2:} Clothing, no matter the type, size, species or sex it's designed for, or condition. ",
+									"{@b 3:}Weapons, even if you can't use it (you {@i can} be persuaded to kindly let your allies keep their weapons, as long as you can see and occasionally touch them). ",
+									"{@b 4:} Tsotchkes, knickknacks, and various types of useless memorabilia. ",
+									"{@b 5:} Interesting rocks. ",
+									"{@b 6:} Teeth, horns, claws, scalps, pelts, and/or eyeballs from the monsters you slay."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"37-39",
+							"{@b Fountain of Hastiness and Slowness.} Roll a die. On an odd number, speed increases by 10 feet. On an even number, your speed decreases by 10 feet."
+						],
+						[
+							"40-42",
+							"{@b Fountain of Healing.} 5d8 hit points are restored to you. If applicable, you also lose the blinded, deafened, paralyzed, and poisoned conditions, a level of exhaustion, and have your reduced hit point maximum restored to normal."
+						],
+						[
+							"43-45",
+							{
+								"entries": [
+									"{@b Fountain of Immunity.} You gain immunity to one type of damage, and roll a die. On an odd number, you gain resistance to a second type of damage. On an even number, you gain a vulnerability to a second type of damage. If the die falls of the table, you gain resistance to a second type of damage and vulnerability to a third. Roll a d8 to determine the damage type:",
+									"{@b 1:} acid. ",
+									"{@b 2:} cold. ",
+									"{@b 3:} fire. ",
+									"{@b 4:} lightning. ",
+									"{@b 5:} necrotic. ",
+									"{@b 6:} psychic. ",
+									"{@b 7:} radiant. ",
+									"{@b 8:} thunder."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"46-48",
+							{
+								"entries": [
+									"{@b Fountain of Magic.} You gain the ability to cast one non-damaging cantrip or spell without the need to expend a spell slot or to use material components. However, every time you cast a non-cantrip spell, you must roll on the Wild Magic Surge table in the Sorcerer description. Roll a d10 to determine the spell:",
+									"{@b 1-3:} One of the following cantrips: {@i druidcraft}, {@i prestidigitation}, or {@i thaumaturgy}. ",
+									"{@b 4-6:} One of the following cantrips: {@i friends}, {@i mage hand}, or {@i message}. ",
+									"{@b 7:} One of the following 1st-level spells: {@i beast bond}, {@i longstrider}, or {@i purify food and drink}. ",
+									"{@b 8:} One of the following 2nd-level spells: {@i animal messenger}, {@i magic mouth}, or {@i skywrite}. ",
+									"{@b 9: } One of the following 3rd-level spells: {@i feign death} or {@i gaseous form}. ",
+									"{@b 10:} One of the following 4th-level spells: {@i arcane eye} or {@i locate creature}.",
+									"    If you gain the ability to cast a cantrip, make a DC 19 Constitution ability check. On a success, you know now know that cantrip {@i permanently}."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"49-51",
+							"{@b Fountain of Monster Attraction.} The next monster you see, and all monsters of that particular species, will be irresistibly attracted to you. Roll a die. On an odd number, that type of monster thinks your delicious. On an even number, that type of monster thinks you're absolutely adorable. If the die falls off the table, you will be declared either the high king of that species or an avatar of one of its gods. What happens after the effect wears off depends on your actions and the natural predilections of that species."
+						],
+						[
+							"52-54",
+							"{@b Fountain of Poison.} You must make a DC 17 Constitution saving throw. You take 36 (8d8) poison damage on a failed save, or half as much on a successful one. In addition, on a failed save, you are poisoned for the duration or until the poison is cured with a {@i lesser restoration} or similar effect."
+						],
+						[
+							"55-57",
+							{
+								"entries": [
+									"{@b Fountain of Polymorphing.} You are turned into something else for the duration. Your game statistics are replaced by the statistics of the creature you have turned into, but you retain your mental ability scores. Roll a d6 to determine what you are turned into:",
+									"{@b 1-2:} You are polymorphed into a different sort of humanoid. Roll on the table for the {@i reincarnation} spell. You retain all of your class abilities.",
+									"{@b 3-4:} You are polymorphed into an aberration, dragon, or monstrosity whose challenge rating is equal to or less than your level. You retain all of your class abilities, although depending on your new form, you may not be able to use them. ",
+									"{@b 5-6:} You are polymorphed into a beast whose CR is 1 or lower. You can't speak or use any of your normal class abilities."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"58-60",
+							"{@b Fountain of Proficiency.} Roll a die. On an odd number, you suddenly become proficient (and know it) in one new skill or tool set. On an even number, you lose one of your proficiencies."
+						],
+						[
+							"61-63",
+							"{@b Fountain of Rearrangement.} Your attributes are switched."
+						],
+						[
+							"64-66",
+							"{@b Fountain of Resistance.} For the duration, you gain resistance to bludgeoning, piercing, and slashing damage nonmagical weapons."
+						],
+						[
+							"67-72",
+							"{@b Fountain of Sex Change.} You become a member of the opposite sex for the duration."
+						],
+						[
+							"73-75",
+							"{@b Fountain of Shrinking.} You shrink, as per the Reduce option of {@i enlarge/reduce}—however, you are now six inches tall. Roll a die. On an odd number, your clothes and belongings shrink with you. On an even number, they don't."
+						],
+						[
+							"76-78",
+							"{@b Fountain of Speech.} Roll a die. On an odd number, you gain the benefits of a {@i speak with animals} spell for the duration. On an even number, you gain the benefits of a {@i speak with plants} spell. If the die falls off the table, you gain the benefits of a {@i speak with dead} spell."
+						],
+						[
+							"79-81",
+							"{@b Fountain of Static Shocks.} Your touch causes an electric shock. Anything or anyone you touch that isn't grounded takes 1d4 lightning damage, whether you want it to or not."
+						],
+						[
+							"82-84",
+							"{@b Fountain of Teleportation.} You are teleported to a random but {@i mostly} safe location within one mile."
+						],
+						[
+							"85-87",
+							"{@b Fountain of Vision Quests.} You gain a vision of a quest in your immediate area (no further than a day's walk from you) that is appropriate to your level and become obsessed with fulfilling that quest."
+						],
+						[
+							"88-90",
+							"{@b Fountain of Vision Changing.} Roll a die. On an odd number, you gain truesight to 10 feet. On an even number, you are blinded."
+						],
+						[
+							"91-93",
+							"{@b Fountain of Visions.} You suddenly have a vision. Roll a die. On an odd number, your vision is of a very powerful monster or NPC; you gain a glimpse of its immediate surroundings and a hint of what makes it so powerful. On an even number, your vision is of a nearby treasure hoard or powerful magical item; you gain an inkling of its worth or abilities but see only a vague shadow of what's guarding it. If the die falls of the table, you gain an extremely bizarre vision that {@i might} point to something important (if not immediately obviously so), or might just be a hallucination."
+						],
+						[
+							"94-96",
+							"{@b Fountain of Wandering.} For the duration, you lose the ability to tell direction, distance, your right from your left, and the ability to tell time or understand a compass."
+						],
+						[
+							"97-99",
+							"{@b Fountain of Youth.} You regress in age. If you're a young adult or adolescent, you become a child. If you're an adult, you become a young adult. If you're a mature adult or elderly, you become an adult. In addition, make a DC 17 Constitution ability check. On a success, this change is {@i permanent} (at least until you age normally). If you fail and roll 1 one, make a DC 17 Constitution saving throw. On a success, nothing else happens, but on a failure, you become an infant for the duration."
+						],
+						[
+							"100",
+							"{@b Fountain of Random Effects.} Roll twice for each drinker and combine the results, ignoring further rolls of 100."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mantle of Mist",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"While wearing this cloak, you may use your action to cast {@i fog cloud}, {@i misty step}, or {@i stinking cloud}. Once you cast one of these spells, you cannot cast that spell again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mantooth",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "3",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "S",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": "by a barbarian or fighter",
+			"entries": [
+				"When fighting a creature that is a spellcaster or has the Innate Spellcasting trait, you get a +2 to hit and damage. In addition, you can also attempt to cut through any magical barrier, including {@i Otiluke's resilient sphere}, {@i prismatic sphere}, and a {@i wall of force}. To do so, you must make a Strength check, with the DC equal to 10 + the spell's level. On a successful check, you have destroyed the barrier."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Map of Illusions",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This map has all the features of a {@item Map of Mapping|EnMa}.",
+				"In addition, this map has 5 charges and regains 1d4+1 expended charges at dawn. If the final charge is expended, roll a d20. On a 1, the map tears and becomes completely nonmagical.",
+				"You can expend a charge to have the map indicate (as a pulsing red area) the presence of either illusions or invisible creatures or objects within your sight. Each charge lasts for 1 minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Map of Magic",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This map has all the features of a {@item Map of Mapping|EnMa}.",
+				"In addition, this map has 5 charges and regains 1d4+1 expended charges at dawn. If the final charge is expended, roll a d20. On a 1, the map tears and becomes completely nonmagical.",
+				"You can expend a charge to have the map indicate (as a pulsing red area) the presence of magic within your line of sight, as if you had cast {@i detect magic}. Each charge lasts for 1 minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Map of Mapping",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This scroll will, upon command, begin magically creating a map of your surrounding area. It will only record objects that the individual holding the map can see—hidden or invisible objects aren't recorded, nor will living creatures. Constructs that can be considered “part of the scenery”—for instance, golems that are designed to appear as normal statuary—will be recorded, but wandering constructs won't be.",
+				"The scroll is the equivalent of an 11 inch × 17 inch sheet of graph paper that has 5 squares per inch. It can be erased in its entirety (but not partially) on command."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Marble of Cleanliness",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.1",
+			"entries": [
+				"This is a small white stone marble. If thrown against a hard object, it explodes into a cloud of white dust that fills a 30-foot cube and spreads around corners. The area is lightly obscured. After 1 minute, the dust vanishes, taking all dust, dirt, grime, and normal, nonmagical insect pests with it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mask of Attractiveness",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"While wearing this decorative half-mask, you have advantage on Charisma rolls made on humanoids of the species and sex(es) in which you are interested."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mask of Combat",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a barbarian or fighter",
+			"weight": "0.5",
+			"entries": [
+				"This mask bears the image of a scarred and fearsome warrior. It has 3 charges. You may use your action to expend a charge. For 1 minute afterwards, you have advantage on all attack rolls and saving throws.",
+				"The mask regains all expended charges daily at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mask of Death",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"While wearing this skull mask, you have advantage on all saving throws against gaze attacks and death saving throws.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This item is cursed, and attuning to it extends the curse to you. Removing the mask doesn't end the curse. As long as you remain cursed, you are unwilling to part with the mask and will insist on wearing it for at least an hour every day. A creature that ends its turn within 15 feet of you must make a DC 13 Constitution saving throw or catch a disease from you. The exact nature of the disease is up to the DM. The victim will remain diseased until the disease runs its course, it dies, or a {@i lesser restoration} is cast on it."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"While you are cursed, you will suffer from and display some very mild symptoms of the disease, but it will never progress far enough in you to severely hinder or harm you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mask of Knowledge",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This mask contains 2d4 spells of a particular class list and school, all of which are 1st-, 2nd-, or 3rd-level spells. The DM will determine the spells. You may cast each spell once, then you can't cast that spell again with this mask until the following dawn. You must still provide material components."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mask of Memory",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "0.5",
+			"entries": [
+				"This mask has no visible eye holes and is decorated with 100 gemstones that form a complex pattern. The gemstones are either brilliant fire opals or slightly dull black opals; the location of each type of gemstone is random. When found, a {@i mask of memory} has a 25 percent chance of only having fire opals, and a 75 percent chance of having 1d100 black opals.",
+				"The mask does not impede your vision, and when wearing it, you have darkvision to 60 feet and truesight to 10 feet, and can't be blinded.",
+				"In addition, you can use the mask to regain an expended spell slot of any level from 1st through 5th. Doing so causes a number of fire opals equal to the spell slot level to turn into black opals. When you have used the last fire opal, you can no longer use the mask to regain spell slots. Its other properties remain, however."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mask of the Wraith",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This horrible, pale mask has 5 charges. While wearing it, you may use your action to expend a charge. For 1 minute afterwards, you have resistance to cold and necrotic damage, and damage from bludgeoning, piercing, and slashing nonmagical weapons that aren't silvered. In addition, you can't be paralyzed or poisoned.",
+				"In addition, you grow long, bone-like claws. You are proficient in these claws. These claws inflict 1d4 + your Strength modifier in slashing damage and 1d8 necrotic damage, and the target's hit point maximum is reduced by the amount of necrotic damage inflicted. The target dies if this effect reduces its hit point maximum to 0. If the target is humanoid, its spirit rises as a specter 1 minute later. The specter isn't under your command but won't attack you or your companions unless you attack first.",
+				"The mask regains 1d4+1 expended charges daily at dusk. If you expend the last charge, roll a d20. On a 1, the mask develops spiderweb cracks and becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Medallion of Defense",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"At your command, this piece of jewelry transforms into a {@i shield +1} or back again."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Curing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"entries": [
+				"This mirror has 7 charges. A creature can use its action to gaze into the mirror and expend a charge. That creature is then subjected to the {@i heal} spell.",
+				"When the mirror runs out of charges, it shatters, becoming nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Duplication",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "10",
+			"entries": [
+				"When you gaze into this large mirror, a duplicate of yourself steps out and attacks. It has the exact same attributes, abilities, and equipment that you do. However, it is resistant to bludgeoning, piercing, and slashing damage from nonmagical weapons, and can't be charmed, frightened, paralyzed, or poisoned. Its alignment is the opposite of yours.",
+				"The duplicate will remain until either it or you are slain. If you die (either by its hands or because of other reasons), the duplicate vanishes, along with everything it had when it first stepped out of the mirror."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Mental Prowess",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "10",
+			"entries": [
+				"This large mirror has 7 charges. You can use your action to expend two or more charges and use the mirror to cast the following spells: {@i clairvoyance} (3 charges), {@i detect thoughts} (2 charges; usable only on a target reflected in the mirror), {@i  plane shift} (5 charges), or {@i scrying} (5 charges)",
+				"The mirror regains 1d6+1 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Reflecting",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "10",
+			"entries": [
+				"This large mirror shows the true appearance of anything reflected in it. Creatures who are shapeshifted or magically disguised are reflected in their true form. Illusions lack a reflections, and invisible creatures can be seen in it.",
+				"Strangely, vampires have a reflection in this mirror."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Retention",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "1",
+			"entries": [
+				"When you speak the command word, this mirror will record all events that occur in front of it for the next 24 hours. You can play the image by speaking the command again. The images play in realtime, but you can rotate the mirror to cause it to speed up, reverse, slow down, or pause. Speaking the command word a third time deletes the entire day's recording (there is no way to delete only part of it), leaving it ready to be used again."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Sending",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "10",
+			"entries": [
+				"This mirror is 3 feet by 5 feet and has 50 charges. You may concentrate on any place you know well and have been to. An image of that place will appear in the mirror. You can then expend a charge to pass an inanimate object through the mirror and into the place that is being shown. The object must be able to fit in the mirror's frame.",
+				"Once all 50 charges have been expended, the mirror shatters and becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Truth",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "1",
+			"entries": [
+				"On command, this mirror causes a ghastly face to appear within it. You may ask it a question. The mirror will truthfully answer the question, as long as the correct answer can be read in the mind of a living creature within 500 miles of it.",
+				"Once you use the mirror, you can't use it again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mirror of Vanity",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "1",
+			"entries": [
+				"A creature who looks into this mirror must make a DC 15 Wisdom saving throw or become charmed by the mirror. While charmed, the creature is incapacitated and can do nothing but admire its reflection.",
+				"If the creature takes damage or has its line of sight interrupted, it may make a new saving throw, ending the effect on a success. Afterwards, the creature will be unaware of how much time has passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mixing Spoon",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"You may use this spoon to mix two potions together. Then, when imbibed, both potions work perfectly and you do not need to roll on the potion miscibility table."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Monster Mask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"This wooden mask is carved into the shape of a face—giant, humanoid, or a monstrosity that has a human-like face, such as a centaur, manticore, or medusa. The creature depicted on the mask will be of Large size or smaller.",
+				"While wearing this mask, you may {@i shapechange} into that creature for up to 1 hour. You don't need to concentrate on maintaining this shape.",
+				"Once you use this ability, you can't use it again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mouse Chariot",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This is a miniature chariot. If you hitch a pair of mice to it and say the command, the chariot enlarges and the mice shapechange into horses. While in horse-form, the mice act as though they were normal domesticated horses who have been trained to pull chariots.",
+				"The {@i mouse chariot} has 24 charges. Each hour or portion thereof it spends in its enlarged form costs 1 charge. While it has charges, you can use it as often as you wish. When it runs out of charges, the horses turn back into mice; a round later, the chariot reverts to miniature form.",
+				"The chariot regains 1d6 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Mug of Plenty",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "1",
+			"entries": [
+				"This large lidded stein has 5 charges. When you speak the command word and expend a charge, the mug fills up with one nonmagical, non-poisonous, non-damaging beverage of your choice.",
+				"The mug regains 1d4+1 charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Muzzle of Lycanthropic Control",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "1",
+			"entries": [
+				"If this muzzle is fastened over the mouth of any lycanthrope that is in beast form, it forces the lycanthrope to remain in beast form until it's removed. If the lycanthrope is in hybrid form, it forces it to assume beast form. The muzzle is magically locked and will remain so until the command word is spoken or a {@i knock} spell is cast on it.",
+				"While wearing the muzzle, the lycanthrope can't talk, use its bite attack, or shapechange, and its speed is reduced by 10 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Nail of Building",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"entries": [
+				"This nail must be used as the very first nail hammered into an entirely wooden structure; this structure must fit inside a 100-foot cube. Later, when the building is complete, the nail must be removed. This causes the entire structure and all of its contents (inanimate, nonliving objects only) to enter into an extradimensional space inside the nail.",
+				"You may at any point then drive the nail into the ground and speak the command word. The building then reappears and the nail loses its magic.",
+				"As this employs extradimensional space, placing it inside a {@i bag of holding} or similar object causes both items to be destroyed and a rift to the Astral Plane to be opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Necklace of Mystic Eidolons",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This necklace has 1d8+1 pyramid-shaped beads hanging from it. You can use an action to detach a bead while imagining a place you have been to within 100 miles of your current location. When the bead hits the ground, an illusory image of you appears at that location. This image functions identically to the one created by the {@i project image} spell, except it lasts no more than 1 hour.",
+				"In addition, you can cast a spell through that image, as if you were standing at its location. Once you do so, the image vanishes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Necklace of Protection from Charm",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This necklace has a large gemstone hanging from it. While wearing the necklace, you have advantage on saving throws against being charmed or frightened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Necklace of Strangulation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This appears to be a helpful necklace, such as a {@i necklace of adaptation}. However, as soon as you put this necklace on, it will grab on to your neck and begin strangling you. You will begin to suffocate unless the necklace can be ripped off. This requires a DC 25 Strength ability check. The necklace can also be cut; its armor class is 18, it has 30 hit points, and immune to poison and psychic damage. In addition, the necklace takes only have the damage dealt to it, and you take the other half. A {@i remove curse} will cause the necklace to instantly fall off.",
+				"The {@i necklace of strangulation} will remain clamped around your neck until you are nothing but a skeleton; only then will it fall off on its own."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Needle of Lively Tattoos",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This needle produces tattoos that move on their own, as if they had been created by the {@i minor illusion} spell. The actual quality of the tattoo depends on the abilities of the tattoo artist."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Needle of Repair",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.1",
+			"entries": [
+				"If you touch this needle to any nonmagical cloth, leather, or metallic item, you can use the needle to cast either {@i mending} or the Cleaning variant of {@i prestidigitation} on it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Net of Plenty",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "3",
+			"entries": [
+				"This net attracts fish and gives you advantage on Intelligence (Survival) rolls to catch fish with it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Net of Spirit Snaring",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Rare",
+			"weight": "3",
+			"property": [
+				"S",
+				"T"
+			],
+			"range": "5/15",
+			"entries": [
+				"This net can be used to restrain creatures that are normally immune to being restrained, including ghosts and other incorporeal undead as well as air elementals and other such creatures. If used to restrain an undead, that creature has disadvantage on rolls made to escape it."
+			],
+			"tier": "Minor",
+			"source": "EnMa"
+		},
+		{
+			"name": "Noisome Spirit Chaser",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"These firecrackers usually come in sets of 1d4+1. If one is lit, it explodes 1 round later in a cloud of foul-smelling (but not dangerous) smoke, which quickly dissipates. All ephemeral, ethereal, or incorporeal fey, fiends, and undead must make a DC 13 Wisdom saving throw or be frightened of you for 1 minute. While frightened, the creature must use the Dash action to move as fast as possible away from the {@i noisome spirit chaser}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Obedient Hourglass",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"While the sand in this hourglass normally falls from the top bulb to the bottom bulb in exactly one hour, you may command it to act as a timer and set it to time as little as ten seconds and as long as ten days."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Agelessness",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to the skin of a living creature, it causes that creature to stop aging for 1 year."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Animation",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can sprinkle this oil over a Medium or smaller plant or inanimate object, which turns it into an awakened plant or animated object. The oil lasts for 1 hour, then the plant or object becomes a normal, inanimate thing again. During this time, the plant or object is charmed by you and follows your orders."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Armor, Type Ⅰ",
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to your skin. As long as you aren't wearing any armor, your natural AC is improved for 10 minutes. The {@i oil of armor} doesn't count as armor, so it can be used in conjunction with spells such as {@i mage armor} or abilities such as a monk's Unarmored Defense.",
+				"Your natural armor class improves to 12."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Armor, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to your skin. As long as you aren't wearing any armor, your natural AC is improved for 10 minutes. The {@i oil of armor} doesn't count as armor, so it can be used in conjunction with spells such as {@i mage armor} or abilities such as a monk's Unarmored Defense.",
+				"Your natural armor class improves to 14."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Armor, Type Ⅲ",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to your skin. As long as you aren't wearing any armor, your natural AC is improved for 10 minutes. The {@i oil of armor} doesn't count as armor, so it can be used in conjunction with spells such as {@i mage armor} or abilities such as a monk's Unarmored Defense.",
+				"Your natural armor class improves to 16"
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Beauty",
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to your skin. A vial usually contains 1d4+2 doses. You become far more attractive than you normally are, and have advantage on Charisma (Persuasion) checks for 1d4 hours."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Buoyancy",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to your skin. A vial usually contains 1d4+2 doses. For 8 hours after, you won't sink in water normally. If someone is attempting to pull you under, you have advantage on Strength checks to resist."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Cloaking",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to a magical item. A vial usually contains 1d4+2 doses. For the next 24 hours, the item won't be detected as magical, as if you had cast the False Aura version of the {@i Nystul's mystic aura} spell on it. In addition, if the item was such that it would normally be detected by the {@i detect evil and good} spell, it won't be."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Disenchantment",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to your skin. Doing so removes one of the following: a curse, lycanthropy, mummy rot, possession, or the charmed condition."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Elasticity",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to your skin. A vial usually contains 1d3 doses. For 1 hour afterwards, you become incredibly flexible. You can move through any opening large enough for a creature one size category smaller than you, your reach increases by 5 feet, you have advantage on Dexterity (Acrobatics) rolls, and you can bend your joints in any direction."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Eternal Fire",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If used to fill a lamp, a pint of this oil will burn constantly for 1 week. Outside of a lamp, however, the oil is non-flammable and non-explosive. A container usually contains 1d4+2 pints of oil."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Feather Falling",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to the skin. For the next 1d4 hours, you will take no damage from falling."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Fumbling",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This appears to {@i oil of resistance} (q.v.) or a similar useful oil. However, when under stress in combat, it turns into an incredibly slippery substance, similar to {@i oil of slipperiness}. Each round, you must make a DC 13 Dexterity saving throw to avoid dropping whatever you are holding. If you fail your roll by 5 or more, you also fall prone.",
+				"The oil lasts for 8 hours, but can be washed off by applying copious amounts of alcohol, by using a {@i dispel magic} or {@i remove curse}, or by applying {@i universal solvent}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Immovability",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"A vial of this usually contains 1d4 doses. As an action, a dose can be applied to the hinges of a door or chest lid, the gears of a machine, the axel of a wagon, or to the moving parts of another object. For the next 8 hours, those moving parts are locked in place. It requires a DC 25 Strength ability check to move the parts, but that usually causes the object to break first, unless it is a very sturdy object."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Metal Fatigue",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This appears to {@i oil of sharpness} or a similar useful oil. If a dose is applied to any nonmagical metal, it rusts the metal in 1 minute. Weapons take a permanent -1 penalty to damage rolls, and armor takes a permanent -1 penalty to the AC it offers.",
+				"However, if this oil is thrown on an iron- or steel-based creature, such as a gorgon or many construct, it inflicts 9 (2d8) fire damage to that creature."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Neutral Scent",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to your skin. A vial usually contains 1d4+2 doses. For 1 hour afterwards, this oil completely removes your scent, and you can't be tracked by smell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Resistance",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply this oil to your skin. For 1 hour afterwards, you have resistance to one type of damage. Roll a d8 to determine the damage type.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"Damage Type"
+					],
+					"rows": [
+						[
+							"1",
+							"Acid"
+						],
+						[
+							"2",
+							"Bludgeoning"
+						],
+						[
+							"3",
+							"Cold"
+						],
+						[
+							"4",
+							"Fire"
+						],
+						[
+							"5",
+							"Force"
+						],
+						[
+							"6",
+							"Lightning"
+						],
+						[
+							"7",
+							"Piercing"
+						],
+						[
+							"8",
+							"Slashing"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Rust-Proofing",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to a metallic object, such as a weapon or armor. A vial usually contains 1d4 doses. For 8 hours afterwards, the object won't suffer from the effects of rust, even if it was caused by rust monsters or {@i oil of metal fatigue} (q.v.)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Scribes",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can brush a dose of this oil on written text. A vial usually contains 1d4+2 doses. The oil will translate the words to a language you can read. It won't harm the surface on which it was brushed, and will dry up in 1 hour, causing the words to return to their original language."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Scrying",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If you can pour a dose of this oil into a bowl of water and then spend a minute studying the silvery swirls it produces, you can use the oil to cast {@i scrying}. A vial usually contains 1d3 doses."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Stone Passage",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, a dose of this oil can be applied to a section of solid stone. This opens a passage in that stone, as if {@i passwall} had been cast on it. The passage lasts for 1 hour, then the stone returns to normal."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of the Dryad",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, this oil can be applied to your skin. For 1 hour afterwards, you may move through trees as if {@i tree stride} had been cast on you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of the Pickpocket",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a dose of this oil to your hands. A vial usually contains 1d4+2 doses. For 10 minutes afterwards, you have advantage on Dexterity (Sleight of Hand) checks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Timelessness",
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, one or more doses of this oil can be applied to an inanimate object. A vial usually contains 1d4+2 doses, and you need one dose to coat a Medium or smaller object, two doses for a Large object, four for a Huge object, and eight for a Gargantuan object. The object will then age at a rate of only 1 day for every year that passes. The oil protects the object from the ravages of time and normal weathering, not from deliberate or magical damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Unlocking",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can pour a dose of this oil into the keyhole of any lock. That lock will then be unlocked. This doesn't work on magical locks or on doors protected by {@i arcane lock.} A vial usually contains 1d4 doses."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Vision, Type Ⅰ",
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a drop of this oil in an eye; it takes two actions to place a drop in both eyes. A vial usually contains 2d4 drops. If you only place the oil on one eye, you will be dizzy and at disadvantage on all Dexterity ability checks, attack rolls, and saving throws that employ vision until the oil wears off in 1 hour or you put a drop in the other eye.",
+				"When placed in your eyes, you gain darkvision to 60 feet for 1 hour. If you already have darkvision, its range increases by 30 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Oil of Vision, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"As an action, you can apply a drop of this oil in an eye; it takes two actions to place a drop in both eyes. A vial usually contains 2d4 drops. If you only place the oil on one eye, you will be dizzy and at disadvantage on all Dexterity ability checks, attack rolls, and saving throws that employ vision until the oil wears off in 1 hour or you put a drop in the other eye.",
+				"When placed in your eyes, you gain truesight to 30 feet for 1 hour."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ointment of Flying",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"This small crystal jar is filled with 1d4+1 doses of a thick mixture that smells like ozone. The jar and its contents weigh 1/2 pound.",
+				"As an action, one dose of the ointment can be applied to the skin. For the next hour, you gain the benefits of the {@i fly} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ointment of Healing, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"entries": [
+				"This small ceramic jar is filled with 1d4+4 doses of a viscous, grainy mixture that smells like cut herbs. As an action, one dose of this ointment can be applied to your skin. You regain 3d6 hit points."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ointment of Healing, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.5",
+			"entries": [
+				"This small ceramic jar is filled with 1d4+4 doses of a viscous, grainy mixture that smells like cut herbs. As an action, one dose of this ointment can be applied to your skin. You regain 70 hit points and lose the blindness, deafness, paralyzed, and poisoned conditions."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ointment of Poison",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This small clay jar is filled with 1d4+1 doses of a thick mixture that smells like incense. The jar and its content weigh 1/2 pound.",
+				"This appears to be {@i ointment of healing}. As an action, one dose of the ointment can be applied to the skin. You must then make a DC 15 Constitution saving throw, taking 8d10 poison damage on a failed saving throw or half as much on a successful one."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Orrery of the Planes",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "4",
+			"entries": [
+				"This complex mechanical device shows the relative positions of the various planes in relation to the prime. If a very powerful, plane-shaking event occurs on one of those planes, the sphere used to denote that plane will alter in appearance to reflect that event."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Parchment of Monster Holding",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"While holding this item, you may cast a spell of 5th level or lower that allows you to conjure or summon creatures, such as {@i conjure animals} or {@i summon lesser demons}. Instead of the creature or creatures appearing as they normally would, an image of the creature appears on the parchment instead. An intelligent creature (Intelligence of 4 or higher) may make a DC 17 Charisma saving throw to resist.",
+				"At a later time, you or someone else may place the parchment on the ground and speak the command word. The creature is then released from the parchment and acts as if you had just cast the spell that summoned it. The parchment is then destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Parchment of Spell Stealing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a wizard",
+			"weight": "0.1",
+			"entries": [
+				"This parchment is found in sheaves of 1d4+2. You become attuned to the entire sheaf of parchment at a time. If you hold this parchment up within 10 feet of a creature casting a spell from the wizard's spell list (regardless of if the caster is a wizard or not), then that creature must make an Intelligence saving throw against your spell save DC. On a failure, some of the spell's energies are sucked into the parchment and the spell's formula appears on the parchment. You can use then use the parchment to copy the spell into your spellbook (requiring the normal amount of time and gold) or use it as a spell scroll. After 7 days, or when you copy the spell or use it as a scroll, the {@i parchment of spell stealing} crumbles into ash.",
+				"Regardless of the original spell's target, the remaining energy that wasn't trapped in the parchment affects you. Regardless of the type of spell that was cast, you must make a Constitution saving throw, using the original caster's spell save DC. You take 3 (1d6) force damage per spell slot level used to cast it on a failed saving throw, or no damage on a successful one.",
+				"If the original caster made its initial Intelligence saving throw, the spell wasn't on the wizard's spell list, or if the spell was cast through a scroll or magical item, the parchment then turns to ash without catching the spell's energy or formula."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pearl of Entrancement",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"If you place this pearl in the mouth of a sleeping or unconscious humanoid, it will remain asleep for 30 days. During this time, it can't be woken up unless the pearl is removed, and will not need food, water, or air. If the pearl is removed before the 30 days are over, it can be reused; otherwise, it dissolves in the target's mouth.",
+				"You may also, once each day, use the pearl to cast {@i dominate person} on that creature, with a duration of 1 hour. The creature will follow your orders, but will appear to others to be sleepwalking or, at best, walking around in a daze.",
+				"You may also use the {@i pearl of entrancement} as the material component for the Hedged Prison or Slumber variant of the {@i imprisonment} spell, in place of the normal jade miniature or soporific herbs. The pearl isn't consumed in the casting, and the target makes its saving throw at disadvantage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pearl of Flying",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"While holding this in one hand, you can fly at a speed of twice your walking move. You can fly for up to 8 hours, then must take a long rest before you can fly again. If you drop the pearl, you will immediately fall."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pearl of the Tides",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"These are large, iridescent pearls. If you hold the pearl in the palm of your hand and concentrate, you can affect the tide, and you continue affecting it for as long as you concentrate, and once you have used the pearl, you can't use it again until the following dawn or dusk—each pearl can be used twice per day. While there are two distinct types of {@i pearls of the tides}, they are often found in pairs, one of each type.",
+				{
+					"items": [
+						{
+							"name": "Pearl of the Ebbing Tides",
+							"entries": [
+								"You can make all water within 120 feet of you recede at the rate of 5 feet each round. Once you stop concentrating, the water instantly rushes back."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Pearl of the Rising Tides",
+							"entries": [
+								"You can make all water within 120 feet of you rise at the rate of 5 feet each round. Once you stop concentrating, the water instantly recedes."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Periapt of Proof Against Sound",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This delicate silver chain has a triangle-cut chunk of smoky quartz attached to it. While you wear it, you are immune to thunder damage and to being deafened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Philter of Glibness",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"After drinking this philter, you gain a +10 to all Deception, Intimidation, and Persuasion skill checks for 1 hour. You also automatically succeed on your saving throw if you are in a {@i zone of truth}, but the {@i zone's} caster will believe that you failed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Philter of Stammering and Stuttering",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This appears to be a {@i philter of glibness}. An {@i identify} spell will reveal its true nature. If you drink it, you lose the ability to speak coherently for 1 hour. You can't cast any spell with a verbal component unless you first succeed on a DC 15 Constitution saving throw, as if you were making a concentration check. In addition, you have disadvantage on Charisma skill checks that involve speech."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pick of Proficiency",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"This is an ivory pick used by musicians to strum instruments. When using the pick, you have proficiency in the Charisma (Performance) skill and proficiency in all stringed musical instruments. If you already have proficiency in Performance and in stringed instruments, you may use twice your proficiency bonus when making skill checks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pin of Communication",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"These pins come in pairs. When two creatures with different languages wear the pins, they can understand each other as if the {@i tongues} spell had been cast on them. This effect remains as long as they are both wearing the pins."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pipes of Animal Calls",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "6",
+			"entries": [
+				"You must be proficient with wind instruments or with the Animal Handling or Nature skill to use these pipes.",
+				"If you picture an animal while blowing through this redwood recorder, you will produce perfect simulations of the sounds that animal makes. You can't speak to animals using this pipe, but you can accurately reproduce warning calls, distress calls, mating calls, and so forth."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pipes of Pain",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "6",
+			"entries": [
+				"You must be proficient with wind instruments to use these pipes. This ebony flute has 3 charges and regains 1d3 expended charges each day at dusk.",
+				"If you use your action to play these pipes and expend a charge, the pipe emits a painful, shrill fluting noise. Any number of creatures you choose that you can see within 30 feet of you must make a DC 15 Constitution saving throw. On a failure, the creature takes 2 (1d4) psychic damage at the start of each of its turns and is stunned until the beginning of its next turn due to the incredible pain the pipe's shrill notes caused. You may continue playing for as long as you want, up to 10 minutes at a time.",
+				"A creature reduced to 0 hit points by these pipes makes its death saving throws (if applicable) at advantage. If the creature succeeds on these saving throws and becomes stable, it regains 1 hit point."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pipes of Sounding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": "by a bard",
+			"weight": "6",
+			"entries": [
+				"You must be proficient with wind instruments to use these pipes. You can use your action to blow through the pipes and have them produce any sound you wish, other than understandable speech. Possible sounds include blowing wind, bird calls, footsteps, screams, and mumbled, unintelligible speech. The sounds continue as long as you wish to play, and you may switch the type of sounds the pipes produce as a bonus action. You can also make the sounds appear to originate in any location within 60 feet of you. You can't use these pipes to create sounds loud enough to inflict damage.",
+				"A creature may use its action to listen critically to the sound you're producing and succeed on an Intelligence (Investigation) check to discern that the sound is false. The DC is 8 + the better of your Deception or Performance skills."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Pipes of the Sewer",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "6",
+			"entries": [
+				"This is a variant on the {@i pipes of the sewer} presented in the {@i Dungeon Master's Guide}.",
+				"These pipes summon one {@creature swarm of bats|mm} per charge spent, ordinary bats and giant bats are indifferent towards you, and you can attempt to take control of a swarm of bats that is under someone else's control. It is otherwise identical to the original version."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Platter of Purity",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "2",
+			"entries": [
+				"This is a silver or golden serving tray, 1 foot wide and 2 feet long. Any food placed on the tray for 1 minute or longer is purified of all nonmagical poisons and contaminants."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Poisonsword",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "6",
+			"dmg1": "{@dice 2d6}",
+			"dmgType": "S",
+			"property": [
+				"H",
+				"2H"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This sword is made from razor-sharp iron-colored crystal, and poison constantly oozes out from minute cracks in it. On a successful hit, it inflicts an addition 7 (2d6) poison damage, and the target must make a DC 19 Constitution saving throw or be poisoned for 1 minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Portable Bridge",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"This rough gray cloth folds to the dimensions of handkerchief. It unfolds into a magical bridge that requires no pillars or cables, is strong as stone, and can take a load of many thousands of pounds without collapsing.",
+				"You can use your action to unfold the {@i portable bridge} on one side of a gap or chasm. The bridge will extend up to 100 feet to the other side. If it can't reach the other side, it folds back up into cloth. You can use your action to take hold of the edges of the cloth and fold it back up."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Portable Spring",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"This shimmering, silvery-blue cloth is folded up to the dimensions of a handkerchief. It unfolds into a circular well 3 feet in diameter. It produces 100 gallons of clear, fresh water each day. You can use your action to take hold of the edges of the cloth and fold it back up."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Agility",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, your Dexterity increases to 19 for 1 hour. This potion is green, with silvery streaks that constantly swirl around inside."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Blindness",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of healing} or other beneficial potion. An {@i identify} spell will reveal its true nature. When you drink this potion, you are blinded for 1d4 hours or until you are subjected to a {@i lesser restoration} or similar spell. This potion looks, smells, and tastes like a {@i potion of clairvoyance} or other beneficial potion. An {@i identify} spell reveals its true nature."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Childishness",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of longevity} or other beneficial potion. An {@i identify} spell will reveal its true nature. When you drink this potion, you regress in age to early childhood (five years old for a human).",
+				"Your Intelligence, Wisdom, and Charisma remain the same, and you retain all of your class abilities. However, your Strength is halved (to a minimum score of 4), and your Dexterity and Constitution are each reduced by 1d4+1 (minimum of one-half your original score), and you become one size category smaller (minimum of Tiny). Your clothing and equipment don't change with you. In addition, you gain a new flaw: {@i I'm a child now, and I sometimes act like it—especially if I really want something or I don't get my way}.",
+				"This is technically not a curse, and {@i remove curse} won't restore you to your original age. A {@i greater restoration} will, but only if cast within 24 hours. Otherwise, the effects are permanent (although you will continue to age at a normal rate) unless a {@i wish} is used to restore you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Confusion",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of mind reading} or other beneficial potion. An {@i identify} spell reveals its true nature. Upon drinking it, you are subjected to the {@i confusion} spell for 10 minutes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Corrosive Touch",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"After drinking this potion, your hands begin sweating acid for 10 minutes, whether you want them to or not. Any creature or object made of wood or leather that you touch takes 7 (2d6) acid damage. This potion is unhealthy yellow color that constantly seethes and boils, although it's cool to the touch."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Craftsmanship",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"For 8 hours after drinking this potion, you may use twice your proficiency bonus when using any artisan tools. This potion has bands of steel-gray and wood-brown that quickly separate back into bands after being shaken."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Creation",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If consumed, this potion does nothing but make you feel nauseated for 1 round. On the potion's bottle, there is a label with a picture of a common inanimate object: a piece of furniture, a shield, a ladder, a wheelbarrow, a common weapon, and so on. If the potion is poured onto the ground, the liquid will congeal and become the object on the label. This transformation is permanent, although a {@i dispel magic} will turn the object into useless goo. The potion's vial looks as though it is filled with sawdust but sounds as if it were filled with a liquid."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Curing Lycanthropy",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If you are an infected lycanthrope and you drink this potion, you are immediately drop to 0 hit point and must make a DC 15 Constitution saving throw. If you succeed, you are cured of lycanthropy. While you must make death saving throws, you do so at advantage. If you fail, you aren't cured and are restored to 1 hit point. The potion is murky green and has a sprig of wolfsbane in it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Deafness",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of healing} or other beneficial potion. An {@i identify} spell will reveal its true nature. When you drink this potion, you are deafened for 1d4 hours or until you are subjected to a {@i lesser restoration} or similar spell. This potion looks, smells, and tastes like a {@i potion of clairvoyance} or other beneficial potion. An {@i identify} spell reveals its true nature."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Defense, Type Ⅰ",
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, your AC improves by +1 for 1 hour. This potion looks steely-gray and is rather granular."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Defense, Type Ⅱ",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, your AC improves by +2 for 1 hour. This potion looks steely-gray and is rather granular."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Defense, Type Ⅲ",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, your AC improves by +3 for 1 hour. This potion looks steely-gray and is rather granular."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Dreaming",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"While you drink this potion, you must concentrate on a person, object, or place, and then you must immediately go to bed. While you sleep, you will have a dream about that thing and learn one completely true thing about it that you didn't already know. The detail will be couched in dream-imagery and might not be easily understood, however."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of False Visions",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of forewarning} (q.v.) or other beneficial potion. An {@i identify} spell reveals its true nature. Upon drinking it, you fall into a trance for 1 minute, during which time you get a false vision of the future. Although the nature of the vision varies, it usually involves you or an ally or loved one enjoying a great triumph or terrible misfortune."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Forewarning",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you go into a trance for 1 minute, during which time you gain a vision of the future. The vision is often heavily symbolized but is always true. This vial seems to be filled with swirling clouds that subtly change color, and shapes appear to constantly form and dissolve."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Forgetfulness",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of mind reading} or other beneficial potion. An {@i identify} spell reveals its true nature. Drinking it causes you to forget everything that has happened to you in the last 24 hours."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Fright",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of healing} or other beneficial potion. An {@i identify} spell will reveal its true nature. Drinking it curses you for 10 minutes. While you are cursed, you are frightened of random creatures and things that are within 10 feet of you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Gray Slumber",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you gain the effects of the {@i feign death} spell for 1 hour. This potion is an opaque gray with shadowy {@i things} floating in it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Greater Restoration",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion is blue with a white bead in it; the bead continually pulses, like a heart.",
+				"When you drink it, you gain the effects of a {@i greater restoration} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Insomnia",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you are immune to being rendered unconscious through any means for 8 hours. You also can't take any long rests during this time. This potion is bright yellow-green and bubbly."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Lesser Restoration",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion is blue with a white bead in it; the bead continually pulses, like a heart.",
+				"When you drink it, you gain the effects of a {@i lesser restoration} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Lethargy",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of speed} or other beneficial potion. An {@i identify} spell reveals its true nature. When you drink this potion, you are under the effects of the {@i slow} spell for 1 hour."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Lycanthropy",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of healing} or other beneficial potion, and when you drink it, you heal 2d4 hit points. An {@i identify} spell will reveal its true nature: on the next full moon, you will turn into a lycanthrope. The DM will choose a lycanthrope or roll on the table to determine the type.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d12",
+						"Lycanthrope Type"
+					],
+					"rows": [
+						[
+							"1",
+							"Werebear"
+						],
+						[
+							"2-3",
+							"Wereboar"
+						],
+						[
+							"4-6",
+							"Wererat"
+						],
+						[
+							"7-8",
+							"Weretiger"
+						],
+						[
+							"9-12",
+							"Werewolf"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Magic Resistance",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you have advantage on saving throws against spells and other magical effects for 10 minutes afterwards. This potion looks like liquid lead."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Mind Restoration",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion cures any type of insanity or confusion, restores memories that have been altered or removed with the {@i modify memory} or similar spell, ends the charmed condition, and reverses the effects of the {@i feeblemind} spell. This potion is a clear purple that sparkles when you shake it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Monsters",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If consumed, this potion does nothing but make you feel nauseated for 1 round. On the potion's bottle, there is a picture of a hobgoblin. If you pour this potion out on the ground, it congeals into several hobgoblins, who immediately attack. If slain or subjected to a {@i dispel magic} spell, they and their equipment dissolve into goo. This potion is rainbow-colored and smells musty.",
+				"Roll a d6 on the following table to determine what type of hobgoblins appear.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d6",
+						"Type of Hobgoblins"
+					],
+					"rows": [
+						[
+							"1-2",
+							"Four {@creature hobgoblin|mm|hobgoblins}"
+						],
+						[
+							"3-4",
+							"Three {@creature hobgoblin|mm|hobgoblins} and one {@creature hobgoblin captain|mm}"
+						],
+						[
+							"5",
+							"Four {@creature hobgoblin captain|mm|hobgoblin captains}"
+						],
+						[
+							"6",
+							"three {@creature hobgoblin captain|mm|hobgoblin captains} and one {@creature hobgoblin warlord|mm}"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Nutrition",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you can go for 1 week without eating or drinking. This potion looks like very thin, watery oatmeal."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Perception",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you gain advantage on all Wisdom (Perception) checks, and your passive Perception increases by +5. This clear potion has an eyeball bobbing in it, which vanishes when the potion is opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Petrifaction",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a {@i potion of invulnerability} or other beneficial potion. An {@i identify} spell reveals its true nature. When you drink this potion, you must make a DC 17 Constitution saving throw or be instantly turned to stone. This condition lasts until magically reversed with a {@i dispel magic} cast with a 6th-level or higher spell slot."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Plant Growth",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If you spend your action to sprinkle this potion over a 10-foot-square patch of vegetation, that area is under the effect of a {@i plant growth} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Pursuit",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, your walking speed doubles, and you can take the Dash option as a bonus action. This potion is bright purple, with lighter purple swirls that zip around the liquid."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Rainbow Hues",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you can use a bonus action to change the coloration of you and everything you are wearing. You may even turn several different colors and any pattern you can think of. If you wish, you can have advantage on Dexterity (Stealth) skill checks while the potion is in effect. The potion lasts for 1d4 hours. Inside the vial, the liquid slowly changes from one color to another."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Recall",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you will remember everything that you do or experience for the next 1 hour in perfect clarity. This potion is crystal clear but fills with golden sparks when shaken or poured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Rest",
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you lose 1 level of exhaustion. This potion is brown and bubbly.",
+				"You can only benefit from one such potion, and then can't benefit from another until you have taken a long rest."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Shadow Form",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you and everything you are carrying turn into a shadow for 1 hour. This potion's container seems to hold a black fog that moves and pours like water.",
+				"In this form, you are immune to being grappled and restrained, and to bludgeoning, piercing, and slashing damage from nonmagical weapons, but you are vulnerable to radiant damage. You can move through a space as narrow as 1 inch without squeezing. When you're in dim light or darkness, you have advantage on Dexterity (Stealth) skill rolls and can take the Hide action as a bonus action. Finally, you gain darkvision to 60 feet, if you didn't have it already.",
+				"However, you can't manipulate objects and can't attack anyone except for other creatures made of shadows, including other creatures who have consumed this potion, creatures such as {@creature shadow|mm|shadows} or {@creature shadow demon|mm|shadow demons}, and creatures native to the Shadowfell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Sleeping",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you instantly fall into a peaceful sleep for 1 hour; the potion only works on willing creatures, however. When you wake up, you gain the benefits for a long rest. The creature will be awoken early if it takes damage or someone uses an action to shake or slap it awake. In that case, the creature won't gain the benefits of this potion. You can only benefit from this potion once, and then can't benefit from another {@i potion of sleeping} until you take a long rest. This potion is a soft, restful blue color."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Sobriety",
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you sober up instantly and without a hangover, no matter how drunk you were or whether you became drunk through mundane or magical means."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Spirit-Binding",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you use your action to splash this potion on any creature with the Amorphous, Ephemeral, Ethereal Jaunt, or Incorporeal Movement trait, that creature solidifies for 10 minutes. It loses any damage resistances it had during this time, and any damage immunities it had become damage resistances. In addition, it loses immunity to the grappled and restrained conditions.",
+				"This potion looks like ether but makes a solid, clunking noise when the vial is shaken."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Tongues",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you gain the effects of the {@i tongues} spell for 1 hour. This potion is a warm purple color and has a tongue floating in it, which vanishes when you open the potion."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Truth",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink a potion, you must make a DC 15 Charisma ability check each time you want to tell a lie for the next 1d4 hours. This potion is a light gold in color and filled with bubbles that constantly form and pop; the bubbles look like little eyes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Useful Appendages",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you immediately grow new appendages, which last for 1d4 hours before withering and falling off. The appendage passes through clothing and armor as if they weren't there. The DM should roll on or pick from the following table. This potion is bone-white with streaks of pale green, and shaking the potion fails to mix the colors.",
+				"Roll a d6 on the following table to determine the appendage that is grown.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d6",
+						"Appendage",
+						"Use"
+					],
+					"rows": [
+						[
+							"1",
+							"10-foot-long prehensile tail",
+							"Can hold onto objects but can't wield weapons; can slap for 1 bludgeoning damage"
+						],
+						[
+							"2",
+							"Two extra arms, under your current arms",
+							"Can hold onto objects; you gain one additional melee or ranged weapon attack for the duration"
+						],
+						[
+							"3",
+							"Two crab claws, under your current arms",
+							"You gain one additional melee weapon attack. You have proficiency with this attack and inflict 3 (1d4) bludgeoning damage plus your Strength modifier, and the target is grappled (escape DC equal to 8 + your Strength modifier + your proficiency bonus)."
+						],
+						[
+							"4",
+							"Two 10-foot-long tentacles",
+							"Can hold onto objects but can't wield weapons; can slap for 1 bludgeoning damage, and on a hit, the target is grappled (escape DC equal to 8 + your Strength modifier + your proficiency bonus)."
+						],
+						[
+							"5",
+							"Four 10-foot-long tentacles",
+							"As per two tentacles, but grappled target has disadvantage when attempting to escape."
+						],
+						[
+							"6",
+							"Pair of wings",
+							"40-foot flying speed"
+						]
+					],
+					"colStyles": [
+						"col-xs-4 text-align-center",
+						"col-xs-4",
+						"col-xs-4"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Potion of Venom",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, you grow a pair of long fangs for 10 minutes. You are proficient in biting with these fangs. If you bite a living creature, that creature takes 1d4 piercing damage and 2d8 poison damage, and must make a DC 15 Constitution saving throw or be poisoned for 1 minute. In addition, while the potion is in effect, you are immune to poison damage and the poisoned condition. This potion is an unpleasant bile-yellow color, and it constantly burbles."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Prism of Distraction",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This scintillating prism has 3 charges. If you hold the prism up to a source of bright light, you may use your action to expend a charge and cast {@i hypnotic pattern}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Arbor",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"You can use your action to grind the token underfoot. You and everything you are carrying then polymorphs into a Large tree. This lasts for 7d12 days, during which you fall into a dream-like state. While in this form, don't need to eat, breathe, or drink—or rather, you gain your nutrients via sunlight and water, like a normal tree. At the end of that time, you will awaken in your true form.",
+				"If, while in tree form, you are damaged to the point of destruction (such as being felled by loggers), you will return to your true form with 1 hit point."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Binding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"When placed on a door, this token adheres to it and locks it with an {@i arcane lock}. For the next 24 hours, anyone besides you who touches the door is subjected to the {@i slow} spell (save DC 15). At the end of this time, the token disappears."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Bridge",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"You can use an action to toss the token over any gap 100 feet wide or narrower, and it will transform into a bridge of shimmering force. The bridge lasts for 24 hours or until you dismiss it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Crown",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"You can use an action to activate this token, which garbs you in rich, noble-looking clothing and jewelry. The token also subtly affects your features and general bearing. Although you don't look any different, you take on a more noble mien. You have advantage on any Charisma skill check used to pose as or interact with nobility At the end of 24 hours, the clothes and token disappear."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Eye",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"If you affix this token over your eye, you gain truesight to a distance of 60 feet, can see magical auras, and can see into the Ethereal Plane to that range as well. In addition, you can't be blinded while wearing this token, and if you were blind in the eye on which you placed the token, the blindness in that eye is cured."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Finger",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"You can use an action to point the finger at a location you can see within 500 feet of you, and then say “there!” You are then teleported to that location and the token disappears."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Jug (Type Ⅰ)",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"You can use an action to turn this token into a jug. It will pour out pure water at a rate of 1 gallon each round for 1d4 minutes. Once it starts pouring, it won't stop producing water. At the end of this time, the jug dissolves into water droplets."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Jug (Type Ⅱ)",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"entries": [
+				"You can use an action to turn this token into a jug. It will pour out holy water at a rate of 1 pint each round for 1 minute. Once it starts pouring, it won't stop producing water. At the end of this time, the jug dissolves into water droplets."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Key",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"If you touch a wall, this token will create a permanent hallway, 10 feet wide × 10 feet high × 100 feet long. You can decide whether you want the hallway to end when it reaches a new passageway or chamber, or if you want it to continue to its full length. Optionally, you can instead use the key to safely open any locked, barred, or sealed door without triggering any protective magic on it. After using the key, it vanishes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Spoon",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"entries": [
+				"You can use an action to turn this token into a plate of familiar, hearty food. The plate replenishes itself until it has produced enough food for 10 Medium creatures. The food can be taken off this plate and dished out to others. In addition, eating even a bite of this food will end the poisoned condition and will cure mummy rot."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quaal's Feather Token, Sword",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This token turns into a full-sized longsword, which lasts for 1 hour before vanishing."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quartermaster's Chest",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "80",
+			"entries": [
+				"This huge, ironbound chest can provide nearly limitless quantities of supplies and equipment. It provides a different object each day. When you open the box, roll a d20 on the following table to determine what is currently in the chest.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d20",
+						"Provided Supplies"
+					],
+					"rows": [
+						[
+							"1-5",
+							"Bland but nutritious food for 100 people for 1 day."
+						],
+						[
+							"6-7",
+							"Fodder for 100 horses for 1 day."
+						],
+						[
+							"8",
+							"750 feet of rope"
+						],
+						[
+							"9",
+							"30 planks of timber, each 2 inches × 6 inches × 3 feet."
+						],
+						[
+							"10",
+							"A bolt of coarse, strong white cloth, 60 feet long and 3 feet wide."
+						],
+						[
+							"11-12",
+							"Miscellaneous equipment, random items, and scraps of metal. No one piece weigh more than 5 pounds or is worth more than 1 gp. Examples include tins of armor polish, balls of string, whetstones, kindling, gaming dice, and so on."
+						],
+						[
+							"13-15",
+							"100 gallons of water."
+						],
+						[
+							"16-17",
+							"100 gallons of cheap ale."
+						],
+						[
+							"18",
+							"100 gallons of good ale."
+						],
+						[
+							"19",
+							"Extremely tasty and nutritious food for 100 people for 1 day."
+						],
+						[
+							"20",
+							"Low-quality and plain—but clean—clothing and/or blankets for 100 people and horses."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				},
+				"Food removed from the {@i quartermaster's chest} lasts for 48 hours before going bad, and liquid that isn't removed from the chest drains away and evaporates after 24 hours.",
+				"Once the chest has been used, it can't be used again until the following dawn. Anything still in the chest at that time disappears."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quill Pen of Copying",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "0.1",
+			"entries": [
+				"To use this pen, you must first create ink by burning a spell scroll and mixing the ashes with high-quality ink worth at least 5 gp per level of spell. Then, if you dip the pen in the ink and lay it on two blank pieces of paper or parchment while speaking the command word, the pen will animate and write out two copies of the spell scroll you burned. This completely uses up the ink you make. Once you use the pen, you can't use it until 7 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quill Pen of Forgery",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"To use this pen, you must first create ink by burning a piece of paper or parchment with a sample of the writing you wish to copy, then mixing the ashes with normal ink; the sample must contain at least 10 words. Then, if you dip the pen in the ink and lay it on a piece of paper or parchment while speaking the command word, the pen will write as you dictate, in a perfect copy of the writing you burned to make the ink. You can create up to 10 full sheets of writing at a time, and once you use the pen, you can't use it again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quill Pen of Long Writing",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This quill pen magically produces its own ink. You can concentrate on the pen for 1 round to make it change ink color or nib size."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quill Pen of Necromancy",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"To use this pen, you must first create ink by burning a bone (of any sort) and mixing the ashes with normal ink. Then, if you dip the pen in ink and lay it on a piece of paper and parchment which lies on top of a grave or directly on or next to a corpse (or urn containing cremated ashes), you may then use the pen to cast {@i speak with dead} on that dead person. The pen will then animate and write the answers. Once you use the pen, you can't use it again until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Quill Pen of Transcription",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"This pen may be commanded to write down all words spoken within 30 feet of it. It will continue indefinitely until told to stop or it runs out of paper or ink. Verbal spell components and the command words for magical items are transcribed as a string of meaningless characters. If multiple voices are transcribed, the quill identifies them by their apparent race and sex, and the order in which they speak (“male human #2”)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rattle of Exorcism",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "2",
+			"entries": [
+				"By shaking and rattling this symbol-painted gourd for 10 minutes while dancing around a possessed creature, you can use the gourd to cast {@i dispel evil and good}. If you have two rattles (you may attune to both and only use one attunement slot) and you cast the Dismissal version of the spell, the creature has disadvantage on its saving throw to resist you.",
+				"You may use the rattles up to two times each day: once to cast the Break Enchantment version, and once to cast the Dismissal version. Once you have cast one of those versions, you can't cast that version again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Affliction",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring grants you resistance to one damage type while wearing it, as per the ring of resistance.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This ring is cursed, and when you attune to it, it extends the curse to you. You may not remove this ring until dispel curse is cast on it."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"While wearing this ring, you have vulnerability to one damage type (rolled on the table in the description for the ring of resistance) and disadvantage on saving throws against magic from one particular school.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d10",
+						"Damage Type"
+					],
+					"rows": [
+						[
+							"1",
+							"Acid"
+						],
+						[
+							"2",
+							"Cold"
+						],
+						[
+							"3",
+							"Fire"
+						],
+						[
+							"4",
+							"Force"
+						],
+						[
+							"5",
+							"Lightning"
+						],
+						[
+							"6",
+							"Necrotic"
+						],
+						[
+							"7",
+							"Poison"
+						],
+						[
+							"8",
+							"Psychic"
+						],
+						[
+							"9",
+							"Radiant"
+						],
+						[
+							"10",
+							"Thunder"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				},
+				{
+					"type": "table",
+					"colLabels": [
+						"d8",
+						"School of Magic"
+					],
+					"rows": [
+						[
+							"1",
+							"Acid"
+						],
+						[
+							"2",
+							"Cold"
+						],
+						[
+							"3",
+							"Fire"
+						],
+						[
+							"4",
+							"Force"
+						],
+						[
+							"5",
+							"Lightning"
+						],
+						[
+							"6",
+							"Necrotic"
+						],
+						[
+							"7",
+							"Poison"
+						],
+						[
+							"8",
+							"Psychic"
+						],
+						[
+							"9",
+							"Radiant"
+						],
+						[
+							"10",
+							"Thunder"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"colLabels": [
+						"1",
+						"Acid"
+					],
+					"rows": [
+						[
+							"1",
+							"Abjuration"
+						],
+						[
+							"2",
+							"Conjuration"
+						],
+						[
+							"3",
+							"Divination"
+						],
+						[
+							"4",
+							"Enchantment"
+						],
+						[
+							"5",
+							"Evocation"
+						],
+						[
+							"6",
+							"Illusion"
+						],
+						[
+							"7",
+							"Necromancy"
+						],
+						[
+							"8",
+							"Transmutation"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Awareness",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you cannot be surprised, and you have advantage on Wisdom (Perception) checks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Bladeturning",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this weapon, you may use your reaction to attempt to deflect an incoming melee attack made by a metal weapon. By using your reaction, you may add +3 to your armor class to one attack each of your turns. You must be able to see the attack, although you don't have to be wielding a weapon yourself.",
+				"If you have the ability from either a class feature or a feat that allows you to use your reaction to parry or otherwise defend yourself from an attack by either adding your proficiency bonus to your AC or rolling a die and subtracting that amount from the damage taken, you may combine the effects of the {@i ring of bladeturning} with that ability in a single use of your reaction."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Blinking",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 5 charges and regains 1d4+1 charges each day at dawn. You may use your action to expend a charge to cast {@i blink}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Cantrips",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has a random cantrip stored within it. While attuned to this ring, you may use your action to cast that cantrip. If you’re a spellcaster, you use your own spell save DC (whether or not the cantrip is normally available to your class). Otherwise, the save DC is equal to 8 + your Charisma modifier + your proficiency bonus."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Clear Thought",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, your Intelligence increases by 1, to a maximum of 20. You also become resistant to psychic damage, immune to being charmed or frightened, and can't be put to sleep magically."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Clumsiness",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring appears to be, and functions as, a {@i ring of feather falling} or {@i ring of free action}.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This ring is cursed, and attuning to it extends the curse to you. You may not remove this ring until dispel curse is cast on it."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"When in combat with a dangerous enemy—a creature that constitutes a Medium or harder encounter difficulty for you—the ring's curse takes effect. You have disadvantage on Dexterity ability checks, Dexterity attack rolls, and Dexterity saving throws. In addition, if you have to make a concentration check when maintaining a spell, you have disadvantage on that roll.",
+				"After 1 hour, you no longer suffer from disadvantage on those rolls."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Command",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 3 charges and regains all expended charges each day at dawn. While you are wearing this ring, you may use your action to expend 1 or more charges to cast the following spells: {@i charm person} (1 charge), {@i command} (1 charge), and {@i suggestion} (2 charges)."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Depetrifaction",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"If you touch the large red ruby set in this ring to a statue of a creature that is petrified, you free that creature from that condition. Once the ring has been used, it can't be used again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Extension",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring contains 5 charges and regains 1d4+1 charges each day at dawn. You may use a bonus action to expend a charge and double the range of any spell that has a range of 5 feet or greater. Optionally, you can extend a charge and change a spell that normally has a range of Touch so that it instead has a range of 30 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Fearlessness",
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you are immune to being frightened.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This ring is cursed, and attuning yourself to the ring extends the curse to you. As long as you are cursed, you can't remove the ring."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"While cursed, you will be convinced you can handle any situation, no matter how difficult or unlikely. You won't be compelled to do anything you believe goes against your sense of morality (i.e., if you're good-aligned, you won't suddenly decide to torch an orphanage), but if it's something you normally wouldn't do because you know success was unlikely (such as stopping the rampaging dragon or challenging the archmage for leadership when you're just an apprentice), you will do it, certain that you're up to the task.",
+				"You also don't become delusional and believe you have gained new abilities, but you will be convinced you know the best way to direct your allies.",
+				"If your DM requires “common sense” ability checks at times in order to help prevent you from doing incredibly stupid things, you make these checks at disadvantage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Fire Starting, Type Ⅰ",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring is set with a large, slightly warm red gemstone and glows with a faint inner light. On command, it will shed bright light to a radius of 5 feet and dim light for a further 5 feet.",
+				"This ring allows you to cast the {@i create bonfire} and {@i control flames} cantrips."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Fire Starting, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring is set with a large, slightly warm red gemstone and glows with a faint inner light. On command, it will shed bright light to a radius of 5 feet and dim light for a further 5 feet.",
+				"This ring allows you to cast the {@i create bonfire} and {@i control flames} cantrips.",
+				"In addition to the above powers, you may use the ring to cast {@i conjure elementals}. You can only conjure fire elementals while using it. If you lose control of the elemental, it simply returns to its own plane rather than turning hostile."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Flying",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 3 charges and regains all expended charges each day at dawn. When you use an action to expend a charge, you may cast {@i fly} on yourself."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Gargoyles",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"You may use your action to command the ring to cast a variant of {@i conjure minor elementals} which causes 1d4+1 gargoyles to appear. Once you have done so, you can't do so again until the following dusk.",
+				"Additionally, as an action, you can see through one gargoyle's eyes and hear what it hears until the start of your next turn, gaining the gargoyle's darkvision. During this time, you are deaf and blind with regard to your own senses. You can use a bonus action to switch to a different gargoyle, or return to your own senses."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Glyphs",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"You may use your action to command the ring to inscribe a {@i symbol}, as per the spell. Once you have done so, you can't do so again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Immunity",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you are immune to all diseases, even diseases caused by spells such as {@i contagion} or diseases caused by curses, such as lycanthropy and mummy rot."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Light",
+			"tier": "Minor",
+			"rarity": "Common",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you can use a bonus action to cast the {@i light} cantrip."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Liquid Identification",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring is set with a clear rock crystal. If you dip the crystal in a liquid, it will change colors, depending on the nature of the liquid.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Color",
+						"Liquid Type"
+					],
+					"rows": [
+						[
+							"Red",
+							"Magical or alchemical potion"
+						],
+						[
+							"Orange",
+							"Oil or alchemist's fire"
+						],
+						[
+							"Yellow",
+							"Contaminated water"
+						],
+						[
+							"Green",
+							"Acid"
+						],
+						[
+							"Blue",
+							"Pure water"
+						],
+						[
+							"Indigo",
+							"Salt water"
+						],
+						[
+							"Violet",
+							"Alcohol of any type"
+						],
+						[
+							"White",
+							"Holy water"
+						],
+						[
+							"Black",
+							"Any poisoned liquid"
+						]
+					],
+					"colStyles": [
+						"col-xs-6",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Many Cantrips",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 1d3+1 random cantrips stored within it. While attuned to this ring, you may use your action to cast one of these cantrips. If you’re a spellcaster, you use your own spell save DC (whether or not the cantrip is normally available to your class). Otherwise, the save DC is equal to 8 + your Charisma modifier + your proficiency bonus."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Quick Action",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": "by a barbarian, fighter, ranger, or paladin",
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you have advantage on initiative rolls. If you are wearing this ring while attuned to a {@i blade of quickness} (q.v.) or a {@i scimitar of speed}, you always go first in initiative, unless you choose not to."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Readiness",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This is a set of two iron rings: one is a small ring to be worn on your finger, and the other is a larger one which must be attached to an inanimate object that weighs 100 pounds of less.",
+				"As long as you wear the smaller ring and are within 100 miles of the larger ring, you may use your action to call the larger ring and the object to which it is attached to you. If the object is a weapon, it appears in your hand. If it's a suit of armor, it appears on you (unless you're already wearing armor, in which case it appears next to you). For any other type of object, it appears on or near you in a way that facilitates it being used immediately.",
+				"You may remove the larger ring and place it on a new object at any time."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Shapechanging, Type Ⅰ",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 3 charges and regains all expended charges each day at dawn. It comes in three varieties, all of which let you use your action to cast {@i shapechange} on yourself. While in your new form, the ring merges with your new body.",
+				"This {@i ring of shapechanging} allows you to assume the form of a single type of beast of CR 4 or lower. The type of beast is set and can’t be changed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Shapechanging, Type Ⅱ",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 3 charges and regains all expended charges each day at dawn. It comes in three varieties, all of which let you use your action to cast {@i shapechange} on yourself. While in your new form, the ring merges with your new body.",
+				"This ring allows you assume the form of a single type of monstrosity that has an Intelligence of 4 or lower and a CR of 5 or lower, such as a griffon or gorgon. The type of monstrosity is set and can’t be changed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Shapechanging, Type Ⅲ",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring has 3 charges and regains all expended charges each day at dawn. It comes in three varieties, all of which let you use your action to cast {@i shapechange} on yourself. While in your new form, the ring merges with your new body.",
+				"This ring allows you to become anything you want, within the confines of the {@i shapechange} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Shocking Grasp",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While attuned to this ring, you can use your action to cast {@i shocking grasp}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Sustenance",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you need only half as much food, drink, and sleep as normal. This doesn't affect the length of time that elves (or other creatures that don't sleep) must rest or trance."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of the Fair Folk",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"This ring gives you several abilities related to fey. You can speak, read, and write Sylvan, have advantage on Intelligence (Arcana), Charisma (Deception), and Charisma (Persuasion) skill checks when dealing with fey, and on Wisdom (Survival) ability checks when you are in the Feywild.",
+				"In addition, you may use your action to use the ring to cast the following spells: {@i commune with nature}, {@i conjure fey}, {@i enlarge/reduce}, or {@i greater invisibility}. Once you have cast one of these spells, you can't cast any other spells with the ring until the following dusk."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Tongues",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While wearing this ring, you can understand, read, write, and speak all languages."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Ring of Truth",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"reqAttune": true,
+			"weight": "0.1",
+			"type": "RG",
+			"entries": [
+				"While you wear this ring, you automatically detect any deliberate lie that is told to you, but at the same time, you yourself can't lie.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"Some, but not all, of these rings are cursed, and once you wear it, you cannot take it off until {@i remove curse} or a similar spell is cast on you."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Robe of Holding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "4",
+			"entries": [
+				"This robe has 1d20+10 pockets, each of which is extradimensional and can hold up to 10 pounds.",
+				"As this employs extradimensional space, placing it inside a {@i bag of holding} or similar object causes both items to be destroyed and a rift to the Astral Plane to be opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Robe of Stone",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a druid",
+			"weight": "4",
+			"entries": [
+				"This robe has 3 charges. You may use your action to expend a charge and command the outer surface of the robe to become as hard as rock for 1 minute, giving you resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons. The robe itself remains flexible.",
+				"The robe regains all expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Robe of the Arctic Wastes",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "4",
+			"entries": [
+				"While wearing this off-white robe, you are unharmed and unhindered by nonmagical cold weather."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Robe of the Desert",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "4",
+			"entries": [
+				"While wearing this beige robe, you are unharmed and unhindered by nonmagical hot weather."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Robe of Vanishing",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"weight": "4",
+			"entries": [
+				"This robe has 3 charges. You may use your action to expend an action and pull the robe's hood over your face. This causes you to vanish into an extradimensional space, much like the one in the {@i rope trick} spell. You may remain in this space for 1 hour before being expelled from it.",
+				"Unlike the {@i rope trick} spell, you can move while in the {@i robe of vanishing}. However, your speed is halved.",
+				"The robe regains all expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rocksplitter",
+			"type": "M",
+			"axe": true,
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "S",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"You gain +2 to hit and damage with this weapon.",
+				"If you strike unworked earth or stone on the ground, you may use your action to cast {@i earthquake}. Once you use this ability, you can't use it again until the next dawn.",
+				"As long as you are attuned to {@i rocksplitter}, you won't fall prone when you cast this spell, or because of an {@i earthquake} or {@i earth tremor} spell cast by someone else, or because of a naturally-occuring earthquake."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rod of Beguiling",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This rod has 5 charges. When you hold it, you can use an action to expend a charge to cause all creatures within 20 feet to be charmed by you. A creature may make a DC 17 Wisdom saving throw to resist. If you or your allies harm a charmed creature, it may make a new saving throw, ending the effect on a success. A charmed creature views you as a friend to be trusted and heeded, and will view all your actions in the best possible light. The charm lasts for 1 hour, and afterwards, the creature isn't aware it was charmed.",
+				"The rod regains 1 expended charge daily at dawn. If the rod is reduced to 0 charges, roll a d20. On a 1, the rod disappears in a burst of radiance."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rod of Building",
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"To use this item, you must have a detailed architectural plan of a building you wish to be constructed that is no larger than 100 feet on a side. The plans should include not only the shape of the building but any designs, color schemes, and ornamentation you want the building to have. Then, using the rod, you trace the outside dimensions of the building's foundation on the ground. Upon completing this, the rod will cause the building to construct itself, brick by brick, using only the earth, air, and pure magical power as material.",
+				"The basic building is constructed at a rate of a 5-foot cube every minute, and the process continues until the entire building as depicted on your plans is built. (Ornamentation takes an additional 1 minute per 5-foot cube).",
+				"Until the building is complete, it is magical. An {@i antimagic field} or similar effect will destroy the part of the building that overlaps with the {@i field}, and a {@i counterspell}, cast with a 8th- or 9th-level spell slot, can be cast to attempt to stop the construction and destroy what has already been built.If the plans are destroyed before the building is complete, the rod stops building.",
+				"Once the building is fully constructed, the rod can't be used again for 30 days. In addition, roll a d20. On a 1, the rod falls into pieces and becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rod of Death",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This rod has 5 charges. You may use this rod as a magic club. On a successful hit, you can expend 1 or more charges to inflict an additional 30 points of necrotic damage per charge spent. If your target is undead, it inflicts radiant damage instead of necrotic damage.",
+				"A living humanoid that dies because of the necrotic damage will rise 1d4 rounds later as a zombie (it its CR was 2 or lower) or a wight (if its CR was 3 or higher). The undead is charmed by you for 24 hours, after which it stops obeying your commands. It doesn't automatically attack you, however. You can spend 1 charge to reassert control over up to two zombies or one wight you created through",
+				"You can also expend 1 or more charges to cast {@i animate dead} (1 charge), {@i create undead} (3 charges), or {@i Abi-Dalzim's horrid wilting} (5 charges).",
+				"The rod regains 1d4 expended charge daily at dawn. If the rod is reduced to 0 charges, roll a d20. On a 1, the rod crumbles to ash."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rod of Health",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a cleric",
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This rod has 3 charges. You can use your action to expend a charge to cast {@i cure wounds} (healing 3d8 hit points) or {@i lesser restoration}, or you can expend 4 charges to cast {@i greater restoration}.",
+				"The rod regains 1d3 expended charge daily at dawn. If the rod is reduced to 0 charges, roll a d20. On a 1, the rod crumbles to ash."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rod of Justice",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This iron rod functions as a {@i mace +1}. On command, you can choose to force your target to make a 17 Constitution saving throw instead of taking damage. On a failure, the creature is paralyzed for 1 minute. It may attempt a new save at the end of each of its turns, ending the effect on itself on a success."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rod of Terror",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This twisted wood-and-bone rod functions as a {@i mace +1}. On command, you can create a terrifying aura with a radius of 30 feet. All creatures in that area that can see you will see a phantasmal image of you, altered to be a representation of their worst nightmares. Each creature must make a DC 18 Wisdom saving throw. On a failure, the creature is frightened of you. Its speed is reduced to 0 feet for 1 minute, and it takes 33 (6d10) psychic damage. It may make a new saving throw at the end of each of its turns, ending the effect on itself on a success."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Rudder of Guidance",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "4",
+			"entries": [
+				"If properly mounted on a ship larger than a rowboat, that ship cannot be forced off-course due to a change in winds or currents. These rudders can also be used on airboats and landboats with the same effect."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sacred Bundle",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a barbarian, druid, fighter, or ranger",
+			"weight": "2",
+			"entries": [
+				"When wearing this bundle, you have advantage on all saving throws, cannot be surprised, and gain a +1 bonus to your AC."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Saddle of Flying",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Uncommon",
+			"weight": "25",
+			"entries": [
+				"When used to saddle a mount, you may say the command word and it will sprout a pair of wings. These wings will last for 1 hour and grant the mount a flying speed of 60 feet. If the mount is still in the air when the hour is up, it will slowly sink to the ground before the wings vanish. Once you use this ability, you can't use it again until the next dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Saddle of the Spirit Horse",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "25",
+			"entries": [
+				"If worn by a horse or other mount (but not a steed summoned via {@i find steed} or {@i find greater steed}, or a {@i phantom steed}), and the mount dies while saddled, the spirit of the horse will awaken and continue to serve you for 24 hours.",
+				"The spirit-horse is visible only as a faintly transparent shape. It is completely ephemeral, except for its ability to hold the saddle and take riders, and can't attack. It hovers a few inches off the ground, allowing it to run across liquids and difficult terrain as if it were normal terrain. If it could fly in life, it retains that ability, but otherwise must run along the ground.",
+				"If you deliberately killed the horse (or had someone else kill it for you), or were cruel to the horse is its life, it will wait until the worst possible time then buck you off, carry you straight to your enemies, run off a cliff, or enact some other sort of revenge. Otherwise, the spirit-horse obeys you completely and tirelessly; it doesn't need to rest and can run at full speed for the entire 24 hours."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scabbard of Holding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "2",
+			"entries": [
+				"This scabbard looks only big enough to hold a large knife, but in fact can hold any sort of bladed weapon in an extradimensional pocket. While the weapon is sheathed, the hilt appears to be knife-sized.",
+				"As this employs extradimensional space, placing it inside a {@i bag of holding} or similar object causes both items to be destroyed and a rift to the Astral Plane to be opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scarf of the Dry Steppes",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.51",
+			"entries": [
+				"While wearing this gauzy brown cloth, you may command it to summon 1d4+1 {@creature invisible stalker|mm|invisible stalkers}. These stalkers will follow your commands for 24 hours, then leave. Once you have used this ability, you can't use it again until 7 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scepter of Truth",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "2",
+			"type": "RD",
+			"entries": [
+				"This rod is intricately carved out of fine wood and decorated with gold and silver leaf. While holding it, you can't lie and will always speak the whole truth."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll Case of Holding",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.51",
+			"entries": [
+				"This scroll case can hold up to 100 scrolls. If the scrolls have titles, they will be put in alphabetical order on your command."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Communication",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"type": "SC",
+			"entries": [
+				"This is a pair of scrolls. If you write a message of up to 100 words on one scroll and then speak the command word, the message will appear on the other scroll, exactly as you had written it. Both scrolls must be on the same plane for this to work.",
+				"You or the holder of the second scroll can speak another command word and cause both scrolls to be erased. Each time you do so, roll a d20. On a 1, the scroll shreds and becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Creation",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"type": "SC",
+			"entries": [
+				"You may draw a picture on this scroll of any non-magical, non-living, inanimate object of Medium size or smaller, then lift the drawing off the scroll. The drawing then becomes a real object, which remains in existence for 24 hours or until you dismiss it. Once you draw a picture on this scroll, you can't use the scroll again for 2 days."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Curses",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"type": "SC",
+			"entries": [
+				"Whether due to mistake made while writing a spell scroll, or a deliberate attempt to sabotage future readers, some scrolls have curses laid on them. The scroll appears to be a normal spell scroll of any type until it's read. An {@i identify} will reveal its true nature.",
+				"The curse is identical to those produced by certain spells, but the duration is usually a lot longer.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d10",
+						"Curse"
+					],
+					"rows": [
+						[
+							"1-5",
+							"Roll a d4. That number is subtracted from every attack roll {@i or} saving throw (DM's choice) the reader makes for the duration."
+						],
+						[
+							"6-10",
+							"Every weapon attack that hits the reader inflicts an additional 2 (1d4) necrotic damage."
+						],
+						[
+							"11-13",
+							{
+								"entries": [
+									"The reader has disadvantage on ability checks and saving throws made with one ability score. Roll a d6 to determine the ability:",
+									"{@b 1:} Strength.",
+									"{@b 2:} Dexterity.",
+									"{@b 3:} Constitution. ",
+									"{@b 4:} Intelligence. ",
+									"{@b 5:} Wisdom. ",
+									"{@b 6:} Charisma."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"14-16",
+							"The reader has disadvantage on attack rolls made with one ability score. Roll a die. On an odd number, it's on all Strength-based attacks. On an even roll, it's on all Dexterity-based attacks."
+						],
+						[
+							"17-19",
+							"During combat or in another stressful situation, the reader must make a DC 15 Wisdom saving throw at the start of each of its turns. On a failure, it wastes its action that turn doing nothing."
+						],
+						[
+							"20",
+							"The reader must make a DC 17 Wisdom saving throw or be placed under a {@i geas} that was deliberately written into the scroll. The DM determines the wording of the {@i geas}."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				},
+				"Roll a d20 to determine the curse's duration:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d10",
+						"Duration"
+					],
+					"rows": [
+						[
+							"1-6",
+							"1 minute"
+						],
+						[
+							"7-12",
+							"10 minutes"
+						],
+						[
+							"13-16",
+							"1 hour"
+						],
+						[
+							"17-19",
+							"1 day"
+						],
+						[
+							"20",
+							"Permanent"
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				},
+				"The curse can be ended early with a {@i remove curse} or {@i greater restoration} spell."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Equipment, Type Ⅰ",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"type": "SC",
+			"entries": [
+				"This scroll has the names of six random, nonmagical, common but generally useful items written on it (typically, anything that can be found in the {@i Player's Handbook} that costs less than 25 gp).",
+				"You may use your action to speak the name of one of the objects on it. Doing so causes the name of the item to vanish from the scroll and the actual object to appear in your hand. Once all six items have been removed from the scroll, the scroll tears and becomes nonmagical. Objects, once created, are permanent, but a {@i dispel magic} will cause them to vanish, as will bringing them into an {@i antimagic field}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Equipment, Type Ⅱ",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"type": "SC",
+			"entries": [
+				"This scroll has the names of six random, nonmagical, common but generally useful items written on it (typically, anything that can be found in the {@i Player's Handbook} that costs less than 25 gp).",
+				"You may use your action to speak the name of one of the objects on it. Doing so causes the item to appear in your hand, and the name of the object is crossed off. After 5 days, the object’s name uncrosses itself and it can be summoned again.",
+				"If you cross off the sixth item before previously-summoned items have had the chance to become available again, roll a d20. On a 1, the scroll tears and becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Illumination",
+			"tier": "Minor",
+			"rarity": "Common",
+			"type": "SC",
+			"entries": [
+				"This small piece of parchment usually comes in sheaves of 2d4 and bears a drawing of a flame. If you set the scroll on fire, it will burn cleanly for 6 hours. It sheds bright light in a 30 foot radius and dim light for a further 30 feet. At the end of 6 hours, the parchment will burn into ashes.",
+				"You can command the scroll to extinguish itself at any time (no action required by you) as long as you can see it. It can't be extinguished by any mundane means, although it's otherwise a normal flame."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Shelter",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"type": "SC",
+			"entries": [
+				"This scroll has a drawing of a door. If you hang the scroll on a solid, upright surface, such as a wall or a tree, and speak the command word, the door enlarges, allowing you and your companions to enter.",
+				"Inside is an area identical to that produced by {@i Leomund's tiny hut}, with the exception that it is extradimensional space. The doorway remains in existence for 8 hours, at which point you are ejected from the room. You may also exit the room at any time. When all creatures have left the room, the scroll turns to ash.",
+				"As this employs extradimensional space, bringing a bag of holding or similar object into the {@i scroll of shelter} causes both items to be destroyed and a rift to the Astral Plane to be opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scroll of Suggestion",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"type": "SC",
+			"entries": [
+				"In order to use this scroll, you must write an official pronouncement, missive, or other similar document, which must be legally, socially, or religiously enforceable. Hidden within the proclamation is a magical {@i suggestion}, which, as per the spell, must be worded in a way to make it reasonable. Anyone who reads the scroll must make a DC 15 Wisdom saving throw or fall under the sway of the {@i suggestion}. The suggestion remains in effect for 1 week."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Scythe",
+			"rarity": "None",
+			"value": "2gp",
+			"weight": "5",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"dmg1": "1d8",
+			"dmgType": "S",
+			"type": "M",
+			"property": [
+				"2H"
+			],
+			"entries": [
+				"Druids and warlocks are proficient in scythes."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Seed of Growth",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.51",
+			"entries": [
+				"A packet of {@i seeds of growth} usually contains 1d6+8 seeds. When a seed is placed on any solid surface, it grows, in 1 round, into a {@creature needle blight|mm}, although it's alignment is neutral. The needle blight is under your command for 1 hour, after which it crumbles into decaying vegetable matter."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Shadowsword",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"This weapon has a very dark, matte blade; it has no tell-tale glint of steel that might betray a wielder who is lurking in the shadows.",
+				"In bright light, the sword is considered magical for purposes of overcoming damage resistance. In dim light, you gain +1 to attack and damage rolls. In darkness, you gain +2.",
+				"In addition, this weapon has 3 charges and regains all expended charges each day at dawn. While holding the sword, you may use your action to expend a charge and cast {@i invisibility} on yourself.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item shortsword|phb}",
+								"{@item rapier|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Shield of Absorption",
+			"type": "S",
+			"rarity": "Uncommon",
+			"weight": "6",
+			"ac": 2,
+			"tier": "Minor",
+			"armor": true,
+			"entries": [
+				"If you are hit with an attack that would reduce your it point maximum or one of your attributes, your shield instead absorbs the attack. You take normal damage, but your hit point or attribute maximums remain untouched.",
+				"Whenever the {@i shield of absorption} absorbs such an attack, roll a d20. On a 1, the shield crumbles to rust and shards of metal and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Shield of the Medusae",
+			"type": "S",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"ac": 2,
+			"tier": "Major",
+			"armor": true,
+			"entries": [
+				"This shield has a mirror finish on the outside surface, and the inside surface is transparent. You can hold the shield up to hide your eyes, preventing you from be subjected to a gaze attack, while still being able to see well enough to attack without penalty.",
+				"In addition, any attack that inflicts radiant damage rebounds. If the attacker was within 5 feet of you, it takes the amount of damage it would have inflicted on you. If it was within 30 feet of you, it takes half as much damage.",
+				"Finally, you are immune to being blinded while wielding this shield."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Shimmering Sash",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "1",
+			"entries": [
+				"This strip of cloth is woven from metallic threads that have an oil-slick rainbow sheen. It has 3 charges and regains all expended charges each day at dawn. When wearing this sash, you may use your action to expend a charge and cast {@i blur} on yourself."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Shovel of Animation",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "5",
+			"entries": [
+				"If you use this shovel to dig up a buried corpse at night, the shovel animates it into either a zombie or skeleton, as if it had cast {@i animate dead} on the corpse. Once you use this ability, you can't use it again until the following dusk.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This shovel is cursed, and attuning to it extends the curse to you. As long as you are attuned to the shovel, the undead will remain under your control. You can choose to end the attunement to it at any time. As soon as the attunement ends, however, the undead you create with it will turn on you and attack."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Shovel of Digging",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "5",
+			"entries": [
+				"This shovel has 7 charges. You can use your action to expend a charge and animate the shovel, which will begin digging by itself, under your direction. It can excavate a 5-foot cube of soil, sand, or loose rubble each round, and each charge lasts 1 minute.",
+				"The shovel regains 1d6+1 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Signaling Arrow",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Common",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"When used to attack, this arrow inflicts an additional 1 point of fire damage, and the target must make a DC 13 Constitution saving throw or be blinded until the end of its next turn.",
+				"If fired into the air, it will trail glittering, colored smoke behind it. The color is indicated by the color of the arrow's fletching and can be any color. Once the arrow reaches a height of 300 feet, it will explode into a sphere of bright, colored light, which can be seen up to a mile away."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Silver Chalice",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"entries": [
+				"This chalice has 3 charges and regains all expended charges each day at dawn. You may spend your action to expend a charge and have the chalice fill with a pint of any nonmagical liquid, including acids and poisons."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Skeletal Potion",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"When you drink this potion, your flesh, muscles, and organs become invisible, as does all organic materials you are wearing, such as cloth or leather. Your skeleton remains clearly visible. This lasts for 1d4 hours. This is an illusion, and physical interaction with you will reveal that your body is still there. Otherwise, it requires a DC 17 Intelligence (Investigation) check to reveal that you aren't actually a skeleton. The potion is crystal clear but has human finger bones floating in it. The bones disappear when the potion is opened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Skull Mask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"While wearing this item, you are immune to the frightened and paralyzed conditions and have resistance to necrotic damage. You are also immune to all diseases, including magical diseases or diseases caused by curses, such as lycanthropy and mummy rot. Your hit point maximum can't be reduced. Finally, if you see a creature that has been petrified, you can recognize it as being a petrified creature and not just a statue.",
+				{
+					"items": [
+						{
+							"name": "Curse",
+							"entries": [
+								"This item is cursed, and attuning to it extends the curse to you. Removing the mask doesn't end the curse. While you are attuned to the {@i skull mask}, you can't hide from undead through magical or mundane means, and undead will always attack you first."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Slingstone of Pulverizing",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Rare",
+			"weight": "0.075",
+			"tier": "Minor",
+			"entries": [
+				"These slingstones are usually found in bags containing 2d4 stones. If fired at a structure or object, it inflicts 21 (6d6) bludgeoning damage. It inflicts normal damage to creatures."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Slippers of Kicking",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a monk",
+			"weight": "1",
+			"entries": [
+				"When wearing these slippers, you get a +2 to attack and damage rolls when kicking or otherwise attacking with your feet and legs."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Snake Staff, Type Ⅰ",
+			"type": "M",
+			"technology": "Staff",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "4",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "B",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This is a {@i quarterstaff +1}, usually carved with twining serpents.",
+				"On command, you can cause it to assume the form of either a {@creature constrictor snake|mm} or a {@creature poisonous snake|mm}. It will remain in that form for 1 minute or you dismiss it, at which point it will turn back into a snake. If killed in snake form, it will return to staff form, broken and no longer magical. It heals all damage while in staff form."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Snake Staff, Type Ⅱ",
+			"type": "M",
+			"technology": "Staff",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "4",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "B",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This is a {@i quarterstaff +1}, usually carved with twining serpents.",
+				"On command, you can cause it to assume the form of either a {@creature giant constrictor snake|mm} or a {@creature giant poisonous snake|mm}. It will remain in that form for 1 minute or you dismiss it, at which point it will turn back into a snake. If killed in snake form, it will return to staff form, broken and no longer magical. It heals all damage while in staff form."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spear of Accuracy, Type Ⅰ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "3",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "P",
+			"property": [
+				"T",
+				"V"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This spear grants you a +1 bonus on attack and damage rolls.",
+				"If you throw this weapon, you have advantage on that roll, and it has a range of 40/120 feet. If you use the spear in melee combat, you don’t have advantage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spear of Accuracy, Type Ⅱ",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "3",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "P",
+			"property": [
+				"T",
+				"V"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This spear grants you a +1 bonus on attack and damage rolls.",
+				"If you throw this weapon, you have advantage on that roll, it has a range of 40/120 feet, and the spear will return to your hand at the end of your turn. If you use the spear in melee combat, you don’t have advantage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spear of Paralysis",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Legendary",
+			"weight": "3",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "P",
+			"property": [
+				"T",
+				"V"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"entries": [
+				"If you hit a creature that is not a construct, elemental, or undead with this weapon in melee combat, it must make a DC 15 Constitution saving throw or be paralyzed until the beginning of its next turn.",
+				"You can also choose for it to be paralyzed for 24 hours on a failed saving throw. Once the spear has paralyzed a creature for that length of time, it won't do so again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spellblade",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"These swords are keyed to a single, specific damaging spell. If you are wielding the sword and that spell is cast at you, you can make a ability check using the attribute you are using to wield the weapon against the caster's spell save DC. If successful, it negates the spell. After doing so, for the next minute, your sword inflicts an additional 4 (1d8) damage of the type inflicted by the spell you just absorbed.",
+				"The {@i spellblade} can negates that spell regardless of its origin. For instance, a {@i spellblade} keyed to {@i fireball} could negate a {@i fireball} created by the spell, one created by a {@i wand of fireballs}, or one created through a death slaad's Innate Spellcasting. It couldn't negate any other type of spell, including a {@i delayed blast fireball}.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item shortsword|phb}",
+								"{@item longsword|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spider Fang",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "1",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This long, thin dagger inflicts an additional 2 (1d4) poison damage on a successful attack. In addition, it has 6 charges. You may use your action to expend 1 charge and cast {@i web}, or to completely destroy all magical and nonmagical webbing in a 10-foot cube. Finally, you ignore movement restrictions caused by webbing.",
+				"The dagger regains 1d6 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spirit Oil",
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If you anoint a corpse with this oil, you can speak with its spirit as if you had cast {@i speak with dead}."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spirit Skull",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "3",
+			"entries": [
+				"This is a skull of a large horned animal, painted with runes an decorated with feathers, polished stones, and strips of leather. To use this item, you must first hang the skull from a tree or place it on a shrine for 7 days. At that point, one or more local nature spirits take up residence within it.",
+				"You may use the spirit skull in the following ways:",
+				{
+					"items": [
+						{
+							"name": "Area Knowledge",
+							"entries": [
+								"The spirit skull has intimate knowledge of the land within 1/2 mile of it and will answer your questions about it. It effectively has a +8 bonus in the History, Medicine, Nature, and Survival skills."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Alarm",
+							"entries": [
+								"The spirit skull becomes aware of all powerful creatures and intelligent beings closeby. If a new creature comes within 1/2 mile of the skull, it will transmit a mental cry only you can hear."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Provenance",
+							"entries": [
+								"If you bring an item to the spirit skull, you can use it to cast {@i legend lore} on the item. If you bring a living, intelligent creature to it, you can use it to cast {@i zone of truth}, centered on itself. Once you have cast one of those spells, you can't cast that spell again until the following dawn."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Spoon of Medicine",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"If you use this spoon to feed a spoonful of honey to a creature, that creature is cured of all nonmagical diseases, as if {@i lesser restoration} had been cast on it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Battle",
+			"type": "M",
+			"technology": "Staff",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "4",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "B",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This {@i quarterstaff +1} has several abilities. While wielding this weapon, you have resistance to force and thunder damage. In addition, when you successfully hit with this weapon, you may cast {@i booming blade} with it, inflicting 4 (1d8) thunder damage. You may only do this once per turn, no matter how many attacks you make.",
+				"Finally, this staff has 5 charges and regains 1d4+1 expended charges each day at dawn. You may use your action to expend 1 or more charges to cast {@i thunderwave} (1 charge) or {@i antilife shell} (5 charges). If you expend the last charge, roll a d20. On a 1, the staff becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Conjuration",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a bard, cleric, druid, sorcerer, warlock, or wizard",
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"This staff has 5 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells: {@i conjure animals} (1 charge), {@i conjure elementals} (4 charges), {@i conjure minor elementals} (2 charges), {@i Evard's black tentacles} (3 charges), or {@i summon lesser demons} (1 charge; you may also choose to summon one will-o'-wisp instead of a demon, but the spell is otherwise the same).",
+				"In addition, you can expend 2 charges to cancel a {@i protection from evil and good} spell within 30 feet of you.",
+				"The staff regains 1d4+1 expended charges each day at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff and whatever creature you summoned will instantly turn on you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Devotion",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a cleric",
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"This staff has 10 charges. While holding it, you can use an action to expend 1 or more of its charges to cast one of the following spells, using your spell save DC: {@i bless} (1 charge), {@i create food and water} (3 charges), {@i cure wounds} (1 charge per 1d8 hit points restored), {@i divine word} (7 charges), {@i enthrall} (2 charges), {@i flame strike} (5 charges), {@i greater restoration} (5 charges), {@i legend lore} (5 charges), {@i lesser restoration} (2 charges), {@i protection from evil and good} (1 charge), {@i purify food and drink} (1 charge), {@i remove curse} (3 charges)",
+				"The staff regains 1d8+2 expended charges each day at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Dispelling",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": true,
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"This staff has 9 charges. You may use your action to touch an object or creature and expend 1 or more charges to cast {@i dispel magic}. You automatically dispel any ongoing magical effect whose level is equal to or less than the number of charges you expend.",
+				"The staff regains 1d6 charges each day at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes a nonmagical quarterstaff."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Harming",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"This staff has 7 charges. You may use your action and expend 1 or more charges to cast one of the following spells: {@i blindness/deafness} (2 charges), {@i contagion} (5 charges), {@i harm} (6 charges), or {@i inflict wounds} (1 charge per 1d8 damage).",
+				"The staff regains 1d6+1 charges each day at dusk. If you expend the last charge, roll a d20. On a 1, the staff becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Night",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"While attuned to this staff, you have darkvision to 120 feet. This staff has 5 charges. You may use your action to expend a charge and dispel any magical light created by a spell of 3rd level or lower. You can also expend 1 or more charges to cast {@i darkness} (1 charge), {@i maddening darkness} (5 charges), or {@i moonbeam} (1 charge).",
+				"Finally, you use your action to summon an {@creature umber hulk|mm}. The umber hulk is friendly to you and your companions and will obey your verbal commands. It will remain for 10 minutes or until it drops to 0 hit points. During this time, you are immune to the umber hulk's Confusing Gaze. After 10 minutes, the umber hulk will depart. Once you use this ability, you can't use it again until 7 days have passed.",
+				"The staff regains 1d3 charges each day at dusk. If you expend the last charge, roll a d20. On a 1, the staff becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of Spell Focusing",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a sorcerer, warlock, or wizard",
+			"weight": "4",
+			"technology": "Staff",
+			"entries": [
+				"You can use this staff as an arcane focus. This staff has 5 charges. You can use your bonus action to expend 1 charge and cause one spell you cast before the end of your next turn to be extremely potent: If the spell requires an attack roll in order to affect your target, you have advantage on that roll. If the spell requires a saving throw in order to affect your target, your target has disadvantage on that roll.",
+				"In addition, you can use a bonus action to expend 2 charges and nullify a target's Magic Resistance until the end of your next turn.",
+				"The staff regains 1d6+1 charges each day at dawn. If you expend the last charge, roll a d20. On a 1, the staff becomes nonmagical."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff of the Ninja",
+			"type": "M",
+			"technology": "Staff",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "B",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This is a {@i quarterstaff +1}. While wielding it, you have advantage on Dexterity (Acrobatic) rolls. You can also use a bonus action to command it to transform into a dagger, glaive, longsword, or spear. In each of these forms, it retains its +1 bonus, and will remain in this altered form 10 minutes before change back into a staff.",
+				"In addition, this staff has 5 charges. You may use your action to expend 1 or more charges to cast the following spells: {@i pass without trace} (1 charges), {@i passwall} (4 charges), or {@i water walk} (2 charges).",
+				"If the {@i staff of the ninja} is in one of its other, bladed forms, you can also use your action to expend 2 charges and envenom the blade. For the next minute, it inflicts an additional 7 (2d6) poison damage with each successful hit.",
+				"The staff regains 1d4+1 charges each day at dusk. If you expend the last charge, roll a d20. On a 1, the staff breaks."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Staff-Mace",
+			"type": "M",
+			"technology": "Staff",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Very Rare",
+			"weight": "4",
+			"dmg1": "{@dice 1d6}",
+			"dmg2": "{@dice 1d8}",
+			"dmgType": "B",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This is a wooden {@i quarterstaff +1}, banded and topped with iron. You can use a bonus action to cause it to transform between its normal quarterstaff form, a walking stick, or a {@i maul +1}. It will remain in walking stick form indefinitely, or in maul form for 10 minutes before changing back into a staff. If you have proficiency with quarterstaves, you magically have proficiency in this weapon when it's in maul form, even if you aren't normally proficient in it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Stair of Ascending and Descending",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"entries": [
+				"This is a wooden board, roughly 5 feet by 1 foot by 1/2-inch thick. It has 3 charges and regains all expended charges each day at dawn. You may place the board on the ground and use your action to expend a charge, and the board will turn into a staircase that will ascend or descend (your choice) one story (up to a maximum of 20 feet). It will pass through ceilings or floors as if {@i passwall} had been cast, allowing the stair's users to walk unimpeded.",
+				"On a second command, the staircase will vanish, and either the topmost stair (for an ascending staircase) or the bottommost stair (for a descending staircase) will remain, allowing you to pick it up and move it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sticky Shield",
+			"type": "S",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"ac": 2,
+			"tier": "Major",
+			"reqAttune": true,
+			"armor": true,
+			"entries": [
+				"When you are attacked by someone wielding a melee weapon, and your attacker fails its attack roll by 5 or more, or rolls a natural 1, that weapon is stuck to the shield and can't be pulled loose with anything less than a {@i wish} or your command; however, it drops off of its own volition 1 hour later. No matter how many weapons are stuck in the shield, the shield doesn't become heavier or unwieldy.",
+				"If a magical weapon is stuck in the shield, the shield's AC bonus increases by +1, to a maximum of +3, for as long as they remain in the shield."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Stirge's Bite",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Very Rare",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"When this arrow hits a living being, it inflicts an additional 5 (1d10) necrotic damage and reduces the target's hit point maximum by the amount of necrotic damage inflicted. In addition, some of the target's blood is drained into a hollow compartment in the arrow, where it will be kept fresh for up to 1 week. The arrow will detach from its target in 1 round. If reclaimed, the blood can be drained from it into another container to be used for whatever purpose you choose. The arrow can be reused.",
+				"The target's hit point maximum is restored after a Short or Long Rest."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Storm Hammer",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Very Rare",
+			"weight": "2",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "B",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"When this {@i warhammer +1} strikes an opponent, it makes a noise like a crash of thunder. The target must make a DC 15 Constitution saving throw or take 3 (1d6) thunder damage. If you roll a critical hit when attacking with this weapon, your target is also deafened for 1 minute."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Storm Star",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d8}",
+			"dmgType": "P",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This is a {@i morningstar +2} made of a very dark metal. While in battle, you may use it to cast {@i chain lightning} (save DC 17). Once you use this ability, you can't use it again until the following dawn.",
+				"If you are currently outdoors and in heavy rain, you may also use your action to cast the {@i thunderclap} cantrip, using the above save DC and inflicting 10 (3d6) thunder damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "String of Warding, Type Ⅰ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "1",
+			"entries": [
+				"This is a piece of string that can be stretched up to 50 feet. If tied to two or more posts, trees, or other upright items, it creates a magical ward. This ward makes it difficult for living beings to pass through it, but doesn't hinder inanimate objects (including missile weapons), spells, constructs, or undead. The string can be untied and reused.",
+				"Passing through this ward requires a DC 13 Strength saving throw and takes up 10 feet of movement.",
+				"The string can be cut. It has AC 15, 10 hit points, is resistant to all forms of damage except or fire and slashing damage, and is immune to poison and psychic damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "String of Warding, Type Ⅱ",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "1",
+			"entries": [
+				"This is a piece of string that can be stretched up to 50 feet. If tied to two or more posts, trees, or other upright items, it creates a magical ward. This ward makes it difficult for living beings to pass through it, but doesn't hinder inanimate objects (including missile weapons), spells, constructs, or undead. The string can be untied and reused.",
+				"Passing through this ward requires a DC 17 Strength saving throw and takes up 15 feet of movement.",
+				"The string can be cut. It has AC 15, 10 hit points, is resistant to all forms of damage except or fire and slashing damage, and is immune to poison and psychic damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sweet Water",
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"If drunk, this clear, silvery potion provides a day's worth of water.",
+				"The {@i potion of sweet water} is meant to be poured into water. It will turn a cube of fouled or salt water up to 100 feet on a side into pure, drinkable water which is immune to further pollution or being turned back into salt water for 8 hours. It can also turn a cube of acid up to 20 feet on a side into pure water."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sword of Blackflame",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "2",
+			"dmg1": "{@dice 1d8}",
+			"dmgType": "P",
+			"property": [
+				"F"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"The blade of this {@i rapier +2} constantly shimmers with clouds of black and white. In dim light and darkness, the blade is invisible to every creature but its wielder.",
+				"This sword has 5 charges. You may use your action to expend a charge and cast {@i silence}, centered on the sword.",
+				"If, while wielding this weapon, you are hit with a magical spell that requires an attack roll, you can expend 1 charge and absorb the attack. The spell will remain in the sword for 1 minute. During that time, you may use your action to release the spell at another target you choose, using the original caster's attack bonus to hit. If you don't release the spell within a minute, the magical energies dissipate.",
+				"The sword regains 1d4+1 expended charges each day at dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sword of Cleaving",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Very Rare",
+			"weight": "6",
+			"dmg1": "{@dice 2d6}",
+			"dmgType": "S",
+			"property": [
+				"H",
+				"2H"
+			],
+			"tier": "Major",
+			"reqAttune": "by a creature with a strength of 18 or higher",
+			"entries": [
+				"When you score a critical hit with this {@i greatsword +1}, you roll the damage dice three times instead of twice. In addition, this sword inflicts double damage to objects and structures."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sword of Insanity",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Very Rare",
+			"weight": "2",
+			"dmg1": "{@dice 1d6}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"L"
+			],
+			"tier": "Major",
+			"entries": [
+				"This sword has a strangely curved and wavy shape. It inflicts an additional 4 (1d8) psychic damage on a successful hit.",
+				"If you roll a natural 20 when attacking with this sword, it releases a burst of psychic energy. Each creature within 30 feet of you that has an Intelligence of 4 or higher must succeed on a DC 17 Intelligence saving throw or take 22 (4d10) psychic damage and be stunned for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Sword of Intercession",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "3",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "S",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"Each of these swords is tied to a specific deity. A worshipper of that god (not necessarily a cleric) may use this weapon with proficiency, even if it's not normally proficient in longswords, and in the worshipper's hands, it is a {@i longsword +2}, and it grants a +2 bonus to all Wisdom saving throws against magic. Finally, you may use it to cast {@i commune}. Once you have done so, you can't do so again until 7 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Table of Plenty",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"This is a plain wooden table, 1 inch high and 5 inches long. On command, it expands to a full-sized dining table with four chairs. If a creature raps on the tabletop, a plate of simple food, slightly more flavorful than that created by the {@i create food and water} spell. Once four meals have been made in this manner, no more meals can be made until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Talisman of Memorization",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"reqAttune": "by a wizard",
+			"weight": "0.1",
+			"entries": [
+				"While attuned to this talisman, you can prepare spells in half the time: 1/2 minute per spell level."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Talisman of the Cockatrice",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"This talisman consists of a magically preserved cockatrice's foot. While wearing it, you are immune to the petrified condition. If you touch a creature with the talisman, that creature must make a DC 15 Constitution saving throw or be petrified for 1 hour. Once you use it in that manner, you can't do so again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Talisman of Tongues",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"reqAttune": true,
+			"weight": "0.1",
+			"entries": [
+				"While wearing this talisman, you can understand any spoken language, and anyone you speak to who has a language of its own can understand you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Thorn of Sleep",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"When a living creature is pricked by this thorn, it must make a DC 15 Constitution saving throw. On a failure, the creature succumbs to the Slumber variant of the {@i imprisonment} spell. Once you use the {@i thorn}, you can't use it again until 7 days have passed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Thought Bottle",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "1",
+			"entries": [
+				"By uncorking this metal flask and thinking very strongly about a particular memory, then speaking a command word, the memory is taken from your mind and stored securely within the bottle. You will remember the gist of it, but not specific details.",
+				"If you later concentrate on the bottle for 1 minute, you can call up any memory stored in it, even if it wasn't originally your memory. Doing so removes the memory from the bottle. The bottle can store up to 10 memories at a time.",
+				"When found, a {@i thought bottle} is likely to already have 1d6 memories already in it."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Throwing Star of Returning",
+			"type": "R",
+			"weapon": true,
+			"weaponCategory": "Simple",
+			"rarity": "Rare",
+			"weight": "0.25",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "P",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"tier": "Minor",
+			"entries": [
+				"These throwing stars usually come in sets of 3. If thrown, this throwing star will return to your hand if it misses. If you retrieve the star, you can use it again."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Thunderbolt",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Very Rare",
+			"weight": "0.075",
+			"tier": "Major",
+			"entries": [
+				"After being fired from a crossbow, a {@i thunderbolt} transforms into a bolt of lightning. On a hit, the target takes 22 (4d10) lightning damage, and all creatures within 5 feet of the target must make a DC 15 Constitution saving throw or be stunned until the end of its next turn and deafened for 1 minute due to the accompanying crash of thunder. A deafened creature may attempt a new saving throw at the end of each of its turns, ending the effect on itself on a success."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Torch of Continual Flame",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Common",
+			"weight": "1",
+			"entries": [
+				"This is a torch on which {@i continual flame} has been cast. While normally as bright as any torch (shedding bright light in a 20-foot radius and dim light for an additional 20 feet), you can also dim it until it's half as bright, or so that it only sheds dim light in a 5 foot radius. You can't extinguish this torch."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Tribal Lance",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Rare",
+			"weight": "6",
+			"dmg1": "{@dice 1d12}",
+			"dmgType": "P",
+			"property": [
+				"R",
+				"S"
+			],
+			"entries": [
+				"This is a {@i lance +1}. It has 5 charges and regains 1d4+1 charges each day at dawn. You may use your action to expend a charge and cast {@i cause fear} on any creature you are facing in battle (or in a mock battle, such as a joust)."
+			],
+			"tier": "Major",
+			"reqAttune": "by a barbarian",
+			"source": "EnMa"
+		},
+		{
+			"name": "Troll's Bane",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Rare",
+			"weight": "3",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "S",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This sword typically has a fiery design etched into the blade or sculpted on the hilt. The wounds inflicted by this {@i longsword +1} prevent a troll (or other creature with the Regeneration trait) from regenerating the following round, as if it had taken fire damage."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Undeadbane",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a priest",
+			"weapon": true,
+			"type": "GV",
+			"entries": [
+				"This weapon gives you a +1 bonus to attack and damage rolls. When you score a critical hit against an undead, you roll the damage dice three times instead of twice.",
+				"In addition, if you are holding this weapon when attempting to turn an undead, the undead has disadvantage on its saving throw.",
+				{
+					"type": "entries",
+					"name": "Base items",
+					"entries": [
+						"This item variant can be applied to the following base items:",
+						{
+							"type": "list",
+							"items": [
+								"{@item mace|phb}",
+								"{@item maul|phb}",
+								"{@item morningstar|phb}"
+							]
+						}
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Unseen Ship's Crew",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Legendary",
+			"weight": "0.1",
+			"entries": [
+				"This is a bosun's whistle that, when blown, summons a crew of fifty {@i unseen servants}. These {@i servants} know how to man a ship and will work for 8 hours before vanishing. Once this item is used, it can't be used again until the following dawn."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Vampiric Sword",
+			"type": "M",
+			"weapon": true,
+			"sword": true,
+			"weaponCategory": "Martial",
+			"rarity": "Very Rare",
+			"weight": "3",
+			"dmg1": "{@dice 1d8}",
+			"dmg2": "{@dice 1d10}",
+			"dmgType": "S",
+			"property": [
+				"V"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"When you hit a living creature with this sword, you gain temporary hit points equal to half the damage you inflict. Only living creatures with blood grant you these hit points."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Vest of Missile Protection",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "2",
+			"entries": [
+				"While wearing this thick, woolen vest, you have resistance to bludgeoning, piercing, and slashing damage from nonmagical missile weapons."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Animation",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"These crystalline wands have 3 charges. You may use your action to expend a charge and cast {@i animate dead} or {@i animate object}.",
+				"The wand regains 1d3 expended charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into dust and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Earth and Stone",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 5 charges. You may use your action to use the wand to cast the {@i mold earth} cantrip. You can also expend 1 or more charges to cast one of the following spells: {@i passwall} (1 charge), {@i move earth} (2 charges), or {@i transmute rock} (1 charge).",
+				"The wand regains 1d4+1 expended charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into dust and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Eyes",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 7 charges. You may use the wand to perform the following actions:",
+				{
+					"items": [
+						{
+							"name": "Spells",
+							"entries": [
+								"You may use your action to expend 1 or more charges and cast the following spells: {@i arcane eye} (3 charges), {@i darkvision} (1 charge), {@i see invisibility} (1 charge), or {@i true seeing} (5 charges)."
+							],
+							"type": "item"
+						},
+						{
+							"name": "Restoration",
+							"entries": [
+								"You can also expend 2 charges to remove the blindness condition from a creature you touch with the wand."
+							],
+							"type": "item"
+						}
+					],
+					"type": "list",
+					"style": "list-hang-notitle"
+				},
+				"The wand regains 1d6+1 charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into flakes of wood and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Feathers",
+			"tier": "Major",
+			"rarity": "Rare",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand is usually topped with a clump of multicolored feathers, hence its name. It has 5 charges. You can use your action to use the wand to cast the {@i gust} or {@i prestidigitation} cantrips. You can also expend 1 or more charges to cast the following spells: {@i gust of wind} (2 charges), {@i Tasha's uncontrollable laughter} (1 charge), or {@i unseen servant} (1 charge). It uses your spell save DC.",
+				"The wand regains 1d4+1 charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, it explodes into feathers and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Frost",
+			"tier": "Major",
+			"rarity": "Legendary",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 5 charges. While holding it, you can expend 1 charge to cast either {@i ice storm} or {@i cone of cold} at its lowest level. You can increase the spell slot level by one for each additional charge you expend. It uses your spell save DC.",
+				"The wand regains 1d4+1 expended charges daily at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into shards of ice and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Illumination",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 7 charges. While holding it, you can use an action to use the wand to cast the {@i dancing lights} or {@i light} cantrips. You can also expend 1 or more charges to cast the following spells: {@i dawn} (1 charge), {@i sunbeam} (2 charges), or {@i sunburst} (4 charges). It uses your spell save DC.",
+				"The wand regains 1d4+3 charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Much Wonder",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This is the same as a {@item wand of wonder|dmg}, except it uses the following table:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d100",
+						"Effect"
+					],
+					"rows": [
+						[
+							"01",
+							"You cast {@i slow}."
+						],
+						[
+							"02",
+							"You cast {@i faerie fire}."
+						],
+						[
+							"03",
+							"You are stunned until the start of your next turn, believing something awesome just happened."
+						],
+						[
+							"04",
+							"You cast {@i gust of wind}."
+						],
+						[
+							"05",
+							"You cast {@i detect thoughts} of the target you chose. If you didn't target a creature, you instead take 1d6 psychic damage."
+						],
+						[
+							"06",
+							"You cast {@i stinking cloud}."
+						],
+						[
+							"07",
+							"Heavy rain falls in a 60-foot radius centered on the target. The area becomes lightly obscured. The rain falls until the start of your next turn."
+						],
+						[
+							"08",
+							"An animal appears in the unoccupied space nearest the target. The animal isn't under your control and acts as it normally would. Roll a d100 to determine which animal appears. On a 01-25, a {@creature rhinoceros|mm} appears; on a 26-50, an {@creature elephant|mm} appears; and on a 51-100, a {@creature rat|mm} appears. See the {@i Monster Manual} for the animal's statistics."
+						],
+						[
+							"09",
+							"You cast {@i lightning bolt}."
+						],
+						[
+							"10",
+							"A cloud of 600 oversized butterflies fills a 30-foot radius centered on the target. The area becomes heavily obscured. The butterflies remain for 10 minutes."
+						],
+						[
+							"11",
+							"You enlarge the target as if you had cast {@i enlarge/reduce}. If the target can't be affected by that spell or if you didn't target a creature, you become the target."
+						],
+						[
+							"12",
+							"You cast {@i darkness}."
+						],
+						[
+							"13",
+							"Grass grows on the ground in a 60-foot radius centered on the target . If grass is already there, it grows to ten times its normal size and remains overgrown for 1 minute."
+						],
+						[
+							"14",
+							"An object of the DM ‘s choice disappears into the Ethereal Plane. The object must be neither worn nor carried, within 120 feet of the target, and no larger than 10 feet in any dimension."
+						],
+						[
+							"15",
+							"You shrink yourself as if you had cast {@i enlarge/reduce} on yourself."
+						],
+						[
+							"16",
+							"You cast {@i fireball}."
+						],
+						[
+							"17",
+							"You cast {@i invisibility} on yourself."
+						],
+						[
+							"18",
+							"Leaves grow from the target. If you chose a point in space as the target, leaves sprout from the creature nearest to that point. Unless they are picked off, the leaves turn brown and fall off after 24 hours."
+						],
+						[
+							"19",
+							"A stream of 1d4 × 10 gems , each worth 1 gp, shoots from the wand's tip in a line 30 feet long and 5 feet wide. Each gem deals 1 bludgeoning damage, and the total damage of the gems is divided equally among all creatures in the line."
+						],
+						[
+							"20",
+							"A burst of colorful shimmering light extends from you in a 30-foot radius. You and each creature in the area that can see must succeed on a DC 15 Constitution saving throw or become blinded for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						],
+						[
+							"21",
+							"The target's skin turns bright blue for 1d10 days. If you chose a point in space, the creature nearest to that point is affected."
+						],
+						[
+							"22",
+							"If you targeted a creature, it must make a DC 15 Constitution saving throw. If you didn't target a creature, you become the target and must make the saving throw. If the saving throw fails by 5 or more, the target is instantly petrified. On any other failed save, the target is restrained and begins to turn to stone. While restrained in this way, the target must repeat the saving throw at the end of its next turn , becoming petrified on a failure or ending the effect on a success. The petrifaction lasts until the target is freed by the {@i greater restoration} spell or similar magic."
+						],
+						[
+							"23",
+							"You are struck by a small lightning bolt and take 1d6 lightning damage. You must make a DC 13 Dexterity saving throw or drop the wand from the electric shock."
+						],
+						[
+							"24",
+							"800 small rubber balls, each 1 inch in diameter, rain down in a 30-foot radius of yourself. All creatures who moves through that area or starts its turn in it must make a DC 15 Dexterity saving throw or fall prone."
+						],
+						[
+							"25",
+							"You summon a flock of doves."
+						],
+						[
+							"26",
+							"You cast {@i chain lightning}."
+						],
+						[
+							"27",
+							"You cast {@i hold monster}."
+						],
+						[
+							"28",
+							"You spin 180°."
+						],
+						[
+							"29",
+							"You inflict a nasty, irritating rash, complete with boils, on the target, causing it to have disadvantage on all Dexterity ability checks, attack rolls, and saving throws for 1 minute. If you didn't target a creature, you take 1d8 poison damage."
+						],
+						[
+							"30",
+							"You summon a {@creature giant vulture|mm}, which attacks you."
+						],
+						[
+							"31",
+							"You cast {@i disintegrate}."
+						],
+						[
+							"32",
+							"You and the target have your positions switched."
+						],
+						[
+							"33",
+							"You heal 2d6 hit points of damage."
+						],
+						[
+							"34",
+							"You cast {@i greater invisibility} on the target."
+						],
+						[
+							"35",
+							"The target is subjected to a brief rain of fish."
+						],
+						[
+							"36",
+							"You summon 2d6 {@creature sprite|mm|sprites}, who attempt to steal the wand from you."
+						],
+						[
+							"37",
+							"The target's weapon or other object that it's carrying turns into a herring. If the target can't be affected by that spell or if you didn't target a creature, you become the target."
+						],
+						[
+							"38",
+							"You cast {@i hypnotic pattern} on everyone within 30 feet of you."
+						],
+						[
+							"39",
+							"You cast {@i mirror image} on the target."
+						],
+						[
+							"40",
+							"You summon an adorable kitten, which befriends you."
+						],
+						[
+							"41",
+							"You cast {@i enhance ability} on yourself, choosing the ability at random."
+						],
+						[
+							"42",
+							"You cause a spectral ram's head to appear, as if you were using a {@i ring of the ram}. The ram headbutts the target, making its attack roll with a +7 bonus and inflicting 33 (6d10) force damage. If you didn't target a creature, the ram's head attacks a nearby object."
+						],
+						[
+							"43",
+							"A Tiny object currently on the target's person sprouts wings and attacks another enemy of yours. Its attack roll is +3 and it inflicts 2 (1d4) damage of a type appropriate to the type of object. If the target is carrying nothing or you didn't have a target, an object of yours is affected."
+						],
+						[
+							"44",
+							"The target loses all hair, fur, or feathers."
+						],
+						[
+							"45",
+							"You summon a {@creature swarm of bats|mm} that flock around your head for 1 round and then fly away."
+						],
+						[
+							"46",
+							"A pit 10 feet deep and wide enough to fit the target opens up underneath the target's feet."
+						],
+						[
+							"47",
+							"You cast {@i chromatic orb}."
+						],
+						[
+							"48",
+							"The target's hair turns into snakes. The snakes will fall out 24 hours later, leaving the target bald."
+						],
+						[
+							"49",
+							"The target is covered with a thick layer of honey."
+						],
+						[
+							"50",
+							"All the coins the target is carrying turn into lead."
+						],
+						[
+							"51",
+							"A stream of acid squirts out of the wand in a 20-foot long, 1-foot wide line. A creature caught in that line must make a Dexterity saving throw, with a DC equal to your spell save DC, or take 4d8 acid damage, or half as much damage on a successful one."
+						],
+						[
+							"52",
+							"A vicious {@creature worg|mm} appears and attacks the target."
+						],
+						[
+							"53",
+							"A vicious housecat appears and hisses at the target."
+						],
+						[
+							"54",
+							"You cast {@i cone of cold}."
+						],
+						[
+							"55",
+							"You cast {@i magic missile}, producing 5 missiles."
+						],
+						[
+							"56",
+							"Flowers shoot out of the wand."
+						],
+						[
+							"57",
+							"Impressive fireworks appear. All creatures within 10 feet of you (including you) must make a DC 15 Constitution saving throw or be blinded, deafened, and stunned until the end of their next turned."
+						],
+						[
+							"58",
+							"You cast {@i levitate} on the target."
+						],
+						[
+							"59",
+							"The target creature turns a random bright color."
+						],
+						[
+							"60",
+							"You cast {@i haste} on the target."
+						],
+						[
+							"61",
+							"A small cloud appears over the target and rains on it. It clears up after a minute."
+						],
+						[
+							"62",
+							"You cast {@i delayed blast fireball}, which goes off in 1d4 rounds. Concentrating on the {@i fireball} won't cause it to go off any earlier or later."
+						],
+						[
+							"63",
+							"Your nose grows to 10 times normal size for 1 minute."
+						],
+						[
+							"64",
+							"The target's armor is turned into leaves, rendering it useless as armor."
+						],
+						[
+							"65",
+							"You cast {@i gust of wind}."
+						],
+						[
+							"66",
+							"Your target must make a Constitution saving throw, with a DC equal to your spell save DC, or take be paralyzed for 10 minutes. If your target can't be affected by this or you didn't have a target, it affects you instead."
+						],
+						[
+							"67",
+							"You cast confusion."
+						],
+						[
+							"68",
+							"An arrow +3 shoots out of the wand and strikes the target, inflicting 7 (1d8+3) piercing damage."
+						],
+						[
+							"69",
+							"You summon a {@creature shadow demon|mm}, which attacks the target. What it does afterwards is up to the DM."
+						],
+						[
+							"70",
+							"You create a small aurora of beautiful, shimmering colors. It doesn't do anything, but is very pretty."
+						],
+						[
+							"71",
+							"You spray the target with a spout of beer."
+						],
+						[
+							"72",
+							"You cast {@i flesh to stone}."
+						],
+						[
+							"73",
+							"Your target grows a tail. If you had no target, you grow on instead."
+						],
+						[
+							"74",
+							"You cast {@i Tasha's hideous laughter}."
+						],
+						[
+							"75",
+							"The target's sex changes for 24 hours."
+						],
+						[
+							"76",
+							"The target is polymorphed into a very angry and violent {@creature ogre|mm}. This lasts until the target is brought to 0 hit points, {@i remove curse} is cast on it, or 24 hours pass."
+						],
+						[
+							"77",
+							"You cast gaseous form."
+						],
+						[
+							"78",
+							"All of the target's magical items begin to glow brightly."
+						],
+						[
+							"79",
+							"You cast {@i pyrotechnics} on all fires within 60 feet of you, producing both fireworks and smoke."
+						],
+						[
+							"80",
+							"You cast {@i conjure fey}."
+						],
+						[
+							"81",
+							"You cast {@i dancing lights}."
+						],
+						[
+							"82",
+							"The target must make a DC 15 Wisdom saving throw or become frightened of you for 1 minute."
+						],
+						[
+							"83",
+							"2d6+4 {@creature rabbit|EnMa|rabbits} appear. (See the {@i figurine of wonder} entry for rabbit statistics.)"
+						],
+						[
+							"84",
+							"You cast reverse gravity on the target."
+						],
+						[
+							"85",
+							"You cast reverse gravity on yourself."
+						],
+						[
+							"86",
+							"100 gold coins shoot from the wand and strike the target, inflicting 3 (1d6) bludgeoning damage. On careful examination, the coins will prove to be fake."
+						],
+						[
+							"87",
+							"A {@creature swarm of insects|mm} appear and attack the target."
+						],
+						[
+							"88",
+							"You cast {@i Evard's black tentacles}."
+						],
+						[
+							"89",
+							"A 30-foot radius area of darkness falls, but blinks out of existence every other round for 1 minute."
+						],
+						[
+							"90",
+							"You cast {@i phantasmal killer}."
+						],
+						[
+							"91",
+							"The target grows thick hair all over its body. This remains for 24 hours, then all the target's hair falls off."
+						],
+						[
+							"92",
+							"The target grows a prehensile tail, permanently."
+						],
+						[
+							"93",
+							"You cast {@i incendiary cloud}."
+						],
+						[
+							"94",
+							{
+								"entries": [
+									"You summon an ooze. Roll a d4 to determine the type: ",
+									"{@b 1:} black pudding.",
+									"{@b 2:} gelatinous cube.",
+									"{@b 3:} gray ooze.",
+									"{@b 4:} ochre jelly."
+								],
+								"type": "entries"
+							}
+						],
+						[
+							"95",
+							"The target is polymorphed into a mongrel dog for 24 hours (use {@creature jackal|mm} attributes)."
+						],
+						[
+							"96",
+							"You grow a pair of wings, which last until you finish a long rest. Roll a die. On an odd number, you gain a flight speed of 50 feet. On an even number, the wings are useless for flying."
+						],
+						[
+							"97",
+							"Eight fiery spheres shoot forth, exploding violently and with great heat when they hit the target. They inflict 1 point of fire damage each."
+						],
+						[
+							"98",
+							"The target gains 15 temporary hit points."
+						],
+						[
+							"99",
+							"You cast summon elemental."
+						],
+						[
+							"100",
+							"The target becomes terribly drunk and is at disadvantage on all Dexterity, Intelligence, and Wisdom ability checks, attack rolls, and saving throws for 1 hour, or until {@i remove curse} is cast on it."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Size Alteration.",
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 5 charges. You can use your action to expend a charge and cast {@i enlarge/reduce}. It uses your spell save DC.",
+				"It regains 1d4+1 charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of the Armory",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 5 charges. You may use your action to touch a creature who is within reach and expend a charge. For the next ten minutes, that creature gains +4 to its armor class and immunity to force and lightning damage.",
+				"The wand regains 1d4+1 expended charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand explodes into harmless sparks and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wand of Warding",
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": "by a spellcaster",
+			"weight": "1",
+			"type": "WD",
+			"entries": [
+				"This wand has 7 charges. While holding it, you can use an action to use the wand to cast one of the following spells: {@i antilife shell} (5 charges), {@i protection from evil and good} (1 charge), {@i shield} (1 charge), or {@i wall of force} (5 charges).",
+				"The wand regains 1d6+1 charges each day at dawn. If you expend the wand's last charge, roll a d20. On a 1, the wand crumbles into ashes and is destroyed."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "War Shirt",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Rare",
+			"reqAttune": "by a barbarian or fighter",
+			"weight": "2",
+			"entries": [
+				"While wearing this shirt, your armor class improves by 1 and you are immune to the frightened condition."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wardstone",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Uncommon",
+			"weight": "0.1",
+			"entries": [
+				"If you hold this stone in the palm of your hand, it grows warm and glows with gentle light (shedding dim light to 5 feet) when actively hostile creatures come within 100 feet of you."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Warstar of the Manticore",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "4",
+			"dmg1": "{@dice 1d8}",
+			"dmgType": "P",
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This {@i morningstar +1} as 5 charges and regains 1d4+1 charges each day at dawn. You may use your action to expend a charge and dire its spikes at one target you can see within 60 of you, making an attack roll to do so. On a hit, the target takes 14 (4d6) piercing damage. The {@i warstar} then instantly grows its spikes back."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wax of Careful Hearing",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"entries": [
+				"This brick of wax can be molded into 10 pairs of earplugs. They don't hinder your hearing, but give you resistance to thunder damage and advantage on saving throws to avoid being deafened."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Well of Dreams",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Legendary",
+			"entries": [
+				"If you throw a coin in this well, a strange and possibly wondrous thing happens to you. If you throw in a platinum coin, you get +3 to your roll.",
+				{
+					"type": "table",
+					"colLabels": [
+						"d20",
+						"Result"
+					],
+					"rows": [
+						[
+							"1-3",
+							"Nothing happens."
+						],
+						[
+							"4",
+							"Your turn into a different type of humanoid. The DM will choose the race or roll on the {@i reincarnate} table."
+						],
+						[
+							"5",
+							"Your hands and feet become webbed, giving you a swim speed of 30 feet. If you already had a swim speed, it increases by 10 feet."
+						],
+						[
+							"6",
+							"15 platinum coins fall on your head."
+						],
+						[
+							"7",
+							"A nonmagical weapon in your possession becomes magical. It doesn't gain a bonus on its attack and damage rolls, but it counts as magical for the purposes of overcoming damage resistance, and it may (DM's choice) gain additional properties."
+						],
+						[
+							"8",
+							"Your lowest ability score increases by +1, and your maximum in that attribute increases to 22."
+						],
+						[
+							"9",
+							"Small insect wings grow from your back permanently. You can't fly with them, but your jumping distance is tripled, and if you gain a fly speed from any other method, such as having a {@i fly} spell cast on you, that speed increases by 10 feet. This wings are permanent until {@i dispel magic} is cast on you."
+						],
+						[
+							"10",
+							"You are cursed with {@creature wereboar|mm} lycanthropy."
+						],
+						[
+							"11",
+							"Brand new boots appear on your feet, replacing whatever it is you're currently wearing."
+						],
+						[
+							"12",
+							"You and everything you're wearing become {@i invisible} until you attack or cast a spell."
+						],
+						[
+							"13",
+							"You grow a 2-foot long beard (or your existing bear grows by 2 feet), even if you're female or a member of a race that doesn't grow beards."
+						],
+						[
+							"14",
+							"Half of your coins vanish."
+						],
+						[
+							"15",
+							"You gain 5,000 XP."
+						],
+						[
+							"16",
+							"All of your coins become the same type of coin that you threw in the well."
+						],
+						[
+							"17",
+							"You become proficient in a new skill."
+						],
+						[
+							"18",
+							"You become proficient in a new saving throw."
+						],
+						[
+							"19",
+							"You are struck by a tiny lightning bolt and take 9 (2d8) lightning damage."
+						],
+						[
+							"20+",
+							"You hear a voice in your head that says, “A wish will come your way when you least expect it.” At some point in the future, when you strongly desire something, that wish will be granted."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Whip of Frost, Fire, and Fear",
+			"type": "M",
+			"weapon": true,
+			"weaponCategory": "Martial",
+			"rarity": "Legendary",
+			"weight": "3",
+			"dmg1": "{@dice 1d4}",
+			"dmgType": "S",
+			"property": [
+				"F",
+				"R"
+			],
+			"tier": "Major",
+			"reqAttune": true,
+			"entries": [
+				"This whip is made of magically flexible, braided strands of electrum, red gold, and iron and gives you +2 to your attack and damage rolls. In addition, the whip produces a secondary effect on a successful hit:",
+				{
+					"type": "table",
+					"colLabels": [
+						"d4",
+						"Result"
+					],
+					"rows": [
+						[
+							"1",
+							"The target must make a DC 17 Constitution saving throw, taking 14 (4d6) cold damage on a failed save or half as much on a successful one."
+						],
+						[
+							"2",
+							"The target must make a DC 17 Constitution saving throw, taking 14 (4d6) fire damage on a failed save or half as much on a successful one."
+						],
+						[
+							"3",
+							"The target must make a DC 17 Wisdom saving throw or become frightened on you."
+						],
+						[
+							"4",
+							"The target takes an additional 5 (2d4) slashing damage."
+						]
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6"
+					]
+				}
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Window of Spying",
+			"wondrous": true,
+			"tier": "Minor",
+			"rarity": "Very Rare",
+			"weight": "4",
+			"entries": [
+				"This is a small pane of sturdy glass, 3 inches square and a quarter inch thick. When you hold it up to a wall, you can see through up to 3 feet of wood or stone or 1/2 inch of metal."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Winged Mask",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "0.5",
+			"entries": [
+				"While you wear this feathery mask, you have a flying speed of 40 feet."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wooden Arrow",
+			"type": "A",
+			"ammunition": true,
+			"rarity": "Legendary",
+			"weight": "0.05",
+			"tier": "Major",
+			"entries": [
+				"This arrow is made entirely from wood—arrowhead, shaft, and fletching alike—and is intricately carved and painted.",
+				"If you fire this arrow from a bow, it completely ignores all forms of metallic armor; it treats studded leather armor as ordinary leather armor. Only non-metal armor and the target's Dexterity bonus are counted for this arrow. If the target is wearing magical metallic armor, then the armor's bonuses, if any, are also counted.",
+				"After firing this arrow, the DM should roll a d6. On a roll of 1 or 2, the arrow breaks. Otherwise, it can be retrieved and re-used.",
+				"This arrow can't damage metal- and stone-based creatures, such as earth elementals, stone or iron golems, or gorgons."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Wyrmhelm",
+			"wondrous": true,
+			"tier": "Major",
+			"rarity": "Very Rare",
+			"reqAttune": true,
+			"weight": "4",
+			"entries": [
+				"This elaborate helmet is made to look like a snarling dragon. While wearing it, you can understand, speak, and read Draconic.",
+				"In addition, this helmet has 5 charges and regains 1d4+1 charges each day at dawn. While wearing this helmet, you can use your action to expend 1 or more charges to cast {@i command} (1 charge), {@i charm monster} (2 charges) or {@i dominate monster} (4 charges). These spells only work on dragons."
+			],
+			"source": "EnMa"
+		},
+		{
+			"name": "Zombie Blood Potion",
+			"tier": "Minor",
+			"rarity": "Rare",
+			"weight": "0.5",
+			"type": "P",
+			"entries": [
+				"This potion looks, smells, and tastes like a potion of healing or other beneficial potion. An {@i identify} spell reveals its true nature. When a humanoid drinks the potion, it must make a DC 15 Intelligence saving throw or be charmed by the creature that mixed the potion. While charmed, its Intelligence becomes 3 (-4), it will take no actions unless explicitly ordered to, and the orders of the creature who mixed the potion supersede all other orders. In addition the creature is immune to the charmed condition (other than the one created by this potion), exhaustion, and frightened conditions, and requires only half as much food, drink, and sleep as it  normally would. The creature is not undead and can't be turned.",
+				"This potion lasts for 1 week. The creature may make a new saving throw at the end of every 24 hours, ending the effect on a success. Additional doses of this potion can extend the duration of the effects. A {@i greater restoration} or similar spell will end the effect."
+			],
+			"source": "EnMa"
+		}
+	],
+	"_meta": {
+		"sources": [
+			{
+				"json": "EnMa",
+				"abbreviation": "EnMa",
+				"full": "Encyclopedia Magica",
+				"authors": [
+					"/u/Faolyn"
+				],
+				"convertedBy": [
+					"Azzurite"
+				],
+				"version": "1.0.0",
+				"url": "http://homebrewery.naturalcrit.com/share/Syy_IAjVG",
+				"targetSchema": "1.0.0"
+			}
+		]
+	}
+}


### PR DESCRIPTION
Adds the encyclopedia magica released in [this post](https://www.reddit.com/r/dndnext/comments/7vod7v/the_not_really_complete_encyclopedia_magica_now/).

It's missing a bunch of links (spell and item), but that's just too much work for me for too little gain