### PR TITLE
Fixing the table links in the items

### DIFF
--- a/item/AeronDrake; Modular Magic Items.json
+++ b/item/AeronDrake; Modular Magic Items.json
@@ -37,7 +37,7 @@
 			"source": "Modular Magic Items",
 			"reqAttune": true,
 			"entries": [
-				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has two {@table Uncommon Properties|MMI|uncommon properties}."
+				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has two {@table Uncommon Properties|Modular Magic Items|uncommon properties}."
 			]
 		},
 		{
@@ -48,7 +48,7 @@
 			"source": "Modular Magic Items",
 			"reqAttune": true,
 			"entries": [
-				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has two {@table Rare Properties|MMI|rare properties}."
+				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has two {@table Rare Properties|Modular Magic Items|rare properties}."
 			]
 		},
 		{
@@ -59,7 +59,7 @@
 			"source": "Modular Magic Items",
 			"reqAttune": true,
 			"entries": [
-				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has one {@table Uncommon Properties|MMI|uncommon property}, one {@table Rare Properties|MMI|rare property}, and one {@table Very Rare Properties|MMI|very rare property}."
+				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has one {@table Uncommon Properties|Modular Magic Items|uncommon property}, one {@table Rare Properties|Modular Magic Items|rare property}, and one {@table Very Rare Properties|Modular Magic Items|very rare property}."
 			]
 		},
 		{
@@ -70,7 +70,7 @@
 			"source": "Modular Magic Items",
 			"reqAttune": true,
 			"entries": [
-				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has one {@table Rare Properties|MMI|rare property}, one {@table Very Rare Properties|MMI|very rare property}, and one {@table Legendary Properties|MMI|Legendary property}."
+				"Work with your DM to determine the nature and properties of this magic item. At this tier, in addition to one {@table Special Features; What Minor Property Does It Have|DMG|minor property}, it also has one {@table Rare Properties|Modular Magic Items|rare property}, one {@table Very Rare Properties|Modular Magic Items|very rare property}, and one {@table Legendary Properties|Modular Magic Items|Legendary property}."
 			]
 		}
 	],


### PR DESCRIPTION
They were formatted as {@table Table Name|MMI|display text} and now properly are {@table Table Name|Modular Magic Items|display text}.