### PR TITLE
Fix Blood Hunter 2020 JSON

### DIFF
--- a/collection/Matthew Mercer; Blood Hunter (2020).json
+++ b/collection/Matthew Mercer; Blood Hunter (2020).json
@@ -15,11 +15,11 @@
 				],
 				"url": "https://www.dmsguild.com/product/301641/Blood-Hunter-Class-for-DD-5e-2020",
 				"dateReleased": "2020-01-27",
-				"version": "3.16-02-2020"
+				"version": "3.06-03-2020"
 			}
 		],
 		"dateAdded": 1580617082,
-		"dateLastModified": 1580617082
+		"dateLastModified": 1583538635
 	},
 	"class": [
 		{

--- a/collection/Matthew Mercer; Blood Hunter (2020).json
+++ b/collection/Matthew Mercer; Blood Hunter (2020).json
@@ -3,8 +3,8 @@
 	"_meta": {
 		"sources": [
 			{
-				"json": "CR2020",
-				"abbreviation": "CR2020",
+				"json": "BH2020",
+				"abbreviation": "BH2020",
 				"full": "Blood Hunter 2020",
 				"authors": [
 					"Matthew Mercer"
@@ -24,7 +24,7 @@
 	"class": [
 		{
 			"name": "Blood Hunter",
-			"source": "CR2020",
+			"source": "BH2020",
 			"hd": {
 				"number": 1,
 				"faces": 10
@@ -654,6 +654,7 @@
 			"subclasses": [
 				{
 					"name": "Order of the Ghostslayer",
+					"source": "BH2020",
 					"subclassFeatures": [
 						[
 							{
@@ -705,7 +706,7 @@
 							{
 								"name": "Blood Curse of the Exorcist",
 								"entries": [
-									"At 15th level, you've honed your hemocraft to tear wicked influence from your allies, punishing those who would infiltrate their body and mind. You gain the {@optfeature Blood Curse of the Exorcist|CR2020} for your Blood Maledict feature. This doesn't count against your number of blood curses known."
+									"At 15th level, you've honed your hemocraft to tear wicked influence from your allies, punishing those who would infiltrate their body and mind. You gain the {@optfeature Blood Curse of the Exorcist|BH2020} for your Blood Maledict feature. This doesn't count against your number of blood curses known."
 								]
 							}
 						],
@@ -722,6 +723,7 @@
 				},
 				{
 					"name": "Order of the Profane Soul",
+					"source": "BH2020",
 					"spellcastingAbility": "int",
 					"casterProgression": "pact",
 					"subclassSpells": [
@@ -738,8 +740,8 @@
 								}
 							],
 							"colLabels": [
-								"{@filter Cantrips Known|spells|level=0|subclass=Blood Hunter: Profane Soul (CR2020)}",
-								"{@filter Spells Known|spells|subclass=Blood Hunter: Profane Soul (CR2020)}",
+								"{@filter Cantrips Known|spells|level=0|subclass=Blood Hunter: Profane Soul (BH2020)}",
+								"{@filter Spells Known|spells|subclass=Blood Hunter: Profane Soul (BH2020)}",
 								"Spell Slots",
 								"Spell Level"
 							],
@@ -760,109 +762,109 @@
 									2,
 									2,
 									1,
-									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									2,
 									2,
 									1,
-									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									2,
 									3,
 									1,
-									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									2,
 									3,
 									2,
-									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 1st|spells|level=1|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									2,
 									4,
 									2,
-									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									2,
 									4,
 									2,
-									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									2,
 									5,
 									2,
-									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									5,
 									2,
-									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									6,
 									2,
-									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									6,
 									2,
-									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 2nd|spells|level=2|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									7,
 									2,
-									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									7,
 									2,
-									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									8,
 									2,
-									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									8,
 									2,
-									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									9,
 									2,
-									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									9,
 									2,
-									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 3rd|spells|level=3|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									10,
 									2,
-									"{@filter 4th|spells|level=4|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 4th|spells|level=4|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								],
 								[
 									3,
 									11,
 									2,
-									"{@filter 4th|spells|level=4|subclass=Blood Hunter: Profane Soul (CR2020)}"
+									"{@filter 4th|spells|level=4|subclass=Blood Hunter: Profane Soul (BH2020)}"
 								]
 							]
 						}
@@ -1077,7 +1079,7 @@
 							{
 								"name": "Blood Curse of the Souleater",
 								"entries": [
-									"Starting at 18th level, you've learned to siphon the soul from your fallen prey. You gain the {@optfeature Blood Curse of the Souleater|CR2020} for your Blood Maledict feature. This does not count against your number of blood curses known."
+									"Starting at 18th level, you've learned to siphon the soul from your fallen prey. You gain the {@optfeature Blood Curse of the Souleater|BH2020} for your Blood Maledict feature. This does not count against your number of blood curses known."
 								]
 							}
 						]
@@ -1086,6 +1088,7 @@
 				},
 				{
 					"name": "Order of the Mutant",
+					"source": "BH2020",
 					"subclassFeatures": [
 						[
 							{
@@ -1255,7 +1258,7 @@
 							{
 								"name": "Blood Curse of Corrosion",
 								"entries": [
-									"Starting at 15th level, your blood curse can wrack a creature's body with terrible toxins. You gain the {@optfeature Blood Curse of Corrosion|CR2020} for your Blood Maledict feature. This does not count against your number of blood curses known."
+									"Starting at 15th level, your blood curse can wrack a creature's body with terrible toxins. You gain the {@optfeature Blood Curse of Corrosion|BH2020} for your Blood Maledict feature. This does not count against your number of blood curses known."
 								]
 							}
 						],
@@ -1272,6 +1275,7 @@
 				},
 				{
 					"name": "Order of the Lycan",
+					"source": "BH2020",
 					"subclassFeatures": [
 						[
 							{
@@ -1456,7 +1460,7 @@
 	"optionalfeature": [
 		{
 			"name": "Blood Curse of the Anxious",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"As a bonus action, you magnify the adrenaline in the body of a creature within 30 feet of you, making them susceptible to forceful influence. Until the end of your next turn, all creatures have advantage on Charisma (Intimidation) checks directed at the target creature.",
 				{
@@ -1470,7 +1474,7 @@
 		},
 		{
 			"name": "Blood Curse of Binding",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"As a bonus action, you can attempt to bind a creature you can see within 30 feet of you that is no more than one size larger than you. The target must succeed on a Strength saving throw or have their speed be reduced to 0 and they can't use reactions until the end of your next turn.",
 				{
@@ -1484,7 +1488,7 @@
 		},
 		{
 			"name": "Blood Curse of Bloated Agony",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"As a bonus action, you curse a creature that you can see within 30 feet of you to painfully swell until the end of your next turn. For the duration of this curse, the creature has disadvantage on Strength and Dexterity ability checks, and suffers 1d8 necrotic damage if it makes more than one melee or ranged attack during its turn.",
 				{
@@ -1498,7 +1502,7 @@
 		},
 		{
 			"name": "Blood Curse of Corrosion",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1525,7 +1529,7 @@
 		},
 		{
 			"name": "Blood Curse of the Exorcist",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1552,7 +1556,7 @@
 		},
 		{
 			"name": "Blood Curse of the Eyeless",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"When a creature you can see within 30 feet of you makes an attack roll, you can use your reaction to roll one hemocraft die and subtract the number rolled from the creature's attack roll. You can choose to use this feature after the creature's roll, but before the DM determines whether the attack roll succeeds. The creature is immune if it is immune to blindness.",
 				{
@@ -1566,7 +1570,7 @@
 		},
 		{
 			"name": "Blood Curse of the Fallen Puppet",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"When a creature you can see within 30 feet drops to 0 hit points, you can use your reaction to make that creature immediately makes a single weapon attack against a target of your choice within its attack range.",
 				{
@@ -1580,7 +1584,7 @@
 		},
 		{
 			"name": "Blood Curse of the Howl",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1607,7 +1611,7 @@
 		},
 		{
 			"name": "Blood Curse of the Marked",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"As a bonus action, you can mark a creature within 30 feet of you. Until the end of your turn, you roll an additional hemocraft die whenever you deal rite damage to the target.",
 				{
@@ -1621,7 +1625,7 @@
 		},
 		{
 			"name": "Blood Curse of the Muddled Mind",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"As a bonus action, you curse a creature that you can see within 30 feet of you that is concentrating on a spell. That creature has disadvantage on the next Constitution saving throw it must make to maintain concentration before the end of your next turn.",
 				{
@@ -1635,7 +1639,7 @@
 		},
 		{
 			"name": "Blood Curse of the Souleater",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1662,7 +1666,7 @@
 		},
 		{
 			"name": "Aether",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1683,7 +1687,7 @@
 		},
 		{
 			"name": "Cruelty",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1704,7 +1708,7 @@
 		},
 		{
 			"name": "Precision",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1725,7 +1729,7 @@
 		},
 		{
 			"name": "Reconstruction",
-			"source": "CR2020",
+			"source": "BH2020",
 			"prerequisite": [
 				{
 					"level": {
@@ -1746,7 +1750,7 @@
 		},
 		{
 			"name": "Alluring",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"Your skin and voice become malleable, allowing you to slightly enhance your appearance and presence. You have advantage on Charisma ability checks. As a side effect, you gain disadvantage on initiative rolls."
 			],
@@ -1754,7 +1758,7 @@
 		},
 		{
 			"name": "Celerity",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"Your Dexterity score increases by 3, as does your Dexterity maximum. This bonus increases by 1 at 11th level (+4) and 18th level (+5). As a side effect, you gain disadvantage on Wisdom saving throws."
 			],
@@ -1762,7 +1766,7 @@
 		},
 		{
 			"name": "Conversant",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain advantage on Intelligence ability checks. As a side effect, you gain disadvantage on Wisdom ability checks."
 			],
@@ -1770,7 +1774,7 @@
 		},
 		{
 			"name": "Deftness",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain advantage on Dexterity ability checks. As a side effect, you gain disadvantage on Wisdom ability checks."
 			],
@@ -1778,7 +1782,7 @@
 		},
 		{
 			"name": "Embers",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain resistance to fire damage. As a side effect, you gain vulnerability to cold damage."
 			],
@@ -1786,7 +1790,7 @@
 		},
 		{
 			"name": "Gelid",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain resistance to cold damage. As a side effect, you gain vulnerability to fire damage."
 			],
@@ -1794,7 +1798,7 @@
 		},
 		{
 			"name": "Impermeable",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain resistance to piercing damage. As a side effect, you gain vulnerability to slashing damage."
 			],
@@ -1802,7 +1806,7 @@
 		},
 		{
 			"name": "Mobile",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You are immune to the grappled and restrained conditions. At 11th level, you also are immune to the paralyzed condition. As a side effect, you gain disadvantage on Strength ability checks."
 			],
@@ -1810,7 +1814,7 @@
 		},
 		{
 			"name": "Nighteye",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain darkvision for up to 60 feet. If you already have darkvision, this increases its range by 60 additional feet. As a side effect, you gain sunlight sensitivity (detailed in the Dark Elf section on page 24 in the Player's Handbook)."
 			],
@@ -1818,7 +1822,7 @@
 		},
 		{
 			"name": "Percipient",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain advantage on Wisdom ability checks. As a side effect, you gain disadvantage on Charisma ability checks."
 			],
@@ -1826,7 +1830,7 @@
 		},
 		{
 			"name": "Potency",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"Your Strength score increases by 3, as does your Strength maximum. This bonus increases by 1 at 11th level (+4) and 18th level (+5). As a side effect, you have disadvantage on Dexterity saving throws."
 			],
@@ -1834,7 +1838,7 @@
 		},
 		{
 			"name": "Rapidity",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"Your speed increases by 10feet. At 15th level, your speed increases by 15 feet instead. As a side effect, you gain disadvantage on Intelligence ability checks."
 			],
@@ -1842,7 +1846,7 @@
 		},
 		{
 			"name": "Sagacity",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"Your Intelligence score increases by 3, as does your Intelligence maximum. This bonus increases by 1 at 11th level (+4) and 18th level (+5). As a side effect, you gain disadvantage on Charisma saving throws."
 			],
@@ -1850,7 +1854,7 @@
 		},
 		{
 			"name": "Shielded",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain resistance to slashing damage. As a side effect, you gain vulnerability to bludgeoning damage."
 			],
@@ -1858,7 +1862,7 @@
 		},
 		{
 			"name": "Unbreakable",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain resistance to bludgeoning damage. As a side effect, you gain vulnerability to piercing damage."
 			],
@@ -1866,7 +1870,7 @@
 		},
 		{
 			"name": "Vermillion",
-			"source": "CR2020",
+			"source": "BH2020",
 			"entries": [
 				"You gain an additional use of your Blood Maledict feature. As a side effect, you gain disadvantage on death saving throws."
 			],


### PR DESCRIPTION
Subclasses didn't have source causing class page to fail to load
Blood Hunter class is separate to Critical Role so source abbreviation was incorrect