### PR TITLE
Moved Revised Artificer upgrades to Optional Features

### DIFF
--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -1683,7 +1683,7 @@
 									"At the end of a short or long rest, pick a spell you know. You can infuse this spell into an item for later use. You must expend any components the spell requires, but this does not expend a spell slot. Subsequently, any creature holding the item with an Intelligence of 6 or higher that is aware there is magic infused in it can expend the stored magic and cast the spell.",
 									"The spell uses your spellcasting modifiers, but is in all other ways treated as if the creature holding it cast the spell. The magic infused in the item fades if you complete a short or long rest without expending the stored spell.",
 									{
-										"name": "Golemsmith Upgrades",
+										"name": "Infusionsmith Upgrades",
 										"entries": [
 											{
 												"type": "optfeature",

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -426,29 +426,29 @@
 				],
 				[
 					{
-						"name": "Artificer Specialist feature",
-						"entries": [
-							"At 3rd level, you gain another feature from your Artificer Specialization."
-						],
-						"gainSubclassFeature": true
-					},
-					{
 						"name": "Specialization Upgrade",
 						"entries": [
 							"Your expert craftsmanship allows you to improve your Specialization's Wondrous Item with new attributes.",
 							"Starting at 3rd level, choose an upgrade from the list at the end of your specialization. The features and properties of your Specialization's Wondrous Item permanently improves in that way.",
 							"You apply an additional upgrade to your Specialization's Wondrous Item at 5th, 7th , 9th , 11th, 13th, 15th, 17th and 19th level. You cannot apply an upgrade more than once, unless the upgrade's description says otherwise. Upgrades cannot be replaced or changed, besides as described in the specialization.",
-							"In any case that Specialization allows the upgrade to be swapped out, Upgrades must always be selected as if the Artificer is the level they were when they got that Upgrade slot. For example, if you replace your Thundercannon and reselect all your upgrades at as a 5th level Artificer, you could select one 3rd level upgrade and one 5th level upgrade, you would not be able to select two upgrades that both had a prerequisite of 5th level artificer."
+							"In any case that Specialization allows the upgrade to be swapped out, Upgrades must always be selected as if the Artificer is the level they were when they got that Upgrade slot. For example, if you replace your Thundercannon and reselect all your upgrades at as a 5th level Artificer, you could select one 3rd level upgrade and one 5th level upgrade, you would not be able to select two upgrades that both had a prerequisite of 5th level artificer.",
+							{
+								"type": "inset",
+								"name": "Customizing Artificer Upgrades",
+								"entries": [
+									"The upgrades for each Artificer Specialization is presented in a list at the end of the Specialization, but invariably there will always be ideas for upgrades not included in that list. At the heart of an Artificer beats an unrelenting drive for creativity, after all!",
+									"It is recommended that if there is Upgrade not included in your class list, you consult your DM to add it.",
+									"An custom upgrade should aim be balanced against the existing non-level restricted upgrades, as the level restricted upgrades are balanced around the limited number of them available."
+								]
+							}
 						]
 					},
 					{
-						"type": "inset",
-						"name": "Customizing Artificer Upgrades",
+						"name": "Artificer Specialist feature",
 						"entries": [
-							"The upgrades for each Artificer Specialization is presented in a list at the end of the Specialization, but invariably there will always be ideas for upgrades not included in that list. At the heart of an Artificer beats an unrelenting drive for creativity, after all!",
-							"It is recommended that if there is Upgrade not included in your class list, you consult your DM to add it.",
-							"An custom upgrade should aim be balanced against the existing non-level restricted upgrades, as the level restricted upgrades are balanced around the limited number of them available."
-						]
+							"At 3rd level, you gain another feature from your Artificer Specialization."
+						],
+						"gainSubclassFeature": true
 					}
 				],
 				[
@@ -747,169 +747,22 @@
 										]
 									},
 									{
-										"name": "Cannonsmith Upgrades",
-										"entries": [
-											{
-												"type": "optfeature",
-												"name": "Autoloading Magazine",
-												"prerequisite": "Magazine",
-												"entries": [
-													"Your Thunder Cannon now automatically chambers the next round, no longer requiring your bonus action to reload."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Blast Shells",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You can choose to fire a blast shell when firing your Thunder Cannon. When firing a Blast Shell, pick a target area within normal range of your Thunder Cannon. Make an attack roll as normal, and apply that attack roll to all targets within a 5 foot radius of your target point.",
-													"You can apply Thundermonger damage to one target creature hit, or apply half of Thundermonger damage to all creatures hit."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Cannon Improvement",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You fine tune your Thunder Cannon's firing mechanism. The Thunder Cannon gains a +1 bonus to Attack and Damage Rolls made with it. You can apply this upgrade up to 3 times.",
-													"After the first time you take this upgrade, the piercing damage dealt by your Thunder Cannon is considered magical."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Divination Scope",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You add a scope to your Thunder Cannon and enchant the lenses with Divination magic. The Scope has 3 Charges. As a bonus action you can use 1 charge to cast Hunter's Mark. As an action you can use 2 charges to cast See Invisibility or 3 charges to cast Clairvoyance.",
-													"The scope regains all charges after a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Echoing Boom",
-												"prerequisite": "Incompatible with Silencer",
-												"entries": [
-													"You pack extra power into your Thundermonger, increasing the damage it deals by {@dice 1d6}."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Extended Barrel",
-												"prerequisite": "",
-												"entries": [
-													"You extend the length of your Thunder Cannon's barrel and add rifling. The normal weapon range of your Thunder Cannon increases by 30 feet, and the maximum range by 90 feet. You can apply this upgrade up to 2 times.",
-													"After applying this twice, if you have the Lightning Charged Bayonet upgrade, the Bayonet gains the Reach property."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Harpoon Reel",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You install a secondary firemode that launches a Harpoon attached to a tightly coiled cord. This attack has a normal range of 30 feet and an maximum range of 60 feet, and it deals only {@dice 1d6} piecing damage. This attack can target a surface, object, or creature.",
-													"A creature struck by this attack is impaled by the Harpoon unless it removes the Harpoon as an action, which causes it to take an additional {@dice 1d6} damage. While the Harpoon is stuck in the target, you are connected to the target by an 60 ft cord.",
-													"While connected in this manner, you can use your bonus action to activate the Reel action, pulling yourself to the location if the target if the target is Medium or larger. A Small or smaller creature is pulled back to you. Alternatively, you can opt to disconnect the cord.",
-													"This attack cannot be used again until the Reel action is taken."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Integrated Magazine",
-												"entries": [
-													"Your Thunder Cannon holds 2 rounds at a time, allowing you to attack twice before a bonus action reload is required."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Lightning Burst",
-												"entries": [
-													"You upgrade your Thunder Cannon to discharge its power in within a 5-feet wide and 60-feet long line. As an action, you can make a special attack. Each creature must make a Dexterity saving throw or take damage equal to the bonus damage of Thundermonger as lightning damage on a failed save, half as much on a successful save. Using this shot counts as applying Thundermonger damage for the turn.",
-													"Firing in this method does not consume ammo."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Lightning Charged Bayonet",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You affix a short blade to the barrel of your Thunder Cannon, allowing you to make a melee weapon attack with it. The blade is a finesse weapon melee weapon that you are proficient with, and deals {@dice 1d6} Piercing damage.",
-													"The blade can be used to apply Thundermonger bonus damage. When Thundermonger bonus damage is dealt with a bayonet attack, the damage type is lightning. Dealing damage this way counts as applying Thundermonger damage for the turn."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Overchannel Capacitor",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You gain the ability to channel your magical power into the Thunder Cannon to overload its damage. You can expend a spell slot to increase the damage dealt by Thundermonger by {@dice 1d8} per spell level spent."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Silencer",
-												"prerequisite": "Incompatible with Echoing Booms",
-												"entries": [
-													"You upgrade your Thunder Cannon with a sound dampening module. Your Thunder Cannon loses the Loud property."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Snap Fire",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You upgrade your Thunder Cannon for quick shots. You can use your reaction to take a opportunity attack with your Thunder Cannon if an enemy comes within 10 ft of you. You have disadvantage on this attack. This attack only deals Thundermonger bonus damage if you have not dealt the bonus damage since the start of your last turn."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Shock Absorber",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You add a reclamation device to your Thunder Cannon to gather energy from the surroundings when it is present. As a reaction to taking Lightning or Thunder Damage, you can cast {@spell absorb elements|xge} without consuming a spell slot. When absorbed in this method, you can apply the bonus damage granted by {@spell absorb elements|xge} to your next Thunder Cannon attack even if you make a ranged attack."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Shock Harpoon",
-												"prerequisite": "9th level Artificer, Harpoon Reel",
-												"entries": [
-													"After hitting a creature with the Harpoon fire mode, you can use a bonus action to deliver a shock. If you have not used it since the start of your turn, you can apply Thundermonger damage as lightning damage. Additionally, the target must make a Constitution saving throw against your spell save DC or be {@condition stunned} until the end of its next turn.",
-													"Once used, the Harpoon must be reeled in before this can be used again."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Storm Blast",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You upgrade your Thunder Cannon to discharge its power in 30-foot cone from the gun. As an action, you can make a special attack. Each creature must make a Strength saving throw, or take half the bonus damage of Thundermonger and be knocked {@condition prone}. Using this shot counts as applying Thundermonger damage for the turn.",
-													"Firing in this way does not consume ammo."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Synaptic Feedback",
-												"prerequisite": "9th level",
-												"entries": [
-													"You install feedback loop into your cannon, allowing you to siphon some energy from your Thunder Cannon to empower your reflexes. Whenever you deal lightning damage with your Thunder Cannon your walking speed increases by 10ft and you can take the Dash or Disengage actions as a bonus action. This boost lasts until the start of your next turn."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Turret Deployment",
-												"prerequisite": "9th level",
-												"entries": [
-													"You can set up your Thunder Cannon and operate it remotely. As an action, you deploy your Thunder Cannon in a spot adjacent to you, and subsequently can attack with it as long as you are within 100 feet of it and you can see the target you are attacking. It still has its normal range from the point it is attacking. A creature adjacent to it in this mode can use an action to render it nonfunctional as a turret."
-												]
-											}
-										]
-									},
-									{
 										"type": "inset",
 										"name": "Firearms In a Campaign Setting",
 										"entries": [
 											"A lot of campaign settings do not feature firearms, and in some of these the Cannonsmith variant of Artificer might not be the right choice, but consider that the Artificer is fundamentally someone that tinkers and explores magic as much as technology. A Thunder Cannon need not be a gunpowder powered device, and in most cases is more an engineering marvel of magic than technology.",
 											"Inversely, in a setting where firearms are more widespread and magic is more limited, feel free to move the slider the other direction."
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"name": "Cannonsmith Upgrades",
+										"entries": [
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Cannonsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -1005,263 +858,6 @@
 											"At 3rd level, you've mastered the essential tools begun to tinker with ways to expand your arsenal. The number of upgrades you have for your class level is increased by one.",
 											"The number of additional upgrades you get increases to two more than the class table at 5th level."
 										]
-									},
-									{
-										"type": "entries",
-										"name": "Gadgetsmith Upgrades",
-										"entries": [
-											{
-												"type": "optfeature",
-												"name": "Airburst Mine",
-												"entries": [
-													"You create a mechanical device capable of producing a devastating blast. You can use this device to cast {@spell shatter} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Boomerang of Hitting",
-												"entries": [
-													"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals {@dice 1d4} damage. At level 5, this weapon gaisn a +1 to attack and damage rolls; this increases to a +2 at level 14.",
-													"Special: When this weapon is Thrown, you can target two creatures within 10 feet of each other, making a separate attack roll against each target.",
-													"This weapon returns to your hand after you make an attack with it using the Thrown property."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Belt of Adjusting Size",
-												"entries": [
-													"You create a belt with a creature size dial on it. While you are wearing this belt, you can use an action to cast {@spell enlarge/reduce} on yourself. Once you use this gadget, you cannot use it again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Binding Rope",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save DC or become {@condition restrained} until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Bracers of Empowerment",
-												"prerequisite": "11th level Artificer",
-												"entries": [
-													"You create bracers that can empower you. You can use this to cast {@spell tenser's transformation|xge} without expending a Spell Slot.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Deployable Wings",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Disintegration Ray",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You create a Disintegratation Ray. You can use this to cast {@spell disintegrate} without expending a Spell Slot.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Gripping Gloves",
-												"prerequisite": "11th level Artificer",
-												"entries": [
-													"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength ({@skill Athletics}) checks involving manipulating things with your hands while wearing these gloves."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Element Eater",
-												"entries": [
-													"You create a device capable of absorbing incoming elemental damage. As a reaction to taking elemental damage, you can activate this device and cast {@spell absorb elements|xge} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Enhanced Grappling Hook",
-												"entries": [
-													"You enhance your grappling hook, increasing its range to 40 feet. Additionally, the enhanced power of the grappling hook means that when pulling yourself to a large or larger creature or object, you can drag one medium or smaller willing or grappled creature within 5 feet of you with you."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Fire Spitter",
-												"entries": [
-													"You create a gadget that creates a quick blast of fire. As an action, you can cast {@spell aganazzar's scorcher|xge} with this gadget, but the gadget cannot be used again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Flashbang",
-												"entries": [
-													"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a Dexterity saving throw or be {@condition blinded} until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Impact Gauntlet",
-												"entries": [
-													"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals {@dice 1d8} bludgeoning damage. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
-													"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll.",
-													"You can apply this upgrade up to 2 times, making a separate item each time."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Lightning Baton",
-												"entries": [
-													"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals {@dice 1d4} bludgeoning damage and {@dice 1d4} lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save DC or become {@condition stunned} until the start of your next turn. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
-													"You can apply this upgrade up to 2 times, making a separate item each time."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Lightning Generator",
-												"prerequisite": "11th level Artificer. Requires Shock Generator.",
-												"entries": [
-													"You upgrade your shock generator with additional lightning capabilities. You can cast {@spell lightning lure|scag} at-will using it, can overload it to cast {@spell lightning bolt}. Once you overload it, you cannot use it to cast {@spell lightning bolt} again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Mechanical Arm",
-												"entries": [
-													"You create a mechanical arm, giving an extra hand. This mechanical arm only functions while it is mounting on gear you are wearing, but can be operated mentally without the need for you hands. This mechanical arm can serve any function a normal hand could, such as holding things, making attacks, interacting with the environment, etc, but does not give you additional actions."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Mechanical Familiar",
-												"entries": [
-													"You can create the blue print for a small mechanical creature. At the end of a long rest, you can choose animate it, and cast {@spell find familiar} with the following modifications. The creatures type is Construct, and you cannot select a creature with a flying speed. This construct stays active until you deactivate it or is destroyed. In either case, you can choose to reactivate it at the end of a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Nimble Gloves",
-												"prerequisite": "11th level Artificer",
-												"entries": [
-													"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity ({@skill Sleight of Hand}) checks involving manipulating things with your hands while wearing these gloves."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Phase Trinket",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast {@spell blink} or {@spell dimension door} using the Stopwatch without expending a Spell Slot.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Jumping Boots",
-												"entries": [
-													"You modify your boots with arcane boosters. While wearing these boots, you are under the effects of the {@spell jump} spell."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Repeating Hand Crossbow",
-												"entries": [
-													"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals {@dice 1d6} piercing damage. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
-													"Special: This weapon does not require a free-hand to load, as it has a built in loader. When you fire this weapon with advantage, once per turn you can forgo advantage on an attack to make one additional attack."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Bee Swarm Rockets",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You design a type of tiny firecracker-like device, which can release rockets in large numbers. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a Dexterity saving throw. Creatures that fail take {@dice 2d6} fire damage, or half as much on a successful one.",
-													"You rebuild your stock to your maximum during a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Shock Generator",
-												"entries": [
-													"You create a device capable of generating potent shocks. You can use this to cast {@spell shocking grasp}. When you cast {@spell shocking grasp} with this feature, you can use either your Dexterity or Intelligence modifier for the melee spell attack roll."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Shocking Hook",
-												"entries": [
-													"You can integrate your Shock Generator and your Grappling Hook. If the target of your Grappling Hook is a creature, you can cast {@spell shocking grasp} on that creature as a bonus action when pulling it to you or being pulled to it."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Sight Lenses",
-												"entries": [
-													"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through fog, mist, smoke, clouds, and non-magical darkness as normal sight up to 15 feet."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Smoke Cloak",
-												"entries": [
-													"Create a cloak that causes you to blend in with smoke. When you start your turn lightly or heavily obscured by smoke, you are {@condition invisible} until your turn ends, you cast a spell, make an attack, or damage an enemy."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Stinking Gas",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast {@spell stinking cloud} rather than {@spell fog cloud}, following the same rules."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Striding Boots",
-												"entries": [
-													"You modify your boots with amplified striding speed. While earing these boots, you are under the effects of {@spell longstrider} spell."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Stopwatch Trinket",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You create a magical stopwatch that manipulates time magic. As an action, you can cast {@spell haste} or {@spell slow} using the Stopwatch without expending a Spell Slot.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Truesight Lenses",
-												"prerequisite": "Sight Lenses.",
-												"entries": [
-													"You upgrade and fine tune your sight lenses, granting you Truesight up to 15 feet."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Useful Universal Key",
-												"prerequisite": "11th level Artificer",
-												"entries": [
-													"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast {@spell passwall} without expending a spell slot.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Zombie Wires",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast {@spell danse macabre|xge} without expended a spell slot.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											}
-										]
 									}
 								]
 							},
@@ -1274,6 +870,17 @@
 										"entries": [
 											"Starting at the 3rd level, during a long rest and taking effect when you complete it, you can disassemble your gadgets and create different ones. When you do this, remove any upgrade you would like, and pick a new upgrade its place. You still must select upgrades that are valid for the level you gained the upgrade at (e.g. at 7th level, you can only have one upgrade that has a prerequisite of 7th level).",
 											"Additionally, if a gadget is destroyed, you can use this feature to recreate it for materials worth 20 gold pieces."
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"name": "Gadgetsmith Upgrades",
+										"entries": [
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Gadgetsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -1426,200 +1033,16 @@
 							{
 								"name": "Intelligent Oversight",
 								"entries": [
-									"Starting at 3rd level, you can use the Help action as a bonus action when assisting your golem. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than 5 feet of you, if the allied creature can see or hear you.",
+									"Starting at 3rd level, you can use the Help action as a bonus action when assisting your golem. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than 5 feet of you, if the allied creature can see or hear you."
+								]
+							},
+							{
+								"type": "entries",
+								"entries": [
 									{
 										"name": "Golemsmith Upgrades",
 										"entries": [
-											{
-												"type": "optfeature",
-												"name": "Arcane Barrage Armament",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
-													"Once used, this armament cannot be used again until the Artificer completes a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Arcane Resonance",
-												"entries": [
-													"Install an essence connection into your golem to sync your magic to it. You can make any spell you cast that targets only you also target your golem."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Cloaking Device",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
-													"It regains all charges after a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Environmental Adaptation",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You add integrated climbing hooks, deployable fins, insulated seals to your Golem. Your Warforged Golem gains a climbing and swimming speed equal to its walking speed.",
-													"Additionally, it gains resistance to Cold and Fire damage."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Expanded",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You enlarge your Warforged Golem, increasing its size category by one. It has advantage on Strength checks and Strength saving throws."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Flamethrower Armament",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. As an action, the golem can cast {@spell burning hands} as a 3rd level spell.",
-													"The spell save DC is equal to your spell save DC. When cast this way, it has no Verbal or Somatic component.",
-													"Once used, this armament cannot be used again until the Artificer completes a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Magical Essence",
-												"entries": [
-													"You infuse a fragment of magical essence into your golem, allowing it to attune to one magical item."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Heavy Armor Plating",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
-													"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Improve Dexterity",
-												"entries": [
-													"You tune the servos in your Warforged Golem. Your Warforged Golem's Dexterity score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Dexterity score is 18."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Improve Strength",
-												"entries": [
-													"You reinforce the power of your golem's core and limbs. Your Warforged Golem's Strength score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Strength score is 18."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Iron Fortress",
-												"prerequisite": "Stabilisation",
-												"entries": [
-													"You increase the size and durability of your golem’s frame. Your Warforged Golem now counts as full cover for people behind it or riding it. Additionally, it cannot be moved against its will while in contact with a floor."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Multiattack Protocol",
-												"prerequisite": "11th level Artificer",
-												"entries": [
-													"Your Warforged Golem gains multiattack. When your Warforged Golem uses the Attack action, it can attack twice."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Mark of Life",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You have attained the understanding of magic and craft a Mark of Life on the forehead of your Warforged Golem, turning it into a Warforged Companion. It gains an Intelligence score of 8, a Wisdom score of 8 and a Charisma score of 8. This allows it to follow more complex commands without direct input, speak, and remember things.",
-													{
-														"type": "inset",
-														"name": "Roleplaying a Warforged Golem",
-														"entries": [
-															"If you choose the Mark of Life upgrade, your Warforged golem becomes sentient companion, capable of learning, thinking, and having opinions. Consider how this may impact your interactions."
-														]
-													}
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Overdrive Protocol",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You build in a special mode allowing your golem go beyond it's normal limitations. As an action, your golem can activate this mode, gaining the effects of {@spell haste} for a number of rounds equal to your Intelligence modifier, but loses its immuninty to {@condition exhaustion} until it completes a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Precision Movements",
-												"prerequisite": "Incompatible with Expanded",
-												"entries": [
-													"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Thundering Stomp",
-												"prerequisite": "Expanded",
-												"entries": [
-													"Your warforged golem can leverage it's increased size and magical nature to unleash a crushing stomp of magical energy when it brings down its foot. Your golem can replace any attack with the {@spell thunderclap|xge} spell using the Artificers level and spell save for casting the spell."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Redundant Systems",
-												"entries": [
-													"You have reinforced your Warforged Golem with layers of protection and redundant systems. It gains additional hitpoints equal to twice your Artificer level. Additionally, it gains advantage on death saving throws."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Remote Casting",
-												"entries": [
-													"You integrate a magical relay into your golem, allowing you use it as a magical familiar. As an action, you can see through your golem's eyes and hear what it hears until the start of your next turn. During this time, you are deaf and blind with regard to your own Senses.",
-													"Additionally, when you Cast a Spell with a range of touch, your golem can deliver the spell as if it had cast the spell. Your golem must be within 100 feet of you, and it must use its reaction to deliver the spell when you cast it. If the spell requires an Attack roll, you use your Attack modifier for the roll."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Runic Wings",
-												"prerequisite": "11th level Artificer. Incompatible with Expanded.",
-												"entries": [
-													"You add rune-engraved wings to your Warforged Golem, granting it a flying speed of 20 feet."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Stabilization",
-												"entries": [
-													"You increase the resilience and stability of your Warforged Golem. It gains proficiency in Constitution Saving Throws and has advantage against saving throws to be knocked down."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Warfare Routines",
-												"entries": [
-													"Your Warforged Golem gains one Fighting Style choosing from Archery, Defense, Dueling, or Great Weapon Fighting."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Warforged Apprentice",
-												"prerequisite": "Mark of Life. 15th level Artificer",
-												"entries": [
-													"Your Warforged Companion begins to apply its abilities to learn new things, gaining a class level in a class of your choosing. Your Warforged Companion gains all the first level features of the chosen class. This does not include health or class proficiencies (for example, selecting Fighter grants only Fighting Style and Second Wind)."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Warforged Adept",
-												"prerequisite": "Warforged Apprentice",
-												"entries": [
-													"Your growth as a Golemsmith is such that your creation is capable of learning and adapting even more skills. It gains all the second level features of the class you selected for the Warforged Apprentice upgrade. This does not include health or class proficiencies (for example, selecting Fighter grants only Action Surge)."
-												]
-											}
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Golemsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -1683,185 +1106,21 @@
 									"At the end of a short or long rest, pick a spell you know. You can infuse this spell into an item for later use. You must expend any components the spell requires, but this does not expend a spell slot. Subsequently, any creature holding the item with an Intelligence of 6 or higher that is aware there is magic infused in it can expend the stored magic and cast the spell.",
 									"The spell uses your spellcasting modifiers, but is in all other ways treated as if the creature holding it cast the spell. The magic infused in the item fades if you complete a short or long rest without expending the stored spell.",
 									{
-										"name": "Infusionsmith Upgrades",
-										"entries": [
-											{
-												"type": "optfeature",
-												"name": "Arcane Armament",
-												"entries": [
-													"You learn mastery of armoring yourself with magical enchantments. You learn the {@spell mage armor} spell and cast it at will. While under the effect of {@spell mage armor}, you can add your Intelligence to your armor class instead of your Dexterity."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Dancing Fires",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"When you animate a weapon with your Animated Weapon feature, you can additionally imbue it with ethereal flames, causing it to deal {@dice 1d6} force damage on hit."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Detonate Armament",
-												"prerequisite": "Arcane Armament. 9th level Artificer",
-												"entries": [
-													"As a reaction to taking damage, you can end the effect of {@spell mage armor} to cast {@spell thunder step|xge} without expending a spell slot.",
-													"Once you do this, you cannot gain the effect of {@spell mage armor} again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Enhanced Attribute",
-												"entries": [
-													"You can enhance a piece of non-magical jewelery with power that boots the wearers abilities. Select an attribute from Strength, Dexterity, Constitution, Wisdom, Intelligence or Charisma, the current and maximum attribute score for that attribute is increased by one while wearing this item. This piece of jewelry provides a benefit only to you.",
-													"You can take this upgrade twice."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Enhanced Weapon Enchantment",
-												"prerequisite": "Weapon Enchantment Expertise",
-												"entries": [
-													"You modify the {@spell magic weapon} and {@spell elemental weapon} spells into a more potent form.",
-													"When you cast the {@spell magic weapon} spell you can augment it with vorpal power; this spell has the effect of the {@spell magic weapon} spell, but in addition attacks made with the weapon score a critical hit on 19 or a 20 die roll, and the weapon deals force damage.",
-													"When you cast {@spell elemental weapon}, the additional damage dealt on hit is increased by an additional {@dice 1d4}, and you can pick force as the damage type in addition to the other options."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Explosive Mine",
-												"prerequisite": "Thunder Mine, 11th level Artificer",
-												"entries": [
-													"When you set a magical trap, you can make the mine cast {@spell fireball} instead of {@spell shatter}."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Flying Boots",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You cast a powerful infusion on a set of boots. The creature wearing these boots is under the effect of the {@spell fly} spell."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Focused Power Duration",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"When you use your Infused Focus power, the spell lasts a number of rounds equal to your Intelligence modifier + proficiency modifier."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Healing Infusion",
-												"entries": [
-													"You master the intricate arts of healing energies interaction with creatures. When you restore health to another creature on your turn, you can add your Intelligence modifier to the health restored."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Life Infusion",
-												"prerequisite": "11th level Artificer",
-												"entries": [
-													"You learn a potent magical infusion that suffuses a creature with life energy. You can cast {@spell regenerate} without expending a spell slot.",
-													"Once you cast this spell in this manner, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Radiant Infusion",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You learn a special infusion for bestowing radiant energy. When you use your Store Magic feature, rather than picking a spell you know, you can cast {@spell holy weapon|xge}. Unless you know this spell from another source, you can only cast this spell using the Store Magic feature. If you have the Weapon Enchantment Expertise upgrade, you have advantage on Constitution saving throws to maintain concentration on this spell."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Shielding Ring",
-												"entries": [
-													"You infuse powerful magic into a non-magical ring. You can use this ring to cast the {@spell shield} spell without expending a spell slot. You cannot use this ring to cast the spell again until you complete a short or long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Skill Infusion",
-												"entries": [
-													"You managed to make the magic of your Infused Weapon so potent that attacks made with it are made as if the wielder had a Fighting Style. Choose a Fighting Style from Dueling, Archery, or Great Weapon Master and apply the effects to attacks made with your Infused and Animated Weapons."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Spell Trapping Ring",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You set a powerful magic into a non-magical ring. You can use this ring to cast {@spell counterspell} without expending a spell slot. When you cast {@spell counterspell} in this way and it succeeds, the spell countered is stored in the ring. You can then cast the stored spell without expending a spell slot, but spell fades if it is not used before you complete a long rest.",
-													"Once you use this ring, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Soul Saving Bond",
-												"entries": [
-													"You set up a special magical bond between you and another creature. When either creature bound by this abilities fails Wisdom, Intelligence, Charisma, or Death saving throw, the other character can make their own saving throw, replacing the failed saved with their own roll. If this ability is used on a death saving throw, the replacement roll is a 20. Once a roll is replaced by this feature, it cannot be used again until both creatures in the bond have completed a short or long rest.",
-													"This bond can be set up with a different creature at the end of a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Thunder Mine",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You can set a magical trap by infusing explosive magic into an item. You can set this item to detonate when someone comes within 5 feet of it, or by a verbal command.",
-													"When the magic trap detonates, it casts {@spell shatter} centered on the item. If a creature is in the area of effect of more than one thunder mine during a turn, they take half damage from any subsequent effects of the mines.",
-													"Setting the magical mine takes a special ritual taking 1 minute, and cannot be moved once placed; any attempt to move it results it in detonating unless the Artificer setting it disarms it.",
-													"You can set a number of these equal to your Intelligence modifier. The number you can place is refreshed when you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Triggered Infusion",
-												"entries": [
-													"When you use your Store Magic feature, you can set a trigger for the effect to occur. If the triggering event occurs, you can use your reaction to activate the stored spell. The trigger event can be a verbal key."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Twin Animated Weapon",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"When you use your Animate Weapon feature, you can target two weapons. They both function as an Animated Weapon, making attacks against targets you attack as per the feature."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Warding Stone",
-												"entries": [
-													"You learn how to weave a protective enchantment on an item. That item gains a pool of temporary hit points equal to your Artificer level. Whoever is carrying this item gains any temporary hit points remaining in this pool, but these are lost when that creature is no longer carrying this item. This pool of temporary hit points refreshes when the Artificer that created it completes a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Weapon Enchantment Expertise",
-												"prerequisite": "5th level Artificer",
-												"entries": [
-													"You refine techniques of magical enhancements for weapons to be easier to use and maintain. You learn the spell {@spell magic weapon}, and at 9th level you learn the spell {@spell elemental weapon}. These do not count against your known spells, and if you already know them you may select a different Artificer spell to learn.",
-													"When you cast {@spell magic weapon} or {@spell elemental weapon}, you can target a weapon that is already magical, adding to any effect the weapon already has. Additionally, when you have to make a Constitution saving throw to maintain concentration, you do so with advantage."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Worn Enchantment",
-												"entries": [
-													"You can enchant an item you a wearing, such as as scarf or cloak to animate and assist you with a task, be it climbing a wall, grappling an enemy, or picking a lock. You can expend a 1st level spell slot to gain proficiency in a Strength or Dexterity skill until you complete a long rest. You can use up all the magic in the item to gain advantage on one check of that skill, immediately ending the effect."
-												]
-											}
-										]
-									},
-									{
 										"type": "inset",
 										"name": "Wondrous Item Infusions",
 										"entries": [
 											"Generally speaking, a magic item that is not otherwise under the purview of another subclass (such as wands) is an appropriate item for an Infusionsmith. At the DMs discretion, most uncommon non-attunement wondrous items make appropriate custom Infusionsmith upgrades."
+										]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"name": "Infusionsmith Upgrades",
+										"entries": [
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Infusionsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -1984,256 +1243,16 @@
 												]
 											}
 										]
-									},
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"entries": [
 									{
-										"type": "entries",
-										"name": "Mechplate Upgrades",
+										"name": "Warsmith Upgrades",
 										"entries": [
-											{
-												"type": "optfeature",
-												"name": "Accelerated Movement",
-												"entries": [
-													"You reduce the weight of your Mechplate's bulk and increase the power to joints. The Mechplates weight is reduced by 15 lbs. While wearing your Mechplate your speed increases by 10 feet. This applies to all movement speeds you have while wearing your armor. You can apply this upgrade up to 2 times."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Active Camouflage Armor",
-												"prerequisite": "5th level",
-												"entries": [
-													"As an action, you can activate active camouflage causing your suit to automatically blend into its surroundings. This lasts until deactivated. While this active, you are considered lightly obscured, and can hide from a creature even when they have a clear line of sight to you. Wisdom ({@skill Perception}) checks to find you that rely on vision are made with disadvantage."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Adaptable Armor",
-												"entries": [
-													"You integrate deployable hooks and fins into your armor, augmenting its mobility. While wearing your Mechplate you gain a climbing speed equal to your walking speed, and you can move up, down, and across vertical surfaces and upside down along ceilings, while leaving your hands free. Additionally, you gain a swim speed equal to your walking speed."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Arcane Visor",
-												"prerequisite": "15th level. Prerequisite: Darkvision Visor",
-												"entries": [
-													"You add a heavily enchanted visor to your Mechplate that augments your vision. The Visor has 6 Charges.",
-													"Once it is integrated into your armor, you can use an Action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell see invisibility} (2 charges) or {@spell true seeing} (4 charges).",
-													"It regains all charges on a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Armor Class",
-												"prerequisite": "5th level",
-												"entries": [
-													"You inforce the structure and materials that make up your Mechplate. Your Mechplate's Armor Class (AC) increases by 1. You can apply this upgrade up to 3 times."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Cloaking Device",
-												"prerequisite": "Active Camouflage",
-												"entries": [
-													"You install an Arcane Cloaking device on your Mechplate. This device has 4 Charges. You can expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
-													"It regains all charges after a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Collapsible",
-												"prerequisite": "5th level. Incompatible with Piloted Golem",
-												"entries": [
-													"Your Mechplate can collapse into a case for easy storage. When transformed this way the armor is indistinguishable from a normal case and weighs 1/3 its normal weight. As an action you can don or doff the armor, allowing it to transform as needed."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Darkvision Visor",
-												"entries": [
-													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Energy Surge",
-												"entries": [
-													"You upgrade your Mechplate gauntlet to support delievering a energy surge. You can use a bonus action to overcharge your gauntlet, and the next {@spell shocking grasp} or Force Blast you hit an enemy with during that turn deals an additional {@dice 1d8} lightning damage and knocks a Large or smaller target 10 feet directly away from you."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Flame Projector",
-												"prerequisite": "9th level. Incompatible with other projectors.",
-												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell burning hands} (1 charge), {@spell fireball} (3 charges), or {@spell wall of fire} (4 charges).",
-													"It regains all charges on a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Flash Freeze Capacitor",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
-												"entries": [
-													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell cone of cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
-													"Once you use this ability, you cannot use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Flight",
-												"prerequisite": "9th level",
-												"entries": [
-													"You integrate a magical propulsion system, integrated in into your Mechplate. While wearing your Mechplate you have a Magical flying speed of 30 feet."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Force Blast",
-												"entries": [
-													"You upgrade your Mechplate gauntlet to allow you to make a ranged spell attack. The weapon fires blasts of arcane energy which deal {@dice 1d8} + your Intelligence modifier Force damage. The range is 30 feet. You are proficient in this weapon. When you take the attack action, you can use this ranged spell attack in place of any attack made."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Grappling Reel",
-												"entries": [
-													"Your Mechplate gains an integrated grappling reel set into your gauntlet. As 1 attack or 1 action, you may target a surface, object or creature within 30 feet. If the target is Large or Smaller, you can make a Grapple check to pull it to you and Grapple it on success. Alternatively, if the target is Large or larger, you can choose to be pulled to it, this does not grapple it."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Integrated Weapon",
-												"prerequisite": "",
-												"entries": [
-													"You integrate a melee weapon into your Mechplate. When you apply this upgrade you must have a weapon to integrate, and you must choose where on your armor the weapon is located. The weapon cannot have the Heavy property. You are proficient with this weapon. As a bonus action you can activate the weapon.",
-													"You must treat it as though you are wielding it with one hand, but you cannot be disarmed of it. Once activated, you can use this weapon when you take the attack action, and it does not require the use of a hand or your mechplate gauntlet. You can apply this upgrade multiple times, selecting a new weapon and new location on your armor to install it."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Integrated Attack",
-												"prerequisite": "9th level, Integrated Weapon",
-												"entries": [
-													"When you activate your Integrated weapon, you can immediately make one attack with it. While it is active, you can make an attack with it using your bonus action."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Lightning Projector",
-												"prerequisite": "9th level. Incompatible with other projectors.",
-												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell thunderwave} (1 charge), {@spell lightning bolt} (3 charges), or {@spell storm sphere|XGE} (4 charges).",
-													"It regains all charges on a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Mechsuit",
-												"prerequisite": "Incompatible with Piloted Golem and Sealed Suit upgrades.",
-												"entries": [
-													"You rebuild your Mechplate to remove the heavy plating. You can retain all benefits and upgrades of the Mechplate, but now serves only as Medium armor, providing a base of 15 AC, and its weight is reduced to 40 lbs."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Piloted Golem",
-												"prerequisite": "Fully upgraded Powered Limbs. Incompatible with Collapsible.",
-												"entries": [
-													"You enlarge your Mechplate, turning it into a piloted mechanical golem. Your size category when wearing the armor increases by one, and you have advantage on Strength checks and Strength saving throws."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Powered Limbs",
-												"prerequisite": "5th level",
-												"entries": [
-													"You upgrade frame and limbs of your armor. The bonus your Mechplate grants to your Strength score and maximum Strength score increases by 1 while wearing this armor. You can apply this upgrade up to 2 times."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Power Slam Capacitor",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
-												"entries": [
-													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell destructive wave} upon landing.",
-													"Once you use this ability, you can not use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Power Fist",
-												"entries": [
-													"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal {@dice 1d8} bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
-													"{@b Special:} When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Reactive Plating",
-												"prerequisite": "15th level",
-												"entries": [
-													"You install special heavy plating, giving you resistance to bludgeoning, piercing, and slashing damage from non-magical sources while wearing your Mechplate. In addition, you can use your reaction when hit by an attack to reduce the damage of that attack by an amount equal to your proficiency bonus."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Recall",
-												"prerequisite": "15th level",
-												"entries": [
-													"When not being worn you can hide your Mechplate in a pocket dimension. As an action on your turn you can magically summon the armor and don it. You can use a bonus action to return the armor to the pocket dimension.",
-													"While in the pocket dimension the armor cannot be affected by other abilities and cannot be interacted with in any way."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Resistance",
-												"entries": [
-													"You tune your Mechplate against certain forms of damage. Choose acid, cold, fire, force, lightning, necrotic, radiant, or thunder damage. While wearing your Mechplate you have resistance to that type of damage. If you apply this upgrade more than once you must choose a different damage type."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Relocation Matrix",
-												"prerequisite": "15th level",
-												"entries": [
-													"You install an arcane transmutation matrix that you can use to convert your magical power into dimensional warp. As an action, you can cast {@spell dimension door} without expending a spell slot. Once you use this ability, you can not use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Sealed Suit",
-												"prerequisite": "5th level",
-												"entries": [
-													"As a bonus action on your turn you can environmentally seal your Mechplate, giving you an air supply for up to 1 hour and making you immune to poison (but not curing you of existing {@condition poisoned} conditions).",
-													"Your armor regains 1 minute of air for every minute that you are not submerged and the armor is not sealed.",
-													"In addition to the above, you are also considered adapted to cold and hot climates while wearing your armor, and you're also acclimated to high altitude while wearing your armor."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Sentient Armor",
-												"entries": [
-													"You install an artificial personality into your Mechplate, making it a sentient item. This sentience assists you in all ways. The bonus your Mechplate grants to your Intelligence score and maximum Intelligence score increases by 1 while wearing this armor. You can apply this upgrade up to 2 times.",
-													"Additionally, when this is fully upgraded, you cannot be surprised while wearing your Mechplate."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Sun Cannon",
-												"prerequisite": "15th level",
-												"entries": [
-													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell sunbeam} without expending a spell slot.",
-													"Once you use this ability, you can not use it again until you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Virtual Wizard",
-												"prerequisite": "15th level, Fully upgraded Sentient Armor",
-												"entries": [
-													"While wearing your Mechplate, your Mechplates built in intelligence assists your spell casting. Your spell save DC and spell attack bonus are each increased by 2."
-												]
-											}
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Warsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -2342,23 +1361,12 @@
 								]
 							},
 							{
-								"name": "Wandsmith Upgrades",
+								"type": "entries",
 								"entries": [
 									{
-										"type": "optfeature",
-										"name": "Magical Wand",
+										"name": "Wandsmith Upgrades",
 										"entries": [
-											"You create a new Wand that you can infuse with a Spell of 1st level or higher you have recorded in your Spellmanual. This wand does not require attunement, but can only be used by you. The Spell must be of a level that you can cast. This wand has three charges. As an action, you can expend a charge to cast the selected spell at its base level. The wand regains all charges at the end of a long rest.",
-											"You can select this upgrade multiple times, selecting a different spell each time you take this upgrade."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Magical Rod",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create a new Rod that you can infuse with of 5th level or higher you have recorded in your Spellmanual. This rod does not require attunement, but can only be used by you. The Spell level must be equal to half or less of your Artificer level (as of when you would get this upgrade), rounded down. This rod has one charge. As an action, you can expend the charge to cast the selected spell at its base level. The wand regains all charges at the end of a long rest.",
-											"You can select this upgrade multiple times, selecting a different spell each time you take this upgrade."
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Wandsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -2518,270 +1526,16 @@
 												]
 											}
 										]
-									},
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"entries": [
 									{
-										"type": "entries",
-										"name": "Alchemist Upgrades",
+										"name": "Potionsmith Upgrades",
 										"entries": [
-											{
-												"type": "optfeature",
-												"name": "Alchemical Acid",
-												"entries": [
-													"As an action you can produce a reaction causing a caustic acid to form. At a creature within 15 feet, you can a toss quick combination of reagents that will cause a splatter of acid in a 5 foot radius. Creatures in that area have to make a Dexterity saving throw, or take {@dice 2d4} acid damage.",
-													"The damage damage increases by 2d4 when you reach 5th level ({@dice 4d4}), 11th level ({@dice 6d4}), and 17th level ({@dice 8d4})."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Adrenaline Serum",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You create a potent serum. As an action on your turn, you can consume this serum, granting you the effects of {@spell haste} and {@spell heroism} for a number of rounds equal to your Intelligence modifier (minimum 1). These effects do not require concentration, but you still suffer the normal effects of the {@spell haste} spell ending when it ends. You can use this a number of times equal to your Constitution modifier (minimum 1) before you must take a long rest to gain the effects from the serum again.",
-													"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become {@condition poisoned} on a failed save."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Aroma Therapies",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You expand your alchemical knowledge to be able to produce incense and simmering reagents that grant effects to those that inhale their fumes. If creatures spend a long rest inhaling fumes from a concoction you devise with this feature, creatures regain all of their expended hit dice when they would normally only recovering half, and cured of any non-magical diseases they are suffering from."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Auto Injector",
-												"entries": [
-													"You create an automatic potion injector that you can wear. As an action, you can load a potion (either an infused potion or a normal potion) into this injector at any time. Subsequently while a potion is loaded into the injector, you can consume the potion using your reaction. Only one option can be held in the injector at a time."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Delivery Mechanism",
-												"entries": [
-													"You modify the stability of your reagents and develop a better delivery mechanism. You can target a point within 30 feet for your instant reactions that target a point. The additional precision allows you to better target the effects, allowing creatures of your choice within the target area to automatically pass a Dexterity saving throw against your effects."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Elixir of Life",
-												"prerequisite": "Philosopher's Stone",
-												"entries": [
-													"You can brew a special potion using your Philosopher stone. Brewing this potion takes 8 hours and requires 1000 gold pieces of special ingredients. An Elixir of Life causes a creature that drinks it to cease aging, and be under the effects of {@spell death ward} for one year, or until the {@spell death ward} is triggered."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Explosive Reaction",
-												"entries": [
-													"You formulate a new instant reaction, a devastating minor explosion. Targeting a point within 15 feet, as an action, you cause an explosion. Creatures within 10 feet of the target point must make a Constitution saving throw, or take {@dice 1d10} thunder damage from the shockwave of the explosion.",
-													"The damage damage increases by 1d10 when you reach 5th level ({@dice 2d10}), 11th level ({@dice 3d10}), and 17th level ({@dice 4d10})."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Fortifying Fumes Reaction",
-												"entries": [
-													"You formulate a new instant reaction, a powerful fortifying stimulate. Targeting a point within 15 feet, as an action, you cause fumes to erupt. Creatures within can choose to hold their breath and not inhale, but creatures that inhale the fumes gain {@dice 1d4} temporary hit points, deal {@dice 1d4} additional damage on their next melee weapon attack made before the end of your next turn, and have advantage on their next Constitution saving throw before the end of your next turn.",
-													"The both the temporary hit points and damage bonus increase by 1d4 when you reach 5th level ({@dice 2d4}), 11th level ({@dice 3d4}), and 17th level ({@dice 4d4})."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Frostbloom Reaction",
-												"entries": [
-													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a Dexterity saving throw, or be caught by the ice taking {@dice 1d6} cold damage; a creature entirely in the area of effect that fails also becoming {@condition restrained} until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
-													"The damage damage increases by 1d6 when you reach 5th level ({@dice 2d6}), 11th level ({@dice 3d6}), and 17th level ({@dice 4d6})."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Greater Adrenaline Shot",
-												"prerequisite": "Adrenaline Serum",
-												"entries": [
-													"You upgrade your adrenaline shot to produce even more extreme and magical effects in the creature it effects. The adrenaline shot also adds the effect of {@spell Tenser's Transformation|xge} when you consume it. This effect only takes place if you are the one consuming the serum. You do not suffer the effects of {@spell Tenser's Transformation|xge} wearing off when the serum effect ends."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Inoculations",
-												"entries": [
-													"You and up to five allies of your choice are inoculated against the poisonous effects you can produce that require a Constitution saving throw (such as the poisonous gas instant reaction or the cloudkill infusion). Additionally, you gain resistance to poison damage."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Infusion Stone",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You use the secrets of Alchemy to create an Infusion Stone. You can use this stone in the process of infusing potions in place of a spell slot level less than or equal to the highest level spell slot you can cast.",
-													"You can use this stone to replace a spell slot for an infusion once. It regains this charge after you complete a long rest."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Mana Potion",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"During a short rest, you can create a mana potion. A mana potion loses its potency if it is not consumed within 1 minute. As an action, a creature can consume a mana potion to restore a spell slot of its choice, up to third level."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Philosopher Stone",
-												"prerequisite": "15th level Artificer",
-												"entries": [
-													"You create a Philosopher's Stone allowing you to recreate wonders of alchemy. So long as you have a supply of non-gold metal, you can create up five pounds of gold a day (250 gold pieces worth)."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Persistent Reactions",
-												"entries": [
-													"Your reactions that effect a target area persist in that area until the start of your next turn. Creatures entering the effect or ending their turn there have to repeat the saving throw against the effect. You can choose to make a reaction not persist at the time of taking the action to cause it."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Potent Reactions",
-												"prerequisite": "9th level Artificer",
-												"entries": [
-													"You refine your reactions increasing the potency. The die you roll to determine the damage or healing effect of your reactions is increased by one. A d4 becomes a d6, a d6 becomes a d8, a d8 becomes a d10, and a d10 becomes a d12."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Poisoner's Proficiency",
-												"entries": [
-													"You delve into the secrets of the darkest secrets of herblore, learning the potent secrets of poison. During a long rest, you can create one of the three following poisons.",
-													{
-														"type": "list",
-														"items": [
-															"Contact poison. You can apply this to a weapon or up to ten pieces of ammunition, lasting until the end of your next long rest. That weapon deals an additional {@dice 1d4} poison damage to targets it strikes.",
-															"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become {@condition poisoned} until they complete a long rest.",
-															"Inhaled poison. This poison can be used to modify your poisonous gas reaction. Anytime before the end of your next long rest, you can use this dose of poison to make your poisonous gas instant reaction have a radius of 10 feet and deal twice as much damage on a failed save."
-														]
-													}
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Secrets of Enhancement",
-												"entries": [
-													"You learn the secrets of infusing powerful enhancements into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
-													{
-														"type": "table",
-														"colLabels": [
-															"Spell Level",
-															"Infusion Spells"
-														],
-														"colStyles": [
-															"col-xs-6 text-align-center",
-															"col-xs-6 text-align-center"
-														],
-														"rows": [
-															[
-																"1st",
-																"{@spell heroism}"
-															],
-															[
-																"2nd",
-																"{@spell enlarge/reduce}"
-															],
-															[
-																"3rd",
-																"{@spell haste}"
-															]
-														]
-													}
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Secrets of Fire",
-												"entries": [
-													"You learn the secrets of infusing fire into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
-													{
-														"type": "table",
-														"colLabels": [
-															"Spell Level",
-															"Infusion Spells"
-														],
-														"colStyles": [
-															"col-xs-6 text-align-center",
-															"col-xs-6 text-align-center"
-														],
-														"rows": [
-															[
-																"1st",
-																"{@spell faerie fire}"
-															],
-															[
-																"2nd",
-																"{@spell dragon's breath|xge}"
-															],
-															[
-																"3rd",
-																"{@spell fireball}"
-															]
-														]
-													}
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Secrets of Frost",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
-												"entries": [
-													"You learn the secrets of infusing fire into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
-													{
-														"type": "table",
-														"colLabels": [
-															"Spell Level",
-															"Infusion Spells"
-														],
-														"colStyles": [
-															"col-xs-6 text-align-center",
-															"col-xs-6 text-align-center"
-														],
-														"rows": [
-															[
-																"1st",
-																"{@spell armor of agathys}"
-															],
-															[
-																"2nd",
-																"{@spell snilloc's snowball swarm|xge}"
-															],
-															[
-																"3rd",
-																"{@spell ice storm}"
-															]
-														]
-													}
-												]
-											},
-											{
-												"type": "inset",
-												"name": "Secrets of...",
-												"entries": [
-													"Almost any set of three spells, a 1st level, 2nd level, and 3rd level spell of either short term buffs or area of effect damage spells is a valid combination of a Secrets of upgrade, so long as there is a thematic connection between the spells. Consult with your DM for other options if the spells you want aren't present here, but the spells should always be either short term buffs or area of effect damage spells, and should not be higher than 3rd level unless they are exceptionally weak for their level."
-												]
-											},
-											{
-												"type": "optfeature",
-												"name": "Weapon Coating.",
-												"entries": [
-													"You learn to how to coat a weapon or piece of ammunition with one of your instant reactions to take effect on hit. As a bonus action, you can apply your instant reaction to a melee weapon or piece of ammunition. Until the end of your turn, the next hit with that weapon or with a coated piece of ammunition will cause the effect of the instant reaction to the target. The creature automatically takes and damage or healing associated with the reaction, but makes a saving throw as normal against any additional effects."
-												]
-											},
-											{
-												"type": "inset",
-												"name": "The Implications",
-												"entries": [
-													"There is an Instant Reaction that restores health, rather than deals damage. This can be applied via weapon coating as well, though the weapon damage of the implement is not negating, perhaps your allies will forgive a blowgun dart coated in a healing draught... if you hit the attack."
-												]
-											}
+											"At 3rd level, you gain an upgrade of your choice. A list of the available options can be found on the {@filter Optional Features|optionalfeatures|Feature Type=Potionsmith} page. When you gain certain artificer levels, you gain additional upgrades of your choice."
 										]
 									}
 								]
@@ -2896,6 +1650,2003 @@
 				"Teleportation Circle",
 				"Transmute Rock",
 				"Wall of Stone"
+			]
+		}
+	],
+	"optionalfeature": [
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Autoloading Magazine",
+			"entries": [
+				"{@i Prerequisite: Magazine}",
+				"Your Thunder Cannon now automatically chambers the next round, no longer requiring your bonus action to reload."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Blast Shells",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You can choose to fire a blast shell when firing your Thunder Cannon. When firing a Blast Shell, pick a target area within normal range of your Thunder Cannon. Make an attack roll as normal, and apply that attack roll to all targets within a 5 foot radius of your target point.",
+				"You can apply Thundermonger damage to one target creature hit, or apply half of Thundermonger damage to all creatures hit."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Cannon Improvement",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You fine tune your Thunder Cannon's firing mechanism. The Thunder Cannon gains a +1 bonus to Attack and Damage Rolls made with it. You can apply this upgrade up to 3 times.",
+				"After the first time you take this upgrade, the piercing damage dealt by your Thunder Cannon is considered magical."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Divination Scope",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You add a scope to your Thunder Cannon and enchant the lenses with Divination magic. The Scope has 3 Charges. As a bonus action you can use 1 charge to cast Hunter's Mark. As an action you can use 2 charges to cast See Invisibility or 3 charges to cast Clairvoyance.",
+				"The scope regains all charges after a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Echoing Boom",
+			"entries": [
+				"{@i Prerequisite Incompatible with Silencer}",
+				"You pack extra power into your Thundermonger, increasing the damage it deals by {@dice 1d6}."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Extended Barrel",
+			"entries": [
+				"You extend the length of your Thunder Cannon's barrel and add rifling. The normal weapon range of your Thunder Cannon increases by 30 feet, and the maximum range by 90 feet. You can apply this upgrade up to 2 times.",
+				"After applying this twice, if you have the Lightning Charged Bayonet upgrade, the Bayonet gains the Reach property."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Harpoon Reel",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install a secondary firemode that launches a Harpoon attached to a tightly coiled cord. This attack has a normal range of 30 feet and an maximum range of 60 feet, and it deals only {@dice 1d6} piecing damage. This attack can target a surface, object, or creature.",
+				"A creature struck by this attack is impaled by the Harpoon unless it removes the Harpoon as an action, which causes it to take an additional {@dice 1d6} damage. While the Harpoon is stuck in the target, you are connected to the target by an 60 ft cord.",
+				"While connected in this manner, you can use your bonus action to activate the Reel action, pulling yourself to the location if the target if the target is Medium or larger. A Small or smaller creature is pulled back to you. Alternatively, you can opt to disconnect the cord.",
+				"This attack cannot be used again until the Reel action is taken."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Integrated Magazine",
+			"entries": [
+				"Your Thunder Cannon holds 2 rounds at a time, allowing you to attack twice before a bonus action reload is required."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Lightning Burst",
+			"entries": [
+				"You upgrade your Thunder Cannon to discharge its power in within a 5-feet wide and 60-feet long line. As an action, you can make a special attack. Each creature must make a Dexterity saving throw or take damage equal to the bonus damage of Thundermonger as lightning damage on a failed save, half as much on a successful save. Using this shot counts as applying Thundermonger damage for the turn.",
+				"Firing in this method does not consume ammo."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Lightning Charged Bayonet",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You affix a short blade to the barrel of your Thunder Cannon, allowing you to make a melee weapon attack with it. The blade is a finesse weapon melee weapon that you are proficient with, and deals {@dice 1d6} Piercing damage.",
+				"The blade can be used to apply Thundermonger bonus damage. When Thundermonger bonus damage is dealt with a bayonet attack, the damage type is lightning. Dealing damage this way counts as applying Thundermonger damage for the turn."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Overchannel Capacitor",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You gain the ability to channel your magical power into the Thunder Cannon to overload its damage. You can expend a spell slot to increase the damage dealt by Thundermonger by {@dice 1d8} per spell level spent."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Silencer",
+			"entries": [
+				"{@i Prerequisite: Incompatible with Echoing Booms}",
+				"You upgrade your Thunder Cannon with a sound dampening module. Your Thunder Cannon loses the Loud property."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Snap Fire",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You upgrade your Thunder Cannon for quick shots. You can use your reaction to take a opportunity attack with your Thunder Cannon if an enemy comes within 10 ft of you. You have disadvantage on this attack. This attack only deals Thundermonger bonus damage if you have not dealt the bonus damage since the start of your last turn."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Shock Absorber",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You add a reclamation device to your Thunder Cannon to gather energy from the surroundings when it is present. As a reaction to taking Lightning or Thunder Damage, you can cast {@spell absorb elements|xge} without consuming a spell slot. When absorbed in this method, you can apply the bonus damage granted by {@spell absorb elements|xge} to your next Thunder Cannon attack even if you make a ranged attack."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Shock Harpoon",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Harpoon Reel}",
+				"After hitting a creature with the Harpoon fire mode, you can use a bonus action to deliver a shock. If you have not used it since the start of your turn, you can apply Thundermonger damage as lightning damage. Additionally, the target must make a Constitution saving throw against your spell save DC or be {@condition stunned} until the end of its next turn.",
+				"Once used, the Harpoon must be reeled in before this can be used again."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Storm Blast",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You upgrade your Thunder Cannon to discharge its power in 30-foot cone from the gun. As an action, you can make a special attack. Each creature must make a Strength saving throw, or take half the bonus damage of Thundermonger and be knocked {@condition prone}. Using this shot counts as applying Thundermonger damage for the turn.",
+				"Firing in this way does not consume ammo."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Synaptic Feedback",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install feedback loop into your cannon, allowing you to siphon some energy from your Thunder Cannon to empower your reflexes. Whenever you deal lightning damage with your Thunder Cannon your walking speed increases by 10ft and you can take the Dash or Disengage actions as a bonus action. This boost lasts until the start of your next turn."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Cannonsmith",
+			"name": "Turret Deployment",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You can set up your Thunder Cannon and operate it remotely. As an action, you deploy your Thunder Cannon in a spot adjacent to you, and subsequently can attack with it as long as you are within 100 feet of it and you can see the target you are attacking. It still has its normal range from the point it is attacking. A creature adjacent to it in this mode can use an action to render it nonfunctional as a turret."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Airburst Mine",
+			"entries": [
+				"You create a mechanical device capable of producing a devastating blast. You can use this device to cast {@spell shatter} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Boomerang of Hitting",
+			"entries": [
+				"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals {@dice 1d4} damage. At level 5, this weapon gaisn a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+				"Special: When this weapon is Thrown, you can target two creatures within 10 feet of each other, making a separate attack roll against each target.",
+				"This weapon returns to your hand after you make an attack with it using the Thrown property."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Belt of Adjusting Size",
+			"entries": [
+				"You create a belt with a creature size dial on it. While you are wearing this belt, you can use an action to cast {@spell enlarge/reduce} on yourself. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Binding Rope",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save DC or become {@condition restrained} until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Bracers of Empowerment",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create bracers that can empower you. You can use this to cast {@spell tenser's transformation|xge} without expending a Spell Slot.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Deployable Wings",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Disintegration Ray",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a Disintegratation Ray. You can use this to cast {@spell disintegrate} without expending a Spell Slot.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Gripping Gloves",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength ({@skill Athletics}) checks involving manipulating things with your hands while wearing these gloves."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Element Eater",
+			"entries": [
+				"You create a device capable of absorbing incoming elemental damage. As a reaction to taking elemental damage, you can activate this device and cast {@spell absorb elements|xge} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Enhanced Grappling Hook",
+			"entries": [
+				"You enhance your grappling hook, increasing its range to 40 feet. Additionally, the enhanced power of the grappling hook means that when pulling yourself to a large or larger creature or object, you can drag one medium or smaller willing or grappled creature within 5 feet of you with you."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Fire Spitter",
+			"entries": [
+				"You create a gadget that creates a quick blast of fire. As an action, you can cast {@spell aganazzar's scorcher|xge} with this gadget, but the gadget cannot be used again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Flashbang",
+			"entries": [
+				"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a Dexterity saving throw or be {@condition blinded} until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Impact Gauntlet",
+			"entries": [
+				"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals {@dice 1d8} bludgeoning damage. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+				"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll.",
+				"You can apply this upgrade up to 2 times, making a separate item each time."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Lightning Baton",
+			"entries": [
+				"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals {@dice 1d4} bludgeoning damage and {@dice 1d4} lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save DC or become {@condition stunned} until the start of your next turn. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+				"You can apply this upgrade up to 2 times, making a separate item each time."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Lightning Generator",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Shock Generator}",
+				"You upgrade your shock generator with additional lightning capabilities. You can cast {@spell lightning lure|scag} at-will using it, can overload it to cast {@spell lightning bolt}. Once you overload it, you cannot use it to cast {@spell lightning bolt} again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Mechanical Arm",
+			"entries": [
+				"You create a mechanical arm, giving an extra hand. This mechanical arm only functions while it is mounting on gear you are wearing, but can be operated mentally without the need for you hands. This mechanical arm can serve any function a normal hand could, such as holding things, making attacks, interacting with the environment, etc, but does not give you additional actions."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Mechanical Familiar",
+			"entries": [
+				"You can create the blue print for a small mechanical creature. At the end of a long rest, you can choose animate it, and cast {@spell find familiar} with the following modifications. The creatures type is Construct, and you cannot select a creature with a flying speed. This construct stays active until you deactivate it or is destroyed. In either case, you can choose to reactivate it at the end of a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Nimble Gloves",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity ({@skill Sleight of Hand}) checks involving manipulating things with your hands while wearing these gloves."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Phase Trinket",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast {@spell blink} or {@spell dimension door} using the Stopwatch without expending a Spell Slot.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Jumping Boots",
+			"entries": [
+				"You modify your boots with arcane boosters. While wearing these boots, you are under the effects of the {@spell jump} spell."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Repeating Hand Crossbow",
+			"entries": [
+				"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals {@dice 1d6} piercing damage. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+				"Special: This weapon does not require a free-hand to load, as it has a built in loader. When you fire this weapon with advantage, once per turn you can forgo advantage on an attack to make one additional attack."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Bee Swarm Rockets",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You design a type of tiny firecracker-like device, which can release rockets in large numbers. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a Dexterity saving throw. Creatures that fail take {@dice 2d6} fire damage, or half as much on a successful one.",
+				"You rebuild your stock to your maximum during a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Shock Generator",
+			"entries": [
+				"You create a device capable of generating potent shocks. You can use this to cast {@spell shocking grasp}. When you cast {@spell shocking grasp} with this feature, you can use either your Dexterity or Intelligence modifier for the melee spell attack roll."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Shocking Hook",
+			"entries": [
+				"You can integrate your Shock Generator and your Grappling Hook. If the target of your Grappling Hook is a creature, you can cast {@spell shocking grasp} on that creature as a bonus action when pulling it to you or being pulled to it."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Sight Lenses",
+			"entries": [
+				"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through fog, mist, smoke, clouds, and non-magical darkness as normal sight up to 15 feet."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Smoke Cloak",
+			"entries": [
+				"Create a cloak that causes you to blend in with smoke. When you start your turn lightly or heavily obscured by smoke, you are {@condition invisible} until your turn ends, you cast a spell, make an attack, or damage an enemy."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Stinking Gas",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast {@spell stinking cloud} rather than {@spell fog cloud}, following the same rules."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Striding Boots",
+			"entries": [
+				"You modify your boots with amplified striding speed. While earing these boots, you are under the effects of {@spell longstrider} spell."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Stopwatch Trinket",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a magical stopwatch that manipulates time magic. As an action, you can cast {@spell haste} or {@spell slow} using the Stopwatch without expending a Spell Slot.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Truesight Lenses",
+			"entries": [
+				"{@i Prerequisite: Sight Lenses}",
+				"You upgrade and fine tune your sight lenses, granting you Truesight up to 15 feet."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Useful Universal Key",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast {@spell passwall} without expending a spell slot.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Gadgetsmith",
+			"name": "Zombie Wires",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast {@spell danse macabre|xge} without expended a spell slot.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Arcane Barrage Armament",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
+				"Once used, this armament cannot be used again until the Artificer completes a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Arcane Resonance",
+			"entries": [
+				"Install an essence connection into your golem to sync your magic to it. You can make any spell you cast that targets only you also target your golem."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Cloaking Device",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
+				"It regains all charges after a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Environmental Adaptation",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You add integrated climbing hooks, deployable fins, insulated seals to your Golem. Your Warforged Golem gains a climbing and swimming speed equal to its walking speed.",
+				"Additionally, it gains resistance to Cold and Fire damage."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Expanded",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You enlarge your Warforged Golem, increasing its size category by one. It has advantage on Strength checks and Strength saving throws."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Flamethrower Armament",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. As an action, the golem can cast {@spell burning hands} as a 3rd level spell.",
+				"The spell save DC is equal to your spell save DC. When cast this way, it has no Verbal or Somatic component.",
+				"Once used, this armament cannot be used again until the Artificer completes a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Magical Essence",
+			"entries": [
+				"You infuse a fragment of magical essence into your golem, allowing it to attune to one magical item."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Heavy Armor Plating",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
+				"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Improve Dexterity",
+			"entries": [
+				"You tune the servos in your Warforged Golem. Your Warforged Golem's Dexterity score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Dexterity score is 18."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Improve Strength",
+			"entries": [
+				"You reinforce the power of your golem's core and limbs. Your Warforged Golem's Strength score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Strength score is 18."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Iron Fortress",
+			"entries": [
+				"{@i Prerequisite: Stabilisation}",
+				"You increase the size and durability of your golem’s frame. Your Warforged Golem now counts as full cover for people behind it or riding it. Additionally, it cannot be moved against its will while in contact with a floor."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Multiattack Protocol",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"Your Warforged Golem gains multiattack. When your Warforged Golem uses the Attack action, it can attack twice."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Mark of Life",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You have attained the understanding of magic and craft a Mark of Life on the forehead of your Warforged Golem, turning it into a Warforged Companion. It gains an Intelligence score of 8, a Wisdom score of 8 and a Charisma score of 8. This allows it to follow more complex commands without direct input, speak, and remember things.",
+				"{@i If you choose the Mark of Life upgrade, your Warforged golem becomes sentient companion, capable of learning, thinking, and having opinions. Consider how this may impact your interactions.}"
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Overdrive Protocol",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You build in a special mode allowing your golem go beyond it's normal limitations. As an action, your golem can activate this mode, gaining the effects of {@spell haste} for a number of rounds equal to your Intelligence modifier, but loses its immuninty to {@condition exhaustion} until it completes a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Precision Movements",
+			"entries": [
+				"{@i Prerequisite: Incompatible with Expanded}",
+				"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Thundering Stomp",
+			"entries": [
+				"{@i Prerequisite: Expanded}",
+				"Your warforged golem can leverage it's increased size and magical nature to unleash a crushing stomp of magical energy when it brings down its foot. Your golem can replace any attack with the {@spell thunderclap|xge} spell using the Artificers level and spell save for casting the spell."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Redundant Systems",
+			"entries": [
+				"You have reinforced your Warforged Golem with layers of protection and redundant systems. It gains additional hitpoints equal to twice your Artificer level. Additionally, it gains advantage on death saving throws."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Remote Casting",
+			"entries": [
+				"You integrate a magical relay into your golem, allowing you use it as a magical familiar. As an action, you can see through your golem's eyes and hear what it hears until the start of your next turn. During this time, you are deaf and blind with regard to your own Senses.",
+				"Additionally, when you Cast a Spell with a range of touch, your golem can deliver the spell as if it had cast the spell. Your golem must be within 100 feet of you, and it must use its reaction to deliver the spell when you cast it. If the spell requires an Attack roll, you use your Attack modifier for the roll."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Runic Wings",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Incompatible with Expanded}",
+				"You add rune-engraved wings to your Warforged Golem, granting it a flying speed of 20 feet."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Stabilization",
+			"entries": [
+				"You increase the resilience and stability of your Warforged Golem. It gains proficiency in Constitution Saving Throws and has advantage against saving throws to be knocked down."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Warfare Routines",
+			"entries": [
+				"Your Warforged Golem gains one Fighting Style choosing from Archery, Defense, Dueling, or Great Weapon Fighting."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Warforged Apprentice",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Mark of Life}",
+				"Your Warforged Companion begins to apply its abilities to learn new things, gaining a class level in a class of your choosing. Your Warforged Companion gains all the first level features of the chosen class. This does not include health or class proficiencies (for example, selecting Fighter grants only Fighting Style and Second Wind)."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Golemsmith",
+			"name": "Warforged Adept",
+			"entries": [
+				"{@i Prerequisite: Warforged Apprentice}",
+				"Your growth as a Golemsmith is such that your creation is capable of learning and adapting even more skills. It gains all the second level features of the class you selected for the Warforged Apprentice upgrade. This does not include health or class proficiencies (for example, selecting Fighter grants only Action Surge)."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Alchemical Acid",
+			"entries": [
+				"As an action you can produce a reaction causing a caustic acid to form. At a creature within 15 feet, you can a toss quick combination of reagents that will cause a splatter of acid in a 5 foot radius. Creatures in that area have to make a Dexterity saving throw, or take {@dice 2d4} acid damage.",
+				"The damage damage increases by 2d4 when you reach 5th level ({@dice 4d4}), 11th level ({@dice 6d4}), and 17th level ({@dice 8d4})."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Adrenaline Serum",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a potent serum. As an action on your turn, you can consume this serum, granting you the effects of {@spell haste} and {@spell heroism} for a number of rounds equal to your Intelligence modifier (minimum 1). These effects do not require concentration, but you still suffer the normal effects of the {@spell haste} spell ending when it ends. You can use this a number of times equal to your Constitution modifier (minimum 1) before you must take a long rest to gain the effects from the serum again.",
+				"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become {@condition poisoned} on a failed save."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Aroma Therapies",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You expand your alchemical knowledge to be able to produce incense and simmering reagents that grant effects to those that inhale their fumes. If creatures spend a long rest inhaling fumes from a concoction you devise with this feature, creatures regain all of their expended hit dice when they would normally only recovering half, and cured of any non-magical diseases they are suffering from."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Auto Injector",
+			"entries": [
+				"You create an automatic potion injector that you can wear. As an action, you can load a potion (either an infused potion or a normal potion) into this injector at any time. Subsequently while a potion is loaded into the injector, you can consume the potion using your reaction. Only one option can be held in the injector at a time."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Delivery Mechanism",
+			"entries": [
+				"You modify the stability of your reagents and develop a better delivery mechanism. You can target a point within 30 feet for your instant reactions that target a point. The additional precision allows you to better target the effects, allowing creatures of your choice within the target area to automatically pass a Dexterity saving throw against your effects."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Elixir of Life",
+			"entries": [
+				"{@i Prerequisite: Philosopher's Stone}",
+				"You can brew a special potion using your Philosopher stone. Brewing this potion takes 8 hours and requires 1000 gold pieces of special ingredients. An Elixir of Life causes a creature that drinks it to cease aging, and be under the effects of {@spell death ward} for one year, or until the {@spell death ward} is triggered."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Explosive Reaction",
+			"entries": [
+				"You formulate a new instant reaction, a devastating minor explosion. Targeting a point within 15 feet, as an action, you cause an explosion. Creatures within 10 feet of the target point must make a Constitution saving throw, or take {@dice 1d10} thunder damage from the shockwave of the explosion.",
+				"The damage damage increases by 1d10 when you reach 5th level ({@dice 2d10}), 11th level ({@dice 3d10}), and 17th level ({@dice 4d10})."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Fortifying Fumes Reaction",
+			"entries": [
+				"You formulate a new instant reaction, a powerful fortifying stimulate. Targeting a point within 15 feet, as an action, you cause fumes to erupt. Creatures within can choose to hold their breath and not inhale, but creatures that inhale the fumes gain {@dice 1d4} temporary hit points, deal {@dice 1d4} additional damage on their next melee weapon attack made before the end of your next turn, and have advantage on their next Constitution saving throw before the end of your next turn.",
+				"The both the temporary hit points and damage bonus increase by 1d4 when you reach 5th level ({@dice 2d4}), 11th level ({@dice 3d4}), and 17th level ({@dice 4d4})."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Frostbloom Reaction",
+			"entries": [
+				"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a Dexterity saving throw, or be caught by the ice taking {@dice 1d6} cold damage; a creature entirely in the area of effect that fails also becoming {@condition restrained} until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
+				"The damage damage increases by 1d6 when you reach 5th level ({@dice 2d6}), 11th level ({@dice 3d6}), and 17th level ({@dice 4d6})."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Greater Adrenaline Shot",
+			"entries": [
+				"{@i Prerequisite: Adrenaline Serum}",
+				"You upgrade your adrenaline shot to produce even more extreme and magical effects in the creature it effects. The adrenaline shot also adds the effect of {@spell Tenser's Transformation|xge} when you consume it. This effect only takes place if you are the one consuming the serum. You do not suffer the effects of {@spell Tenser's Transformation|xge} wearing off when the serum effect ends."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Inoculations",
+			"entries": [
+				"You and up to five allies of your choice are inoculated against the poisonous effects you can produce that require a Constitution saving throw (such as the poisonous gas instant reaction or the cloudkill infusion). Additionally, you gain resistance to poison damage."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Infusion Stone",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You use the secrets of Alchemy to create an Infusion Stone. You can use this stone in the process of infusing potions in place of a spell slot level less than or equal to the highest level spell slot you can cast.",
+				"You can use this stone to replace a spell slot for an infusion once. It regains this charge after you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Mana Potion",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"During a short rest, you can create a mana potion. A mana potion loses its potency if it is not consumed within 1 minute. As an action, a creature can consume a mana potion to restore a spell slot of its choice, up to third level."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Philosopher Stone",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a Philosopher's Stone allowing you to recreate wonders of alchemy. So long as you have a supply of non-gold metal, you can create up five pounds of gold a day (250 gold pieces worth)."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Persistent Reactions",
+			"entries": [
+				"Your reactions that effect a target area persist in that area until the start of your next turn. Creatures entering the effect or ending their turn there have to repeat the saving throw against the effect. You can choose to make a reaction not persist at the time of taking the action to cause it."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Potent Reactions",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You refine your reactions increasing the potency. The die you roll to determine the damage or healing effect of your reactions is increased by one. A d4 becomes a d6, a d6 becomes a d8, a d8 becomes a d10, and a d10 becomes a d12."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Poisoner's Proficiency",
+			"entries": [
+				"You delve into the secrets of the darkest secrets of herblore, learning the potent secrets of poison. During a long rest, you can create one of the three following poisons.",
+				{
+					"type": "list",
+					"items": [
+						"Contact poison. You can apply this to a weapon or up to ten pieces of ammunition, lasting until the end of your next long rest. That weapon deals an additional {@dice 1d4} poison damage to targets it strikes.",
+						"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become {@condition poisoned} until they complete a long rest.",
+						"Inhaled poison. This poison can be used to modify your poisonous gas reaction. Anytime before the end of your next long rest, you can use this dose of poison to make your poisonous gas instant reaction have a radius of 10 feet and deal twice as much damage on a failed save."
+					]
+				}
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Secrets of Enhancement",
+			"entries": [
+				"You learn the secrets of infusing powerful enhancements into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
+				{
+					"type": "table",
+					"colLabels": [
+						"Spell Level",
+						"Infusion Spells"
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6 text-align-center"
+					],
+					"rows": [
+						[
+							"1st",
+							"{@spell heroism}"
+						],
+						[
+							"2nd",
+							"{@spell enlarge/reduce}"
+						],
+						[
+							"3rd",
+							"{@spell haste}"
+						]
+					]
+				},
+				"{@i Almost any set of three spells, a 1st level, 2nd level, and 3rd level spell of either short term buffs or area of effect damage spells is a valid combination of a Secrets of upgrade, so long as there is a thematic connection between the spells. Consult with your DM for other options if the spells you want aren't present here, but the spells should always be either short term buffs or area of effect damage spells, and should not be higher than 3rd level unless they are exceptionally weak for their level.}"
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Secrets of Fire",
+			"entries": [
+				"You learn the secrets of infusing fire into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
+				{
+					"type": "table",
+					"colLabels": [
+						"Spell Level",
+						"Infusion Spells"
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6 text-align-center"
+					],
+					"rows": [
+						[
+							"1st",
+							"{@spell faerie fire}"
+						],
+						[
+							"2nd",
+							"{@spell dragon's breath|xge}"
+						],
+						[
+							"3rd",
+							"{@spell fireball}"
+						]
+					]
+				},
+				"{@i Almost any set of three spells, a 1st level, 2nd level, and 3rd level spell of either short term buffs or area of effect damage spells is a valid combination of a Secrets of upgrade, so long as there is a thematic connection between the spells. Consult with your DM for other options if the spells you want aren't present here, but the spells should always be either short term buffs or area of effect damage spells, and should not be higher than 3rd level unless they are exceptionally weak for their level.}"
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Secrets of Frost",
+			"entries": [
+				"You learn the secrets of infusing fire into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
+				{
+					"type": "table",
+					"colLabels": [
+						"Spell Level",
+						"Infusion Spells"
+					],
+					"colStyles": [
+						"col-xs-6 text-align-center",
+						"col-xs-6 text-align-center"
+					],
+					"rows": [
+						[
+							"1st",
+							"{@spell armor of agathys}"
+						],
+						[
+							"2nd",
+							"{@spell snilloc's snowball swarm|xge}"
+						],
+						[
+							"3rd",
+							"{@spell ice storm}"
+						]
+					]
+				},
+				"{@i Almost any set of three spells, a 1st level, 2nd level, and 3rd level spell of either short term buffs or area of effect damage spells is a valid combination of a Secrets of upgrade, so long as there is a thematic connection between the spells. Consult with your DM for other options if the spells you want aren't present here, but the spells should always be either short term buffs or area of effect damage spells, and should not be higher than 3rd level unless they are exceptionally weak for their level.}"
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Potionsmith",
+			"name": "Weapon Coating",
+			"entries": [
+				"You learn to how to coat a weapon or piece of ammunition with one of your instant reactions to take effect on hit. As a bonus action, you can apply your instant reaction to a melee weapon or piece of ammunition. Until the end of your turn, the next hit with that weapon or with a coated piece of ammunition will cause the effect of the instant reaction to the target. The creature automatically takes and damage or healing associated with the reaction, but makes a saving throw as normal against any additional effects.",
+				"{@i There is an Instant Reaction that restores health, rather than deals damage. This can be applied via weapon coating as well, though the weapon damage of the implement is not negating, perhaps your allies will forgive a blowgun dart coated in a healing draught... if you hit the attack.}"
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Accelerated Movement",
+			"entries": [
+				"You reduce the weight of your Mechplate's bulk and increase the power to joints. The Mechplates weight is reduced by 15 lbs. While wearing your Mechplate your speed increases by 10 feet. This applies to all movement speeds you have while wearing your armor. You can apply this upgrade up to 2 times."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Active Camouflage Armor",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"As an action, you can activate active camouflage causing your suit to automatically blend into its surroundings. This lasts until deactivated. While this active, you are considered lightly obscured, and can hide from a creature even when they have a clear line of sight to you. Wisdom ({@skill Perception}) checks to find you that rely on vision are made with disadvantage."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Adaptable Armor",
+			"entries": [
+				"You integrate deployable hooks and fins into your armor, augmenting its mobility. While wearing your Mechplate you gain a climbing speed equal to your walking speed, and you can move up, down, and across vertical surfaces and upside down along ceilings, while leaving your hands free. Additionally, you gain a swim speed equal to your walking speed."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Arcane Visor",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Darkvision Visor}",
+				"You add a heavily enchanted visor to your Mechplate that augments your vision. The Visor has 6 Charges.",
+				"Once it is integrated into your armor, you can use an Action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell see invisibility} (2 charges) or {@spell true seeing} (4 charges).",
+				"It regains all charges on a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Armor Class",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You inforce the structure and materials that make up your Mechplate. Your Mechplate's Armor Class (AC) increases by 1. You can apply this upgrade up to 3 times."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Cloaking Device",
+			"entries": [
+				"{@i Prerequisite: Active Camouflage}",
+				"You install an Arcane Cloaking device on your Mechplate. This device has 4 Charges. You can expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
+				"It regains all charges after a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Collapsible",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Incompatible with Piloted Golem}",
+				"Your Mechplate can collapse into a case for easy storage. When transformed this way the armor is indistinguishable from a normal case and weighs 1/3 its normal weight. As an action you can don or doff the armor, allowing it to transform as needed."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Darkvision Visor",
+			"entries": [
+				"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Energy Surge",
+			"entries": [
+				"You upgrade your Mechplate gauntlet to support delievering a energy surge. You can use a bonus action to overcharge your gauntlet, and the next {@spell shocking grasp} or Force Blast you hit an enemy with during that turn deals an additional {@dice 1d8} lightning damage and knocks a Large or smaller target 10 feet directly away from you."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Flame Projector",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Incompatible with other projectors}",
+				"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell burning hands} (1 charge), {@spell fireball} (3 charges), or {@spell wall of fire} (4 charges).",
+				"It regains all charges on a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Flash Freeze Capacitor",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Incompatible with other capacitors}",
+				"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell cone of cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
+				"Once you use this ability, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Flight",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You integrate a magical propulsion system, integrated in into your Mechplate. While wearing your Mechplate you have a Magical flying speed of 30 feet."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Force Blast",
+			"entries": [
+				"You upgrade your Mechplate gauntlet to allow you to make a ranged spell attack. The weapon fires blasts of arcane energy which deal {@dice 1d8} + your Intelligence modifier Force damage. The range is 30 feet. You are proficient in this weapon. When you take the attack action, you can use this ranged spell attack in place of any attack made."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Grappling Reel",
+			"entries": [
+				"Your Mechplate gains an integrated grappling reel set into your gauntlet. As 1 attack or 1 action, you may target a surface, object or creature within 30 feet. If the target is Large or Smaller, you can make a Grapple check to pull it to you and Grapple it on success. Alternatively, if the target is Large or larger, you can choose to be pulled to it, this does not grapple it."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Integrated Weapon",
+			"entries": [
+				"You integrate a melee weapon into your Mechplate. When you apply this upgrade you must have a weapon to integrate, and you must choose where on your armor the weapon is located. The weapon cannot have the Heavy property. You are proficient with this weapon. As a bonus action you can activate the weapon.",
+				"You must treat it as though you are wielding it with one hand, but you cannot be disarmed of it. Once activated, you can use this weapon when you take the attack action, and it does not require the use of a hand or your mechplate gauntlet. You can apply this upgrade multiple times, selecting a new weapon and new location on your armor to install it."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Integrated Attack",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Integrated Weapon}",
+				"When you activate your Integrated weapon, you can immediately make one attack with it. While it is active, you can make an attack with it using your bonus action."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Lightning Projector",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Incompatible with other projectors}",
+				"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell thunderwave} (1 charge), {@spell lightning bolt} (3 charges), or {@spell storm sphere|XGE} (4 charges).",
+				"It regains all charges on a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Mechsuit",
+			"entries": [
+				"{@i Prerequisite: Incompatible with Piloted Golem and Sealed Suit upgrades}",
+				"You rebuild your Mechplate to remove the heavy plating. You can retain all benefits and upgrades of the Mechplate, but now serves only as Medium armor, providing a base of 15 AC, and its weight is reduced to 40 lbs."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Piloted Golem",
+			"entries": [
+				"{@i Prerequisite: Fully upgraded Powered Limbs, Incompatible with Collapsible}",
+				"You enlarge your Mechplate, turning it into a piloted mechanical golem. Your size category when wearing the armor increases by one, and you have advantage on Strength checks and Strength saving throws."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Powered Limbs",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You upgrade frame and limbs of your armor. The bonus your Mechplate grants to your Strength score and maximum Strength score increases by 1 while wearing this armor. You can apply this upgrade up to 2 times."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Power Slam Capacitor",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Incompatible with other capacitors}",
+				"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell destructive wave} upon landing.",
+				"Once you use this ability, you can not use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Power Fist",
+			"entries": [
+				"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal {@dice 1d8} bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+				"{@b Special:} When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Reactive Plating",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install special heavy plating, giving you resistance to bludgeoning, piercing, and slashing damage from non-magical sources while wearing your Mechplate. In addition, you can use your reaction when hit by an attack to reduce the damage of that attack by an amount equal to your proficiency bonus."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Recall",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"When not being worn you can hide your Mechplate in a pocket dimension. As an action on your turn you can magically summon the armor and don it. You can use a bonus action to return the armor to the pocket dimension.",
+				"While in the pocket dimension the armor cannot be affected by other abilities and cannot be interacted with in any way."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Resistance",
+			"entries": [
+				"You tune your Mechplate against certain forms of damage. Choose acid, cold, fire, force, lightning, necrotic, radiant, or thunder damage. While wearing your Mechplate you have resistance to that type of damage. If you apply this upgrade more than once you must choose a different damage type."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Relocation Matrix",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install an arcane transmutation matrix that you can use to convert your magical power into dimensional warp. As an action, you can cast {@spell dimension door} without expending a spell slot. Once you use this ability, you can not use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Sealed Suit",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"As a bonus action on your turn you can environmentally seal your Mechplate, giving you an air supply for up to 1 hour and making you immune to poison (but not curing you of existing {@condition poisoned} conditions).",
+				"Your armor regains 1 minute of air for every minute that you are not submerged and the armor is not sealed.",
+				"In addition to the above, you are also considered adapted to cold and hot climates while wearing your armor, and you're also acclimated to high altitude while wearing your armor."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Sentient Armor",
+			"entries": [
+				"You install an artificial personality into your Mechplate, making it a sentient item. This sentience assists you in all ways. The bonus your Mechplate grants to your Intelligence score and maximum Intelligence score increases by 1 while wearing this armor. You can apply this upgrade up to 2 times.",
+				"Additionally, when this is fully upgraded, you cannot be surprised while wearing your Mechplate."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Sun Cannon",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell sunbeam} without expending a spell slot.",
+				"Once you use this ability, you can not use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Warsmith",
+			"name": "Virtual Wizard",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Fully upgraded Sentient Armor}",
+				"While wearing your Mechplate, your Mechplates built in intelligence assists your spell casting. Your spell save DC and spell attack bonus are each increased by 2."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Arcane Armament",
+			"entries": [
+				"You learn mastery of armoring yourself with magical enchantments. You learn the {@spell mage armor} spell and cast it at will. While under the effect of {@spell mage armor}, you can add your Intelligence to your armor class instead of your Dexterity."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Dancing Fires",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"When you animate a weapon with your Animated Weapon feature, you can additionally imbue it with ethereal flames, causing it to deal {@dice 1d6} force damage on hit."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Detonate Armament",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Arcane Armament}",
+				"As a reaction to taking damage, you can end the effect of {@spell mage armor} to cast {@spell thunder step|xge} without expending a spell slot.",
+				"Once you do this, you cannot gain the effect of {@spell mage armor} again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Enhanced Attribute",
+			"entries": [
+				"You can enhance a piece of non-magical jewelery with power that boots the wearers abilities. Select an attribute from Strength, Dexterity, Constitution, Wisdom, Intelligence or Charisma, the current and maximum attribute score for that attribute is increased by one while wearing this item. This piece of jewelry provides a benefit only to you.",
+				"You can take this upgrade twice."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Enhanced Weapon Enchantment",
+			"entries": [
+				"{@i Prerequisite: Weapon Enchantment Expertise}",
+				"You modify the {@spell magic weapon} and {@spell elemental weapon} spells into a more potent form.",
+				"When you cast the {@spell magic weapon} spell you can augment it with vorpal power; this spell has the effect of the {@spell magic weapon} spell, but in addition attacks made with the weapon score a critical hit on 19 or a 20 die roll, and the weapon deals force damage.",
+				"When you cast {@spell elemental weapon}, the additional damage dealt on hit is increased by an additional {@dice 1d4}, and you can pick force as the damage type in addition to the other options."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Explosive Mine",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"{@i Prerequisite: Thunder Mine}",
+				"When you set a magical trap, you can make the mine cast {@spell fireball} instead of {@spell shatter}."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Flying Boots",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You cast a powerful infusion on a set of boots. The creature wearing these boots is under the effect of the {@spell fly} spell."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Focused Power Duration",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"When you use your Infused Focus power, the spell lasts a number of rounds equal to your Intelligence modifier + proficiency modifier."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Healing Infusion",
+			"entries": [
+				"You master the intricate arts of healing energies interaction with creatures. When you restore health to another creature on your turn, you can add your Intelligence modifier to the health restored."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Life Infusion",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You learn a potent magical infusion that suffuses a creature with life energy. You can cast {@spell regenerate} without expending a spell slot.",
+				"Once you cast this spell in this manner, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Radiant Infusion",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You learn a special infusion for bestowing radiant energy. When you use your Store Magic feature, rather than picking a spell you know, you can cast {@spell holy weapon|xge}. Unless you know this spell from another source, you can only cast this spell using the Store Magic feature. If you have the Weapon Enchantment Expertise upgrade, you have advantage on Constitution saving throws to maintain concentration on this spell."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Shielding Ring",
+			"entries": [
+				"You infuse powerful magic into a non-magical ring. You can use this ring to cast the {@spell shield} spell without expending a spell slot. You cannot use this ring to cast the spell again until you complete a short or long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Skill Infusion",
+			"entries": [
+				"You managed to make the magic of your Infused Weapon so potent that attacks made with it are made as if the wielder had a Fighting Style. Choose a Fighting Style from Dueling, Archery, or Great Weapon Master and apply the effects to attacks made with your Infused and Animated Weapons."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Spell Trapping Ring",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 9,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You set a powerful magic into a non-magical ring. You can use this ring to cast {@spell counterspell} without expending a spell slot. When you cast {@spell counterspell} in this way and it succeeds, the spell countered is stored in the ring. You can then cast the stored spell without expending a spell slot, but spell fades if it is not used before you complete a long rest.",
+				"Once you use this ring, you cannot use it again until you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Soul Saving Bond",
+			"entries": [
+				"You set up a special magical bond between you and another creature. When either creature bound by this abilities fails Wisdom, Intelligence, Charisma, or Death saving throw, the other character can make their own saving throw, replacing the failed saved with their own roll. If this ability is used on a death saving throw, the replacement roll is a 20. Once a roll is replaced by this feature, it cannot be used again until both creatures in the bond have completed a short or long rest.",
+				"This bond can be set up with a different creature at the end of a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Thunder Mine",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You can set a magical trap by infusing explosive magic into an item. You can set this item to detonate when someone comes within 5 feet of it, or by a verbal command.",
+				"When the magic trap detonates, it casts {@spell shatter} centered on the item. If a creature is in the area of effect of more than one thunder mine during a turn, they take half damage from any subsequent effects of the mines.",
+				"Setting the magical mine takes a special ritual taking 1 minute, and cannot be moved once placed; any attempt to move it results it in detonating unless the Artificer setting it disarms it.",
+				"You can set a number of these equal to your Intelligence modifier. The number you can place is refreshed when you complete a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Triggered Infusion",
+			"entries": [
+				"When you use your Store Magic feature, you can set a trigger for the effect to occur. If the triggering event occurs, you can use your reaction to activate the stored spell. The trigger event can be a verbal key."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Twin Animated Weapon",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 15,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"When you use your Animate Weapon feature, you can target two weapons. They both function as an Animated Weapon, making attacks against targets you attack as per the feature."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Warding Stone",
+			"entries": [
+				"You learn how to weave a protective enchantment on an item. That item gains a pool of temporary hit points equal to your Artificer level. Whoever is carrying this item gains any temporary hit points remaining in this pool, but these are lost when that creature is no longer carrying this item. This pool of temporary hit points refreshes when the Artificer that created it completes a long rest."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Weapon Enchantment Expertise",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 5,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You refine techniques of magical enhancements for weapons to be easier to use and maintain. You learn the spell {@spell magic weapon}, and at 9th level you learn the spell {@spell elemental weapon}. These do not count against your known spells, and if you already know them you may select a different Artificer spell to learn.",
+				"When you cast {@spell magic weapon} or {@spell elemental weapon}, you can target a weapon that is already magical, adding to any effect the weapon already has. Additionally, when you have to make a Constitution saving throw to maintain concentration, you do so with advantage."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Infusionsmith",
+			"name": "Worn Enchantment",
+			"entries": [
+				"You can enchant an item you a wearing, such as as scarf or cloak to animate and assist you with a task, be it climbing a wall, grappling an enemy, or picking a lock. You can expend a 1st level spell slot to gain proficiency in a Strength or Dexterity skill until you complete a long rest. You can use up all the magic in the item to gain advantage on one check of that skill, immediately ending the effect."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Wandsmith",
+			"name": "Magical Wand",
+			"entries": [
+				"You create a new Wand that you can infuse with a Spell of 1st level or higher you have recorded in your Spellmanual. This wand does not require attunement, but can only be used by you. The Spell must be of a level that you can cast. This wand has three charges. As an action, you can expend a charge to cast the selected spell at its base level. The wand regains all charges at the end of a long rest.",
+				"You can select this upgrade multiple times, selecting a different spell each time you take this upgrade."
+			]
+		},
+		{
+			"source": "ArtificerRevised",
+			"featureType": "Wandsmith",
+			"name": "Magical Rod",
+			"prerequisite": [
+				{
+					"type": "prereqLevel",
+					"level": 11,
+					"class": {
+						"name": "Artificer"
+					}
+				}
+			],
+			"entries": [
+				"You create a new Rod that you can infuse with of 5th level or higher you have recorded in your Spellmanual. This rod does not require attunement, but can only be used by you. The Spell level must be equal to half or less of your Artificer level (as of when you would get this upgrade), rounded down. This rod has one charge. As an action, you can expend the charge to cast the selected spell at its base level. The wand regains all charges at the end of a long rest.",
+				"You can select this upgrade multiple times, selecting a different spell each time you take this upgrade."
 			]
 		}
 	]

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -677,7 +677,7 @@
 										"name": "Thunder Cannon",
 										"entries": [
 											"At 1st level, you forge a deadly firearm using a combination of arcane magic and your knowledge of engineering and metallurgy. This firearm is called a Thunder Cannon.",
-											"You are proficient with the Thunder Cannon. The firearm is a two-handed ranged weapon that deals 2d6 piercing damage. Its normal range is 60 feet, and its maximum range is 180 feet.",
+											"You are proficient with the Thunder Cannon. The firearm is a two-handed ranged weapon that deals {@dice 2d6} piercing damage. Its normal range is 60 feet, and its maximum range is 180 feet.",
 											"Once fired, it must be reloaded as a bonus action.",
 											{
 												"type": "inset",
@@ -710,7 +710,7 @@
 														"type": "entries",
 														"name": "Hand Cannon",
 														"entries": [
-															"You modify your Thunder Cannon with lightweight components and a shorter barrel. Its weight becomes 7 lbs. Your Thunder Cannon becomes a one handed ranged weapon. It deals 1d8 damage piercing damage (instead of 2d6) and its normal range becomes 20 feet and its maximum range 60 feet."
+															"You modify your Thunder Cannon with lightweight components and a shorter barrel. Its weight becomes 7 lbs. Your Thunder Cannon becomes a one handed ranged weapon. It deals {@dice 1d8} damage piercing damage (instead of 2d6) and its normal range becomes 20 feet and its maximum range 60 feet."
 														]
 													},
 													{
@@ -742,8 +742,8 @@
 										"name": "Thundermonger",
 										"entries": [
 											"At 3rd level, you've developed the arcane engineering skill to upgrade your Thundercannon to deliver its shots with greater force.",
-											"Once per turn, you can deal an extra 1d6 thunder damage to one creature you hit with an Attack using Thunder Cannon. After discharging this bonus damage, the you cannot deal this bonus damage again until the start of your next turn.",
-											"This extra damage increases by 1d6 when you reach certain levels in this class: 5th level (2d6), 7th level (3d6), 9th level (4d6), 11th level (5d6), 13th level (6d6), 15th level (7d6), 17th level (8d6), and 19th level (9d6)."
+											"Once per turn, you can deal an extra {@dice 1d6} thunder damage to one creature you hit with an Attack using Thunder Cannon. After discharging this bonus damage, the you cannot deal this bonus damage again until the start of your next turn.",
+											"This extra damage increases by 1d6 when you reach certain levels in this class: 5th level ({@dice 2d6}), 7th level ({@dice 3d6}), 9th level ({@dice 4d6}), 11th level ({@dice 5d6}), 13th level ({@dice 6d6}), 15th level ({@dice 7d6}), 17th level ({@dice 8d6}), and 19th level ({@dice 9d6)."
 										]
 									},
 									{
@@ -789,7 +789,7 @@
 												"name": "Echoing Boom",
 												"prerequisite": "Incompatible with Silencer",
 												"entries": [
-													"You pack extra power into your Thundermonger, increasing the damage it deals by 1d6."
+													"You pack extra power into your Thundermonger, increasing the damage it deals by {@dice 1d6}."
 												]
 											},
 											{
@@ -806,8 +806,8 @@
 												"name": "Harpoon Reel",
 												"prerequisite": "5th level Artificer",
 												"entries": [
-													"You install a secondary firemode that launches a Harpoon attached to a tightly coiled cord. This attack has a normal range of 30 feet and an maximum range of 60 feet, and it deals only 1d6 piecing damage. This attack can target a surface, object, or creature.",
-													"A creature struck by this attack is impaled by the Harpoon unless it removes the Harpoon as an action, which causes it to take an additional 1d6 damage. While the Harpoon is stuck in the target, you are connected to the target by an 60 ft cord.",
+													"You install a secondary firemode that launches a Harpoon attached to a tightly coiled cord. This attack has a normal range of 30 feet and an maximum range of 60 feet, and it deals only {@dice 1d6} piecing damage. This attack can target a surface, object, or creature.",
+													"A creature struck by this attack is impaled by the Harpoon unless it removes the Harpoon as an action, which causes it to take an additional {@dice 1d6} damage. While the Harpoon is stuck in the target, you are connected to the target by an 60 ft cord.",
 													"While connected in this manner, you can use your bonus action to activate the Reel action, pulling yourself to the location if the target if the target is Medium or larger. A Small or smaller creature is pulled back to you. Alternatively, you can opt to disconnect the cord.",
 													"This attack cannot be used again until the Reel action is taken."
 												]
@@ -832,7 +832,7 @@
 												"name": "Lightning Charged Bayonet",
 												"prerequisite": "5th level Artificer",
 												"entries": [
-													"You affix a short blade to the barrel of your Thunder Cannon, allowing you to make a melee weapon attack with it. The blade is a finesse weapon melee weapon that you are proficient with, and deals 1d6 Piercing damage.",
+													"You affix a short blade to the barrel of your Thunder Cannon, allowing you to make a melee weapon attack with it. The blade is a finesse weapon melee weapon that you are proficient with, and deals {@dice 1d6} Piercing damage.",
 													"The blade can be used to apply Thundermonger bonus damage. When Thundermonger bonus damage is dealt with a bayonet attack, the damage type is lightning. Dealing damage this way counts as applying Thundermonger damage for the turn."
 												]
 											},
@@ -841,7 +841,7 @@
 												"name": "Overchannel Capacitor",
 												"prerequisite": "5th level Artificer",
 												"entries": [
-													"You gain the ability to channel your magical power into the Thunder Cannon to overload its damage. You can expend a spell slot to increase the damage dealt by Thundermonger by 1d8 per spell level spent."
+													"You gain the ability to channel your magical power into the Thunder Cannon to overload its damage. You can expend a spell slot to increase the damage dealt by Thundermonger by {@dice 1d8} per spell level spent."
 												]
 											},
 											{
@@ -1123,7 +1123,7 @@
 											{
 												"type": "optfeature",
 												"name": "Lightning Generator",
-												"prerequisite":"11th level Artificer. Requires Shock Generator.",
+												"prerequisite": "11th level Artificer. Requires Shock Generator.",
 												"entries": [
 													"You upgrade your shock generator with additional lightning capabilities. You can cast {@spell lightning lure|scag} at-will using it, can overload it to cast {@spell lightning bolt}. Once you overload it, you cannot use it to cast {@spell lightning bolt} again until you complete a short or long rest."
 												]
@@ -1317,335 +1317,309 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Runesmith",
+								"name": "Golemsmith",
 								"entries": [
-									"A Runesmith is an Artificer that has delved into the power and mystery of Runes that forge the the basis of many of the greatest feats of magic ever wrought. They pursue ancient knowledge and uncover new secrets never known to the world. They build on structured systematic magic to bend the laws of the world to their will.",
-									"A typical Runesmith is a voracious mind that seeks to unlock the very secrets of life and magic. By drawing and infusing their Runes, they can work powerful magic.",
+									"A Golemsmith is an Artificer that has committed themselves to creating a true work of artifice, forging a golem. A painstaking life ambition, they plan and design meticulously, even if in practice sometimes compromises on materials must be made.",
+									"Why a Golemsmith embarks in on the quest to forge this artificial construct of life can vary. For many it the pure pursuit of forging the perfect creation, while for others, it is simply so they do not have to carry around their loot, or to have a loyal companion to count on at all times.",
+									"A Golemsmith is rarely chaotic, as they are by their natures people of great care and discipline: those are not would not have succeeded where they have, but some have been set on their path by such events that might drive them interact chaotically with society as a whole.",
 									{
 										"type": "entries",
-										"name": "Runesmith's Proficiency",
+										"name": "Golemsmith's Proficiency",
 										"entries": [
-											"At 1st level, you gain proficiency with {@item smith's tools|phb} and {@item jeweler's tools|phb}, and can select two more languages that you can read and write (but not speak).",
-											"Your knowledge of runic magic gives you a natural affinity for scribing spell scrolls. Creating a magic spell scroll only takes you half the time and material cost it would normally take."
+											"When you choose this specialization at 1st level, you gain proficiency with {@item smith's tools|phb} and {@item tinker's tools|phb}."
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Runecraft",
+										"name": "Warforged Golem",
 										"entries": [
-											"At 1st level, you gain the ability to Runecraft items. At the end of a Long Rest, you can place up to two runes on nonmagical items. The number of items increases to 3 runes at 5th level Artificer, 4 runes at 9th, 5 runes at 13th, and 6 runes at 17th.",
-											"The runes effects fade at the end of your next long rest, at which point the same rune or a different rune may be selected.",
-											"These runed items grant the following benefits only to you. A weapon or piece of armor can have multiple Runes active on it, a piece of jewelry can only have a single Rune active on it at a given time.",
+											"Starting at 1st level, you have forged a mechanical golem to carry out your orders and protect you. The golem is controlled via a pendent that only you can attune to.",
 											{
-												"type": "list",
-												"items": [
+												"type": "inset",
+												"name": "Control Pendant",
+												"entries": [
+													"{@i Wondrous Item, Attunement (creator only).}",
+													"While attuned to this gem, you have control of your Warforged Golem. Your Warforged Golem acts on your Initiative."
+												]
+											},
+											"The Warforged Golem obeys your commands as best as it can. It takes its turn on your initiative, though it doesn't take an action unless you command it to. On your turn, you can verbally command the construct where to move (no action required by you) and take an action, which requires your action to do. It has Proficiency in Shields, Simple Weapons and Martial Weapons.",
+											"Your Warforged Golem's Proficiency increases when yours does. Additionally, it gains 5 hit points for every level in Artificer you gain. If the golem is killed, it can be returned to life via normal means, such as with the revivify spell. In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest. If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 100 gp of raw materials.",
+											"Over the course of a short rest, you can restore hitpoints equal to your Intelligence modifier + your Artificer level to your golem, or repair it to full health during a long rest.",
+											{
+												"type": "inset",
+												"name": "Warforged Golem",
+												"entries": [
+													"{@i Medium Construct, unaligned}",
+													"{@b Armor Class:} 16 (Natural Armor)",
+													"{@b Hit Points:} 10 + ([Golem's Constitution Modifier +5] * Artificer Level)",
+													"{@b Speed:} 25ft",
 													{
-														"type": "item",
-														"name": "Rune of Ability:",
-														"entry": "A piece of jewellery or armor with this Rune grants grants a +1 to an Ability Score of your choice, as well as the maximum for that score while it is active."
+														"type": "table",
+														"colLabels": [
+															"STR",
+															"DEX",
+															"CON",
+															"INT",
+															"WIS",
+															"CHA"
+														],
+														"colStyles": [
+															"col-xs-2 text-align-center",
+															"col-xs-2 text-align-center",
+															"col-xs-2 text-align-center",
+															"col-xs-2 text-align-center",
+															"col-xs-2 text-align-center",
+															"col-xs-2 text-align-center"
+														],
+														"rows": [
+															[
+																"16 ({@hit +3})",
+																"12 ({@hit +1})",
+																"14 ({@hit +2})",
+																"4 ({@hit -3})",
+																"5 ({@hit -3})",
+																"1 ({@hit -5})"
+															]
+														]
 													},
+													"{@b Damage Immunities:} poison, psychic",
+													"{@b Condition Immunities:} exhaustion, charmed, poisoned",
+													"{@b Senses:} passive Perception 7",
+													"{@b Languages:} Understands creator's languages, but cannot speak",
+													"{@b Actions:}",
 													{
-														"type": "item",
-														"name": "Rune of Flametongue:",
-														"entry": "A melee weapon inscribed with this Rune deals 1d6 bonus fire damage. This spell's damage increases by 1d6 when you reach 5th level Artificer (2d6), 11th level (3d6), and 17th level (4d6)."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Protection:",
-														"entry": "A piece of jewellery or armor with this Rune grants +1 to armor class. At 5th level Artificer it grants +1 to all Saving Throws as well."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Regeneration:",
-														"entry": "A piece of jewellery or armor with this Rune allows you to recover health equal to your Artificer level when you take a short rest."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Recovery:",
-														"entry": "A piece of jewellery with this Rune allows you to recover Spell Slots equal to or less than quarter your Artificer level (rounded up) during a short rest. For example, you can recover a 1st level spell slot if you're 1st level artificer, and two 1st level spells slots or a 2nd level at level if you're a 5th-level artificer."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Enhancement:",
-														"entry": " A weapon inscribed with this Rune gain a +1 bonus to attack and damage rolls. The bonus increases to +2 at 9th level, and increases to +3 at 17th level."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Vorpal Force:",
-														"entry": "A weapon inscribed with this Rune deals all damage dealt with it as Force damage."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Warding:",
-														"entry": "A piece of armor inscribed with this Rune generates a shield of temporary hitpoints equal to you Artificer level. These temporary hitpoints are refreshed when you take a short or long rest."
+														"type": "entries",
+														"name": "Attack Protocol",
+														"entries": [
+															"{@i Slam:} {@hit +5} to hit, reach 5 ft., one target. {@i Hit} {@dice 1d4+3}"
+														]
 													}
 												]
 											},
-											"You can be effected by only a single instance of any given rune."
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"name": "Warforged Servant",
-								"entries": [
-									"At 3rd level, you have attained the forging skill, arcane knowledge, and mastery of rune magic to create a Warforged Golem. This golem is controlled by a magic Runed Pendant:",
-									{
-										"type": "inset",
-										"name": "Runed Pendant",
-										"entries": [
-											"{@i Wondrous Item, Attunement (creator only).}",
-											"While attuned to this gem, you have control of your Mechanical Servant. Your Mechanical Servant acts on your Initiative."
-										]
-									},
-									"The Warforged Golem obeys your commands as best as it can. It takes its turn on your initiative, though it doesn't take an action unless you command it to. On your turn, you can verbally command the construct where to move (no action required by you) and take the Help or Attack action. It has Proficiency in Simple Weapons.",
-									"Your Warforged Golem's Proficiency increases when yours does. Additionally, it gains 5 hit points for every level in Artificer you gain. If the golem is killed, it can be returned to life via normal means, such as with the revivify spell.",
-									"In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest. If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 1,000 gp of raw materials. It regains all health at the end of a long rest.",
-									"In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest.",
-									"If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 1,000 gp of raw materials.",
-									{
-										"type": "inset",
-										"name": "Warforged Golem",
-										"entries": [
-											"{@i Medium Construct, unaligned}",
-											"{@b Armor Class:} 14 (Natural Armor)",
-											"{@b Hit Points:} 10 + (5 per Artificer Level)",
-											"{@b Speed:} 25ft",
 											{
-												"type": "table",
-												"colLabels": [
-													"STR",
-													"DEX",
-													"CON",
-													"INT",
-													"WIS",
-													"CHA"
-												],
-												"colStyles": [
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center"
-												],
-												"rows": [
-													[
-														"14 ({@hit +2})",
-														"12 ({@hit +1})",
-														"14 ({@hit +2})",
-														"4 ({@hit -3})",
-														"5 ({@hit -3})",
-														"1 ({@hit -5})"
-													]
-												]
-											},
-											"{@b Damage Immunities:} poison, psychic",
-											"{@b Condition Immunities:} exhaustion, charmed, poisoned",
-											"{@b Senses:} passive Perception 7",
-											"{@b Languages:} Understands creator's languages, but cannot speak",
-											"{@b Actions:}",
-											{
-												"type": "entries",
-												"name": "Attack Protocol",
+												"type": "inset",
+												"name": "Variant Golem Types",
 												"entries": [
-													"{@i Slam:} {@hit +4} to hit, reach 5 ft., one target. {@i Hit} {@dice 1d4+2}"
+													"The default assumption of the Golemsmith is that they are building a roughly humanoid Warforged Golem, but this is not inherently necessarily. If your vision as golem creator takes you elsewhere, work with your DM on if this is merely a reflavoring, or if there are mechanical differences. Some examples might include:",
+													{
+														"type": "entries",
+														"name": "Quadrupedal",
+														"entries": [
+															"You might make a more beast-like Golem, set on all fours. Such a golem would probably lose its ability to wield weapons and shields, but may have a higher natural attack ({@dice 1d8}), higher durability (6 hp per Artificer level), and faster movement (35 feet)."
+														]
+													},
+													{
+														"type": "entries",
+														"name": "Mechanical Abomination",
+														"entries": [
+															"Maybe your vision skews more toward the 'mad' end of the spectrum, and is not easy to quanitify. Maybe it has mechanical tentacles that can grapple at 10 feet. The golem gains reach 10 feet, but loses its ability to wield martial weapons, and its haphazard construction means movement is challenging (20 feet)."
+														]
+													}
 												]
 											}
 										]
 									}
 								]
-							},
+							}
+						],
+						[
 							{
-								"name": "Runesmith Upgrades",
+								"name": "Intelligent Oversight",
 								"entries": [
+									"Starting at 3rd level, you can use the Help action as a bonus action when assisting your golem. Additionally, when you use the Help action to aid an ally in attacking a creature, the target of that attack can be within 30 feet of you, rather than 5 feet of you, if the allied creature can see or hear you.",
 									{
-										"type": "optfeature",
-										"name": "Arcane Barrage Armament",
-										"prerequisite": "9th level. This is incompatable with any other armaments.",
+										"name": "Golemsmith Upgrades",
 										"entries": [
-											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
-											"The charges are regained after a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Cloaking Device",
-										"prerequisite": "15th level",
-										"entries": [
-											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
-											"It regains all charges after a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Environmental Adaptation",
-										"prerequisite": "5th level.",
-										"entries": [
-											"You add integrated climbing hooks, deployable fins, insulated seals to your Golem. Your Warforged Golem gains a climbing and swimming speed equal to its walking speed.",
-											"Additionally, it gains resistance to Cold and Fire damage."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Expanded",
-										"prerequisite": "9th level",
-										"entries": [
-											"You enlarge your Warforged Golem, increasing its size category by one. It has advantage on Strength checks and Strength saving throws."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Evasive Maneuvers",
-										"entries": [
-											"Warforged Golem may add its Dexterity Modifier to its AC while not wearing heavy armor. Additionally, you can now command it to take the Dash, Disengage and Dodge actions."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Flamethrower Armament",
-										"prerequisite": "9th level",
-										"entries": [
-											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell burning hands} as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
-											"The charges are regained after a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Powerful Grappler",
-										"entries": [
-											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the {@skill Athletics} skill and has advantage on attacks against creatures that it is grappling."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Heavy Armor Plating",
-										"prerequisite": "5th level Artificer. Warforged Golem Strength Score of 15 or higher.",
-										"entries": [
-											"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
-											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Improve Dexterity",
-										"entries": [
-											"You tune the servos in your Warforged Golem. Your Warforged Golem's Dexterity score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Dexterity score is 18."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Improve Strength",
-										"entries": [
-											"You reinforce the power of your golem's core and limbs. Your Warforged Golem's Strength score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Strength score is 18."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Integrated Shields",
-										"entries": [
-											"Your Warforged Golem gains Proficiency with shields, allowing it to equip a shield without penalty."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Iron Fortress",
-										"prerequisite": "Stabilisation",
-										"entries": [
-											"You increase the size and durability of your golem's frame. Your Warforged Golem now counts as full cover for those adjacent to it and it cannot be moved against its will while in contact with a floor."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Multiattack Protocol",
-										"prerequisite": "11th level Artificer",
-										"entries": [
-											"Your Warforged Golem gains multiattack. When your Mechanical Servant uses the Attack action, it can attack twice."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Martial Weapons Protocols",
-										"prerequisite": "5th level Artificer",
-										"entries": [
-											"Your Mechanical Servant gains Proficiency with Martial Weapons."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Mark of Life",
-										"prerequisite": "9th level Artificer",
-										"entries": [
-											"You have attained the understanding of magic and craft a Mark of Life on the forehead of your Warforged Golem, turning it into a Warforged Companion. It gains and Intelligence score of 8 and a Charisma score of 6. This allows it to use Infused Magic you create, as well as follow more complex commands without direct input, speak, and remember things."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Roleplaying a Warforged Companion",
-										"entries": [
-											"If you choose the Mark of Life upgrade, your Warforged golem becomes sentient companion, capable of learning, thinking, and having opinions. Consider how this may impact your interactions."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Precision Movements",
-										"entries": [
-											"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Redundant Systems",
-										"entries": [
-											"You have reinforced your Warforged Golem with layers of protection and redundant systems. It gains additional hitpoints equal to twice your Artificer level. Additionally, it gains advantage on death saving throws."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Rune Golem",
-										"prerequisite": "5th level",
-										"entries": [
-											"You've leaned to draw runes in such a way that the golem can benefit from the effect if the Rune is drawn on the golem or its gear. You can apply runes from Runecraft to your golem, each rune applied to the golem counts toward the maximum runes drawn, and the golem gains the benefits of the rune instead of you."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Runic Wings",
-										"prerequisite": "11th level Artificer. Incompatible with Expanded.",
-										"entries": [
-											"You add rune engraved wings to your Warforged Golem, granting it a flying speed of 20 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Warfare Routines",
-										"entries": [
-											"Your Warforged Golem gains one Fighting Style choosing from Duelling, Great Weapon Fighting, Defence, or Archery."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Stabilization",
-										"entries": [
-											"You increase the resilience and stability of your Warforged Golem. It gains proficiency in Constitution Saving Throws and has advantage against saving throws to be knocked down."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Warforged Apprentice",
-										"prerequisite": "Mark of Life. 15th level",
-										"entries": [
-											"Your Warforged Companion begins to apply its abilities to learn new things, gaining a class level in a class of your choosing. Your Warforged Companion gains all the first level features of a class of your choice. This does not include health or class proficiencies (for example, selecting Fighter grants only Fighting Style and Second Wind)."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Warforged Adept",
-										"prerequisite": "Warforged Apprentice",
-										"entries": [
-											"Your growth as a Runesmith is such that your creation is capable of learning and adapting even more skills. It gains all the second level features of the class you selected for the Warforged Apprentice upgrade. This does not include health or class proficiencies (for example, selecting Fighter grants only Action Surge)."
+											{
+												"type": "optfeature",
+												"name": "Arcane Barrage Armament",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
+													"Once used, this armament cannot be used again until the Artificer completes a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Arcane Resonance",
+												"entries": [
+													"Install an essence connection into your golem to sync your magic to it. You can make any spell you cast that targets only you also target your golem."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Cloaking Device",
+												"prerequisite": "15th level Artificer",
+												"entries": [
+													"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
+													"It regains all charges after a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Environmental Adaptation",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You add integrated climbing hooks, deployable fins, insulated seals to your Golem. Your Warforged Golem gains a climbing and swimming speed equal to its walking speed.",
+													"Additionally, it gains resistance to Cold and Fire damage."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Expanded",
+												"prerequisite": "9th level Artificer",
+												"entries": [
+													"You enlarge your Warforged Golem, increasing its size category by one. It has advantage on Strength checks and Strength saving throws."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Flamethrower Armament",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. As an action, the golem can cast {@spell burning hands} as a 3rd level spell.",
+													"The spell save DC is equal to your spell save DC. When cast this way, it has no Verbal or Somatic component.",
+													"Once used, this armament cannot be used again until the Artificer completes a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Magical Essence",
+												"entries": [
+													"You infuse a fragment of magical essence into your golem, allowing it to attune to one magical item."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Heavy Armor Plating",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
+													"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Improve Dexterity",
+												"entries": [
+													"You tune the servos in your Warforged Golem. Your Warforged Golem's Dexterity score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Dexterity score is 18."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Improve Strength",
+												"entries": [
+													"You reinforce the power of your golem's core and limbs. Your Warforged Golem's Strength score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Strength score is 18."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Iron Fortress",
+												"prerequisite": "Stabilisation",
+												"entries": [
+													"You increase the size and durability of your golem’s frame. Your Warforged Golem now counts as full cover for people behind it or riding it. Additionally, it cannot be moved against its will while in contact with a floor."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Multiattack Protocol",
+												"prerequisite": "11th level Artificer",
+												"entries": [
+													"Your Warforged Golem gains multiattack. When your Warforged Golem uses the Attack action, it can attack twice."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Mark of Life",
+												"prerequisite": "9th level Artificer",
+												"entries": [
+													"You have attained the understanding of magic and craft a Mark of Life on the forehead of your Warforged Golem, turning it into a Warforged Companion. It gains an Intelligence score of 8, a Wisdom score of 8 and a Charisma score of 8. This allows it to follow more complex commands without direct input, speak, and remember things.",
+													{
+														"type": "inset",
+														"name": "Roleplaying a Warforged Golem",
+														"entries": [
+															"If you choose the Mark of Life upgrade, your Warforged golem becomes sentient companion, capable of learning, thinking, and having opinions. Consider how this may impact your interactions."
+														]
+													}
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Overdrive Protocol",
+												"prerequisite": "9th level Artificer",
+												"entries": [
+													"You build in a special mode allowing your golem go beyond it's normal limitations. As an action, your golem can activate this mode, gaining the effects of {@spell haste} for a number of rounds equal to your Intelligence modifier, but loses its immuninty to {@condition exhaustion} until it completes a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Precision Movements",
+												"prerequisite": "Incompatible with Expanded",
+												"entries": [
+													"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Thundering Stomp",
+												"prerequisite": "Expanded",
+												"entries": [
+													"Your warforged golem can leverage it's increased size and magical nature to unleash a crushing stomp of magical energy when it brings down its foot. Your golem can replace any attack with the {@spell thunderclap|xge} spell using the Artificers level and spell save for casting the spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Redundant Systems",
+												"entries": [
+													"You have reinforced your Warforged Golem with layers of protection and redundant systems. It gains additional hitpoints equal to twice your Artificer level. Additionally, it gains advantage on death saving throws."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Remote Casting",
+												"entries": [
+													"You integrate a magical relay into your golem, allowing you use it as a magical familiar. As an action, you can see through your golem's eyes and hear what it hears until the start of your next turn. During this time, you are deaf and blind with regard to your own Senses.",
+													"Additionally, when you Cast a Spell with a range of touch, your golem can deliver the spell as if it had cast the spell. Your golem must be within 100 feet of you, and it must use its reaction to deliver the spell when you cast it. If the spell requires an Attack roll, you use your Attack modifier for the roll."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Runic Wings",
+												"prerequisite": "11th level Artificer. Incompatible with Expanded.",
+												"entries": [
+													"You add rune-engraved wings to your Warforged Golem, granting it a flying speed of 20 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Stabilization",
+												"entries": [
+													"You increase the resilience and stability of your Warforged Golem. It gains proficiency in Constitution Saving Throws and has advantage against saving throws to be knocked down."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Warfare Routines",
+												"entries": [
+													"Your Warforged Golem gains one Fighting Style choosing from Archery, Defense, Dueling, or Great Weapon Fighting."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Warforged Apprentice",
+												"prerequisite": "Mark of Life. 15th level Artificer",
+												"entries": [
+													"Your Warforged Companion begins to apply its abilities to learn new things, gaining a class level in a class of your choosing. Your Warforged Companion gains all the first level features of the chosen class. This does not include health or class proficiencies (for example, selecting Fighter grants only Fighting Style and Second Wind)."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Warforged Adept",
+												"prerequisite": "Warforged Apprentice",
+												"entries": [
+													"Your growth as a Golemsmith is such that your creation is capable of learning and adapting even more skills. It gains all the second level features of the class you selected for the Warforged Apprentice upgrade. This does not include health or class proficiencies (for example, selecting Fighter grants only Action Surge)."
+												]
+											}
 										]
 									}
 								]
@@ -1653,42 +1627,17 @@
 						],
 						[
 							{
-								"name": "Infuse Magic",
+								"name": "Autonomous Action",
 								"entries": [
-									"Starting at 5th level, you gain the ability to channel your artificer spells into runic symbols for later use.",
-									"When you cast an artificer spell with a casting time of 1 action, you can increase its casting time to 1 minute. If you do so and hold a nonmagical item throughout the casting, you expend a spell slot, but none of the spell's effects occur. Instead, the spell transfers into that item for later use if the item doesn't already contain a spell from this feature.",
-									"Any creature holding the item thereafter can use an action to activate the spell if the creature has an Intelligence score of at least 6. The spell is cast using your spellcasting ability, targeting the creature that activates the item.",
-									"If the spell targets more than one creature, the creature that activates the item selects the additional targets. If the spell has an area of effect, it is centred on the item. If the spell's range is self, it targets the creature that activates the item. If the spell requires concentration, the creature that activates the item maintains the concentration as if they had cast the spell.",
-									"When you infuse a spell in this way, it must be used within 8 hours. After that time, its magic fades and is wasted. You can have a limited number of infused spells at the same time. The number equals your Intelligence modifier."
+									"Starting at 5th level, you no longer need to spend your actionto direct the golem to use its action, and it can act following mental commands communicated via the control pendant (no action required by Artificer)."
 								]
 							}
 						],
 						[
 							{
-								"name": "Instant Runes",
+								"name": "Perfected Design",
 								"entries": [
-									"At 14th level, when you cast a spell with a somatic component, you can use your bonus action to trace an runic symbol, choosing from one of three effects.",
-									{
-										"type": "list",
-										"items": [
-											{
-												"type": "item",
-												"name": "Rune of Power:",
-												"entry": "You can increase the spell level of the effect by one (if applicable)."
-											},
-											{
-												"type": "item",
-												"name": "Rune of Dominion:",
-												"entry": "You can increase the DC of the saving throw by an amount equal to your Intelligence modifier."
-											},
-											{
-												"type": "item",
-												"name": "Rune of Persistence:",
-												"entry": "You can make the Rune persist, maintaining concentration on the spell for you. This last a number of rounds equal to your Intelligence Modifier."
-											}
-										]
-									},
-									"You must then finish a long rest to use an Instant Rune again."
+									"Starting at 14th level, your golem can add your Intelligence modifier to all of its attack rolls, skill checks, and saving throws."
 								]
 							}
 						]
@@ -1701,71 +1650,26 @@
 					"subclassFeatures": [
 						[
 							{
-								"name": "Runesmith",
+								"name": "Infusionsmith",
 								"entries": [
-									"A Runesmith is an Artificer that has delved into the power and mystery of Runes that forge the the basis of many of the greatest feats of magic ever wrought. They pursue ancient knowledge and uncover new secrets never known to the world. They build on structured systematic magic to bend the laws of the world to their will.",
-									"A typical Runesmith is a voracious mind that seeks to unlock the very secrets of life and magic. By drawing and infusing their Runes, they can work powerful magic.",
+									"An Infusionsmith is, in some ways, perhaps the most quintessential type of Artificer. While other artificiers may delve in mechanics and tinkering, an Infusionsmith is an artificer that tinkers with magic itself.",
+									"These are cutting edge of magical engineering, understanding the principle applications of magic. An Infusionsmith would have ground to stand on in calling a wizard an impulsive spell slinger, for these are the artificers that work their magic through careful and meticulous method, laying down magic they may not use for hours, or painstakingly crafting a long lasting enchantment.",
 									{
 										"type": "entries",
-										"name": "Runesmith's Proficiency",
+										"name": "Infusionsmith's Proficiency",
 										"entries": [
-											"At 1st level, you gain proficiency with {@item smith's tools|phb} and {@item jeweler's tools|phb}, and can select two more languages that you can read and write (but not speak).",
-											"Your knowledge of runic magic gives you a natural affinity for scribing spell scrolls. Creating a magic spell scroll only takes you half the time and material cost it would normally take."
+											"At 1st level, you gain proficiency with {@item jeweler's tools|phb} and {@item calligrapher's supplies|phb}.",
+											"Your knowledge of infusion magic gives you a natural affinity for scribing spell scrolls. Creating a magic spell scroll only takes you half the time and material cost it would normally take."
 										]
 									},
 									{
 										"type": "entries",
-										"name": "Runecraft",
+										"name": "Infused Weapon",
 										"entries": [
-											"At 1st level, you gain the ability to Runecraft items. At the end of a Long Rest, you can place up to two runes on nonmagical items. The number of items increases to 3 runes at 5th level Artificer, 4 runes at 9th, 5 runes at 13th, and 6 runes at 17th.",
-											"The runes effects fade at the end of your next long rest, at which point the same rune or a different rune may be selected.",
-											"These runed items grant the following benefits only to you. A weapon or piece of armor can have multiple Runes active on it, a piece of jewelry can only have a single Rune active on it at a given time.",
-											{
-												"type": "list",
-												"items": [
-													{
-														"type": "item",
-														"name": "Rune of Ability:",
-														"entry": "A piece of jewellery or armor with this Rune grants grants a +1 to an Ability Score of your choice, as well as the maximum for that score while it is active."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Flametongue:",
-														"entry": "A melee weapon inscribed with this Rune deals 1d6 bonus fire damage. This spell's damage increases by 1d6 when you reach 5th level Artificer (2d6), 11th level (3d6), and 17th level (4d6)."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Protection:",
-														"entry": "A piece of jewellery or armor with this Rune grants +1 to armor class. At 5th level Artificer it grants +1 to all Saving Throws as well."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Regeneration:",
-														"entry": "A piece of jewellery or armor with this Rune allows you to recover health equal to your Artificer level when you take a short rest."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Recovery:",
-														"entry": "A piece of jewellery with this Rune allows you to recover Spell Slots equal to or less than quarter your Artificer level (rounded up) during a short rest. For example, you can recover a 1st level spell slot if you're 1st level artificer, and two 1st level spells slots or a 2nd level at level if you're a 5th-level artificer."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Enhancement:",
-														"entry": " A weapon inscribed with this Rune gain a +1 bonus to attack and damage rolls. The bonus increases to +2 at 9th level, and increases to +3 at 17th level."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Vorpal Force:",
-														"entry": "A weapon inscribed with this Rune deals all damage dealt with it as Force damage."
-													},
-													{
-														"type": "item",
-														"name": "Rune of Warding:",
-														"entry": "A piece of armor inscribed with this Rune generates a shield of temporary hitpoints equal to you Artificer level. These temporary hitpoints are refreshed when you take a short or long rest."
-													}
-												]
-											},
-											"You can be effected by only a single instance of any given rune."
+											"Starting at 1st level, you can infuse your weapon with a powerful magic. As a bonus action, you can infuse a weapon you are holding, causing it to burst into ethereal flames.",
+											"The first time you hit an attack with that weapon before the end of your next turn, it deals an additional {@dice 1d6} force damage, and the infusion ends.",
+											"This damage increases by 1d6 at 5th level Artificer ({@dice 2d6}), and again at 11th level ({@dice 3d6}) and 17th level ({@dice 4d6}).",
+											"When attacking with an infused weapon, you can use you Intelligence modifier in place of your Strength or Dexterity modifier for the attack and damage rolls."
 										]
 									}
 								]
@@ -1773,263 +1677,191 @@
 						],
 						[
 							{
-								"name": "Warforged Servant",
+								"name": "Store Magic",
 								"entries": [
-									"At 3rd level, you have attained the forging skill, arcane knowledge, and mastery of rune magic to create a Warforged Golem. This golem is controlled by a magic Runed Pendant:",
+									"Starting at 3rd level, you gain the ability to channel your artificer spells into a non-magical item for later use.",
+									"At the end of a short or long rest, pick a spell you know. You can infuse this spell into an item for later use. You must expend any components the spell requires, but this does not expend a spell slot. Subsequently, any creature holding the item with an Intelligence of 6 or higher that is aware there is magic infused in it can expend the stored magic and cast the spell.",
+									"The spell uses your spellcasting modifiers, but is in all other ways treated as if the creature holding it cast the spell. The magic infused in the item fades if you complete a short or long rest without expending the stored spell.",
 									{
-										"type": "inset",
-										"name": "Runed Pendant",
+										"name": "Golemsmith Upgrades",
 										"entries": [
-											"{@i Wondrous Item, Attunement (creator only).}",
-											"While attuned to this gem, you have control of your Mechanical Servant. Your Mechanical Servant acts on your Initiative."
-										]
-									},
-									"The Warforged Golem obeys your commands as best as it can. It takes its turn on your initiative, though it doesn't take an action unless you command it to. On your turn, you can verbally command the construct where to move (no action required by you) and take the Help or Attack action. It has Proficiency in Simple Weapons.",
-									"Your Warforged Golem's Proficiency increases when yours does. Additionally, it gains 5 hit points for every level in Artificer you gain. If the golem is killed, it can be returned to life via normal means, such as with the revivify spell.",
-									"In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest. If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 1,000 gp of raw materials. It regains all health at the end of a long rest.",
-									"In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest.",
-									"If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 1,000 gp of raw materials.",
-									{
-										"type": "inset",
-										"name": "Warforged Golem",
-										"entries": [
-											"{@i Medium Construct, unaligned}",
-											"{@b Armor Class:} 14 (Natural Armor)",
-											"{@b Hit Points:} 10 + (5 per Artificer Level)",
-											"{@b Speed:} 25ft",
 											{
-												"type": "table",
-												"colLabels": [
-													"STR",
-													"DEX",
-													"CON",
-													"INT",
-													"WIS",
-													"CHA"
-												],
-												"colStyles": [
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center",
-													"col-xs-2 text-align-center"
-												],
-												"rows": [
-													[
-														"14 ({@hit +2})",
-														"12 ({@hit +1})",
-														"14 ({@hit +2})",
-														"4 ({@hit -3})",
-														"5 ({@hit -3})",
-														"1 ({@hit -5})"
-													]
-												]
-											},
-											"{@b Damage Immunities:} poison, psychic",
-											"{@b Condition Immunities:} exhaustion, charmed, poisoned",
-											"{@b Senses:} passive Perception 7",
-											"{@b Languages:} Understands creator's languages, but cannot speak",
-											"{@b Actions:}",
-											{
-												"type": "entries",
-												"name": "Attack Protocol",
+												"type": "optfeature",
+												"name": "Arcane Armament",
 												"entries": [
-													"{@i Slam:} {@hit +4} to hit, reach 5 ft., one target. {@i Hit} {@dice 1d4+2}"
+													"You learn mastery of armoring yourself with magical enchantments. You learn the {@spell mage armor} spell and cast it at will. While under the effect of {@spell mage armor}, you can add your Intelligence to your armor class instead of your Dexterity."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Dancing Fires",
+												"prerequisite": "9th level Artificer",
+												"entries": [
+													"When you animate a weapon with your Animated Weapon feature, you can additionally imbue it with ethereal flames, causing it to deal {@dice 1d6} force damage on hit."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Detonate Armament",
+												"prerequisite": "Arcane Armament. 9th level Artificer",
+												"entries": [
+													"As a reaction to taking damage, you can end the effect of {@spell mage armor} to cast {@spell thunder step|xge} without expending a spell slot.",
+													"Once you do this, you cannot gain the effect of {@spell mage armor} again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Enhanced Attribute",
+												"entries": [
+													"You can enhance a piece of non-magical jewelery with power that boots the wearers abilities. Select an attribute from Strength, Dexterity, Constitution, Wisdom, Intelligence or Charisma, the current and maximum attribute score for that attribute is increased by one while wearing this item. This piece of jewelry provides a benefit only to you.",
+													"You can take this upgrade twice."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Enhanced Weapon Enchantment",
+												"prerequisite": "Weapon Enchantment Expertise",
+												"entries": [
+													"You modify the {@spell magic weapon} and {@spell elemental weapon} spells into a more potent form.",
+													"When you cast the {@spell magic weapon} spell you can augment it with vorpal power; this spell has the effect of the {@spell magic weapon} spell, but in addition attacks made with the weapon score a critical hit on 19 or a 20 die roll, and the weapon deals force damage.",
+													"When you cast {@spell elemental weapon}, the additional damage dealt on hit is increased by an additional {@dice 1d4}, and you can pick force as the damage type in addition to the other options."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Explosive Mine",
+												"prerequisite": "Thunder Mine, 11th level Artificer",
+												"entries": [
+													"When you set a magical trap, you can make the mine cast {@spell fireball} instead of {@spell shatter}."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Flying Boots",
+												"prerequisite": "15th level Artificer",
+												"entries": [
+													"You cast a powerful infusion on a set of boots. The creature wearing these boots is under the effect of the {@spell fly} spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Focused Power Duration",
+												"prerequisite": "15th level Artificer",
+												"entries": [
+													"When you use your Infused Focus power, the spell lasts a number of rounds equal to your Intelligence modifier + proficiency modifier."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Healing Infusion",
+												"entries": [
+													"You master the intricate arts of healing energies interaction with creatures. When you restore health to another creature on your turn, you can add your Intelligence modifier to the health restored."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Life Infusion",
+												"prerequisite": "11th level Artificer",
+												"entries": [
+													"You learn a potent magical infusion that suffuses a creature with life energy. You can cast {@spell regenerate} without expending a spell slot.",
+													"Once you cast this spell in this manner, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Radiant Infusion",
+												"prerequisite": "15th level Artificer",
+												"entries": [
+													"You learn a special infusion for bestowing radiant energy. When you use your Store Magic feature, rather than picking a spell you know, you can cast {@spell holy weapon|xge}. Unless you know this spell from another source, you can only cast this spell using the Store Magic feature. If you have the Weapon Enchantment Expertise upgrade, you have advantage on Constitution saving throws to maintain concentration on this spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Shielding Ring",
+												"entries": [
+													"You infuse powerful magic into a non-magical ring. You can use this ring to cast the {@spell shield} spell without expending a spell slot. You cannot use this ring to cast the spell again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Skill Infusion",
+												"entries": [
+													"You managed to make the magic of your Infused Weapon so potent that attacks made with it are made as if the wielder had a Fighting Style. Choose a Fighting Style from Dueling, Archery, or Great Weapon Master and apply the effects to attacks made with your Infused and Animated Weapons."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Spell Trapping Ring",
+												"prerequisite": "9th level Artificer",
+												"entries": [
+													"You set a powerful magic into a non-magical ring. You can use this ring to cast {@spell counterspell} without expending a spell slot. When you cast {@spell counterspell} in this way and it succeeds, the spell countered is stored in the ring. You can then cast the stored spell without expending a spell slot, but spell fades if it is not used before you complete a long rest.",
+													"Once you use this ring, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Soul Saving Bond",
+												"entries": [
+													"You set up a special magical bond between you and another creature. When either creature bound by this abilities fails Wisdom, Intelligence, Charisma, or Death saving throw, the other character can make their own saving throw, replacing the failed saved with their own roll. If this ability is used on a death saving throw, the replacement roll is a 20. Once a roll is replaced by this feature, it cannot be used again until both creatures in the bond have completed a short or long rest.",
+													"This bond can be set up with a different creature at the end of a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Thunder Mine",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You can set a magical trap by infusing explosive magic into an item. You can set this item to detonate when someone comes within 5 feet of it, or by a verbal command.",
+													"When the magic trap detonates, it casts {@spell shatter} centered on the item. If a creature is in the area of effect of more than one thunder mine during a turn, they take half damage from any subsequent effects of the mines.",
+													"Setting the magical mine takes a special ritual taking 1 minute, and cannot be moved once placed; any attempt to move it results it in detonating unless the Artificer setting it disarms it.",
+													"You can set a number of these equal to your Intelligence modifier. The number you can place is refreshed when you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Triggered Infusion",
+												"entries": [
+													"When you use your Store Magic feature, you can set a trigger for the effect to occur. If the triggering event occurs, you can use your reaction to activate the stored spell. The trigger event can be a verbal key."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Twin Animated Weapon",
+												"prerequisite": "15th level Artificer",
+												"entries": [
+													"When you use your Animate Weapon feature, you can target two weapons. They both function as an Animated Weapon, making attacks against targets you attack as per the feature."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Warding Stone",
+												"entries": [
+													"You learn how to weave a protective enchantment on an item. That item gains a pool of temporary hit points equal to your Artificer level. Whoever is carrying this item gains any temporary hit points remaining in this pool, but these are lost when that creature is no longer carrying this item. This pool of temporary hit points refreshes when the Artificer that created it completes a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Weapon Enchantment Expertise",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You refine techniques of magical enhancements for weapons to be easier to use and maintain. You learn the spell {@spell magic weapon}, and at 9th level you learn the spell {@spell elemental weapon}. These do not count against your known spells, and if you already know them you may select a different Artificer spell to learn.",
+													"When you cast {@spell magic weapon} or {@spell elemental weapon}, you can target a weapon that is already magical, adding to any effect the weapon already has. Additionally, when you have to make a Constitution saving throw to maintain concentration, you do so with advantage."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Worn Enchantment",
+												"entries": [
+													"You can enchant an item you a wearing, such as as scarf or cloak to animate and assist you with a task, be it climbing a wall, grappling an enemy, or picking a lock. You can expend a 1st level spell slot to gain proficiency in a Strength or Dexterity skill until you complete a long rest. You can use up all the magic in the item to gain advantage on one check of that skill, immediately ending the effect."
 												]
 											}
 										]
-									}
-								]
-							},
-							{
-								"name": "Runesmith Upgrades",
-								"entries": [
-									{
-										"type": "optfeature",
-										"name": "Arcane Barrage Armament",
-										"prerequisite": "9th level. This is incompatable with any other armaments.",
-										"entries": [
-											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
-											"The charges are regained after a long rest."
-										]
 									},
 									{
-										"type": "optfeature",
-										"name": "Cloaking Device",
-										"prerequisite": "15th level",
+										"type": "inset",
+										"name": "Wondrous Item Infusions",
 										"entries": [
-											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
-											"It regains all charges after a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Environmental Adaptation",
-										"prerequisite": "5th level.",
-										"entries": [
-											"You add integrated climbing hooks, deployable fins, insulated seals to your Golem. Your Warforged Golem gains a climbing and swimming speed equal to its walking speed.",
-											"Additionally, it gains resistance to Cold and Fire damage."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Expanded",
-										"prerequisite": "9th level",
-										"entries": [
-											"You enlarge your Warforged Golem, increasing its size category by one. It has advantage on Strength checks and Strength saving throws."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Evasive Maneuvers",
-										"entries": [
-											"Warforged Golem may add its Dexterity Modifier to its AC while not wearing heavy armor. Additionally, you can now command it to take the Dash, Disengage and Dodge actions."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Flamethrower Armament",
-										"prerequisite": "9th level",
-										"entries": [
-											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell burning hands} as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
-											"The charges are regained after a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Powerful Grappler",
-										"entries": [
-											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the {@skill Athletics} skill and has advantage on attacks against creatures that it is grappling."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Heavy Armor Plating",
-										"prerequisite": "5th level Artificer. Warforged Golem Strength Score of 15 or higher.",
-										"entries": [
-											"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
-											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Improve Dexterity",
-										"entries": [
-											"You tune the servos in your Warforged Golem. Your Warforged Golem's Dexterity score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Dexterity score is 18."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Improve Strength",
-										"entries": [
-											"You reinforce the power of your golem's core and limbs. Your Warforged Golem's Strength score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Strength score is 18."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Integrated Shields",
-										"entries": [
-											"Your Warforged Golem gains Proficiency with shields, allowing it to equip a shield without penalty."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Iron Fortress",
-										"prerequisite": "Stabilisation",
-										"entries": [
-											"You increase the size and durability of your golem's frame. Your Warforged Golem now counts as full cover for those adjacent to it and it cannot be moved against its will while in contact with a floor."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Multiattack Protocol",
-										"prerequisite": "11th level Artificer",
-										"entries": [
-											"Your Warforged Golem gains multiattack. When your Mechanical Servant uses the Attack action, it can attack twice."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Martial Weapons Protocols",
-										"prerequisite": "5th level Artificer",
-										"entries": [
-											"Your Mechanical Servant gains Proficiency with Martial Weapons."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Mark of Life",
-										"prerequisite": "9th level Artificer",
-										"entries": [
-											"You have attained the understanding of magic and craft a Mark of Life on the forehead of your Warforged Golem, turning it into a Warforged Companion. It gains and Intelligence score of 8 and a Charisma score of 6. This allows it to use Infused Magic you create, as well as follow more complex commands without direct input, speak, and remember things."
-										]
-									},
-									{
-										"type": "entries",
-										"name": "Roleplaying a Warforged Companion",
-										"entries": [
-											"If you choose the Mark of Life upgrade, your Warforged golem becomes sentient companion, capable of learning, thinking, and having opinions. Consider how this may impact your interactions."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Precision Movements",
-										"entries": [
-											"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Redundant Systems",
-										"entries": [
-											"You have reinforced your Warforged Golem with layers of protection and redundant systems. It gains additional hitpoints equal to twice your Artificer level. Additionally, it gains advantage on death saving throws."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Rune Golem",
-										"prerequisite": "5th level",
-										"entries": [
-											"You've leaned to draw runes in such a way that the golem can benefit from the effect if the Rune is drawn on the golem or its gear. You can apply runes from Runecraft to your golem, each rune applied to the golem counts toward the maximum runes drawn, and the golem gains the benefits of the rune instead of you."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Runic Wings",
-										"prerequisite": "11th level Artificer. Incompatible with Expanded.",
-										"entries": [
-											"You add rune engraved wings to your Warforged Golem, granting it a flying speed of 20 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Warfare Routines",
-										"entries": [
-											"Your Warforged Golem gains one Fighting Style choosing from Duelling, Great Weapon Fighting, Defence, or Archery."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Stabilization",
-										"entries": [
-											"You increase the resilience and stability of your Warforged Golem. It gains proficiency in Constitution Saving Throws and has advantage against saving throws to be knocked down."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Warforged Apprentice",
-										"prerequisite": "Mark of Life. 15th level",
-										"entries": [
-											"Your Warforged Companion begins to apply its abilities to learn new things, gaining a class level in a class of your choosing. Your Warforged Companion gains all the first level features of a class of your choice. This does not include health or class proficiencies (for example, selecting Fighter grants only Fighting Style and Second Wind)."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Warforged Adept",
-										"prerequisite": "Warforged Apprentice",
-										"entries": [
-											"Your growth as a Runesmith is such that your creation is capable of learning and adapting even more skills. It gains all the second level features of the class you selected for the Warforged Apprentice upgrade. This does not include health or class proficiencies (for example, selecting Fighter grants only Action Surge)."
+											"Generally speaking, a magic item that is not otherwise under the purview of another subclass (such as wands) is an appropriate item for an Infusionsmith. At the DMs discretion, most uncommon non-attunement wondrous items make appropriate custom Infusionsmith upgrades."
 										]
 									}
 								]
@@ -2037,42 +1869,28 @@
 						],
 						[
 							{
-								"name": "Infuse Magic",
+								"name": "Animated Weapon",
 								"entries": [
-									"Starting at 5th level, you gain the ability to channel your artificer spells into runic symbols for later use.",
-									"When you cast an artificer spell with a casting time of 1 action, you can increase its casting time to 1 minute. If you do so and hold a nonmagical item throughout the casting, you expend a spell slot, but none of the spell's effects occur. Instead, the spell transfers into that item for later use if the item doesn't already contain a spell from this feature.",
-									"Any creature holding the item thereafter can use an action to activate the spell if the creature has an Intelligence score of at least 6. The spell is cast using your spellcasting ability, targeting the creature that activates the item.",
-									"If the spell targets more than one creature, the creature that activates the item selects the additional targets. If the spell has an area of effect, it is centred on the item. If the spell's range is self, it targets the creature that activates the item. If the spell requires concentration, the creature that activates the item maintains the concentration as if they had cast the spell.",
-									"When you infuse a spell in this way, it must be used within 8 hours. After that time, its magic fades and is wasted. You can have a limited number of infused spells at the same time. The number equals your Intelligence modifier."
+									"Starting at 5th level, you can animate a weapon to strike your enemies. At the end of a long rest, you can touch a melee weapon in your possession and infuse it with animating magic. You do not need to have proficiency with this weapon. During this time, when you take the attack action, you can mentally direct the animated weapon to attack a creature within within 30 feet of you; this can be in addition to making an attack with a carried weapon as normal.",
+									"Additionally, whenever you cast {@spell magic weapon}, {@spell elemental weapon}, or {@spell holy weapon|xge}, your animated weapon also gains the benefits of the spell as long as you are concentrating on it.",
+									"The weapon returns to your side after every attack. If there is no path between you and the target of your attack, the attack fails, but the animated weapon otherwise ignores cover",
+									"When attacking with an animated weapon, it is treated as if you had proficiency in the weapon (whether you do or not) and you can use you Intelligence modifier in place of your Strength or Dexterity modifier for the attack and damage rolls.",
+									{
+										"type": "inset",
+										"name": "Animated Attack ACtions",
+										"entries": [
+											"This ability functions largely like Extra Attack, and does not interact with attacks not made with the Attack action, such as {@spell booming blade|scag}, but can be made independently of attacking with a carried weapon if you only want to attack with the animated weapon."
+										]
+									}
 								]
 							}
 						],
 						[
 							{
-								"name": "Instant Runes",
+								"name": "Infused Focus",
 								"entries": [
-									"At 14th level, when you cast a spell with a somatic component, you can use your bonus action to trace an runic symbol, choosing from one of three effects.",
-									{
-										"type": "list",
-										"items": [
-											{
-												"type": "item",
-												"name": "Rune of Power:",
-												"entry": "You can increase the spell level of the effect by one (if applicable)."
-											},
-											{
-												"type": "item",
-												"name": "Rune of Dominion:",
-												"entry": "You can increase the DC of the saving throw by an amount equal to your Intelligence modifier."
-											},
-											{
-												"type": "item",
-												"name": "Rune of Persistence:",
-												"entry": "You can make the Rune persist, maintaining concentration on the spell for you. This last a number of rounds equal to your Intelligence Modifier."
-											}
-										]
-									},
-									"You must then finish a long rest to use an Instant Rune again."
+									"Starting at 14th level, you can anchor a powerful spell into an item. When you cast a concentration spell, you can anchor it to an item, and do not need to maintain concentration. The spell lasts a number of rounds equal to your Intelligence modifier, after which the spell ends.",
+									"Once you use this ability, you must complete a short or long rest before using it again."
 								]
 							}
 						]
@@ -2239,7 +2057,7 @@
 												"type": "optfeature",
 												"name": "Energy Surge",
 												"entries": [
-													"You upgrade your Mechplate gauntlet to support delievering a energy surge. You can use a bonus action to overcharge your gauntlet, and the next Shocking Grasp or Force Blast you hit an enemy with during that turn deals an additional 1d8 lightning damage and knocks a Large or smaller target 10 feet directly away from you."
+													"You upgrade your Mechplate gauntlet to support delievering a energy surge. You can use a bonus action to overcharge your gauntlet, and the next {@spell shocking grasp} or Force Blast you hit an enemy with during that turn deals an additional {@dice 1d8} lightning damage and knocks a Large or smaller target 10 feet directly away from you."
 												]
 											},
 											{
@@ -2599,7 +2417,7 @@
 										"type": "entries",
 										"name": "Alchemist's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with Blowguns, {@item Alchemist's supplies|phb} and {@item Glassblower's tools|phb}.",
+											"When you choose this specialization at 1st level, you gain proficiency with Blowguns, {@item Alchemist's supplies|phb} and {@item Herbalism kit|phb}.",
 											"Your knowledge of alchemy gives you a natural affinity for brewing potions. Creating a potion through normal crafting takes you only half the time and cost it would normally take."
 										]
 									},
@@ -2839,7 +2657,7 @@
 													{
 														"type": "list",
 														"items": [
-															"Contact poison. You can apply this to a weapon or up to ten pieces of ammunition, lasting until the end of your next long rest. That weapon deals an additional 1d4 poison damage to targets it strikes.",
+															"Contact poison. You can apply this to a weapon or up to ten pieces of ammunition, lasting until the end of your next long rest. That weapon deals an additional {@dice 1d4} poison damage to targets it strikes.",
 															"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become {@condition poisoned} until they complete a long rest.",
 															"Inhaled poison. This poison can be used to modify your poisonous gas reaction. Anytime before the end of your next long rest, you can use this dose of poison to make your poisonous gas instant reaction have a radius of 10 feet and deal twice as much damage on a failed save."
 														]

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -539,7 +539,7 @@
 					{
 						"name": "Study of Magic",
 						"entries": [
-							"At 11th level, your proficieny in the workings of magic has become so great you can cast {@spell detect magic} and {@spell identify} at will. Additionally, you have advantage on all Intelligence (Arcana) checks to understand the workings of magical traps, effects, or runes."
+							"At 11th level, your proficieny in the workings of magic has become so great you can cast {@spell detect magic} and {@spell identify} at will. Additionally, you have advantage on all Intelligence ({@skill Arcana}) checks to understand the workings of magical traps, effects, or runes."
 						]
 					},
 					{
@@ -666,7 +666,7 @@
 										"type": "entries",
 										"name": "Cannonsmith's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with tinker's tools and smith's tools.",
+											"When you choose this specialization at 1st level, you gain proficiency with {@item tinker's tools|phb} and {@item smith's tools|phb}.",
 											"You gain the knowledge to forge rounds for your Thunder Cannon, and can create them with the proper tools during a Long Rest.",
 											"You can create up to 50 rounds of ammunition during a long rest, with materials costing 1 gold piece per 10 rounds."
 										]
@@ -864,7 +864,7 @@
 												"name": "Shock Absorber",
 												"prerequisite": "9th level Artificer",
 												"entries": [
-													"You add a reclamation device to your Thunder Cannon to gather energy from the surroundings when it is present. As a reaction to taking Lightning or Thunder Damage, you can cast Absorb Elements without consuming a spell slot. When absorbed in this method, you can apply the bonus damage granted by Absorb Elements to your next Thunder Cannon attack even if you make a ranged attack."
+													"You add a reclamation device to your Thunder Cannon to gather energy from the surroundings when it is present. As a reaction to taking Lightning or Thunder Damage, you can cast {@spell absorb elements|xge} without consuming a spell slot. When absorbed in this method, you can apply the bonus damage granted by {@spell absorb elements|xge} to your next Thunder Cannon attack even if you make a ranged attack."
 												]
 											},
 											{
@@ -872,7 +872,7 @@
 												"name": "Shock Harpoon",
 												"prerequisite": "9th level Artificer, Harpoon Reel",
 												"entries": [
-													"After hitting a creature with the Harpoon fire mode, you can use a bonus action to deliver a shock. If you have not used it since the start of your turn, you can apply Thundermonger damage as lightning damage. Additionally, the target must make a Constitution saving throw against your spell save DC or be stunned until the end of its next turn.",
+													"After hitting a creature with the Harpoon fire mode, you can use a bonus action to deliver a shock. If you have not used it since the start of your turn, you can apply Thundermonger damage as lightning damage. Additionally, the target must make a Constitution saving throw against your spell save DC or be {@condition stunned} until the end of its next turn.",
 													"Once used, the Harpoon must be reeled in before this can be used again."
 												]
 											},
@@ -881,7 +881,7 @@
 												"name": "Storm Blast",
 												"prerequisite": "5th level Artificer",
 												"entries": [
-													"You upgrade your Thunder Cannon to discharge its power in 30-foot cone from the gun. As an action, you can make a special attack. Each creature must make a Strength saving throw, or take half the bonus damage of Thundermonger and be knocked prone. Using this shot counts as applying Thundermonger damage for the turn.",
+													"You upgrade your Thunder Cannon to discharge its power in 30-foot cone from the gun. As an action, you can make a special attack. Each creature must make a Strength saving throw, or take half the bonus damage of Thundermonger and be knocked {@condition prone}. Using this shot counts as applying Thundermonger damage for the turn.",
 													"Firing in this way does not consume ammo."
 												]
 											},
@@ -959,7 +959,7 @@
 										"type": "entries",
 										"name": "Gadgetsmith's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with nets, rapiers, whips, and tinker's tools."
+											"When you choose this specialization at 1st level, you gain proficiency with nets, rapiers, whips, and {@item tinker's tools|phb}."
 										]
 									},
 									{
@@ -1004,254 +1004,252 @@
 											"At 3rd level, you've mastered the essential tools begun to tinker with ways to expand your arsenal. The number of upgrades you have for your class level is increased by one.",
 											"The number of additional upgrades you get increases to two more than the class table at 5th level."
 										]
+									},
+									{
+										"type": "entries",
+										"name": "Gadgetsmith Upgrades",
+										"entries": [
+											{
+												"type": "optfeature",
+												"name": "Antimagical Shackle",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You create an antimagical shackle. When you are adjacent to a creature, as an action you can attempt to shackle them to yourself or a nearby object using these shackles. The you make a Dexterity ({@skill Sleight of Hand}) check contested by a Strength ({@skill Athletics}) or Dexterity ({@skill Acorbatics}) check. On failure, they are shackled to the creature or object you attempted to shackle them to, and can move only by moving it if they are able to.",
+													"Additionally, while shackled by these shackles, they cannot teleport, planeshift, polymorph, shapechange, dematerialize, or turn into an amorphous form. As an action they can make a Strength saving throw against your spell save DC to break the shackles once shackled, otherwise these shackles last until you remove them.",
+													"This shackles have no effect on creatures immune to being {@condition grappled} or {@condition restrained}."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Boomerang of Hitting",
+												"entries": [
+													"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals 1d4 damage.",
+													"Special: When this weapon is Thrown, you can target three creatures within 10 feet of each other, making a separate attack roll against each target.",
+													"This weapon returns to your hand after you make an attack with it using the Thrown property."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Belt of Adjusting Size",
+												"entries": [
+													"You create a belt with a creature size dial on it. While you are wearing this belt, you can use an action to cast {@spell enlarge/reduce} on yourself. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Binding Rope",
+												"prerequisite": "5th level Artificer",
+												"entries": [
+													"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save or become {@condition restrained} until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Bracers of Empowerment",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create bracers that can empower you. You can use this to cast {@spell tenser's transformation|xge} without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Deployable Wings",
+												"prerequisite": "9th level",
+												"entries": [
+													"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Disintegration Ray",
+												"prerequisite": "15th level",
+												"entries": [
+													"You create a Disintegratation Ray. You can use this to cast {@spell disintegrate} without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Gripping Gloves",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength ({@skill Athletics}) checks involving manipulating things with your hands while wearing these gloves."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Element Eater",
+												"entries": [
+													"You create a device capable of absorbing incoming elemental damage. As a reaction to taking elemental damage, you can activate this device and cast {@spell absorb elements|xge} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Enhanced Grappling Hook",
+												"entries": [
+													"You enhance your grappling hook, increasing its range to 40 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Fire Spitter",
+												"entries": [
+													"You create a gadget that creates a quick blast of fire. As an action, you can cast {@spell aganazzar's scorcher|xge} with this gadget, but the gadget cannot be used again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Flashbang",
+												"entries": [
+													"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a dexterity saving throw or be {@condition blinded} until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Impact Gauntlet",
+												"entries": [
+													"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals 1d8 bludgeoning damage.",
+													"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Lightning Baton",
+												"entries": [
+													"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals 1d4 bludgeoning damage and 1d4 lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save or become {@condition stunned} until the start of your next turn."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Mechanical Arm",
+												"entries": [
+													"You create a mechanical arm, giving an extra hand. This mechanical arm only functions while it is mounting on gear you are wearing, but can be operated mentally without the need for you hands. This mechanical arm can serve any function a normal hand could, such as holding things, making attacks, interacting with the environment, etc, but does not give you additional actions."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Mechanical Familiar",
+												"entries": [
+													"You can create the blue print for a small mechanical creature. At the end of a long rest, you can choose animate it, and cast {@spell find familiar} with the following modifications. The creatures type is Construct, and you cannot select a creature with a flying speed. This construct stays active until you deactivate it or is destroyed. In either case, you can choose to reactivate it at the end of a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Nimble Gloves",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity (Slight of Hand) checks involving manipulating things with your hands while wearing these gloves."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Phase Trinket",
+												"prerequisite": "9th level. Incompatible with other Trinkets.",
+												"entries": [
+													"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast {@spell blink} or {@spell dimension door} using the Stopwatch without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Jumping Boots",
+												"entries": [
+													"You modify your boots with arcane boosters. While wearing these boots, you are under the effects of the {@spell jump} spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Repeating Hand Crossbow",
+												"entries": [
+													"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals 1d6 piercing damage.",
+													"Special: This weapon does not require a free-hand to load, as it has a built in loader."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Bee Swarm Rockets",
+												"prerequisite": "15th level",
+												"entries": [
+													"You design a type of tiny firecracker like device, that can be released in large number. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a dexterity saving throw. Creatures that fail take 2d6 fire damage, or half as much on a successful one.",
+													"You rebuild your stock to your maximum during a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Shocking Hook",
+												"entries": [
+													"You can integrate your Shock Generator and your Grappling Hook. If the target of your Grappling Hook is a creature, you can cast {@spell shocking grasp} on that creature as a bonus action when pulling it to you or being pulled to it."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Sight Lenses",
+												"entries": [
+													"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through Fog, Mist, Smoke, Clouds, and non-Magical Darkness as normal sight up to 15 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Smoke Cloak",
+												"entries": [
+													"Create a cloak that causes you to blend in with smoke. When you start your turn lightly or heavily obscured by smoke, you are {@condition invisible} until your turn ends, you cast a spell, make an attack, or damage an enemy."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Stinking Gas",
+												"prerequisite": "9th level",
+												"entries": [
+													"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast {@spell stinking cloud} rather than {@spell fog cloud}, following the same rules."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Striding Boots",
+												"entries": [
+													"You modify your boots with amplified striding speed. While earing these boots, you are under the effects of {@spell longstrider} spell."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Stopwatch Trinket",
+												"prerequisite": "9th level, Incompatible with other Trinkets.",
+												"entries": [
+													"You create a magical stopwatch that manipulates time magic. As an action, you can cast {@spell haste} or {@spell slow} using the Stopwatch without expending a Spell Slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Truesight Lenses",
+												"prerequisite": "Sight Lenses.",
+												"entries": [
+													"You upgrade and fine tune your sight lenses, granting you Truesight up to 15 feet."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Useful Universal Key",
+												"prerequisite": "11th level",
+												"entries": [
+													"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast {@spell passwall} without expending a spell slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Zombie Wires",
+												"prerequisite": "15th level",
+												"entries": [
+													"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast {@spell danse macabre|xge} without expended a spell slot.",
+													"Once you use this ability, you cannot use it again until you complete a long rest."
+												]
+											}
+										]
 									}
 								]
 							},
-							{
-								"type": "entries",
-								"name": "Gadgetsmith Upgrades",
-								"entries": [
-									{
-										"type": "optfeature",
-										"name": "Antimagical Shackle",
-										"prerequisite": "5th level Artificer",
-										"entries": [
-											"You create an antimagical shackle. When you are adjacent to a creature, as an action you can attempt to shackle them to yourself or a nearby object using these shackles. The you make a Dexterity (Sleight of Hand) check contested by a Strength (Athletics) or Dexterity (Acorbatics) check. On failure, they are shackled to the creature or object you attempted to shackle them to, and can move only by moving it if they are able to.",
-											"Additionally, while shackled by these shackles, they cannot teleport, planeshift, polymorph, shapechange, dematerialize, or turn into an amorphous form. As an action they can make a Strength saving throw against your spell save DC to break the shackles once shackled, otherwise these shackles last until you remove them.",
-											"This shackles have no effect on creatures immune to being grappled or restrained."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Boomerang of Hitting",
-										"entries": [
-											"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals 1d4 damage.",
-											"Special: When this weapon is Thrown, you can target three creatures within 10 feet of each other, making a separate attack roll against each target.",
-											"This weapon returns to your hand after you make an attack with it using the Thrown property."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Belt of Adjusting Size",
-										"entries": [
-											"You create a belt with a creature size dial on it. While you are wearing this belt, you can use an action to cast Enlarge/Reduce on yourself. Once you use this gadget, you cannot use it again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Binding Rope",
-										"prerequisite": "5th level Artificer",
-										"entries": [
-											"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save or become restrained until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Bracers of Empowerment",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create bracers that can empower you. You can use this to cast Tensor's Transformation without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Deployable Wings",
-										"prerequisite": "9th level",
-										"entries": [
-											"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Disintegration Ray",
-										"prerequisite": "15th level",
-										"entries": [
-											"You create a Disintegratation Ray. You can use this to cast Distintegrate without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Gripping Gloves",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength (Athletics) checks involving manipulating things with your hands while wearing these gloves."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Element Eater",
-										"entries": [
-											"You create a device capable of absorbing incoming elemental damage. As a reaction to taking elemental damage, you can activate this device and cast Absorb Elements without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Enhanced Grappling Hook",
-										"entries": [
-											"You enhance your grappling hook, increasing its range to 40 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Fire Spitter",
-										"entries": [
-											"You create a gadget that creates a quick blast of fire. As an action, you can cast Aganazzar's Scorcher with this gadget, but the gadget cannot be used again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Flashbang",
-										"entries": [
-											"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a dexterity saving throw or be blinded until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Impact Gauntlet",
-										"entries": [
-											"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals 1d8 bludgeoning damage.",
-											"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Lightning Baton",
-										"entries": [
-											"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals 1d4 bludgeoning damage and 1d4 lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save or become stunned until the start of your next turn."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Mechanical Arm",
-										"entries": [
-											"You create a mechanical arm, giving an extra hand. This mechanical arm only functions while it is mounting on gear you are wearing, but can be operated mentally without the need for you hands. This mechanical arm can serve any function a normal hand could, such as holding things, making attacks, interacting with the environment, etc, but does not give you additional actions."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Mechanical Familiar",
-										"entries": [
-											"You can create the blue print for a small mechanical creature. At the end of a long rest, you can choose animate it, and cast Find Familiar with the following modifications. The creatures type is Construct, and you cannot select a creature with a flying speed. This construct stays active until you deactivate it or is destroyed. In either case, you can choose to reactivate it at the end of a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Nimble Gloves",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity (Slight of Hand) checks involving manipulating things with your hands while wearing these gloves."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Phase Trinket",
-										"prerequisite": "9th level. Incompatible with other Trinkets.",
-										"entries": [
-											"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast Blink or Dimension Door using the Stopwatch without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Jumping Boots",
-										"entries": [
-											"You modify your boots with arcane boosters. While wearing these boots, you are under the effects of the Jump spell."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Repeating Hand Crossbow",
-										"entries": [
-											"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals 1d6 piercing damage.",
-											"Special: This weapon does not require a free-hand to load, as it has a built in loader."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Bee Swarm Rockets",
-										"prerequisite": "15th level",
-										"entries": [
-											"You design a type of tiny firecracker like device, that can be released in large number. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a dexterity saving throw. Creatures that fail take 2d6 fire damage, or half as much on a successful one.",
-											"You rebuild your stock to your maximum during a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Shocking Hook",
-										"entries": [
-											"You can integrate your Shock Generator and your Grappling Hook. If the target of your Grappling Hook is a creature, you can cast Shocking Grasp on that creature as a bonus action when pulling it to you or being pulled to it."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Sight Lenses",
-										"entries": [
-											"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through Fog, Mist, Smoke, Clouds, and non-Magical Darkness as normal sight up to 15 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Smoke Cloak",
-										"entries": [
-											"Create a cloak that causes you to blend in with smoke. When you start your turn lightly or heavily obscured by smoke, you are invisible until your turn ends, you cast a spell, make an attack, or damage an enemy."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Stinking Gas",
-										"prerequisite": "9th level",
-										"entries": [
-											"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast Stinking Cloud rather than Fog Cloud, following the same rules."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Striding Boots",
-										"entries": [
-											"You modify your boots with amplified striding speed. While earing these boots, you are under the effects of Longstrider spell."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Stopwatch Trinket",
-										"prerequisite": "9th level, Incompatible with other Trinkets.",
-										"entries": [
-											"You create a magical stopwatch that manipulates time magic. As an action, you can cast Haste or Slow using the Stopwatch without expending a Spell Slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Truesight Lenses",
-										"prerequisite": "Sight Lenses.",
-										"entries": [
-											"You upgrade and fine tune your sight lenses, granting you Truesight up to 15 feet."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Useful Universal Key",
-										"prerequisite": "11th level",
-										"entries": [
-											"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast Passwall without expending a spell slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									},
-									{
-										"type": "optfeature",
-										"name": "Zombie Wires",
-										"prerequisite": "15th level",
-										"entries": [
-											"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast Danse Macabre without expended a spell slot.",
-											"Once you use this ability, you cannot use it again until you complete a long rest."
-										]
-									}
-								]
-							}
-						],
-						[
 							{
 								"type": "entries",
 								"entries": [
@@ -1312,7 +1310,7 @@
 										"type": "entries",
 										"name": "Runesmith's Proficiency",
 										"entries": [
-											"At 1st level, you gain proficiency with smith's tools and jeweler's tools, and can select two more languages that you can read and write (but not speak).",
+											"At 1st level, you gain proficiency with {@item smith's tools|phb} and {@item jeweler's tools|phb}, and can select two more languages that you can read and write (but not speak).",
 											"Your knowledge of runic magic gives you a natural affinity for scribing spell scrolls. Creating a magic spell scroll only takes you half the time and material cost it would normally take."
 										]
 									},
@@ -1453,7 +1451,7 @@
 										"name": "Arcane Barrage Armament",
 										"prerequisite": "9th level. This is incompatable with any other armaments.",
 										"entries": [
-											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast Magic Missile as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
+											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
 											"The charges are regained after a long rest."
 										]
 									},
@@ -1462,7 +1460,7 @@
 										"name": "Cloaking Device",
 										"prerequisite": "15th level",
 										"entries": [
-											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: Invisibility (2 charges), Greater Invisibility (4 charges).",
+											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
 											"It regains all charges after a long rest."
 										]
 									},
@@ -1495,7 +1493,7 @@
 										"name": "Flamethrower Armament",
 										"prerequisite": "9th level",
 										"entries": [
-											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast Burning Hands as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
+											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell burning hands} as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
 											"The charges are regained after a long rest."
 										]
 									},
@@ -1503,7 +1501,7 @@
 										"type": "optfeature",
 										"name": "Powerful Grappler",
 										"entries": [
-											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the Athletics skill and has advantage on attacks against creatures that it is grappling."
+											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the {@skill Athletics} skill and has advantage on attacks against creatures that it is grappling."
 										]
 									},
 									{
@@ -1512,7 +1510,7 @@
 										"prerequisite": "5th level Artificer. Warforged Golem Strength Score of 15 or higher.",
 										"entries": [
 											"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
-											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity (Stealth) checks."
+											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
 										]
 									},
 									{
@@ -1579,7 +1577,7 @@
 										"type": "optfeature",
 										"name": "Precision Movements",
 										"entries": [
-											"Your Warforged Golem gains Proficiency in the Stealth skill and with Thieves' Tools. Additionally, it gains an integrated set of Thieve's Tools that are always available (unless removed)."
+											"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
 										]
 									},
 									{
@@ -1696,7 +1694,7 @@
 										"type": "entries",
 										"name": "Warsmith's Proficiency",
 										"entries": [
-											"At 1st level, you gain proficiency with heavy armor and smith's tools."
+											"At 1st level, you gain proficiency with heavy armor and {@item smith's tools|phb}."
 										]
 									},
 									{
@@ -1786,7 +1784,7 @@
 												"name": "Active Camouflage Armor",
 												"prerequisite": "5th level",
 												"entries": [
-													"As an action, you can activate active camouflage causing your suit to automatically blend into its surroundings. This lasts until deactivated. While this active, you are considered lightly obscured, and can hide from a creature even when they have a clear line of sight to you. Wisdom (Perception) checks to find you that rely on vision are made with disadvantage."
+													"As an action, you can activate active camouflage causing your suit to automatically blend into its surroundings. This lasts until deactivated. While this active, you are considered lightly obscured, and can hide from a creature even when they have a clear line of sight to you. Wisdom ({@skill Perception}) checks to find you that rely on vision are made with disadvantage."
 												]
 											},
 											{
@@ -1802,7 +1800,7 @@
 												"prerequisite": "15th level. Prerequisite: Darkvision Visor",
 												"entries": [
 													"You add a heavily enchanted visor to your Mechplate that augments your vision. The Visor has 6 Charges.",
-													"Once it is integrated into your armor, you can use an Action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: See Invisibility (2 charges) or True Seeing (4 charges).",
+													"Once it is integrated into your armor, you can use an Action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell see invisibility} (2 charges) or {@spell true seeing} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1819,7 +1817,7 @@
 												"name": "Cloaking Device",
 												"prerequisite": "Active Camouflage",
 												"entries": [
-													"You install an Arcane Cloaking device on your Mechplate. This device has 4 Charges. You can expend 1 or more charges to cast one of the following spells using its action: Invisibility (2 charges), Greater Invisibility (4 charges).",
+													"You install an Arcane Cloaking device on your Mechplate. This device has 4 Charges. You can expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
 													"It regains all charges after a long rest."
 												]
 											},
@@ -1981,7 +1979,7 @@
 												"name": "Relocation Matrix",
 												"prerequisite": "15th level",
 												"entries": [
-													"You install an arcane transmutation matrix that you can use to convert your magical power into dimensional warp. As an action, you can cast Dimension Door without expending a spell slot. Once you use this ability, you can not use it again until you complete a long rest."
+													"You install an arcane transmutation matrix that you can use to convert your magical power into dimensional warp. As an action, you can cast {@spell dimension door} without expending a spell slot. Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},
 											{
@@ -1989,7 +1987,7 @@
 												"name": "Sealed Suit",
 												"prerequisite": "5th level",
 												"entries": [
-													"As a bonus action on your turn you can environmentally seal your Mechplate, giving you an air supply for up to 1 hour and making you immune to poison (but not curing you of existing poisoned conditions).",
+													"As a bonus action on your turn you can environmentally seal your Mechplate, giving you an air supply for up to 1 hour and making you immune to poison (but not curing you of existing {@condition poisoned} conditions).",
 													"Your armor regains 1 minute of air for every minute that you are not submerged and the armor is not sealed.",
 													"In addition to the above, you are also considered adapted to cold and hot climates while wearing your armor, and you're also acclimated to high altitude while wearing your armor."
 												]
@@ -2071,7 +2069,7 @@
 										"type": "entries",
 										"name": "Wandsmith's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with woodcrafter's tools and jeweler's tools.",
+											"When you choose this specialization at 1st level, you gain proficiency with {@item woodcarver's tools|phb} and {@item jeweler's tools|phb}.",
 											"Additionally, when using wondrous item Wand that has rolls a d20 when the last charge is consumed, rolling a 1 on that roll will no longer result in that wand being destroyed."
 										]
 									},
@@ -2202,7 +2200,7 @@
 										"type": "entries",
 										"name": "Alchemist's Proficiency",
 										"entries": [
-											"When you choose this specialization at 1st level, you gain proficiency with Blowguns, Alchemist's supplies and Glassblower's tools.",
+											"When you choose this specialization at 1st level, you gain proficiency with Blowguns, {@item Alchemist's supplies|phb} and {@item Glassblower's tools|phb}.",
 											"Your knowledge of alchemy gives you a natural affinity for brewing potions. Creating a potion through normal crafting takes you only half the time and cost it would normally take."
 										]
 									},
@@ -2233,7 +2231,7 @@
 												"type": "entries",
 												"name": "Poisonous Gas",
 												"entries": [
-													"As an action you can produce a reaction causing noxious fumes. At point within 15 feet, you can toss quick combination of things that will cause a whiff of poisonus gas to erupt spreading to a radius of 5 feet. Creatures in that area have to make a constitution saving throw, or take 1d4 poison damage and become poisoned until the end of their next turn.",
+													"As an action you can produce a reaction causing noxious fumes. At point within 15 feet, you can toss quick combination of things that will cause a whiff of poisonus gas to erupt spreading to a radius of 5 feet. Creatures in that area have to make a constitution saving throw, or take 1d4 poison damage and become {@condition poisoned} until the end of their next turn.",
 													"The damage damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4)."
 												]
 											},
@@ -2287,7 +2285,7 @@
 													],
 													[
 														"5th",
-														"{@spell cloudkill}, {@spell skill empowerment}"
+														"{@spell cloudkill}, {@spell skill empowerment|xge}"
 													]
 												]
 											},
@@ -2322,7 +2320,7 @@
 												"prerequisite": "9th level",
 												"entries": [
 													"You create a potent serum. As an action on your turn, you can consume this serum, granting you the effects of Haste and Heroism for a number of rounds equal to your Intelligence modifier (minimum 1). These effects do not require concentration, but you still suffer the normal effects of the Haste spell ending when it ends. You can use this a number of times equal to your constitution modifier (minimum 1) before you must take a long rest to gain the effects from the serum again.",
-													"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become poisoned on a failed save."
+													"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become {@condition poisoned} on a failed save."
 												]
 											},
 											{
@@ -2367,7 +2365,7 @@
 												"type": "optfeature",
 												"name": "Frostbloom Reaction",
 												"entries": [
-													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a dexterity saving throw, or be caught by the ice taking 1d6 cold damage; a creature entirely in the area of effect that fails also becoming restrained until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
+													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a dexterity saving throw, or be caught by the ice taking 1d6 cold damage; a creature entirely in the area of effect that fails also becoming {@condition restrained} until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
 													"The damage damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
 												]
 											},
@@ -2435,7 +2433,7 @@
 														"type": "list",
 														"items": [
 															"Contact poison. You can apply this to a weapon or up to ten pieces of ammunition, lasting until the end of your next long rest. That weapon deals an additional 1d4 poison damage to targets it strikes.",
-															"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become poisoned until they complete a long rest.",
+															"Ingested poison. This a simple flavorless powder. If a creature consumes a full dose of this poison before the end of your next long rest, after one minute has passed they must make a Constitution saving throw with disadvantage against your spell save DC or take a number of d10 equal to your Artificer level in poison damage, and become {@condition poisoned} until they complete a long rest.",
 															"Inhaled poison. This poison can be used to modify your poisonous gas reaction. Anytime before the end of your next long rest, you can use this dose of poison to make your poisonous gas instant reaction have a radius of 10 feet and deal twice as much damage on a failed save."
 														]
 													}
@@ -2496,7 +2494,7 @@
 															],
 															[
 																"2nd",
-																"{@spell dragon's breath}"
+																"{@spell dragon's breath|xge}"
 															],
 															[
 																"3rd",
@@ -2529,7 +2527,7 @@
 															],
 															[
 																"2nd",
-																"{@spell snilloc's snowball swarm}"
+																"{@spell snilloc's snowball swarm|xge}"
 															],
 															[
 																"3rd",

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,7 +8,7 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5",
+				"version": "1.5.1",
 				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
@@ -325,7 +325,8 @@
 					"heavy crossbows"
 				],
 				"tools": [
-					"thieves' tools"
+					"thieves' tools",
+					"one other tool of your choice"
 				],
 				"skills": {
 					"choose": 3,
@@ -352,7 +353,7 @@
 			"classFeatures": [
 				[
 					{
-						"name": "Artificer Specialist",
+						"name": "Artificer Specialization",
 						"entries": [
 							"At 1st level, you focus your craft on a particular specialization: Cannonsmith, Gadgetsmith, Golemsmith, Infusionsmith, Potionsmith, Warsmith or Wandsmith, each of which are detailed at the end of the class description. Your choice grants you features at 1st level and again at 3rd, 5th, and 14th level."
 						],
@@ -978,14 +979,14 @@
 												"type": "optfeature",
 												"name": "Smoke Bomb",
 												"entries": [
-													"As an action, you can use this to instantly cast {@spell fog cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
+													"As an action, you can use this to instantly cast {@spell fog cloud} on yourself without expending a spell slot. It lasts rounds equal to your Intelligence modifier and does not require concentration."
 												]
 											},
 											{
 												"type": "optfeature",
-												"name": "Shock Generator",
+												"name": "Gadgetsmith Weapon",
 												"entries": [
-													"As an action, you can use this to cast {@spell shocking grasp}."
+													"Pick one of Boomerang of Hitting, Impact Gauntlets, Repeating Crossbow, Shock Generator or Lightning Baton from the upgrade section. You receive this upgrade and does not count against your upgrade total."
 												]
 											}
 										]
@@ -1011,20 +1012,17 @@
 										"entries": [
 											{
 												"type": "optfeature",
-												"name": "Antimagical Shackle",
-												"prerequisite": "5th level Artificer",
+												"name": "Airburst Mine",
 												"entries": [
-													"You create an antimagical shackle. When you are adjacent to a creature, as an action you can attempt to shackle them to yourself or a nearby object using these shackles. The you make a Dexterity ({@skill Sleight of Hand}) check contested by a Strength ({@skill Athletics}) or Dexterity ({@skill Acorbatics}) check. On failure, they are shackled to the creature or object you attempted to shackle them to, and can move only by moving it if they are able to.",
-													"Additionally, while shackled by these shackles, they cannot teleport, planeshift, polymorph, shapechange, dematerialize, or turn into an amorphous form. As an action they can make a Strength saving throw against your spell save DC to break the shackles once shackled, otherwise these shackles last until you remove them.",
-													"This shackles have no effect on creatures immune to being {@condition grappled} or {@condition restrained}."
+													"You create a mechanical device capable of producing a devastating blast. You can use this device to cast {@spell shatter} without expending a spell slot, but the gadget cannot be used again until you complete a short or long rest."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Boomerang of Hitting",
 												"entries": [
-													"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals 1d4 damage.",
-													"Special: When this weapon is Thrown, you can target three creatures within 10 feet of each other, making a separate attack roll against each target.",
+													"You create a magical boomerang. You have proficiency in this weapon, and it has the Finesse, Thrown (30/90), and Special properties, and deals {@dice 1d4} damage. At level 5, this weapon gaisn a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+													"Special: When this weapon is Thrown, you can target two creatures within 10 feet of each other, making a separate attack roll against each target.",
 													"This weapon returns to your hand after you make an attack with it using the Thrown property."
 												]
 											},
@@ -1040,13 +1038,13 @@
 												"name": "Binding Rope",
 												"prerequisite": "5th level Artificer",
 												"entries": [
-													"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save or become {@condition restrained} until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
+													"You create a rope that is capable of animating and binding a target. As an action, target a creature within 30 feet. The target must make a Dexterity Saving throw against your Spell Save DC or become {@condition restrained} until the end of your next turn. If you are currently grappling the target, it makes the Dexterity saving throw with disadvantage. The rope can only restrain one target a time."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Bracers of Empowerment",
-												"prerequisite": "11th level",
+												"prerequisite": "11th level Artificer",
 												"entries": [
 													"You create bracers that can empower you. You can use this to cast {@spell tenser's transformation|xge} without expending a Spell Slot.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
@@ -1055,7 +1053,7 @@
 											{
 												"type": "optfeature",
 												"name": "Deployable Wings",
-												"prerequisite": "9th level",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"You build a set of deployable artificial wings. You can deploy this as a bonus action, or as a reaction to falling. When deployed, these give you a flying speed of 30 feet."
 												]
@@ -1063,7 +1061,7 @@
 											{
 												"type": "optfeature",
 												"name": "Disintegration Ray",
-												"prerequisite": "15th level",
+												"prerequisite": "15th level Artificer",
 												"entries": [
 													"You create a Disintegratation Ray. You can use this to cast {@spell disintegrate} without expending a Spell Slot.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
@@ -1072,7 +1070,7 @@
 											{
 												"type": "optfeature",
 												"name": "Gripping Gloves",
-												"prerequisite": "11th level",
+												"prerequisite": "11th level Artificer",
 												"entries": [
 													"You create a set of gloves with a powerful assisted grip. Your Strength score and maximum Strength score increases by 2 while wearing these gloves. You gain advantage on Strength ({@skill Athletics}) checks involving manipulating things with your hands while wearing these gloves."
 												]
@@ -1088,7 +1086,7 @@
 												"type": "optfeature",
 												"name": "Enhanced Grappling Hook",
 												"entries": [
-													"You enhance your grappling hook, increasing its range to 40 feet."
+													"You enhance your grappling hook, increasing its range to 40 feet. Additionally, the enhanced power of the grappling hook means that when pulling yourself to a large or larger creature or object, you can drag one medium or smaller willing or grappled creature within 5 feet of you with you."
 												]
 											},
 											{
@@ -1102,22 +1100,32 @@
 												"type": "optfeature",
 												"name": "Flashbang",
 												"entries": [
-													"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a dexterity saving throw or be {@condition blinded} until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
+													"You create a high luminary discharge device. As an action, you can target a point within 30 feet. Any creature within 20 feet of the targeted point must make a Dexterity saving throw or be {@condition blinded} until the end of its next turn. Once you use this gadget, you cannot use it again until you complete a short or long rest."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Impact Gauntlet",
 												"entries": [
-													"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals 1d8 bludgeoning damage.",
-													"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
+													"You create a weapon capable of amplifying the impact of your blows. You have proficiency in this weapon, and it has the Finesse, Light and Special properties. It deals {@dice 1d8} bludgeoning damage. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+													"Special: When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll.",
+													"You can apply this upgrade up to 2 times, making a separate item each time."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Lightning Baton",
 												"entries": [
-													"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals 1d4 bludgeoning damage and 1d4 lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save or become {@condition stunned} until the start of your next turn."
+													"You combine incorporate elements of your shock generator design into a baton, creating a new weapon. You have proficiency in this weapon, and it has the Finesse and Light properties. It deals {@dice 1d4} bludgeoning damage and {@dice 1d4} lightning damage on hit. If you score a critical strike with this weapon, the target must succeed a Constitution saving throw against your Spell Save DC or become {@condition stunned} until the start of your next turn. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+													"You can apply this upgrade up to 2 times, making a separate item each time."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Lightning Generator",
+												"prerequisite":"11th level Artificer. Requires Shock Generator.",
+												"entries": [
+													"You upgrade your shock generator with additional lightning capabilities. You can cast {@spell lightning lure|scag} at-will using it, can overload it to cast {@spell lightning bolt}. Once you overload it, you cannot use it to cast {@spell lightning bolt} again until you complete a short or long rest."
 												]
 											},
 											{
@@ -1137,15 +1145,15 @@
 											{
 												"type": "optfeature",
 												"name": "Nimble Gloves",
-												"prerequisite": "11th level",
+												"prerequisite": "11th level Artificer",
 												"entries": [
-													"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity (Slight of Hand) checks involving manipulating things with your hands while wearing these gloves."
+													"You create magical gloves the increase your dexterity. Your Dexterity score and maximum Dexterity score increases by 2 while wearing these gloves. You gain advantage on Dexterity ({@skill Sleight of Hand}) checks involving manipulating things with your hands while wearing these gloves."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Phase Trinket",
-												"prerequisite": "9th level. Incompatible with other Trinkets.",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"You create a magical stopwatch that manipulates ethereal magic. As an action, you can cast {@spell blink} or {@spell dimension door} using the Stopwatch without expending a Spell Slot.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
@@ -1162,17 +1170,24 @@
 												"type": "optfeature",
 												"name": "Repeating Hand Crossbow",
 												"entries": [
-													"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals 1d6 piercing damage.",
-													"Special: This weapon does not require a free-hand to load, as it has a built in loader."
+													"You build an improved hand crossbow. You have proficiency in this weapon, and it has the Ammunition (range 30/120), Light, and Special properties and deals {@dice 1d6} piercing damage. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+													"Special: This weapon does not require a free-hand to load, as it has a built in loader. When you fire this weapon with advantage, once per turn you can forgo advantage on an attack to make one additional attack."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Bee Swarm Rockets",
-												"prerequisite": "15th level",
+												"prerequisite": "15th level Artificer",
 												"entries": [
-													"You design a type of tiny firecracker like device, that can be released in large number. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a dexterity saving throw. Creatures that fail take 2d6 fire damage, or half as much on a successful one.",
+													"You design a type of tiny firecracker-like device, which can release rockets in large numbers. You have a maximum number of rockets equal to your Artificer level. You can release between one and the number you have remaining as an action. Each rocket targets a point you can see within 40 feet. Creatures within 10 feet of a target point must make a Dexterity saving throw. Creatures that fail take {@dice 2d6} fire damage, or half as much on a successful one.",
 													"You rebuild your stock to your maximum during a long rest."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Shock Generator",
+												"entries": [
+													"You create a device capable of generating potent shocks. You can use this to cast {@spell shocking grasp}. When you cast {@spell shocking grasp} with this feature, you can use either your Dexterity or Intelligence modifier for the melee spell attack roll."
 												]
 											},
 											{
@@ -1186,7 +1201,7 @@
 												"type": "optfeature",
 												"name": "Sight Lenses",
 												"entries": [
-													"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through Fog, Mist, Smoke, Clouds, and non-Magical Darkness as normal sight up to 15 feet."
+													"You create a set of lenses you can integrate into a set of goggles, glasses, or other vision assistance that allow you to see through obscurement. You can see through fog, mist, smoke, clouds, and non-magical darkness as normal sight up to 15 feet."
 												]
 											},
 											{
@@ -1199,7 +1214,7 @@
 											{
 												"type": "optfeature",
 												"name": "Stinking Gas",
-												"prerequisite": "9th level",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"You make a more potent compound for your Smoke Bomb. When use a Smoke Bomb, you can choose to cast {@spell stinking cloud} rather than {@spell fog cloud}, following the same rules."
 												]
@@ -1214,7 +1229,7 @@
 											{
 												"type": "optfeature",
 												"name": "Stopwatch Trinket",
-												"prerequisite": "9th level, Incompatible with other Trinkets.",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"You create a magical stopwatch that manipulates time magic. As an action, you can cast {@spell haste} or {@spell slow} using the Stopwatch without expending a Spell Slot.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
@@ -1231,7 +1246,7 @@
 											{
 												"type": "optfeature",
 												"name": "Useful Universal Key",
-												"prerequisite": "11th level",
+												"prerequisite": "11th level Artificer",
 												"entries": [
 													"You create a Universal Key to obstacles, transmuting them into not-obstacles. As an aciton, you can apply this key to a surface to cast {@spell passwall} without expending a spell slot.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
@@ -1240,7 +1255,7 @@
 											{
 												"type": "optfeature",
 												"name": "Zombie Wires",
-												"prerequisite": "15th level",
+												"prerequisite": "15th level Artificer",
 												"entries": [
 													"You create an advanced system of magical threads that you can shoot out, and use to make nearby corpses dance to your commands. As an action, you can cast {@spell danse macabre|xge} without expended a spell slot.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
@@ -1298,7 +1313,7 @@
 					"shortName": "Gadgetsmith"
 				},
 				{
-					"name": "Runesmith",
+					"name": "Golemsmith",
 					"subclassFeatures": [
 						[
 							{
@@ -1679,7 +1694,391 @@
 						]
 					],
 					"source": "ArtificerRevised",
-					"shortName": "Runesmith"
+					"shortName": "Golemsmith"
+				},
+				{
+					"name": "Infusionsmith",
+					"subclassFeatures": [
+						[
+							{
+								"name": "Runesmith",
+								"entries": [
+									"A Runesmith is an Artificer that has delved into the power and mystery of Runes that forge the the basis of many of the greatest feats of magic ever wrought. They pursue ancient knowledge and uncover new secrets never known to the world. They build on structured systematic magic to bend the laws of the world to their will.",
+									"A typical Runesmith is a voracious mind that seeks to unlock the very secrets of life and magic. By drawing and infusing their Runes, they can work powerful magic.",
+									{
+										"type": "entries",
+										"name": "Runesmith's Proficiency",
+										"entries": [
+											"At 1st level, you gain proficiency with {@item smith's tools|phb} and {@item jeweler's tools|phb}, and can select two more languages that you can read and write (but not speak).",
+											"Your knowledge of runic magic gives you a natural affinity for scribing spell scrolls. Creating a magic spell scroll only takes you half the time and material cost it would normally take."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Runecraft",
+										"entries": [
+											"At 1st level, you gain the ability to Runecraft items. At the end of a Long Rest, you can place up to two runes on nonmagical items. The number of items increases to 3 runes at 5th level Artificer, 4 runes at 9th, 5 runes at 13th, and 6 runes at 17th.",
+											"The runes effects fade at the end of your next long rest, at which point the same rune or a different rune may be selected.",
+											"These runed items grant the following benefits only to you. A weapon or piece of armor can have multiple Runes active on it, a piece of jewelry can only have a single Rune active on it at a given time.",
+											{
+												"type": "list",
+												"items": [
+													{
+														"type": "item",
+														"name": "Rune of Ability:",
+														"entry": "A piece of jewellery or armor with this Rune grants grants a +1 to an Ability Score of your choice, as well as the maximum for that score while it is active."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Flametongue:",
+														"entry": "A melee weapon inscribed with this Rune deals 1d6 bonus fire damage. This spell's damage increases by 1d6 when you reach 5th level Artificer (2d6), 11th level (3d6), and 17th level (4d6)."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Protection:",
+														"entry": "A piece of jewellery or armor with this Rune grants +1 to armor class. At 5th level Artificer it grants +1 to all Saving Throws as well."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Regeneration:",
+														"entry": "A piece of jewellery or armor with this Rune allows you to recover health equal to your Artificer level when you take a short rest."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Recovery:",
+														"entry": "A piece of jewellery with this Rune allows you to recover Spell Slots equal to or less than quarter your Artificer level (rounded up) during a short rest. For example, you can recover a 1st level spell slot if you're 1st level artificer, and two 1st level spells slots or a 2nd level at level if you're a 5th-level artificer."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Enhancement:",
+														"entry": " A weapon inscribed with this Rune gain a +1 bonus to attack and damage rolls. The bonus increases to +2 at 9th level, and increases to +3 at 17th level."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Vorpal Force:",
+														"entry": "A weapon inscribed with this Rune deals all damage dealt with it as Force damage."
+													},
+													{
+														"type": "item",
+														"name": "Rune of Warding:",
+														"entry": "A piece of armor inscribed with this Rune generates a shield of temporary hitpoints equal to you Artificer level. These temporary hitpoints are refreshed when you take a short or long rest."
+													}
+												]
+											},
+											"You can be effected by only a single instance of any given rune."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"name": "Warforged Servant",
+								"entries": [
+									"At 3rd level, you have attained the forging skill, arcane knowledge, and mastery of rune magic to create a Warforged Golem. This golem is controlled by a magic Runed Pendant:",
+									{
+										"type": "inset",
+										"name": "Runed Pendant",
+										"entries": [
+											"{@i Wondrous Item, Attunement (creator only).}",
+											"While attuned to this gem, you have control of your Mechanical Servant. Your Mechanical Servant acts on your Initiative."
+										]
+									},
+									"The Warforged Golem obeys your commands as best as it can. It takes its turn on your initiative, though it doesn't take an action unless you command it to. On your turn, you can verbally command the construct where to move (no action required by you) and take the Help or Attack action. It has Proficiency in Simple Weapons.",
+									"Your Warforged Golem's Proficiency increases when yours does. Additionally, it gains 5 hit points for every level in Artificer you gain. If the golem is killed, it can be returned to life via normal means, such as with the revivify spell.",
+									"In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest. If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 1,000 gp of raw materials. It regains all health at the end of a long rest.",
+									"In addition, over the course of a long rest, you can repair a slain servant if you have access to its body. It returns to life with 1 hit point at the end of the rest.",
+									"If the servant is beyond recovery, you can reproduce the construct exactly as it was, with four days of work (eight hours each day) and 1,000 gp of raw materials.",
+									{
+										"type": "inset",
+										"name": "Warforged Golem",
+										"entries": [
+											"{@i Medium Construct, unaligned}",
+											"{@b Armor Class:} 14 (Natural Armor)",
+											"{@b Hit Points:} 10 + (5 per Artificer Level)",
+											"{@b Speed:} 25ft",
+											{
+												"type": "table",
+												"colLabels": [
+													"STR",
+													"DEX",
+													"CON",
+													"INT",
+													"WIS",
+													"CHA"
+												],
+												"colStyles": [
+													"col-xs-2 text-align-center",
+													"col-xs-2 text-align-center",
+													"col-xs-2 text-align-center",
+													"col-xs-2 text-align-center",
+													"col-xs-2 text-align-center",
+													"col-xs-2 text-align-center"
+												],
+												"rows": [
+													[
+														"14 ({@hit +2})",
+														"12 ({@hit +1})",
+														"14 ({@hit +2})",
+														"4 ({@hit -3})",
+														"5 ({@hit -3})",
+														"1 ({@hit -5})"
+													]
+												]
+											},
+											"{@b Damage Immunities:} poison, psychic",
+											"{@b Condition Immunities:} exhaustion, charmed, poisoned",
+											"{@b Senses:} passive Perception 7",
+											"{@b Languages:} Understands creator's languages, but cannot speak",
+											"{@b Actions:}",
+											{
+												"type": "entries",
+												"name": "Attack Protocol",
+												"entries": [
+													"{@i Slam:} {@hit +4} to hit, reach 5 ft., one target. {@i Hit} {@dice 1d4+2}"
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"name": "Runesmith Upgrades",
+								"entries": [
+									{
+										"type": "optfeature",
+										"name": "Arcane Barrage Armament",
+										"prerequisite": "9th level. This is incompatable with any other armaments.",
+										"entries": [
+											"You install a shoulder mounted armament to your golem, charged with arcane power. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell magic missile} as a 3rd level spell. When cast this way, it has no Verbal or Somatic component.",
+											"The charges are regained after a long rest."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Cloaking Device",
+										"prerequisite": "15th level",
+										"entries": [
+											"You install an Arcane Cloaking device on your Warforged Golem. This device has 4 Charges. You can direct the golem to expend 1 or more charges to cast one of the following spells using its action: {@spell invisibility} (2 charges), {@spell greater invisibility} (4 charges).",
+											"It regains all charges after a long rest."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Environmental Adaptation",
+										"prerequisite": "5th level.",
+										"entries": [
+											"You add integrated climbing hooks, deployable fins, insulated seals to your Golem. Your Warforged Golem gains a climbing and swimming speed equal to its walking speed.",
+											"Additionally, it gains resistance to Cold and Fire damage."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Expanded",
+										"prerequisite": "9th level",
+										"entries": [
+											"You enlarge your Warforged Golem, increasing its size category by one. It has advantage on Strength checks and Strength saving throws."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Evasive Maneuvers",
+										"entries": [
+											"Warforged Golem may add its Dexterity Modifier to its AC while not wearing heavy armor. Additionally, you can now command it to take the Dash, Disengage and Dodge actions."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Flamethrower Armament",
+										"prerequisite": "9th level",
+										"entries": [
+											"You install a shoulder mounted armament to your golem, heavily enchanted with flame spells. This armament has 3 charges. As an action, the golem can expend 1 charge to cast {@spell burning hands} as a 3rd level spell. The DC of the spell is 15. When cast this way, it has no Verbal or Somatic component.",
+											"The charges are regained after a long rest."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Powerful Grappler",
+										"entries": [
+											"You increase the power of the golem's grip, your Warforged Golem gains proficiency in the {@skill Athletics} skill and has advantage on attacks against creatures that it is grappling."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Heavy Armor Plating",
+										"prerequisite": "5th level Artificer. Warforged Golem Strength Score of 15 or higher.",
+										"entries": [
+											"You can incorporate a suit of Heavy Armor into your Warforged Golem. Your Warforged Golem's AC becomes the AC granted by the incorporated armor. While incorporated with your Warforged Golem in this way, the Warforged Golem has Proficiency with that armor.",
+											"While equipped with Heavy Armor, your Warforged Golem has disadvantage on Dexterity ({@skill Stealth}) checks."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Improve Dexterity",
+										"entries": [
+											"You tune the servos in your Warforged Golem. Your Warforged Golem's Dexterity score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Dexterity score is 18."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Improve Strength",
+										"entries": [
+											"You reinforce the power of your golem's core and limbs. Your Warforged Golem's Strength score increases by 2. You may apply this upgrade multiple times. A Warforged Golem's maximum Strength score is 18."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Integrated Shields",
+										"entries": [
+											"Your Warforged Golem gains Proficiency with shields, allowing it to equip a shield without penalty."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Iron Fortress",
+										"prerequisite": "Stabilisation",
+										"entries": [
+											"You increase the size and durability of your golem's frame. Your Warforged Golem now counts as full cover for those adjacent to it and it cannot be moved against its will while in contact with a floor."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Multiattack Protocol",
+										"prerequisite": "11th level Artificer",
+										"entries": [
+											"Your Warforged Golem gains multiattack. When your Mechanical Servant uses the Attack action, it can attack twice."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Martial Weapons Protocols",
+										"prerequisite": "5th level Artificer",
+										"entries": [
+											"Your Mechanical Servant gains Proficiency with Martial Weapons."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Mark of Life",
+										"prerequisite": "9th level Artificer",
+										"entries": [
+											"You have attained the understanding of magic and craft a Mark of Life on the forehead of your Warforged Golem, turning it into a Warforged Companion. It gains and Intelligence score of 8 and a Charisma score of 6. This allows it to use Infused Magic you create, as well as follow more complex commands without direct input, speak, and remember things."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Roleplaying a Warforged Companion",
+										"entries": [
+											"If you choose the Mark of Life upgrade, your Warforged golem becomes sentient companion, capable of learning, thinking, and having opinions. Consider how this may impact your interactions."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Precision Movements",
+										"entries": [
+											"Your Warforged Golem gains Proficiency in the {@skill Stealth} skill and with {@item Thieves' Tools|phb}. Additionally, it gains an integrated set of {@item Thieves' Tools|phb} that are always available (unless removed)."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Redundant Systems",
+										"entries": [
+											"You have reinforced your Warforged Golem with layers of protection and redundant systems. It gains additional hitpoints equal to twice your Artificer level. Additionally, it gains advantage on death saving throws."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Rune Golem",
+										"prerequisite": "5th level",
+										"entries": [
+											"You've leaned to draw runes in such a way that the golem can benefit from the effect if the Rune is drawn on the golem or its gear. You can apply runes from Runecraft to your golem, each rune applied to the golem counts toward the maximum runes drawn, and the golem gains the benefits of the rune instead of you."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Runic Wings",
+										"prerequisite": "11th level Artificer. Incompatible with Expanded.",
+										"entries": [
+											"You add rune engraved wings to your Warforged Golem, granting it a flying speed of 20 feet."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Warfare Routines",
+										"entries": [
+											"Your Warforged Golem gains one Fighting Style choosing from Duelling, Great Weapon Fighting, Defence, or Archery."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Stabilization",
+										"entries": [
+											"You increase the resilience and stability of your Warforged Golem. It gains proficiency in Constitution Saving Throws and has advantage against saving throws to be knocked down."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Warforged Apprentice",
+										"prerequisite": "Mark of Life. 15th level",
+										"entries": [
+											"Your Warforged Companion begins to apply its abilities to learn new things, gaining a class level in a class of your choosing. Your Warforged Companion gains all the first level features of a class of your choice. This does not include health or class proficiencies (for example, selecting Fighter grants only Fighting Style and Second Wind)."
+										]
+									},
+									{
+										"type": "optfeature",
+										"name": "Warforged Adept",
+										"prerequisite": "Warforged Apprentice",
+										"entries": [
+											"Your growth as a Runesmith is such that your creation is capable of learning and adapting even more skills. It gains all the second level features of the class you selected for the Warforged Apprentice upgrade. This does not include health or class proficiencies (for example, selecting Fighter grants only Action Surge)."
+										]
+									}
+								]
+							}
+						],
+						[
+							{
+								"name": "Infuse Magic",
+								"entries": [
+									"Starting at 5th level, you gain the ability to channel your artificer spells into runic symbols for later use.",
+									"When you cast an artificer spell with a casting time of 1 action, you can increase its casting time to 1 minute. If you do so and hold a nonmagical item throughout the casting, you expend a spell slot, but none of the spell's effects occur. Instead, the spell transfers into that item for later use if the item doesn't already contain a spell from this feature.",
+									"Any creature holding the item thereafter can use an action to activate the spell if the creature has an Intelligence score of at least 6. The spell is cast using your spellcasting ability, targeting the creature that activates the item.",
+									"If the spell targets more than one creature, the creature that activates the item selects the additional targets. If the spell has an area of effect, it is centred on the item. If the spell's range is self, it targets the creature that activates the item. If the spell requires concentration, the creature that activates the item maintains the concentration as if they had cast the spell.",
+									"When you infuse a spell in this way, it must be used within 8 hours. After that time, its magic fades and is wasted. You can have a limited number of infused spells at the same time. The number equals your Intelligence modifier."
+								]
+							}
+						],
+						[
+							{
+								"name": "Instant Runes",
+								"entries": [
+									"At 14th level, when you cast a spell with a somatic component, you can use your bonus action to trace an runic symbol, choosing from one of three effects.",
+									{
+										"type": "list",
+										"items": [
+											{
+												"type": "item",
+												"name": "Rune of Power:",
+												"entry": "You can increase the spell level of the effect by one (if applicable)."
+											},
+											{
+												"type": "item",
+												"name": "Rune of Dominion:",
+												"entry": "You can increase the DC of the saving throw by an amount equal to your Intelligence modifier."
+											},
+											{
+												"type": "item",
+												"name": "Rune of Persistence:",
+												"entry": "You can make the Rune persist, maintaining concentration on the spell for you. This last a number of rounds equal to your Intelligence Modifier."
+											}
+										]
+									},
+									"You must then finish a long rest to use an Instant Rune again."
+								]
+							}
+						]
+					],
+					"source": "ArtificerRevised",
+					"shortName": "Infusionsmith"
 				},
 				{
 					"name": "Warsmith",
@@ -1708,7 +2107,7 @@
 												"entries": [
 													"{@i Wondrous Item, Attunement (creator only).}",
 													"{@b Weight} 5 lb.",
-													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell shocking grasp} cantrip and can cast it through the gauntlet."
+													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal {@dice 1d6} bludgeoning damage, and you learn the {@spell shocking grasp} cantrip and can cast it through the gauntlet."
 												]
 											},
 											"If you lose your mechplate gauntlet, you can remake it during a long rest with 25 gold worth of materials, or can scavenge for materials and forge it over two days of work (eight hours a day) without the material expense."
@@ -1873,7 +2272,7 @@
 												"type": "optfeature",
 												"name": "Force Blast",
 												"entries": [
-													"You upgrade your Mechplate gauntlet to allow you to make a ranged spell attack. The weapon fires blasts of arcane energy which deal 1d8 + your Intelligence modifier Force damage. The range is 30 feet. You are proficient in this weapon. When you take the attack action, you can use this ranged spell attack in place of any attack made."
+													"You upgrade your Mechplate gauntlet to allow you to make a ranged spell attack. The weapon fires blasts of arcane energy which deal {@dice 1d8} + your Intelligence modifier Force damage. The range is 30 feet. You are proficient in this weapon. When you take the attack action, you can use this ranged spell attack in place of any attack made."
 												]
 											},
 											{
@@ -1946,7 +2345,7 @@
 												"type": "optfeature",
 												"name": "Power Fist",
 												"entries": [
-													"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal 1d8 bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
+													"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal {@dice 1d8} bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
 													"{@b Special:} When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
 												]
 											},
@@ -2190,7 +2589,7 @@
 									"An alchemist can be a scholar who has delved much of the knowledge the world has to offer or an explorer that has unlocked the secrets of the wilderness. Their knowledge could come being friends of the fey, or unfettered access to the royal library. As such, alchemists can be good or evil, lawful or chaotic.",
 									{
 										"type": "inset",
-										"name": "Alchemist's Proficiency",
+										"name": "Alchemists and Potions",
 										"entries": [
 											"Immediately on making an alchemist, one may think of the magic potions that exist in most D&D settings, from the simple Healing Potion to the legendary Potion of Storm Giant Strength, however, someone does not need to be an Alchemist to make these, as crafting rules for them are open to all classes, and best outlined in Xanathar's Guide to Everything.",
 											"An alchemist with their proficiency will certainly have the edge in potion crafting, but these potions are not fundamental to the class."
@@ -2223,24 +2622,24 @@
 												"type": "entries",
 												"name": "Alchemical Fire",
 												"entries": [
-													"As an action you can produce a reaction causing a searing flame. At point within 15 feet, you can toss quick combination of things that will cause searing fire to flare up in a 5 foot radius. Creatures in that area have to make a dexterity saving throw, or take 1d8 fire damage.",
-													"The damage damage increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8)."
+													"As an action you can produce a reaction causing a searing flame. At point within 15 feet, you can toss quick combination of things that will cause searing fire to flare up in a 5 foot radius. Creatures in that area have to make a Dexterity saving throw, or take {@dice 1d8} fire damage.",
+													"The damage damage increases by 1d8 when you reach 5th level ({@dice 2d8}), 11th level ({@dice 3d8}), and 17th level ({@dice 4d8})."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Poisonous Gas",
 												"entries": [
-													"As an action you can produce a reaction causing noxious fumes. At point within 15 feet, you can toss quick combination of things that will cause a whiff of poisonus gas to erupt spreading to a radius of 5 feet. Creatures in that area have to make a constitution saving throw, or take 1d4 poison damage and become {@condition poisoned} until the end of their next turn.",
-													"The damage damage increases by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4)."
+													"As an action you can produce a reaction causing noxious fumes. At point within 15 feet, you can toss quick combination of things that will cause a whiff of poisonus gas to erupt spreading to a radius of 5 feet. Creatures in that area have to make a Constitution saving throw, or take {@dice 1d4} poison damage and become {@condition poisoned} until the end of their next turn.",
+													"The damage damage increases by 1d4 when you reach 5th level ({@dice 2d4}), 11th level ({@dice 3d4}), and 17th level ({@dice 4d4})."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Healing Draught",
 												"entries": [
-													"As a bonus action, you can produce combination that will provide potent magical healing. Immediately after creating the draught, you can use your action to consume it or administer it to a creature within 5 feet. A creature who drinks this draught regains 1d8 health. A creature can benefit from a number of these healing draughts equal to their constitution modifier (minimum 1), after which they provide no additional benefit until they complete a long rest. A Healing Draught that is not consumed by the end of your turn loses its potency.",
-													"The healing increases by 1d8 when you reach 5th level (2d8), 11th level (3d8), and 17th level (4d8)."
+													"As a bonus action, you can produce combination that will provide potent magical healing. Immediately after creating the draught, you can use your action to consume it or administer it to a creature within 5 feet. A creature who drinks this draught regains {@dice 1d8} health. A creature can benefit from a number of these healing draughts equal to their Constitution modifier (minimum 1), after which they provide no additional benefit until they complete a long rest. A Healing Draught that is not consumed by the end of your turn loses its potency.",
+													"The healing increases by 1d8 when you reach 5th level ({@dice 2d8}), 11th level ({@dice 3d8}), and 17th level ({@dice 4d8})."
 												]
 											}
 										]
@@ -2291,7 +2690,7 @@
 											},
 											"When you cast the spell in this way, the spell does not take effect immediately, but is infused into the potion. If the spell grants an effect or restores health, the creature will gain the effect of the spell when the potion is consumed.",
 											"If the spell has an area of effect area, that area of effect take place when the vial is broken, with the effect centered on where the vial breaks. As an action, you or another creature can either consume the vial, or throw it up to 30 feet where it shatters on impact.",
-											"If the spell has a persistent effect that requries concentration, it does not require concentration to maintain, but it's duration is shortened to a number of rounds equal to your intelligence modifier. A spell that does not require concetration lasts its normal duration. An infused potion loses its potency if it is not used by the end of your next long rest.",
+											"If the spell has a persistent effect that requries concentration, it does not require concentration to maintain, but it's duration is shortened to a number of rounds equal to your Intelligence modifier. A spell that does not require concetration lasts its normal duration. An infused potion loses its potency if it is not used by the end of your next long rest.",
 											"You can gain additional spells for your Alchemical Infusions through your Alchemist upgrades.",
 											{
 												"type": "inset",
@@ -2308,19 +2707,27 @@
 										"entries": [
 											{
 												"type": "optfeature",
-												"name": "Aroma Therapies",
-												"prerequisite": "9th level",
+												"name": "Alchemical Acid",
 												"entries": [
-													"You expand your alchemical knowledge to be able to produce incense and simmering reagents that grant effects to those that inhale their fumes. If creatures spend a long rest inhaling fumes from a concoction you devise with this feature, creatures regain all of their expended hit dice when they would normally only recovering half, and cured of any non-magical diseases they are suffering from."
+													"As an action you can produce a reaction causing a caustic acid to form. At a creature within 15 feet, you can a toss quick combination of reagents that will cause a splatter of acid in a 5 foot radius. Creatures in that area have to make a Dexterity saving throw, or take {@dice 2d4} acid damage.",
+													"The damage damage increases by 2d4 when you reach 5th level ({@dice 4d4}), 11th level ({@dice 6d4}), and 17th level ({@dice 8d4})."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Adrenaline Serum",
-												"prerequisite": "9th level",
+												"prerequisite": "9th level Artificer",
 												"entries": [
-													"You create a potent serum. As an action on your turn, you can consume this serum, granting you the effects of Haste and Heroism for a number of rounds equal to your Intelligence modifier (minimum 1). These effects do not require concentration, but you still suffer the normal effects of the Haste spell ending when it ends. You can use this a number of times equal to your constitution modifier (minimum 1) before you must take a long rest to gain the effects from the serum again.",
+													"You create a potent serum. As an action on your turn, you can consume this serum, granting you the effects of {@spell haste} and {@spell heroism} for a number of rounds equal to your Intelligence modifier (minimum 1). These effects do not require concentration, but you still suffer the normal effects of the {@spell haste} spell ending when it ends. You can use this a number of times equal to your Constitution modifier (minimum 1) before you must take a long rest to gain the effects from the serum again.",
 													"Another creature can take this dose, but they must pass a Constitution saving throw equal to your spell save to gain the effects, and become {@condition poisoned} on a failed save."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Aroma Therapies",
+												"prerequisite": "9th level Artificer",
+												"entries": [
+													"You expand your alchemical knowledge to be able to produce incense and simmering reagents that grant effects to those that inhale their fumes. If creatures spend a long rest inhaling fumes from a concoction you devise with this feature, creatures regain all of their expended hit dice when they would normally only recovering half, and cured of any non-magical diseases they are suffering from."
 												]
 											},
 											{
@@ -2334,7 +2741,7 @@
 												"type": "optfeature",
 												"name": "Delivery Mechanism",
 												"entries": [
-													"You modify the stability of your reagents and develop a better delivery mechanism. You can target a point within 30 feet for your instant reactions that target a point. The additional precision allows you to better target the effects, allowing creatures of your choice within the target area to automatically pass a dexterity saving throw against your effects."
+													"You modify the stability of your reagents and develop a better delivery mechanism. You can target a point within 30 feet for your instant reactions that target a point. The additional precision allows you to better target the effects, allowing creatures of your choice within the target area to automatically pass a Dexterity saving throw against your effects."
 												]
 											},
 											{
@@ -2342,31 +2749,31 @@
 												"name": "Elixir of Life",
 												"prerequisite": "Philosopher's Stone",
 												"entries": [
-													"You can brew a special potion using your Philosopher stone. Brewing this potion takes 8 hours and requires 1000 gold pieces of special ingredients. An Elixir of Life causes a creature that drinks it to cease aging, and be under the effects of death ward for one year, or until the death ward is triggered."
+													"You can brew a special potion using your Philosopher stone. Brewing this potion takes 8 hours and requires 1000 gold pieces of special ingredients. An Elixir of Life causes a creature that drinks it to cease aging, and be under the effects of {@spell death ward} for one year, or until the {@spell death ward} is triggered."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Explosive Reaction",
 												"entries": [
-													"You formulate a new instant reaction, a devastating minor explosion. Targeting a point within 15 feet, as an action, you cause an explosion. Creatures within 10 feet of the target point must make a constitution saving throw, or take 1d10 thunder damage from the shockwave of the explosion.",
-													"The damage damage increases by 1d10 when you reach 5th level (2d10), 11th level (3d10), and 17th level (4d10)."
+													"You formulate a new instant reaction, a devastating minor explosion. Targeting a point within 15 feet, as an action, you cause an explosion. Creatures within 10 feet of the target point must make a Constitution saving throw, or take {@dice 1d10} thunder damage from the shockwave of the explosion.",
+													"The damage damage increases by 1d10 when you reach 5th level ({@dice 2d10}), 11th level ({@dice 3d10}), and 17th level ({@dice 4d10})."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Fortifying Fumes Reaction",
 												"entries": [
-													"You formulate a new instant reaction, a powerful fortifying stimulate. Targeting a point within 15 feet, as an action, you cause fumes to erupt. Creatures within can choose to hold their breath and not inhale, but creatures that inhale the fumes gain 1d4 temporary hit points, deal 1d4 additional damage on their next melee weapon attack made before the end of your next turn, and have advantage on their next Constitution saving throw before the end of your next turn.",
-													"The both the temporary hit points and damage bonus increase by 1d4 when you reach 5th level (2d4), 11th level (3d4), and 17th level (4d4)."
+													"You formulate a new instant reaction, a powerful fortifying stimulate. Targeting a point within 15 feet, as an action, you cause fumes to erupt. Creatures within can choose to hold their breath and not inhale, but creatures that inhale the fumes gain {@dice 1d4} temporary hit points, deal {@dice 1d4} additional damage on their next melee weapon attack made before the end of your next turn, and have advantage on their next Constitution saving throw before the end of your next turn.",
+													"The both the temporary hit points and damage bonus increase by 1d4 when you reach 5th level ({@dice 2d4}), 11th level ({@dice 3d4}), and 17th level ({@dice 4d4})."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Frostbloom Reaction",
 												"entries": [
-													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a dexterity saving throw, or be caught by the ice taking 1d6 cold damage; a creature entirely in the area of effect that fails also becoming {@condition restrained} until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
-													"The damage damage increases by 1d6 when you reach 5th level (2d6), 11th level (3d6), and 17th level (4d6)."
+													"You formulate a new endothermic reaction, a devastating localized cold snap that creates an instant bloom of ice. Target a point within 15 feet, as an action, you cause an the area to erupt in frost. The area within 10 feet of the target becomes difficult terrain until the end of your next turn, and any creature in the area must make a Dexterity saving throw, or be caught by the ice taking {@dice 1d6} cold damage; a creature entirely in the area of effect that fails also becoming {@condition restrained} until the end of their next turn. They can use their action to make a Strength saving throw to break free of the ice early.",
+													"The damage damage increases by 1d6 when you reach 5th level ({@dice 2d6}), 11th level ({@dice 3d6}), and 17th level ({@dice 4d6})."
 												]
 											},
 											{
@@ -2374,20 +2781,20 @@
 												"name": "Greater Adrenaline Shot",
 												"prerequisite": "Adrenaline Serum",
 												"entries": [
-													"You upgrade your adrenaline shot to produce even more extreme and magical effects in the creature it effects. The adrenaline shot also adds the effect of Tensor's Transformation when you consume it. This effect only takes place if you are the one consuming the serum. You do not suffer the effects of Tensor's Transformation wearing off when the serum effect ends."
+													"You upgrade your adrenaline shot to produce even more extreme and magical effects in the creature it effects. The adrenaline shot also adds the effect of {@spell Tenser's Transformation|xge} when you consume it. This effect only takes place if you are the one consuming the serum. You do not suffer the effects of {@spell Tenser's Transformation|xge} wearing off when the serum effect ends."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Inoculations",
 												"entries": [
-													"You and up to five allies of your choice are inoculated against the poisonous effects you can produce that require a constitution saving throw (such as the poisonous gas instant reaction or the cloudkill infusion). Additionally, you gain resistance to poison damage."
+													"You and up to five allies of your choice are inoculated against the poisonous effects you can produce that require a Constitution saving throw (such as the poisonous gas instant reaction or the cloudkill infusion). Additionally, you gain resistance to poison damage."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Infusion Stone",
-												"prerequisite": "9th level",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"You use the secrets of Alchemy to create an Infusion Stone. You can use this stone in the process of infusing potions in place of a spell slot level less than or equal to the highest level spell slot you can cast.",
 													"You can use this stone to replace a spell slot for an infusion once. It regains this charge after you complete a long rest."
@@ -2396,7 +2803,7 @@
 											{
 												"type": "optfeature",
 												"name": "Mana Potion",
-												"prerequisite": "9th level",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"During a short rest, you can create a mana potion. A mana potion loses its potency if it is not consumed within 1 minute. As an action, a creature can consume a mana potion to restore a spell slot of its choice, up to third level."
 												]
@@ -2404,9 +2811,9 @@
 											{
 												"type": "optfeature",
 												"name": "Philosopher Stone",
-												"prerequisite": "15th level",
+												"prerequisite": "15th level Artificer",
 												"entries": [
-													"You create a Philosopher's Stone allowing you recreate wonders of alchemy. So long as you have a supply of non-gold metal, you can create up five pounds of gold a day (250 gold pieces worth)."
+													"You create a Philosopher's Stone allowing you to recreate wonders of alchemy. So long as you have a supply of non-gold metal, you can create up five pounds of gold a day (250 gold pieces worth)."
 												]
 											},
 											{
@@ -2419,7 +2826,7 @@
 											{
 												"type": "optfeature",
 												"name": "Potent Reactions",
-												"prerequisite": "9th level",
+												"prerequisite": "9th level Artificer",
 												"entries": [
 													"You refine your reactions increasing the potency. The die you roll to determine the damage or healing effect of your reactions is increased by one. A d4 becomes a d6, a d6 becomes a d8, a d8 becomes a d10, and a d10 becomes a d12."
 												]
@@ -2474,7 +2881,6 @@
 											{
 												"type": "optfeature",
 												"name": "Secrets of Fire",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
 													"You learn the secrets of infusing fire into your Alchemical Infusions. You can add the following spells to your list of available spells for alchemical infusions:",
 													{
@@ -2570,7 +2976,7 @@
 									{
 										"name": "Empowered Alchemy",
 										"entries": [
-											"Starting at 5th level, when you deal damage or restore health with an instant reaction or alchemical infusion, you can add your intelligence modifier to the damage dealt or health restored."
+											"Starting at 5th level, when you deal damage or restore health with an instant reaction or alchemical infusion, you can add your Intelligence modifier to the damage dealt or health restored."
 										]
 									}
 								]

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,8 +8,8 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5",
-				"url": "http://homebrewery.naturalcrit.com/share/H1ZDtpyaT-",
+				"version": "1.5.1",
+				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
 		]
@@ -320,7 +320,9 @@
 					"medium"
 				],
 				"weapons": [
-					"simple"
+					"simple",
+					"hand crossbows",
+					"heavy crossbows"
 				],
 				"tools": [
 					"thieves' tools"
@@ -342,9 +344,9 @@
 			"startingEquipment": {
 				"additionalFromBackground": true,
 				"default": [
-					"(a) a handaxe and a light hammer or (b) any two simple weapons.",
-					"(a)  scale mail or (b) leather armor",
-					"thieves' tools and a dungeoneer's pack"
+					"(a) a {@item light crossbow|phb} and {@item crossbow bolts (20)|phb|20 bolts} or (b) any two {@filter simple weapons|items|source=phb|category=basic|type=simple weapon}",
+					"(a) {@item scale mail|phb}, (b) {@item leather armor|phb}, or (c) {@item chain mail|phb}",
+					"{@item thieves' tools|phb} and a {@item dungeoneer's pack|phb}"
 				]
 			},
 			"classFeatures": [
@@ -477,7 +479,7 @@
 						"type": "entries",
 						"name": "Arcane Reconstruction",
 						"entries": [
-							"At 6th level, you have mastered the knowledge of using magic to repair things. You learn the Mending cantrip, and can cast it at will. Additionally, you learn the Cure Wounds spell. If you already know Cure Wounds you can select another spell from the Artificer list. When you cast Cure Wounds, it can heal constructs in addition to normally valid targets. Both Mending and Cure Wounds learned through this features are considered Artificer spells for you."
+							"At 6th level, you have mastered the knowledge of using magic to repair things. You learn the {@spell mending} cantrip, and can cast it at will. Additionally, you learn the {@spell cure wounds} spell. If you already know {@spell cure wounds} you can select another spell from the Artificer list. When you cast {@spell cure wounds}, it can heal constructs in addition to normally valid targets. Both {@spell mending} and {@spell cure wounds} learned through this features are considered Artificer spells for you."
 						]
 					},
 					{
@@ -976,14 +978,14 @@
 												"type": "optfeature",
 												"name": "Smoke Bomb",
 												"entries": [
-													"As an action, you can use this to instantly cast {@spell Fog Cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
+													"As an action, you can use this to instantly cast {@spell fog cloud} on yourself without expending a spell slot. It lasts rounds equal to your intelligence modifier and does not require concentration."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Shock Generator",
 												"entries": [
-													"As an action, you can use this to cast {@spell Shocking Grasp}."
+													"As an action, you can use this to cast {@spell shocking grasp}."
 												]
 											}
 										]
@@ -1708,7 +1710,7 @@
 												"entries": [
 													"{@i Wondrous Item, Attunement (creator only).}",
 													"{@b Weight} 5 lb.",
-													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell Shocking Grasp} cantrip and can cast it through the gauntlet."
+													"While wearing this gauntlet, you have proficiency in Martial Weapons, unarmed strikes using this gauntlet deal 1d6 bludgeoning damage, and you learn the {@spell shocking grasp} cantrip and can cast it through the gauntlet."
 												]
 											},
 											"If you lose your mechplate gauntlet, you can remake it during a long rest with 25 gold worth of materials, or can scavenge for materials and forge it over two days of work (eight hours a day) without the material expense."
@@ -1848,7 +1850,7 @@
 												"name": "Flame Projector",
 												"prerequisite": "9th level. Incompatible with other projectors.",
 												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell Burning Hands} (1 charge), {@spell Fireball} (3 charges), or {@spell Wall of Fire} (4 charges).",
+													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell burning hands} (1 charge), {@spell fireball} (3 charges), or {@spell wall of fire} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1857,7 +1859,7 @@
 												"name": "Flash Freeze Capacitor",
 												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
-													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell Cone of Cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
+													"You install a capacitor that builds an icy chill until it unleashed in a deadly burst. As an action, you can unleash it, casting {@spell cone of cold}, and the area effected freezes, becoming difficult terrian until the start of your next turn.",
 													"Once you use this ability, you cannot use it again until you complete a long rest."
 												]
 											},
@@ -1905,7 +1907,7 @@
 												"name": "Lightning Projector",
 												"prerequisite": "9th level. Incompatible with other projectors.",
 												"entries": [
-													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell Thunderwave} (1 charge), {@spell Lightning Bolt} (3 charges), or {@spell Storm Sphere|XGE} (4 charges).",
+													"The Projector has 6 Charges. Once it is integrated into your armor, you can use an action to expend 1 or more of its Charges to cast one of the following Spells from it, using your spell save DC: {@spell thunderwave} (1 charge), {@spell lightning bolt} (3 charges), or {@spell storm sphere|XGE} (4 charges).",
 													"It regains all charges on a long rest."
 												]
 											},
@@ -1938,14 +1940,13 @@
 												"name": "Power Slam Capacitor",
 												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
-													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell Destructive Wave} upon landing.",
+													"You install a capacitor that builds up destructive energy. As an Action, you can leap a distance up to your movementment speed, casting {@spell destructive wave} upon landing.",
 													"Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},
 											{
 												"type": "optfeature",
 												"name": "Power Fist",
-												"prerequisite": "11th level. Incompatible with other capacitors.",
 												"entries": [
 													"You upgrade your Mechplate gauntlet to reflect a commitment to using it to punch things, with increased reinforcement and weight, and better arm support from your suit. Your Mechplate gauntlet's unarmed strike is upgraded to deal 1d8 bludgeoning damage and gains the Special property. At level 5, this weapon gains a +1 to attack and damage rolls; this increases to a +2 at level 14.",
 													"{@b Special:} When you make an attack roll, you can choose to forgo adding your Proficiency modifier to the attack roll. If the attack hits, you can add double your Proficiency modifier to the damage roll."
@@ -2006,7 +2007,7 @@
 												"name": "Sun Cannon",
 												"prerequisite": "15th level",
 												"entries": [
-													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell Sunbeam} without expending a spell slot.",
+													"You install a sun cannon into your mechplate, allowing for emmiting devestating solar lazer blasts. As an action, you can cast {@spell sunbeam} without expending a spell slot.",
 													"Once you use this ability, you can not use it again until you complete a long rest."
 												]
 											},

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -8,7 +8,7 @@
 				"authors": [
 					"/u/KibblesTasty"
 				],
-				"version": "1.5.1",
+				"version": "1.5",
 				"url": "https://www.gmbinder.com/share/-LAEn6ZdC6lYUKhQ67Qk",
 				"targetSchema": "1.0.0"
 			}
@@ -1825,17 +1825,17 @@
 											},
 											{
 												"type": "optfeature",
-												"name": "Darkvision Visor",
-												"entries": [
-													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
-												]
-											},
-											{
-												"type": "optfeature",
 												"name": "Collapsible",
 												"prerequisite": "5th level. Incompatible with Piloted Golem",
 												"entries": [
 													"Your Mechplate can collapse into a case for easy storage. When transformed this way the armor is indistinguishable from a normal case and weighs 1/3 its normal weight. As an action you can don or doff the armor, allowing it to transform as needed."
+												]
+											},
+											{
+												"type": "optfeature",
+												"name": "Darkvision Visor",
+												"entries": [
+													"While wearing your Mechplate, you have darkvision to a range of 60 feet. If you already have darkvision, this upgrade increases its range by 60 feet."
 												]
 											},
 											{

--- a/creature/Tobias Beis; Critter Compendium.json
+++ b/creature/Tobias Beis; Critter Compendium.json
@@ -6,7 +6,7 @@
 				"abbreviation": "CC (3pp)",
 				"full": "Critter Compendium (3pp)",
 				"authors": [
-					"Kobold Press"
+					"Tobias Beis"
 				],
 				"version": "1.0",
 				"url": "https://www.dmsguild.com/product/210151/Critter-Compendium",


### PR DESCRIPTION
Moved the upgrades for all Revised Artificer subclasses into Optional Features because they took up way too much space and now you can sort and pick them by level. Added a link for each subclass to their relevant filtered optional features list.