### PR TITLE
Revised Artificer patch and Critter Compendium author fix

### DIFF
--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -539,7 +539,7 @@
 					{
 						"name": "Study of Magic",
 						"entries": [
-							"At 11th level, your proficieny in the workings of magic has become so great you can cast {@spell detect magic} and {@spell identify} at will. Additionally, you have advantage on all Intelligence (Arcana) checks to understand the workings of magical traps, effects, or runes."
+							"At 11th level, your proficieny in the workings of magic has become so great you can cast {@spell detect magic} and {@spell identify} at will. Additionally, you have advantage on all Intelligence ({@skill Arcana}) checks to understand the workings of magical traps, effects, or runes."
 						]
 					},
 					{
@@ -666,7 +666,7 @@
 										"type": "entries",
 										"name": "Cannonsmith's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with tinker's tools and smith's tools.",
+											"When you choose this specialization at 1st level, you gain proficiency with {@item tinker's tools|phb} and {@item smith's tools|phb}.",
 											"You gain the knowledge to forge rounds for your Thunder Cannon, and can create them with the proper tools during a Long Rest.",
 											"You can create up to 50 rounds of ammunition during a long rest, with materials costing 1 gold piece per 10 rounds."
 										]
@@ -864,7 +864,7 @@
 												"name": "Shock Absorber",
 												"prerequisite": "9th level Artificer",
 												"entries": [
-													"You add a reclamation device to your Thunder Cannon to gather energy from the surroundings when it is present. As a reaction to taking Lightning or Thunder Damage, you can cast Absorb Elements without consuming a spell slot. When absorbed in this method, you can apply the bonus damage granted by Absorb Elements to your next Thunder Cannon attack even if you make a ranged attack."
+													"You add a reclamation device to your Thunder Cannon to gather energy from the surroundings when it is present. As a reaction to taking Lightning or Thunder Damage, you can cast {@spell absorb elements|xge} without consuming a spell slot. When absorbed in this method, you can apply the bonus damage granted by {@spell absorb elements|xge} to your next Thunder Cannon attack even if you make a ranged attack."
 												]
 											},
 											{
@@ -872,7 +872,7 @@
 												"name": "Shock Harpoon",
 												"prerequisite": "9th level Artificer, Harpoon Reel",
 												"entries": [
-													"After hitting a creature with the Harpoon fire mode, you can use a bonus action to deliver a shock. If you have not used it since the start of your turn, you can apply Thundermonger damage as lightning damage. Additionally, the target must make a Constitution saving throw against your spell save DC or be stunned until the end of its next turn.",
+													"After hitting a creature with the Harpoon fire mode, you can use a bonus action to deliver a shock. If you have not used it since the start of your turn, you can apply Thundermonger damage as lightning damage. Additionally, the target must make a Constitution saving throw against your spell save DC or be {@condition stunned} until the end of its next turn.",
 													"Once used, the Harpoon must be reeled in before this can be used again."
 												]
 											},
@@ -881,7 +881,7 @@
 												"name": "Storm Blast",
 												"prerequisite": "5th level Artificer",
 												"entries": [
-													"You upgrade your Thunder Cannon to discharge its power in 30-foot cone from the gun. As an action, you can make a special attack. Each creature must make a Strength saving throw, or take half the bonus damage of Thundermonger and be knocked prone. Using this shot counts as applying Thundermonger damage for the turn.",
+													"You upgrade your Thunder Cannon to discharge its power in 30-foot cone from the gun. As an action, you can make a special attack. Each creature must make a Strength saving throw, or take half the bonus damage of Thundermonger and be knocked {@condition prone}. Using this shot counts as applying Thundermonger damage for the turn.",
 													"Firing in this way does not consume ammo."
 												]
 											},
@@ -959,7 +959,7 @@
 										"type": "entries",
 										"name": "Gadgetsmith's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with nets, rapiers, whips, and tinker's tools."
+											"When you choose this specialization at 1st level, you gain proficiency with nets, rapiers, whips, and {@item tinker's tools|phb}."
 										]
 									},
 									{
@@ -1004,254 +1004,252 @@
 											"At 3rd level, you've mastered the essential tools begun to tinker with ways to expand your arsenal. The number of upgrades you have for your class level is increased by one.",
 											"The number of additional upgrades you get increases to two more than the class table at 5th level."
 										]
+									},
+									{
+										"type": "entries",
+										"name": "Gadgetsmith Upgrades",
+										"entries": [
+											{
+												"type": "optfeature",
+												"name": "Antimagical Shackle",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You create an antimagical shackle. When you are adjacent to a creature, as an action you can attempt to shackle them to yourself or a nearby object using these shackles. The you make a Dexterity ({@skill Sleight of Hand}) check contested by a Strength ({@skill Athletics}) or Dexterity ({@skill Acorbatics}) check. On failure, they are shackled to the creature or object you attempted to shackle them to, and can move only by moving it if they are able to.",
+													"Additionally, while shackled by these shackles, they cannot teleport, planeshift, polymorph, shapechange, dematerialize, or turn into an amorphous form. As an action they can make a Strength saving throw against your spell save DC to break the shackles once shackled, otherwise these shackles last until you remove them.",
+													"This shackles have no effect on creatures immune to being {@condition grappled} or {@condition restrained}."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Boomerang of Hitting",
+												"entries": [
+													"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals 1d4 damage.",
+													"Special: When this weapon is Thrown, you can target three creatures within 10 feet of each other, making a separate attack roll against each target.",
+													"This weapon returns to your hand after you make an attack with it using the Thrown property."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Belt of Adjusting Size",
+												"entries": [
+													"You create a belt with a creature size dial on it. While you are wearing this belt, you can use an action to cast {@spell enlarge/reduce} on yourself. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Binding Rope",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save or become {@condition restrained} until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Bracers of Empowerment",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create bracers that can empower you. You can use this to cast {@spell tenser's transformation|xge} without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Deployable Wings",
+												"prerequisite": "9th level",
+												"entries": [
+													"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Disintegration Ray",
+												"prerequisite": "15th level",
+												"entries": [
+													"You create a Disintegratation Ray. You can use this to cast {@spell disintegrate} without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Gripping Gloves",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength ({@skill Athletics}) checks involving manipulating things with your hands while wearing these gloves."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Element Eater",
+												"entries": [
+													"You create a device capable of absorbing incoming elemental damage. As a reaction to taking elemental damage, you can activate this device and cast {@spell absorb elements|xge} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Enhanced Grappling Hook",
+												"entries": [
+													"You enhance your grappling hook, increasing its range to 40 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Fire Spitter",
+												"entries": [
+													"You create a gadget that creates a quick blast of fire. As an action, you can cast {@spell aganazzar's scorcher|xge} with this gadget, but the gadget cannot be used again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Flashbang",
+												"entries": [
+													"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a dexterity saving throw or be {@condition blinded} until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Impact Gauntlet",
+												"entries": [
+													"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals 1d8 bludgeoning damage.",
+													"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Lightning Baton",
+												"entries": [
+													"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals 1d4 bludgeoning damage and 1d4 lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save or become {@condition stunned} until the start of your next turn."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Mechanical Arm",
+												"entries": [
+													"You create a mechanical arm, giving an extra hand. This mechanical arm only functions while it is mounting on gear you are wearing, but can be operated mentally without the need for you hands. This mechanical arm can serve any function a normal hand could, such as holding things, making attacks, interacting with the environment, etc, but does not give you additional actions."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Mechanical Familiar",
+												"entries": [
+													"You can create the blue print for a small mechanical creature. At the end of a long rest, you can choose animate it, and cast {@spell find familiar} with the following modifications. The creatures type is Construct, and you cannot select a creature with a flying speed. This construct stays active until you deactivate it or is destroyed. In either case, you can choose to reactivate it at the end of a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Nimble Gloves",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity (Slight of Hand) checks involving manipulating things with your hands while wearing these gloves."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Phase Trinket",
+												"prerequisite": "9th level. Incompatible with other Trinkets.",
+												"entries": [
+													"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast {@spell blink} or {@spell dimension door} using the Stopwatch without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Jumping Boots",
+												"entries": [
+													"You modify your boots with arcane boosters. While wearing these boots, you are under the effects of the {@spell jump} spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Repeating Hand Crossbow",
+												"entries": [
+													"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals 1d6 piercing damage.",
+													"Special: This weapon does not require a free-hand to load, as it has a built in loader."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Bee Swarm Rockets",
+												"prerequisite": "15th level",
+												"entries": [
+													"You design a type of tiny firecracker like device, that can be released in large number. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a dexterity saving throw. Creatures that fail take 2d6 fire damage, or half as much on a successful one.",
+													"You rebuild your stock to your maximum during a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Shocking Hook",
+												"entries": [
+													"You can integrate your Shock Generator and your Grappling Hook. If the target of your Grappling Hook is a creature, you can cast {@spell shocking grasp} on that creature as a bonus action when pulling it to you or being pulled to it."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Sight Lenses",
+												"entries": [
+													"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through Fog, Mist, Smoke, Clouds, and non-Magical Darkness as normal sight up to 15 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Smoke Cloak",
+												"entries": [
+													"Create a cloak that causes you to blend in with smoke. When you start your turn lightly or heavily obscured by smoke, you are {@condition invisible} until your turn ends, you cast a spell, make an attack, or damage an enemy."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Stinking Gas",
+												"prerequisite": "9th level",
+												"entries": [
+													"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast {@spell stinking cloud} rather than {@spell fog cloud}, following the same rules."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Striding Boots",
+												"entries": [
+													"You modify your boots with amplified striding speed. While earing these boots, you are under the effects of {@spell longstrider} spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Stopwatch Trinket",
+												"prerequisite": "9th level, Incompatible with other Trinkets.",
+												"entries": [
+													"You create a magical stopwatch that manipulates time magic. As an action, you can cast {@spell haste} or {@spell slow} using the Stopwatch without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Truesight Lenses",
+												"prerequisite": "Sight Lenses.",
+												"entries": [
+													"You upgrade and fine tune your sight lenses, granting you Truesight up to 15 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Useful Universal Key",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast {@spell passwall} without expending a spell slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Zombie Wires",
+												"prerequisite": "15th level",
+												"entries": [
+													"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast {@spell danse macabre|xge} without expended a spell slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											}
+										]
 									}
 								]
 							},
-							{
-								"type": "entries",
-								"name": "Gadgetsmith Upgrades",
-								"entries": [
-									{
-										"type": "optfeature",
-										"name": "Antimagical Shackle",
-										"prerequisite": "5th level Artificer",
-										"entries": [
-											"You create an antimagical shackle. When you are adjacent to a creature, as an action you can attempt to shackle them to yourself or a nearby object using these shackles. The you make a Dexterity (Sleight of Hand) check contested by a Strength (Athletics) or Dexterity (Acorbatics) check. On failure, they are shackled to the creature or object you attempted to shackle them to, and can move only by moving it if they are able to.",
-											"Additionally, while shackled by these shackles, they cannot teleport, planeshift, polymorph, shapechange, dematerialize, or turn into an amorphous form. As an action they can make a Strength saving throw against your spell save DC to break the shackles once shackled, otherwise these shackles last until you remove them.",
-											"This shackles have no effect on creatures immune to being grappled or restrained."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Boomerang of Hitting",
-										"entries": [
-											"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals 1d4 damage.",
-											"Special: When this weapon is Thrown, you can target three creatures within 10 feet of each other, making a separate attack roll against each target.",
-											"This weapon returns to your hand after you make an attack with it using the Thrown property."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Belt of Adjusting Size",
-										"entries": [
-											"You create a belt with a creature size dial on it. While you are wearing this belt, you can use an action to cast Enlarge/Reduce on yourself. Once you use this gadget, you cannot use it again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Binding Rope",
-										"prerequisite": "5th level Artificer",
-										"entries": [
-											"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save or become restrained until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Bracers of Empowerment",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create bracers that can empower you. You can use this to cast Tensor's Transformation without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Deployable Wings",
-										"prerequisite": "9th level",
-										"entries": [
-											"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Disintegration Ray",
-										"prerequisite": "15th level",
-										"entries": [
-											"You create a Disintegratation Ray. You can use this to cast Distintegrate without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Gripping Gloves",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength (Athletics) checks involving manipulating things with your hands while wearing these gloves."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Element Eater",
-										"entries": [
-											"You create a device capable of absorbing incoming elemental damage. As a reaction to taking elemental damage, you can activate this device and cast Absorb Elements without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Enhanced Grappling Hook",
-										"entries": [
-											"You enhance your grappling hook, increasing its range to 40 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Fire Spitter",
-										"entries": [
-											"You create a gadget that creates a quick blast of fire. As an action, you can cast Aganazzar's Scorcher with this gadget, but the gadget cannot be used again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Flashbang",
-										"entries": [
-											"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a dexterity saving throw or be blinded until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Impact Gauntlet",
-										"entries": [
-											"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals 1d8 bludgeoning damage.",
-											"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Lightning Baton",
-										"entries": [
-											"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals 1d4 bludgeoning damage and 1d4 lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save or become stunned until the start of your next turn."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Mechanical Arm",
-										"entries": [
-											"You create a mechanical arm, giving an extra hand. This mechanical arm only functions while it is mounting on gear you are wearing, but can be operated mentally without the need for you hands. This mechanical arm can serve any function a normal hand could, such as holding things, making attacks, interacting with the environment, etc, but does not give you additional actions."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Mechanical Familiar",
-										"entries": [
-											"You can create the blue print for a small mechanical creature. At the end of a long rest, you can choose animate it, and cast Find Familiar with the following modifications. The creatures type is Construct, and you cannot select a creature with a flying speed. This construct stays active until you deactivate it or is destroyed. In either case, you can choose to reactivate it at the end of a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Nimble Gloves",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity (Slight of Hand) checks involving manipulating things with your hands while wearing these gloves."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Phase Trinket",
-										"prerequisite": "9th level. Incompatible with other Trinkets.",
-										"entries": [
-											"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast Blink or Dimension Door using the Stopwatch without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Jumping Boots",
-										"entries": [
-											"You modify your boots with arcane boosters. While wearing these boots, you are under the effects of the Jump spell."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Repeating Hand Crossbow",
-										"entries": [
-											"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals 1d6 piercing damage.",
-											"Special: This weapon does not require a free-hand to load, as it has a built in loader."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Bee Swarm Rockets",
-										"prerequisite": "15th level",
-										"entries": [
-											"You design a type of tiny firecracker like device, that can be released in large number. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a dexterity saving throw. Creatures that fail take 2d6 fire damage, or half as much on a successful one.",
-											"You rebuild your stock to your maximum during a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Shocking Hook",
-										"entries": [
-											"You can integrate your Shock Generator and your Grappling Hook. If the target of your Grappling Hook is a creature, you can cast Shocking Grasp on that creature as a bonus action when pulling it to you or being pulled to it."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Sight Lenses",
-										"entries": [
-											"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through Fog, Mist, Smoke, Clouds, and non-Magical Darkness as normal sight up to 15 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Smoke Cloak",
-										"entries": [
-											"Create a cloak that causes you to blend in with smoke. When you start your turn lightly or heavily obscured by smoke, you are invisible until your turn ends, you cast a spell, make an attack, or damage an enemy."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Stinking Gas",
-										"prerequisite": "9th level",
-										"entries": [
-											"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast Stinking Cloud rather than Fog Cloud, following the same rules."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Striding Boots",
-										"entries": [
-											"You modify your boots with amplified striding speed. While earing these boots, you are under the effects of Longstrider spell."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Stopwatch Trinket",
-										"prerequisite": "9th level, Incompatible with other Trinkets.",
-										"entries": [
-											"You create a magical stopwatch that manipulates time magic. As an action, you can cast Haste or Slow using the Stopwatch without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Truesight Lenses",
-										"prerequisite": "Sight Lenses.",
-										"entries": [
-											"You upgrade and fine tune your sight lenses, granting you Truesight up to 15 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Useful Universal Key",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast Passwall without expending a spell slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Zombie Wires",
-										"prerequisite": "15th level",
-										"entries": [
-											"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast Danse Macabre without expended a spell slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									}
-								]
-							}
-						],
-						[
 							{
 								"type": "entries",
 								"entries": [
@@ -1312,7 +1310,7 @@
 										"type": "entries",
 										"name": "Runesmith's Proficiency",
 										"entries": [
-											"At 1st level, you gain proficiency with smith's tools and jeweler's tools, and can select two more languages that you can read and write (but not speak).",
+											"At 1st level, you gain proficiency with {@item smith's tools|phb} and {@item jeweler's tools|phb}, and can select two more languages that you can read and write (but not speak).",
 											"Your knowledge of runic magic gives you a natural affinity for scribing spell scrolls. Creating a magic spell scroll only takes you half the time and material cost it would normally take."
 										]
 									},
@@ -1453,7 +1451,7 @@
 										"name": "Arcane Barrage Armament",
 										"prerequisite": "9th level. This is incompatable with any other armaments.",
 										"entries": [
-											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast Magic Missile as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
+											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
 											"The charges are regained after a long rest."
 										]
 									},
@@ -1462,7 +1460,7 @@
 										"name": "Cloaking Device",
 										"prerequisite": "15th level",
 										"entries": [
-											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: Invisibility (2 charges), Greater Invisibility (4 charges).",
+											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
 											"It regains all charges after a long rest."
 										]
 									},
@@ -1495,7 +1493,7 @@
 										"name": "Flamethrower Armament",
 										"prerequisite": "9th level",
 										"entries": [
-											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast Burning Hands as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
+											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell burning hands} as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
 											"The charges are regained after a long rest."
 										]
 									},
@@ -1503,7 +1501,7 @@
 										"type": "optfeature",
 										"name": "Powerful Grappler",
 										"entries": [
-											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the Athletics skill and has advantage on attacks against creatures that it is grappling."
+											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the {@skill Athletics} skill and has advantage on attacks against creatures that it is grappling."
 										]
 									},
 									{
@@ -1512,7 +1510,7 @@
 										"prerequisite": "5th level Artificer. Warforged Golem Strength Score of 15 or higher.",
 										"entries": [
 											"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
-											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity (Stealth) checks."
+											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
 										]
 									},
 									{
@@ -1579,7 +1577,7 @@
 										"type": "optfeature",
 										"name": "Precision Movements",
 										"entries": [
-											"Your Warforged Golem gains Proficiency in the Stealth skill and with Thieves' Tools. Additionally, it gains an integrated set of Thieve's Tools that are always available (unless removed)."
+											"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
 										]
 									},
 									{
@@ -1696,7 +1694,7 @@
 										"type": "entries",
 										"name": "Warsmith's Proficiency",
 										"entries": [
-											"At 1st level, you gain proficiency with heavy armor and smith's tools."
+											"At 1st level, you gain proficiency with heavy armor and {@item smith's tools|phb}."
 										]
 									},
 									{
@@ -1786,7 +1784,7 @@
 												"name": "Active Camouflage Armor",
 												"prerequisite": "5th level",
 												"entries": [
-													"As an action, you can activate active camouflage causing your suit to automatically blend into its surroundings. This lasts until deactivated. While this active, you are considered lightly obscured, and can hide from a creature even when they have a clear line of sight to you. Wisdom (Perception) checks to find you that rely on vision are made with disadvantage."
+													"As an action, you can activate active camouflage causing your suit to automatically blend into its surroundings. This lasts until deactivated. While this active, you are considered lightly obscured, and can hide from a creature even when they have a clear line of sight to you. Wisdom ({@skill Perception}) checks to find you that rely on vision are made with disadvantage."
 												]
 											},
 											{
@@ -1802,7 +1800,7 @@
 												"prerequisite": "15th level. Prerequisite: Darkvision Visor",
 												"entries": [
 													"You add a heavily enchanted visor to your Mechplate that augments your vision. The Visor has 6 Charges.",
-													"Once it is integrated into your armor, you can use an Action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: See Invisibility (2 charges) or True Seeing (4 charges).",
+													"Once it is integrated into your armor, you can use an Action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell see invisibility} (2 charges) or {@spell true seeing} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1819,7 +1817,7 @@
 												"name": "Cloaking Device",
 												"prerequisite": "Active Camouflage",
 												"entries": [
-													"You install an Arcane Cloaking device on your Mechplate. This device has 4 Charges. You can expend 1 or more charges to cast one of the following spells using its action: Invisibility (2 charges), Greater Invisibility (4 charges).",
+													"You install an Arcane Cloaking device on your Mechplate. This device has 4 Charges. You can expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
 													"It regains all charges after a long rest."
 												]
 											},
@@ -1981,7 +1979,7 @@
 												"name": "Relocation Matrix",
 												"prerequisite": "15th level",
 												"entries": [
-													"You install an arcane transmutation matrix that you can use to convert your magical power into dimensional warp. As an action, you can cast Dimension Door without expending a spell slot. Once you use this ability, you can not use it again until you complete a long rest."
+													"You install an arcane transmutation matrix that you can use to convert your magical power into dimensional warp. As an action, you can cast {@spell dimension door} without expending a spell slot. Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},
 											{
@@ -1989,7 +1987,7 @@
 												"name": "Sealed Suit",
 												"prerequisite": "5th level",
 												"entries": [
-													"As a bonus action on your turn you can environmentally seal your Mechplate, giving you an air supply for up to 1 hour and making you immune to poison (but not curing you of existing poisoned conditions).",
+													"As a bonus action on your turn you can environmentally seal your Mechplate, giving you an air supply for up to 1 hour and making you immune to poison (but not curing you of existing {@condition poisoned} conditions).",
 													"Your armor regains 1 minute of air for every minute that you are not submerged and the armor is not sealed.",
 													"In addition to the above, you are also considered adapted to cold and hot climates while wearing your armor, and you're also acclimated to high altitude while wearing your armor."
 												]
@@ -2071,7 +2069,7 @@
 										"type": "entries",
 										"name": "Wandsmith's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with woodcrafter's tools and jeweler's tools.",
+											"When you choose this specialization at 1st level, you gain proficiency with {@item woodcarver's tools|phb} and {@item jeweler's tools|phb}.",
 											"Additionally, when using wondrous item Wand that has rolls a d20 when the last charge is consumed, rolling a 1 on that roll will no longer result in that wand being destroyed."
 										]
 									},
@@ -2202,7 +2200,7 @@
 										"type": "entries",
 										"name": "Alchemist's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with Blowguns, Alchemist's supplies and Glassblower's tools.",
+											"When you choose this specialization at 1st level, you gain proficiency with Blowguns, {@item Alchemist's supplies|phb} and {@item Glassblower's tools|phb}.",
 											"Your knowledge of alchemy gives you a natural affinity for brewing potions. Creating a potion through normal crafting takes you only half the time and cost it would normally take."
 										]
 									},
@@ -2233,7 +2231,7 @@
 												"type": "entries",
 												"name": "Poisonous Gas",
 												"entries": [
-													"As an action you can produce a reaction causing noxious fumes. At point within 15 feet, you can toss quick combination of things that will cause a whiff of poisonus gas to erupt spreading to a radius of 5 feet. Creatures in that area have to make a constitution saving throw, or take 1d4 poison damage and become poisoned until the end of their next turn.",
+													"As an action you can produce a reaction causing noxious fumes. At point within 15 feet, you can toss quick combination of things that will cause a whiff of poisonus gas to erupt spreading to a radius of 5 feet. Creatures in that area have to make a constitution saving throw, or take 1d4 poison damage and become {@condition poisoned} until the end of their next turn.",
 													"The damage damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4)."
 												]
 											},
@@ -2287,7 +2285,7 @@
 													],
 													[
 														"5th",
-														"{@spell cloudkill}, {@spell skill empowerment}"
+														"{@spell cloudkill}, {@spell skill empowerment|xge}"
 													]
 												]
 											},
@@ -2322,7 +2320,7 @@
 												"prerequisite": "9th level",
 												"entries": [
 													"You create a potent serum. As an action on your turn, you can consume this serum, granting you the effects of Haste and Heroism for a number of rounds equal to your Intelligence modifier (minimum 1). These effects do not require concentration, but you still suffer the normal effects of the Haste spell ending when it ends. You can use this a number of times equal to your constitution modifier (minimum 1) before you must take a long rest to gain the effects from the serum again.",
-													"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become poisoned on a failed save."
+													"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become {@condition poisoned} on a failed save."
 												]
 											},
 											{
@@ -2367,7 +2365,7 @@
 												"type": "optfeature",
 												"name": "Frostbloom Reaction",
 												"entries": [
-													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a dexterity saving throw, or be caught by the ice taking 1d6 cold damage; a creature entirely in the area of effect that fails also becoming restrained until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
+													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a dexterity saving throw, or be caught by the ice taking 1d6 cold damage; a creature entirely in the area of effect that fails also becoming {@condition restrained} until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
 													"The damage damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
 												]
 											},
@@ -2435,7 +2433,7 @@
 														"type": "list",
 														"items": [
 															"Contact poison. You can apply this to a weapon or up to ten pieces of ammunition, lasting until the end of your next long rest. That weapon deals an additional 1d4 poison damage to targets it strikes.",
-															"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become poisoned until they complete a long rest.",
+															"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become {@condition poisoned} until they complete a long rest.",
 															"Inhaled poison. This poison can be used to modify your poisonous gas reaction. Anytime before the end of your next long rest, you can use this dose of poison to make your poisonous gas instant reaction have a radius of 10 feet and deal twice as much damage on a failed save."
 														]
 													}
@@ -2496,7 +2494,7 @@
 															],
 															[
 																"2nd",
-																"{@spell dragon's breath}"
+																"{@spell dragon's breath|xge}"
 															],
 															[
 																"3rd",
@@ -2529,7 +2527,7 @@
 															],
 															[
 																"2nd",
-																"{@spell snilloc's snowball swarm}"
+																"{@spell snilloc's snowball swarm|xge}"
 															],
 															[
 																"3rd",

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,8 +8,8 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5",
-				"url": "http://homebrewery.naturalcrit.com/share/H1ZDtpyaT-",
+				"version": "1.5.1",
+				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
 		]
@@ -320,7 +320,9 @@
 					"medium"
 				],
 				"weapons": [
-					"simple"
+					"simple",
+					"hand crossbows",
+					"heavy crossbows"
 				],
 				"tools": [
 					"thieves' tools"
@@ -342,9 +344,9 @@
 			"startingEquipment": {
 				"additionalFromBackground": true,
 				"default": [
-					"(a) a handaxe and a light hammer or (b) any two simple weapons.",
-					"(a)  scale mail or (b) leather armor",
-					"thieves' tools and a dungeoneer's pack"
+					"(a) a {@item light crossbow|phb} and {@item crossbow bolts (20)|phb|20 bolts} or (b) any two {@filter simple weapons|items|source=phb|category=basic|type=simple weapon}",
+					"(a) {@item scale mail|phb}, (b) {@item leather armor|phb}, or (c) {@item chain mail|phb}",
+					"{@item thieves' tools|phb} and a {@item dungeoneer's pack|phb}"
 				]
 			},
 			"classFeatures": [
@@ -477,7 +479,7 @@
 						"type": "entries",
 						"name": "Arcane Reconstruction",
 						"entries": [
-							"At 6th level, you have mastered the knowledge of using magic to repair things. You learn the Mending cantrip, and can cast it at will. Additionally, you learn the Cure Wounds spell. If you already know Cure Wounds you can select another spell from the Artificer list. When you cast Cure Wounds, it can heal constructs in addition to normally valid targets. Both Mending and Cure Wounds learned through this features are considered Artificer spells for you."
+							"At 6th level, you have mastered the knowledge of using magic to repair things. You learn the {@spell mending} cantrip, and can cast it at will. Additionally, you learn the {@spell cure wounds} spell. If you already know {@spell cure wounds} you can select another spell from the Artificer list. When you cast {@spell cure wounds}, it can heal constructs in addition to normally valid targets. Both {@spell mending} and {@spell cure wounds} learned through this features are considered Artificer spells for you."
 						]
 					},
 					{
@@ -976,14 +978,14 @@
 												"type": "optfeature",
 												"name": "Smoke Bomb",
 												"entries": [
-													"As an action, you can use this to instantly cast {@spell Fog Cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
+													"As an action, you can use this to instantly cast {@spell fog cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Shock Generator",
 												"entries": [
-													"As an action, you can use this to cast {@spell Shocking Grasp}."
+													"As an action, you can use this to cast {@spell shocking grasp}."
 												]
 											}
 										]
@@ -1708,7 +1710,7 @@
 												"entries": [
 													"{@i Wondrous Item, Attunement (creator only).}",
 													"{@b Weight} 5 lb.",
-													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell Shocking Grasp} cantrip and can cast it through the gauntlet."
+													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell shocking grasp} cantrip and can cast it through the gauntlet."
 												]
 											},
 											"If you lose your mechplate gauntlet, you can remake it during a long rest with 25 gold worth of materials, or can scavenge for materials and forge it over two days of work (eight hours a day) without the material expense."
@@ -1848,7 +1850,7 @@
 												"name": "Flame Projector",
 												"prerequisite": "9th level. Incompatible with other projectors.",
 												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell Burning Hands} (1 charge), {@spell Fireball} (3 charges), or {@spell Wall of Fire} (4 charges).",
+													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell burning hands} (1 charge), {@spell fireball} (3 charges), or {@spell wall of fire} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1857,7 +1859,7 @@
 												"name": "Flash Freeze Capacitor",
 												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
-													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell Cone of Cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
+													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell cone of cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
 												]
 											},
@@ -1905,7 +1907,7 @@
 												"name": "Lightning Projector",
 												"prerequisite": "9th level. Incompatible with other projectors.",
 												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell Thunderwave} (1 charge), {@spell Lightning Bolt} (3 charges), or {@spell Storm Sphere|XGE} (4 charges).",
+													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell thunderwave} (1 charge), {@spell lightning bolt} (3 charges), or {@spell storm sphere|XGE} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1938,14 +1940,13 @@
 												"name": "Power Slam Capacitor",
 												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
-													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell Destructive Wave} upon landing.",
+													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell destructive wave} upon landing.",
 													"Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Power Fist",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
 													"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal 1d8 bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
 													"{@b Special:} When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
@@ -2006,7 +2007,7 @@
 												"name": "Sun Cannon",
 												"prerequisite": "15th level",
 												"entries": [
-													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell Sunbeam} without expending a spell slot.",
+													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell sunbeam} without expending a spell slot.",
 													"Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,7 +8,7 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5.1",
+				"version": "1.5",
 				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
@@ -1825,17 +1825,17 @@
 											},
 											{
 												"type": "optfeature",
-												"name": "Darkvision Visor",
-												"entries": [
-													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
-												]
-											},
-											{
-												"type": "optfeature",
 												"name": "Collapsible",
 												"prerequisite": "5th level. Incompatible with Piloted Golem",
 												"entries": [
 													"Your Mechplate can collapse into a case for easy storage. When transformed this way the armor is indistinguishable from a normal case and weighs 1/3 its normal weight. As an action you can don or doff the armor, allowing it to transform as needed."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Darkvision Visor",
+												"entries": [
+													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
 												]
 											},
 											{

--- a/creature/Tobias Beis; Critter Compendium.json
+++ b/creature/Tobias Beis; Critter Compendium.json
@@ -6,7 +6,7 @@
 				"abbreviation": "CC (3pp)",
 				"full": "Critter Compendium (3pp)",
 				"authors": [
-					"Kobold Press"
+					"Tobias Beis"
 				],
 				"version": "1.0",
 				"url": "https://www.dmsguild.com/product/210151/Critter-Compendium",


### PR DESCRIPTION
Lots of changes for the Revised Artificer

- Fixed the broken Gadgetsmith subclass, the specializations were showing at the wrong levels and the upgrades weren't formatted correctly
- Fixed the Warsmith's misordering of some upgrades and the Power Fist upgrade had an erroneous prerequisite
- Added a lot of spell, skill, condition, and item links, corrected some incorrect ones
- Updated the source link to the latest GMBinder link from KibblesTasty
- Corrected the starting equipment and proficiencies (added the missing hand crossbow and heavy crossbow)

One small fix for the Critter Compendium, the author was listed as Kobold Press so fixed that to say Tobias Beis