### PR TITLE
Tweaked formatting to remove redundancy

### DIFF
--- a/race/Middle Finger of Vecna; Awakened Golem.json
+++ b/race/Middle Finger of Vecna; Awakened Golem.json
@@ -34,7 +34,6 @@
 				"Damage Resistance"
 			],
 			"entries": [
-				"Though mighty, you are far from indestructible. You possess the following racial traits:",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Bugbear.json
+++ b/race/Middle Finger of Vecna; Bugbear.json
@@ -35,7 +35,6 @@
 				"Monstrous Race"
 			],
 			"entries": [
-				"As a goblinoid, you have the following characteristics.",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Dhampyr.json
+++ b/race/Middle Finger of Vecna; Dhampyr.json
@@ -30,7 +30,6 @@
 			"speed": 30,
 			"darkvision": 120,
 			"entries": [
-				"As a Dhampyr, your character has the following traits:",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Illumian.json
+++ b/race/Middle Finger of Vecna; Illumian.json
@@ -42,7 +42,6 @@
 				"Spellcasting"
 			],
 			"entries": [
-				"Your illumian character has the following traits.",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Merfolk.json
+++ b/race/Middle Finger of Vecna; Merfolk.json
@@ -34,7 +34,6 @@
 				"Amphibious"
 			],
 			"entries": [
-				"Merfolk have the following racial traits:",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Satyr.json
+++ b/race/Middle Finger of Vecna; Satyr.json
@@ -36,7 +36,6 @@
 				"Monstrous Race"
 			],
 			"entries": [
-				"Satyrs have the following racial traits:",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Sirine.json
+++ b/race/Middle Finger of Vecna; Sirine.json
@@ -37,7 +37,6 @@
 				"Skill Proficiency"
 			],
 			"entries": [
-				"Sirines have the following racial traits:",
 				{
 					"name": "Age",
 					"entries": [

--- a/race/Middle Finger of Vecna; Tibbit.json
+++ b/race/Middle Finger of Vecna; Tibbit.json
@@ -30,7 +30,6 @@
 			},
 			"size": "S",
 			"entries": [
-				"You share the following feline characteristics with other tibbits.",
 				{
 					"name": "Age",
 					"entries": [


### PR DESCRIPTION
Tweaks to remove redundancies in trait blocks.
Unsure whether or not these should have them, but it adds a redundant line at the top preceding feature explanations.