### PR TITLE
Path of the Bloodrager added to Codex of Allies

### DIFF
--- a/subclass/Clan Crafter Hralding; Codex of Allies.json
+++ b/subclass/Clan Crafter Hralding; Codex of Allies.json
@@ -6,8 +6,7 @@
 				"abbreviation": "CoA 3pp",
 				"full": "Mordenkainen's Codex of Allies",
 				"authors": [
-					"Clan Crafter Hralding",
-					"Aarowaim"
+					"Clan Crafter Hralding"
 				],
 				"version": "1.2",
 				"url": "https://www.dmsguild.com/product/243863/Mordenkainens-Codex-of-Allies",

--- a/subclass/Clan Crafter Hralding; Codex of Allies.json
+++ b/subclass/Clan Crafter Hralding; Codex of Allies.json
@@ -4,11 +4,12 @@
 			{
 				"json": "CoA 3pp",
 				"abbreviation": "CoA 3pp",
-				"full": "Path of the Immortal Titan",
+				"full": "Mordenkainen's Codex of Allies",
 				"authors": [
-					"Clan Crafter Hralding"
+					"Clan Crafter Hralding",
+					"Aarowaim"
 				],
-				"version": "1.1",
+				"version": "1.2",
 				"url": "https://www.dmsguild.com/product/243863/Mordenkainens-Codex-of-Allies",
 				"targetSchema": "1.0.0"
 			}
@@ -16,6 +17,70 @@
 		"dateAdded": 1529430240
 	},
 	"subclass": [
+		{
+			"class": "Barbarian",
+			"name": "Path of the Bloodrager",
+			"subclassFeatures": [
+				[
+					{
+						"name": "Path of the Bloodrager",
+						"entries": [
+							"Some barbarians are compelled by their innate bloodlust to follow The Path of the Bloodrager. Bloodragers are perilous front line combatants that can devastate foes with a power linked to bloodshed. These barbarians, like berserkers, revel in violence and take little account for their well-being in battle. Wherever they can be found, Bloodragers fight until they can stand no longer.",
+							{
+								"type": "entries",
+								"name": "Bloodrage",
+								"entries": [
+									"Starting at 3rd level, when you begin raging you gain 3 Bloodrage dice, which are d12s. At 6th, 10th, and 14th level you gain another Bloodrage die when you begin raging.",
+									"Additionally, whenever you reduce a small or larger creature to 0 hit points with a melee attack while you are raging you can use your reaction to bathe yourself in the blood of your foe, gaining 1 Bloodrage die.",
+									"Whenever you deal damage with a melee weapon attack you can spend 1 Bloodrage die or expend 1 hit die to increase the damage of the attack by the number rolled and also gain a number of temporary hit points equal to the number rolled. You can only increase your damage in this way once each round.",
+									"The temporary hit points and any remaining Bloodrage dice disappear when you stop raging."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"type": "entries",
+						"name": "Crippling Blow",
+						"entries": [
+							"At 6th level, whenever you spend a Bloodrage die or hit die to increase an attack's damage, you can channel your fury into a crippling blow. The target must succeed on a Constitution saving throw (DC equals 8 + your Proficiency bonus + your Strength modifier) or have its movement speed reduced by half until it succeeds on the saving throw. The creature can repeat this saving throw at the start of each of its turns."
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Blood Hunt",
+								"entries": [
+									"At 10th level you gain the ability to smell blood in the air like a wild beast. You may use your action to learn the direction of any beast or humanoid below half of its maximum HP within five miles. You have advantage on Survival checks made to track creatures whose direction you know. You can track a scent for one hour, or until a wind of a moderate speed disperses the trail.",
+									"In addition, while raging, as a bonus action you can move up to your speed toward an enemy of your choice that you can see, or a creature whose direction you know from using this feature. You must end this movement closer to the creature than you started."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Lord of Blood",
+								"entries": [
+									"When you reach 14th level, your rage can push you beyond the limits of your mortal body.",
+									"Whenever you increase your damage with a Bloodrage die, you can choose to spend an additional Bloodrage die or expend a hit die in addition to a Bloodrage die.",
+									"If you spend 2 dice in this manner and use your Crippling Blow feature you can choose to forego gaining temporary hit points from 1 or 2 dice. If you forego the hit points from 2 dice and the creature fails its saving throw, its movement speed is instead reduced to 0 feet."
+								]
+							}
+						]
+					}
+				]
+			],
+			"source": "CoA 3pp",
+			"shortName": "Bloodrager"
+		},
 		{
 			"class": "Barbarian",
 			"name": "Path of the Immortal Titan",


### PR DESCRIPTION
Updated the "Codex of Allies" entry to include a second subclass. There are many more missing documentation and this PR serves as a test of whether I properly understand the JSON format.