### PR TITLE
Updates for KibblesTasty Revised Artificer

### DIFF
--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,8 +8,8 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5",
-				"url": "http://homebrewery.naturalcrit.com/share/H1ZDtpyaT-",
+				"version": "1.5.1",
+				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
 		]
@@ -320,7 +320,9 @@
 					"medium"
 				],
 				"weapons": [
-					"simple"
+					"simple",
+					"hand crossbows",
+					"heavy crossbows"
 				],
 				"tools": [
 					"thieves' tools"
@@ -342,9 +344,9 @@
 			"startingEquipment": {
 				"additionalFromBackground": true,
 				"default": [
-					"(a) a handaxe and a light hammer or (b) any two simple weapons.",
-					"(a)  scale mail or (b) leather armor",
-					"thieves' tools and a dungeoneer's pack"
+					"(a) a {@item light crossbow|phb} and {@item crossbow bolts (20)|phb|20 bolts} or (b) any two {@filter simple weapons|items|source=phb|category=basic|type=simple weapon}",
+					"(a) {@item scale mail|phb}, (b) {@item leather armor|phb}, or (c) {@item chain mail|phb}",
+					"{@item thieves' tools|phb} and a {@item dungeoneer's pack|phb}"
 				]
 			},
 			"classFeatures": [
@@ -477,7 +479,7 @@
 						"type": "entries",
 						"name": "Arcane Reconstruction",
 						"entries": [
-							"At 6th level, you have mastered the knowledge of using magic to repair things. You learn the Mending cantrip, and can cast it at will. Additionally, you learn the Cure Wounds spell. If you already know Cure Wounds you can select another spell from the Artificer list. When you cast Cure Wounds, it can heal constructs in addition to normally valid targets. Both Mending and Cure Wounds learned through this features are considered Artificer spells for you."
+							"At 6th level, you have mastered the knowledge of using magic to repair things. You learn the {@spell mending} cantrip, and can cast it at will. Additionally, you learn the {@spell cure wounds} spell. If you already know {@spell cure wounds} you can select another spell from the Artificer list. When you cast {@spell cure wounds}, it can heal constructs in addition to normally valid targets. Both {@spell mending} and {@spell cure wounds} learned through this features are considered Artificer spells for you."
 						]
 					},
 					{
@@ -976,14 +978,14 @@
 												"type": "optfeature",
 												"name": "Smoke Bomb",
 												"entries": [
-													"As an action, you can use this to instantly cast {@spell Fog Cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
+													"As an action, you can use this to instantly cast {@spell fog cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Shock Generator",
 												"entries": [
-													"As an action, you can use this to cast {@spell Shocking Grasp}."
+													"As an action, you can use this to cast {@spell shocking grasp}."
 												]
 											}
 										]
@@ -1708,7 +1710,7 @@
 												"entries": [
 													"{@i Wondrous Item, Attunement (creator only).}",
 													"{@b Weight} 5 lb.",
-													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell Shocking Grasp} cantrip and can cast it through the gauntlet."
+													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell shocking grasp} cantrip and can cast it through the gauntlet."
 												]
 											},
 											"If you lose your mechplate gauntlet, you can remake it during a long rest with 25 gold worth of materials, or can scavenge for materials and forge it over two days of work (eight hours a day) without the material expense."
@@ -1848,7 +1850,7 @@
 												"name": "Flame Projector",
 												"prerequisite": "9th level. Incompatible with other projectors.",
 												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell Burning Hands} (1 charge), {@spell Fireball} (3 charges), or {@spell Wall of Fire} (4 charges).",
+													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell burning hands} (1 charge), {@spell fireball} (3 charges), or {@spell wall of fire} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1857,7 +1859,7 @@
 												"name": "Flash Freeze Capacitor",
 												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
-													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell Cone of Cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
+													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell cone of cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
 												]
 											},
@@ -1905,7 +1907,7 @@
 												"name": "Lightning Projector",
 												"prerequisite": "9th level. Incompatible with other projectors.",
 												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell Thunderwave} (1 charge), {@spell Lightning Bolt} (3 charges), or {@spell Storm Sphere|XGE} (4 charges).",
+													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell thunderwave} (1 charge), {@spell lightning bolt} (3 charges), or {@spell storm sphere|XGE} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1938,14 +1940,13 @@
 												"name": "Power Slam Capacitor",
 												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
-													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell Destructive Wave} upon landing.",
+													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell destructive wave} upon landing.",
 													"Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Power Fist",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
 													"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal 1d8 bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
 													"{@b Special:} When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
@@ -2006,7 +2007,7 @@
 												"name": "Sun Cannon",
 												"prerequisite": "15th level",
 												"entries": [
-													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell Sunbeam} without expending a spell slot.",
+													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell sunbeam} without expending a spell slot.",
 													"Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,7 +8,7 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5.1",
+				"version": "1.5",
 				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
@@ -1825,17 +1825,17 @@
 											},
 											{
 												"type": "optfeature",
-												"name": "Darkvision Visor",
-												"entries": [
-													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
-												]
-											},
-											{
-												"type": "optfeature",
 												"name": "Collapsible",
 												"prerequisite": "5th level. Incompatible with Piloted Golem",
 												"entries": [
 													"Your Mechplate can collapse into a case for easy storage. When transformed this way the armor is indistinguishable from a normal case and weighs 1/3 its normal weight. As an action you can don or doff the armor, allowing it to transform as needed."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Darkvision Visor",
+												"entries": [
+													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
 												]
 											},
 											{


### PR DESCRIPTION
I corrected a few things for the Revised Artificer, mostly for Warsmith

- Updated the source link to the latest gmbinder link from KibblesTasty
- Corrected the proficiences by adding hand crossbows and heavy crossbows
- Corrected the starting equipment and made the items links to the items like the other classes
- Made the spells on the Warsmith link to the spells like other classes do
- Removed an erroneous prerequisite on the Warsmith's Power Fist upgrade
- Rearranged Collapsible to be before Darkvision Visor in Warmisth's upgrade list so it is alphabetical