### PR TITLE
fix(collection): fix errors causing Shape Maker to fail

### DIFF
--- a/collection/Daniel Nnorth; Slivers and Magical Items.json
+++ b/collection/Daniel Nnorth; Slivers and Magical Items.json
@@ -857,7 +857,8 @@
 				}
 			],
 			"hp": {
-				"special": "\t60 (8d8 + 24)"
+				"average": 60,
+				"formula": "8d8 + 24"
 			},
 			"speed": {
 				"walk": 30

--- a/collection/Kobold Press; Creature Codex.json
+++ b/collection/Kobold Press; Creature Codex.json
@@ -32,11 +32,10 @@
 		{
 			"name": "New Languages",
 			"entries": [
-				"Reflecting the Sapir\u2013Whorf hypothesis that the structure of a language modifies congition, these languages influence the .",
 				{
 					"entries": [
 						"{@b Umbral}",
-						"Umbral is the language of the shadow elves, a corrupted dialect of Elvish, and spoken by most creatures of shadow. Those who speak it can gain a +1 to one Dexterity (Stealth) check 1/day.",
+						"Umbral is the language of the shadow elves, a corrupted dialect of Elvish, and spoken by most creatures of shadow. Those who speak it can gain a +1 to one Dexterity ({@skill Stealth}) check 1/day.",
 						"",
 						"{@B Void}",
 						"Void Speech is the language of the Outer Darkness in the Midgard campaign setting, spoken by vile things that are malevolent towards humans and their allies, and who seek to bring about the ruinous apocalypse of the dark gods. Substitute any ancient language with an evil reputation if you are using another setting."
@@ -182,7 +181,7 @@
 			],
 			"passive": 12,
 			"languages": [
-				"Understands but can't speak"
+				"understands all but can't speak"
 			],
 			"cr": "5",
 			"page": 7,
@@ -28186,7 +28185,7 @@
 			],
 			"hp": {
 				"average": 123,
-				"forumla": "13d10 + 52"
+				"formula": "13d10 + 52"
 			},
 			"speed": {
 				"walk": 50
@@ -29458,9 +29457,18 @@
 			"type": "fey",
 			"source": "CCodex (3pp)",
 			"alignment": [
-				"C",
-				"N",
-				"E"
+				{
+					"alignment": [
+						"C",
+						"E"
+					]
+				},
+				{
+					"alignment": [
+						"C",
+						"N"
+					]
+				}
 			],
 			"ac": [
 				{
@@ -55249,15 +55257,16 @@
 			"variant": [
 				{
 					"type": "variant",
-					"name": "DOOMSPEAKERS IN MIDGARD",
+					"name": "Doomspeakers in Midgard",
 					"entries": [
-						"In the Southlands, doomspeakers recruit many of the gnolls of the Sarkland Desert to their cause. The gnolls are drawn by the doomspeakers' strength and the thought of easy conquest. Doomspeakers have a hidden complex in the south that serves as their main base of operations and the resting place of the Book of Nine Dooms, a book containing magic that uses raw, violent emotion as fuel. They also maintain a presence on the Rothenian Plain, both in caves under Demon Mountain by permission of its Master and in the forests north of the plain. When using the Midgard setting, change the doomspeaker's spells to the following (see \"Fifth Edition Appendix\" in the Midgard Worldbook): 1st level (4 slots):",
+						"In the Southlands, doomspeakers recruit many of the gnolls of the Sarkland Desert to their cause. The gnolls are drawn by the doomspeakers' strength and the thought of easy conquest. Doomspeakers have a hidden complex in the south that serves as their main base of operations and the resting place of the Book of Nine Dooms, a book containing magic that uses raw, violent emotion as fuel. They also maintain a presence on the Rothenian Plain, both in caves under Demon Mountain by permission of its Master and in the forests north of the plain. When using the Midgard setting, change the doomspeaker's spells to the following (see \"Fifth Edition Appendix\" in the {@italic Midgard Worldbook})",
 						{
 							"type": "list",
-							"entries": [
-								"1st level (4 slots): bane, bloody smite*, doom of the cracked shield*, memento mori*",
-								"2nd level (3 slots): bloodshot*, caustic blood*, magic weapon",
-								"3rd level (3 slots): blood armor*, conjure undead*, dispel magic"
+							"style": "list-hang-notitle",
+							"items": [
+								"1st level (4 slots): {@spell bane}, {@spell bloody smite|Dmvm (3pp)}, {@spell doom of the cracked shield|Dmvm (3pp)}, {@spell memento mori|Dmvm (3pp)}",
+								"2nd level (3 slots): {@spell bloodshot|Dmvm (3pp)}, {@spell caustic blood|Dmvm (3pp)}, {@spell magic weapon|phb}",
+								"3rd level (3 slots): {@spell blood armor|Dmvm (3pp)}, {@spell conjure undead|Dmvm (3pp)}, {@spell dispel magic}"
 							]
 						}
 					]
@@ -55277,12 +55286,21 @@
 					}
 				],
 				"entries": [
-					"The only creatures more vile than demons\u2014creatures born irredeemably evil\u2014are those who willingly adopt a demon's cruel ways. Worst among the demon worshipers are the fallen paladins known as doomspeakers, warriors so ensorcelled by power that they would burn the world just to rule its ashes. These  creatures walk the path of evil not by birth but by choice, and they breed cruelty in their hearts so dark that no glimmer of compassion can pierce it. Doomspeakers raise vast hordes of weak-minded and rage-fueled followers to run roughshod over the world. Empowered by their leader's evil magic, such legions can trample even mighty armies into the mud.",
+					"The only creatures more vile than demons—creatures born irredeemably evil—are those who willingly adopt a demon's cruel ways. Worst among the demon worshipers are the fallen paladins known as doomspeakers, warriors so ensorcelled by power that they would burn the world just to rule its ashes. These  creatures walk the path of evil not by birth but by choice, and they breed cruelty in their hearts so dark that no glimmer of compassion can pierce it. Doomspeakers raise vast hordes of weak-minded and rage-fueled followers to run roughshod over the world. Empowered by their leader's evil magic, such legions can trample even mighty armies into the mud.",
 					{
 						"type": "inset",
-						"name": "DOOMSPEAKERS IN MIDGARD",
+						"name": "Doomspeakers in Midgard",
 						"entries": [
-							"In the Southlands, doomspeakers recruit many of the gnolls of the Sarkland Desert to their cause. The gnolls are drawn by the doomspeakers' strength and the thought of easy conquest. Doomspeakers have a hidden complex in the south that serves as their main base of operations and the resting place of the Book of Nine Dooms, a book containing magic that uses raw, violent emotion as fuel. They also maintain a presence on the Rothenian Plain, both in caves under Demon Mountain by permission of its Master and in the forests north of the plain. When using the Midgard setting, change the doomspeaker's spells to the following (see \"Fifth Edition Appendix\" in the Midgard Worldbook): 1st level (4 slots): bane, bloody smite*, doom of the cracked shield*, memento mori* 2nd level (3 slots): bloodshot*, caustic blood*, magic weapon 3rd level (3 slots): blood armor*, conjure undead*, dispel magic "
+							"In the Southlands, doomspeakers recruit many of the gnolls of the Sarkland Desert to their cause. The gnolls are drawn by the doomspeakers' strength and the thought of easy conquest. Doomspeakers have a hidden complex in the south that serves as their main base of operations and the resting place of the Book of Nine Dooms, a book containing magic that uses raw, violent emotion as fuel. They also maintain a presence on the Rothenian Plain, both in caves under Demon Mountain by permission of its Master and in the forests north of the plain. When using the Midgard setting, change the doomspeaker's spells to the following (see \"Fifth Edition Appendix\" in the {@italic Midgard Worldbook})",
+							{
+								"type": "list",
+								"style": "list-hang-notitle",
+								"items": [
+									"1st level (4 slots): {@spell bane}, {@spell bloody smite|Dmvm (3pp)}, {@spell doom of the cracked shield|Dmvm (3pp)}, {@spell memento mori|Dmvm (3pp)}",
+									"2nd level (3 slots): {@spell bloodshot|Dmvm (3pp)}, {@spell caustic blood|Dmvm (3pp)}, {@spell magic weapon|phb}",
+									"3rd level (3 slots): {@spell blood armor|Dmvm (3pp)}, {@spell conjure undead|Dmvm (3pp)}, {@spell dispel magic}"
+								]
+							} 
 						]
 					}
 				]
@@ -55327,7 +55345,8 @@
 							]
 						}
 					},
-					"ability": "cha"
+					"ability": "cha",
+					"type": "spellcasting"
 				}
 			]
 		},
@@ -57762,8 +57781,8 @@
 			"source": "CCodex (3pp)",
 			"alignment": [
 				"L",
-				"NX",
 				"G",
+				"NY",
 				"E"
 			],
 			"ac": [

--- a/collection/Sean O'Connor; Inkantations.json
+++ b/collection/Sean O'Connor; Inkantations.json
@@ -7765,7 +7765,7 @@
 			"name": "Bloodline Brand",
 			"prerequisite": [
 				{
-					"special": "Tattoo, Sorcerer"
+					"other": "Tattoo, Sorcerer"
 				}
 			],
 			"entries": [
@@ -7786,7 +7786,7 @@
 			"name": "Fellowship Tattoo",
 			"prerequisite": [
 				{
-					"special": "Tattoo, Must be a member of a guild, military unit, adventuring company, or the like."
+					"other": "Tattoo, Must be a member of a guild, military unit, adventuring company, or the like."
 				}
 			],
 			"entries": [
@@ -7809,7 +7809,7 @@
 			"name": "Greater (un)Holy Tattoo",
 			"prerequisite": [
 				{
-					"special": "Tattoo, {@feat Improved (Un)Holy Tattoo|INK}, Divine Caster, Level 12"
+					"other": "Tattoo, {@feat Improved (Un)Holy Tattoo|INK}, Divine Caster, Level 12"
 				}
 			],
 			"entries": [
@@ -7831,7 +7831,7 @@
 			"name": "Grotesque tattoo",
 			"prerequisite": [
 				{
-					"special": "Tattoo, may NOT have {@feat Sexy Tattoo|INK}"
+					"other": "Tattoo, may NOT have {@feat Sexy Tattoo|INK}"
 				}
 			],
 			"entries": [
@@ -7853,7 +7853,7 @@
 			"name": "(un)Holy Tattoo (Tattoo)",
 			"prerequisite": [
 				{
-					"special": "Tattoo"
+					"other": "Tattoo"
 				}
 			],
 			"entries": [
@@ -7876,7 +7876,7 @@
 			"name": "Improved (un)Holy Tattoo",
 			"prerequisite": [
 				{
-					"special": "{@feat Holy Tattoo|INK}, Divine Caster, Level 5"
+					"other": "{@feat Holy Tattoo|INK}, Divine Caster, Level 5"
 				}
 			],
 			"entries": [
@@ -7913,7 +7913,7 @@
 			"name": "Quick Healer",
 			"prerequisite": [
 				{
-					"special": "Tattoo"
+					"other": "Tattoo"
 				}
 			],
 			"entries": [
@@ -7936,7 +7936,7 @@
 			"name": "Reflexive Tattoo",
 			"prerequisite": [
 				{
-					"special": "Tattoo"
+					"other": "Tattoo"
 				}
 			],
 			"entries": [
@@ -7957,7 +7957,7 @@
 			"name": "Sexy Tattoo",
 			"prerequisite": [
 				{
-					"special": "Tattoo, may NOT have {@feat Grotesque Tattoo|INK}"
+					"other": "Tattoo, may NOT have {@feat Grotesque Tattoo|INK}"
 				}
 			],
 			"entries": [
@@ -7979,7 +7979,7 @@
 			"name": "Tattoo Mastery",
 			"prerequisite": [
 				{
-					"special": "Tattoo, Wizard"
+					"other": "Tattoo, Wizard"
 				}
 			],
 			"entries": [
@@ -8000,7 +8000,7 @@
 			"name": "Wizard's Mark",
 			"prerequisite": [
 				{
-					"special": "Tattoo, Wizard"
+					"other": "Tattoo, Wizard"
 				}
 			],
 			"entries": [

--- a/creature/Regerem; Book of Beautiful Horrors.json
+++ b/creature/Regerem; Book of Beautiful Horrors.json
@@ -6722,7 +6722,8 @@
 				}
 			],
 			"hp": {
-				"special": "136(12d12 + 60)"
+				"average": 136,
+				"formula": "12d12 + 60"
 			},
 			"speed": {
 				"walk": 40,

--- a/psionic/Sample - Giddy; Black Lily Techniques.json
+++ b/psionic/Sample - Giddy; Black Lily Techniques.json
@@ -28,7 +28,6 @@
 			"name": "Mastery of Mastery",
 			"source": "Giddy",
 			"type": "D",
-			"description": "You align yourself with yourself. When you learn this discipline, choose up to five effects which cost psi points to activate from other disciplines. You may activate any of those effects as though they belong to this discipline, but must pay one additional psi point to do so. This extra psi point does not count towards points spent on the activation for the purposes of determining the effects of the activation.",
 			"focus": "While focused on this discipline, if you have 11 or more levels in the Mystic class, your psi limit is increased by one.",
 			"modes": [
 				{
@@ -42,7 +41,11 @@
 					]
 				}
 			],
-			"order": "Awakened"
+			"order": "Awakened",
+			"entries": [
+				"You align yourself with yourself. When you learn this discipline, choose up to five effects which cost psi points to activate from other disciplines. You may activate any of those effects as though they belong to this discipline, but must pay one additional psi point to do so. This extra psi point does not count towards points spent on the activation for the purposes of determining the effects of the activation."
+			]
 		}
 	]
 }
+

--- a/schema.json
+++ b/schema.json
@@ -1,6 +1,6 @@
 {
 	"$schema": "http://json-schema.org/draft-06/schema#",
-	"version": "1.1.3",
+	"version": "1.1.4",
 	"type": "object",
 	"description": "Homebrew for 5etools. Should include arrays titled similarly to the main site data, e.g. `spell` or `class`",
 	"definitions": {
@@ -1382,6 +1382,32 @@
 					"patternProperties": {
 						".*": {
 							"type": "string"
+						}
+					}
+				},
+				"psionicTypes": {
+					"type": "object",
+					"description": "Object names are psionic type abbreviations (e.g. `\"X\"`); values should be objects with `\"full\"`` (used in the main entry, e.g. \"Greater Discipline\") and `\"short\"` (used in the list view, e.g. `\"G. Discipline\"`) key/values.",
+					"patternProperties": {
+						".*": {
+							"type": "object",
+							"properties": {
+								"full": {
+									"type": "string"
+								},
+								"short": {
+									"type": "string"
+								},
+								"hasOrder": {
+									"description": "If this type has a psionic order.",
+									"type": "boolean"
+								},
+								"isAltDisplay": {
+									"description": "If this type should display its psionic type/order with the format \"Greater Discipline (Awakened)\" instead of the standard \"Awakened Greater Discipline\"",
+									"type": "boolean"
+								}
+							},
+							"required": ["full", "short"]
 						}
 					}
 				},


### PR DESCRIPTION
fix(feats): use correct property names
fix(CCodex (3pp)): fix type on hp 'formula'
feat(schema): add custom psionic types
chore(psionics): use new entity format
fix(ccodex-3pp:new-languages): remove header entry and add {@}
Header entry is partial sentence and not in the text of the Creature Codex.
Add {@check Stealth} link in keeping with style guide.
fix(CCodex (3pp)): add word 'all' in aatxe language section
fix(ccodex (3pp)): fix json structure on kappa alignment
fix(Ccodex (3pp)): fix inset and variant of doomspeaker
fix(ccodex-3pp:war chaplain): correct alignment section
Alignment array elements for 'any lawful alignment' corrected

Issue #282 

-----
	modified:   collection/Daniel Nnorth; Slivers and Magical Items.json
	modified:   collection/Kobold Press; Creature Codex.json
	modified:   collection/Sean O'Connor; Inkantations.json
	modified:   creature/Regerem; Book of Beautiful Horrors.json
	modified:   psionic/Sample - Giddy; Black Lily Techniques.json
	modified:   schema.json