### PR TITLE
pull request: fix(modnar:cooking-and-brewing): close open curly brace …

### DIFF
--- a/collection/Modnar; Cooking and Brewing.json
+++ b/collection/Modnar; Cooking and Brewing.json
@@ -127,13 +127,19 @@
 						"1 - {@bold Buzzed}. Disadvantage on {@skill Perception} checks & against effects that impart the {@condition Charmed} condition. Advantage on saves versus things that impart the {@condition Frightened} condition.",
 						"2 - {@bold Tipsy}. Disadvantage on all opposition ability checks (eg. against Persuasion, or grapple attempts). Gain d8 temporary Hp.",
 						"3 - {@bold Merry}. Gain {@condition Poisoned} condition. Take -1 Dexterity, Intelligence, Wisdom, & Charisma attribute damage.",
-						"4 - {@bold Drunk Requires ability checks to be successful on their desired actions. Running; Talking; etc. Take -1 Dexterity, Intelligence, Wisdom, & Charisma attribute damage.",
+						"4 - {@bold Drunk} Requires ability checks to be successful on their desired actions (e.g. Running, Talking). Take -1 Dexterity, Intelligence, Wisdom, & Charisma attribute damage.",
 						"5 - {@bold Falling Down Drunk}. Gains {@condition Incapacitated} condition, at this point failed recovery saves lead to the {@condition unconscious}. Gain 1 levels of Exhaustion. Take -1 Dexterity, Intelligence, Wisdom, & Charisma attribute damage.",
 						"6 - {@bold Passed-Out Drunk}. {@condition Unconscious}. Gain 1 levels of Exhaustion."
 					]
 				},
-				"Recovery Saves: Each hour the creature makes another Constitution save check agasint the current DC to remove one level of intoxicated. Each hour the DC value lowers the creature's Constitution bonus per hour. Failed saves that fail by 10 or more, adds a level of Intoxication.",
-				" - this CAN mean the saves become more toxic for lower Constitution creatures and the person moves into deeper levels of intoxication even death."
+				{
+					"type": "entries",
+					"name": "Recovery Saves",
+					"entries": [
+						"Each hour the creature makes another Constitution save check agasint the current DC to remove one level of intoxicated. Each hour the DC value lowers the creature's Constitution bonus per hour. Failed saves that fail by 10 or more, adds a level of Intoxication.",
+						"This {@bold can} mean the saves become more toxic for lower Constitution creatures and the person moves into deeper levels of intoxication or even death."
+					]
+				}
 			]
 		},
 		{


### PR DESCRIPTION
... on condition intoxicated:drunk

improve: isolate 'Recovery Saves' to an inline header with nested entries

 Changes to be committed:
	modified:   collection/Modnar; Cooking and Brewing.json