### PR TITLE
Typo and Tag Pass on NftFR Invocations

### DIFF
--- a/optionalfeature/Sandwichbear; Notes from the Far Realm.json
+++ b/optionalfeature/Sandwichbear; Notes from the Far Realm.json
@@ -22,7 +22,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Acid Splash"
+						"acid splash"
 					]
 				}
 			],
@@ -38,7 +38,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Dancing Lights"
+						"dancing lights"
 					]
 				}
 			],
@@ -54,12 +54,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Vicious Mockery"
+						"vicious mockery"
 					]
 				}
 			],
 			"entries": [
-				"If a creature fails its saving throw against vicious mockery, it falls prone if it moves more than half of its speed before the end of your next turn."
+				"If a creature fails its saving throw against vicious mockery, it falls {@condition prone} if it moves more than half of its speed before the end of your next turn."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -70,12 +70,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Shillelagh"
+						"shillelagh"
 					]
 				}
 			],
 			"entries": [
-				"Once on each of your turns when you hit a creature with a weapon under the effect of shillelagh, you can cause the creature to take force damage equal to 1d4 + your warlock level."
+				"Once on each of your turns when you hit a creature with a weapon under the effect of shillelagh, you can cause the creature to take force damage equal to {@dice 1d4} + your warlock level."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -86,8 +86,8 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Guidance",
-						"Resistance"
+						"guidance",
+						"resistance"
 					]
 				}
 			],
@@ -103,12 +103,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Spare the Dying"
+						"spare the dying"
 					]
 				}
 			],
 			"entries": [
-				"When you cast spare the dying, the target is under the effect of a feign death spell until it regains any hit points."
+				"When you cast spare the dying, the target is under the effect of a {@spell feign death} spell until it regains any hit points."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -119,7 +119,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Minor Illusion"
+						"minor illusion"
 					]
 				}
 			],
@@ -135,7 +135,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Blade Ward"
+						"blade ward"
 					]
 				}
 			],
@@ -151,7 +151,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Light"
+						"light"
 					]
 				}
 			],
@@ -167,7 +167,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"True Strike"
+						"true strike"
 					]
 				}
 			],
@@ -183,7 +183,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Friends"
+						"friends"
 					]
 				}
 			],
@@ -199,7 +199,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Ray of Frost"
+						"ray of frost"
 					]
 				}
 			],
@@ -215,9 +215,9 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Druidcraft",
-						"Prestidigitation",
-						"Thaumaturgy"
+						"druidcraft",
+						"prestidigitation",
+						"thaumaturgy"
 					]
 				}
 			],
@@ -233,12 +233,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Shocking Grasp"
+						"shocking grasp"
 					]
 				}
 			],
 			"entries": [
-				"When you cast shocking grasp, you can expend a warlock spell slot to amplify the attack. You gain a bonus to the attack roll equal to the level of the spell slot. If the attack hits, the target takes an extra 1d8 lightning damage per level of the spell slot and it must succeed on a Constitution saving throw against your warlock spell save DC or it is paralyzed until the start of your next turn."
+				"When you cast shocking grasp, you can expend a warlock spell slot to amplify the attack. You gain a bonus to the attack roll equal to the level of the spell slot. If the attack hits, the target takes an extra a {@dice 1d8} lightning damage per level of the spell slot and it must succeed on a Constitution saving throw against your warlock spell save DC or it is {@condition paralyzed} until the start of your next turn."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -249,12 +249,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Chill Touch"
+						"chill touch"
 					]
 				}
 			],
 			"entries": [
-				"A humanoid killed by chill touch rises up as a zombie at the start of your next turn. The zombie pursues whatever creature it can see that is closest to it. It remains animated for a number of rounds equal to your Charisma modifier (minimum of 1), after which time the zombie becomes inanimate once more."
+				"A humanoid killed by chill touch rises up as a {@creature zombie} at the start of your next turn. The zombie pursues whatever creature it can see that is closest to it. It remains animated for a number of rounds equal to your Charisma modifier (minimum of 1), after which time the zombie becomes inanimate once more."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -265,12 +265,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Sacred Flame"
+						"sacred flame"
 					]
 				}
 			],
 			"entries": [
-				"When you deal damage to a fiend or undead with sacred flame, you can deal maximum damage, instead of rolling"
+				"When you deal damage to a fiend or undead with sacred flame, you can deal maximum damage, instead of rolling."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -281,7 +281,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Mage Hand"
+						"mage hand"
 					]
 				}
 			],
@@ -297,7 +297,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Fire Bolt"
+						"fire bolt"
 					]
 				}
 			],
@@ -313,12 +313,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Produce Flame"
+						"produce flame"
 					]
 				}
 			],
 			"entries": [
-				"When you attack a creature with the flame created by produce flame, you can expend a warlock spell slot to unleash a fiery explosion at the target's location. The target and each creature within 10 feet of it must make a Dexterity saving throw. On a failed save, a creature takes 3d4 fire damage per level of the spell slot. On a successful save, it takes half as much damage."
+				"When you attack a creature with the flame created by produce flame, you can expend a warlock spell slot to unleash a fiery explosion at the target's location. The target and each creature within 10 feet of it must make a Dexterity saving throw. On a failed save, a creature takes {@dice 3d4} fire damage per level of the spell slot. On a successful save, it takes half as much damage."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -329,12 +329,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Message"
+						"message"
 					]
 				}
 			],
 			"entries": [
-				"When you cast message, you can choose to convey a series of eldritch phrases to the target. If you do so, the target must succeed on a Wisdom saving throw against your warlock spell save DC or it is under the effect of a confusion spell until the end of its turn, or until it takes any damage."
+				"When you cast message, you can choose to convey a series of eldritch phrases to the target. If you do so, the target must succeed on a Wisdom saving throw against your warlock spell save DC or it is under the effect of a {@spell confusion} spell until the end of its turn, or until it takes any damage."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"
@@ -345,7 +345,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Thorn Whip"
+						"thorn whip"
 					]
 				}
 			],
@@ -361,7 +361,7 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Mending"
+						"mending"
 					]
 				}
 			],
@@ -377,12 +377,12 @@
 				{
 					"type": "prereqSpell",
 					"entries": [
-						"Poison Spray"
+						"poison spray"
 					]
 				}
 			],
 			"entries": [
-				"When a creature fails its saving throw against poison spray, it is poisoned until the end of your next turn."
+				"When a creature fails its saving throw against poison spray, it is {@condition poisoned} until the end of your next turn."
 			],
 			"source": "NftFR 3pp",
 			"featureType": "EI"


### PR DESCRIPTION
Fixes incorrect spell capitalization and adds tags as needed.