### PR TITLE
Ranges fixed

### DIFF
--- a/item/TheApoApostolov; Items for Grit and Glory.json
+++ b/item/TheApoApostolov; Items for Grit and Glory.json
@@ -2454,7 +2454,8 @@
 			"source": "GAG",
 			"property": [
 				"LITE",
-				"LIMT"
+				"LIMT",
+				"THRO"
 			],
 			"entries": [
 				"Simple Thrown Weapons"
@@ -2473,7 +2474,8 @@
 			"dmgType": "P",
 			"source": "GAG",
 			"property": [
-				"LITE"
+				"LITE",
+				"THRO"
 			],
 			"entries": [
 				"Simple Thrown Weapons"
@@ -2492,7 +2494,8 @@
 			"source": "GAG",
 			"property": [
 				"LITE",
-				"PELL"
+				"PELL",
+                "A"
 			],
 			"entries": [
 				"Simple Thrown Weapons"
@@ -2511,7 +2514,8 @@
 			"dmgType": "P",
 			"source": "GAG",
 			"property": [
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Bows"
@@ -2531,7 +2535,8 @@
 			"source": "GAG",
 			"property": [
 				"PELL",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Bows"
@@ -2552,7 +2557,8 @@
 			"property": [
 				"BRUT",
 				"STR9",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2572,7 +2578,8 @@
 			"source": "GAG",
 			"property": [
 				"BRUT",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2593,7 +2600,8 @@
 			"property": [
 				"BRUT",
 				"STR1",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2615,7 +2623,8 @@
 				"BRUT",
 				"LIMN",
 				"STR1",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2637,7 +2646,8 @@
 				"BRUT",
 				"LIMN",
 				"STR9",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2659,7 +2669,8 @@
 				"BRUT",
 				"LIMN",
 				"STR3",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2685,7 +2696,8 @@
 				"STR3",
 				"2H",
 				"VOLL",
-				"WOUP"
+				"WOUP",
+                "A"
 			],
 			"entries": [
 				"Martial Bows"
@@ -2706,7 +2718,8 @@
 			"property": [
 				"LITE",
 				"L",
-				"PTBK"
+				"PTBK",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2728,7 +2741,8 @@
 				"LITE",
 				"LOA5",
 				"MAG6",
-				"PTBK"
+				"PTBK",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2749,7 +2763,8 @@
 			"property": [
 				"LOA1",
 				"STCK",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2771,7 +2786,8 @@
 				"LOA2",
 				"MAG2",
 				"STCK",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2792,7 +2808,8 @@
 			"property": [
 				"LOA5",
 				"MAG6",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2814,7 +2831,8 @@
 				"H",
 				"LOA2",
 				"STCK",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2836,7 +2854,8 @@
 				"H",
 				"LOA4",
 				"MAG2",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2858,7 +2877,8 @@
 				"H",
 				"LOA7",
 				"MAG6",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2880,7 +2900,8 @@
 				"CAL3",
 				"LOA1",
 				"STCK",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2902,7 +2923,8 @@
 				"LD",
 				"PELL",
 				"STCK",
-				"2H"
+				"2H",
+                "A"
 			],
 			"entries": [
 				"Simple Crossbows"
@@ -2921,7 +2943,8 @@
 			"dmgType": "P",
 			"source": "GAG",
 			"property": [
-				"LD"
+				"LD",
+                "A"
 			],
 			"entries": [
 				"Other Martial Ranged Weapons "
@@ -2940,7 +2963,8 @@
 			"dmgType": "P",
 			"source": "GAG",
 			"property": [
-				"LD"
+				"LD",
+                "A"
 			],
 			"entries": [
 				"Other Martial Ranged Weapons"
@@ -2962,7 +2986,8 @@
 				"LOA4",
 				"2H",
 				"MIS2",
-				"SUN3"
+				"SUN3",
+                "A"
 			],
 			"entries": [
 				"Medieval Firearms"
@@ -2986,7 +3011,8 @@
 				"MAG2",
 				"2H",
 				"MIS2",
-				"SUN3"
+				"SUN3",
+                "A"
 			],
 			"entries": [
 				"Medieval Firearms"
@@ -3011,7 +3037,8 @@
 				"MAG2",
 				"2H",
 				"MIS2",
-				"SUN3"
+				"SUN3",
+                "A"
 			],
 			"entries": [
 				"Medieval Firearms"
@@ -3034,7 +3061,8 @@
 				"LOA3",
 				"PTBK",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3058,7 +3086,8 @@
 				"LOA3",
 				"PTBK",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3081,7 +3110,8 @@
 				"LOA3",
 				"PTBK",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3104,7 +3134,8 @@
 				"LITE",
 				"LO12",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3127,7 +3158,8 @@
 				"LOA3",
 				"PTBK",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3150,7 +3182,8 @@
 				"LOA7",
 				"PTBK",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3172,7 +3205,8 @@
 				"LOA9",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3195,7 +3229,8 @@
 				"LOA9",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3218,7 +3253,8 @@
 				"LOA6",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3240,7 +3276,8 @@
 				"LOA6",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3263,7 +3300,8 @@
 				"LOA6",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3286,7 +3324,8 @@
 				"LOA9",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3309,7 +3348,8 @@
 				"LOA2",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3333,7 +3373,8 @@
 				"MAG9",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3355,7 +3396,8 @@
 				"LOA9",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3379,7 +3421,8 @@
 				"LOA6",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3402,7 +3445,8 @@
 				"MAG3",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3424,7 +3468,8 @@
 				"LOA1",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3447,7 +3492,8 @@
 				"LOA9",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3471,7 +3517,8 @@
 				"MAG2",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3494,7 +3541,8 @@
 				"LOA2",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3517,7 +3565,8 @@
 				"LOA6",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3541,7 +3590,8 @@
 				"MAG2",
 				"2H",
 				"VELO",
-				"MIS1"
+				"MIS1",
+                "A"
 			],
 			"entries": [
 				"Renaissance Firearms"
@@ -3565,7 +3615,8 @@
 				"LITE",
 				"MAG2",
 				"PTBK",
-				"VELO"
+				"VELO",
+                "A"
 			],
 			"entries": [
 				"Industrial Firearms"
@@ -3588,7 +3639,8 @@
 				"LITE",
 				"MAG6",
 				"PTBK",
-				"VELO"
+				"VELO",
+                "A"
 			],
 			"entries": [
 				"Industrial Firearms"
@@ -3610,7 +3662,8 @@
 				"CAL2",
 				"LOA2",
 				"2H",
-				"VELO"
+				"VELO",
+                "A"
 			],
 			"entries": [
 				"Industrial Firearms"
@@ -3632,7 +3685,8 @@
 				"CAL3",
 				"LD",
 				"2H",
-				"VELO"
+				"VELO",
+                "A"
 			],
 			"entries": [
 				"Industrial Firearms"
@@ -3655,7 +3709,8 @@
 				"LOA3",
 				"MAG7",
 				"2H",
-				"VELO"
+				"VELO",
+                "A"
 			],
 			"entries": [
 				"Industrial Firearms"
@@ -3679,7 +3734,8 @@
 				"LOA1",
 				"MAG2",
 				"2H",
-				"VELO"
+				"VELO",
+                "A"
 			],
 			"entries": [
 				"Industrial Firearms"

--- a/item/TheApoApostolov; Items for Grit and Glory.json
+++ b/item/TheApoApostolov; Items for Grit and Glory.json
@@ -3686,7 +3686,8 @@
 				"LD",
 				"2H",
 				"VELO",
-                "A"
+				"A"
+				
 			],
 			"entries": [
 				"Industrial Firearms"

--- a/item/TheApoApostolov; Items for Grit and Glory.json
+++ b/item/TheApoApostolov; Items for Grit and Glory.json
@@ -714,7 +714,8 @@
 			"property": [
 				"FINE",
 				"LITE",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Axes"
@@ -735,7 +736,8 @@
 			"property": [
 				"FINE",
 				"LITE",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Axes"
@@ -880,7 +882,8 @@
 			"property": [
 				"FINE",
 				"LITE",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Blades"
@@ -1248,7 +1251,8 @@
 			"property": [
 				"FINE",
 				"LITE",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Bludgeoning Weapons"
@@ -1450,7 +1454,8 @@
 			"property": [
 				"THRO",
 				"FRA1",
-				"SHP1"
+				"SHP1",
+				"T"
 			],
 			"entries": [
 				"Simple Polearms"
@@ -1520,7 +1525,8 @@
 				"SHP1",
 				"THRE",
 				"THRO",
-				"V"
+				"V",
+				"T"
 			],
 			"entries": [
 				"Simple Polearms"
@@ -1891,7 +1897,8 @@
 				"SHP1",
 				"THRE",
 				"THRO",
-				"V"
+				"V",
+				"T"
 			],
 			"entries": [
 				"Martial Polearms"
@@ -1963,7 +1970,8 @@
 				"RESB",
 				"RESL",
 				"R",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Flexible Weapons"
@@ -2027,7 +2035,8 @@
 				"GRAP",
 				"RESL",
 				"R",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Martial Flexible Weapons"
@@ -2049,7 +2058,8 @@
 				"GRAP",
 				"RESA",
 				"RESH",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Martial Flexible Weapons"
@@ -2072,7 +2082,8 @@
 				"ONG1",
 				"RESA",
 				"RESH",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Martial Flexible Weapons"
@@ -2455,7 +2466,8 @@
 			"property": [
 				"LITE",
 				"LIMT",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Thrown Weapons"
@@ -2475,7 +2487,8 @@
 			"source": "GAG",
 			"property": [
 				"LITE",
-				"THRO"
+				"THRO",
+				"T"
 			],
 			"entries": [
 				"Simple Thrown Weapons"
@@ -5216,7 +5229,7 @@
 					"type": "entries",
 					"name": "Revised Thrown",
 					"entries": [
-						"If a weapon has the thrown property, you can throw the weapon to make a ranged attack. If the weapon is a melee weapon, you use the same ability modifier for that attack roll and damage roll that you would use for a melee attack with the weapon. For example, if you throw a handaxe, you use your Strength, but if you throw a dagger, you can use either your Strength or your Dexterity, since the dagger has the finesse property. Drawing a Thrown weapon is part of the attack, but you need a free hand. You may use your bonus action to recover any Thrown weapon within your reach. At the end of combat, you can recover all undamaged Thrown weapons by taking up to a minute to search the battlefield. When you take damage from a thrown weapon and it causes an Open Wound (pg. 8), the weapon remains lodged in the target. Any time you use your action during your turn with one or several lodged weapons in you, you take 1d4 internal damage. Removing a lodged weapon is an action."
+						"Drawing a Thrown weapon is part of the attack, but you need a free hand. You may use your bonus action to recover any Thrown weapon within your reach. At the end of combat, you can recover all undamaged Thrown weapons by taking up to a minute to search the battlefield. When you take damage from a thrown weapon and it causes an Open Wound (pg. 8), the weapon remains lodged in the target. Any time you use your action during your turn with one or several lodged weapons in you, you take 1d4 internal damage. Removing a lodged weapon is an action."
 					]
 				}
 			]


### PR DESCRIPTION
Added "A" properties to ranged weapons to display ranges.
Added "T" properties to thrown weapons to display ranges.
Previously had just used custom properties for these, but it seems the schema requires the in-built properties to be used to display ranges. It would be cool if there was a work around.