### PR TITLE
Fix typos and minor errors

### DIFF
--- a/collection/JVC Parry; Call from the Deep.json
+++ b/collection/JVC Parry; Call from the Deep.json
@@ -16,7 +16,7 @@
 			}
 		],
 		"dateAdded": 1579711362,
-		"dateLastModified": 1584155867
+		"dateLastModified": 1585500000
 	},
 	"feat": [
 		{
@@ -127,7 +127,7 @@
 			"source": "CallfromtheDeep",
 			"page": 269,
 			"entries": [
-				"Your time spent aboard boats ahs earned you the following benefits:",
+				"Your time spent aboard boats has earned you the following benefits:",
 				{
 					"type": "list",
 					"items": [
@@ -236,7 +236,7 @@
 			"reqAttune": true,
 			"baseItem": "plate armor|phb",
 			"entries": [
-				"You have a +1 bonus to AC while wearing this armour. While wearing the armour underwater, you can speak it's command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, you doff the armour, or you are no longer underwater"
+				"You have a +1 bonus to AC while wearing this armour. While wearing the armour underwater, you can speak {@homebrew its|it's} command word as an action to create a bubble of air around your head. It allows you to breathe normally underwater. This bubble stays with you until you speak the command word again, you doff the armour, or you are no longer underwater"
 			]
 		},
 		{
@@ -272,8 +272,8 @@
 						"Effect"
 					],
 					"colStyles": [
-						"col-1 text-center",
-						"col-11"
+						"col-2 text-center",
+						"col-10"
 					],
 					"rows": [
 						[
@@ -329,7 +329,7 @@
 						}
 					]
 				},
-				"Once inside the pilot can operate the suit through thought. The suit ahs two {@action Attack} options, both of which require an action:",
+				"Once inside the pilot can operate the suit through thought. The suit has two {@action Attack} options, both of which require an action:",
 				{
 					"type": "list",
 					"items": [
@@ -2486,7 +2486,7 @@
 				{
 					"name": "Demoralising Beam",
 					"entries": [
-						"{@atk rw} {@hit 10} to hit, range 60 ft., one target. {@h}16 ({@damage 2d10 + 5}) force damage. If the target is a humanoid, its Charisma score is reduced by {@dice 1d4}. This reduction lasts until the target finishes a short or long rest. The target deis if this reduces its Charisma to 0."
+						"{@atk rw} {@hit 10} to hit, range 60 ft., one target. {@h}16 ({@damage 2d10 + 5}) force damage. If the target is a humanoid, its Charisma score is reduced by {@dice 1d4}. This reduction lasts until the target finishes a short or long rest. The target dies if this reduces its Charisma to 0."
 					]
 				},
 				{
@@ -2988,7 +2988,7 @@
 				{
 					"name": "Magic Resistance",
 					"entries": [
-						"The sahuagin ahs advantage on saving throws against spells and other magical effects."
+						"The sahuagin has advantage on saving throws against spells and other magical effects."
 					]
 				},
 				{
@@ -3751,7 +3751,7 @@
 				{
 					"name": "Magic Resistance",
 					"entries": [
-						"Druskis has advantage on saving throws against spells and other magical effects."
+						"Luzgrigaul has advantage on saving throws against spells and other magical effects."
 					]
 				},
 				{

--- a/collection/Kobold Press; Deep Magic 04 Illumination Magic.json
+++ b/collection/Kobold Press; Deep Magic 04 Illumination Magic.json
@@ -17,7 +17,7 @@
 			}
 		],
 		"dateAdded": 1580670213,
-		"dateLastModified": 1581454644
+		"dateLastModified": 1585424407
 	},
 	"subclass": [
 		{
@@ -1414,7 +1414,6 @@
 		{
 			"source": "DM04",
 			"name": "Talithe Val'Shiar",
-			"isNpc": true,
 			"size": "M",
 			"page": 215,
 			"type": {
@@ -1481,7 +1480,7 @@
 				{
 					"name": "Master of the Endless Night",
 					"entries": [
-						"Talithe increases the spell save DC and spell attack modifier of cantrips she casts in dim light or darkness by 1.."
+						"Talithe increases the spell save DC and spell attack modifier of cantrips she casts in dim light or darkness by 1."
 					]
 				},
 				{

--- a/collection/Kobold Press; Deep Magic 17 Mythos Magic.json
+++ b/collection/Kobold Press; Deep Magic 17 Mythos Magic.json
@@ -17,7 +17,7 @@
 			}
 		],
 		"dateAdded": 1580670213,
-		"dateLastModified": 1581454644
+		"dateLastModified": 1585425252
 	},
 	"item": [
 		{
@@ -29,7 +29,7 @@
 			"reqAttune": true,
 			"entries": [
 				"This fragmentary black book is reputed to descend from forgotten realms of Hyperborea. It contains puzzling guidelines for frightful necromantic rituals and maddening interdimensional travel.",
-				"The book contains the following spells: {@spell semblance of dread|dm17}, {@spell ectoplasm|dm17}, {@spell animate dead}, {@spell speak with dead}, {@spell emanation of Yoth|dm17}, {@spell green decay|dm17}, {@spell yellow sign|dm17}, {@spell eldritch communion|dm17}, {@spell create undead}, {@spell arcane gate}, {@spell harm}, {@spell right the stars|dm17}, {@spell astral projection}, {@footnote Void rift}|A spell in the {@i Midgard Heroes Handbook} by Kobold Press, which is currently unconverted for 5eTools.}, and any additional spells of the GM's choosing.",
+				"The book contains the following spells: {@spell semblance of dread|dm17}, {@spell ectoplasm|dm17}, {@spell animate dead}, {@spell speak with dead}, {@spell emanation of Yoth|dm17}, {@spell green decay|dm17}, {@spell yellow sign|dm17}, {@spell eldritch communion|dm17}, {@spell create undead}, {@spell arcane gate}, {@spell harm}, {@spell right the stars|dm17}, {@spell astral projection}, {@footnote Void rift|A spell in the {@i Midgard Heroes Handbook} by Kobold Press, which is currently unconverted for 5eTools.}, and any additional spells of the GM's choosing.",
 				"If you attune to this item, you can use it as a spellbook and as an arcane focus. In addition, while holding the book, you can use a bonus action to cast a necromancy spell that is written in this tome without expending a spell slot or using any verbal or somatic components. Once used, this property of the book can't be used again until the next dawn."
 			]
 		},
@@ -220,7 +220,7 @@
 								{
 									"type": "quote",
 									"entries": [
-										"\"When the stars were right, they could plunge from world to world through the sky. . .\""
+										"\"When the stars were right, they could plunge from world to world through the sky . . .\""
 									],
 									"by": "(From \"The Festival\" by H. P. Lovecraft)"
 								},
@@ -311,7 +311,7 @@
 										],
 										[
 											"7",
-											"\"I often hear the thin, monotonous piping of a demonic flute. Listen. . . can't you hear it?\""
+											"\"I often hear the thin, monotonous piping of a demonic flute. Listen . . . can't you hear it?\""
 										],
 										[
 											"8",
@@ -448,7 +448,7 @@
 				],
 				[
 					"7",
-					"\"I often hear the thin, monotonous piping of a demonic flute. Listen. . . can't you hear it?\""
+					"\"I often hear the thin, monotonous piping of a demonic flute. Listen . . . can't you hear it?\""
 				],
 				[
 					"8",
@@ -616,7 +616,7 @@
 				],
 				[
 					"161\u2013170",
-					"\"I often hear the thin, monotonous piping of a demonic flute. Listen. . . can't you hear it?\""
+					"\"I often hear the thin, monotonous piping of a demonic flute. Listen . . . can't you hear it?\""
 				],
 				[
 					"171\u2013180",

--- a/trap/James Introcaso; 20 New Traps.json
+++ b/trap/James Introcaso; 20 New Traps.json
@@ -15,7 +15,7 @@
 			}
 		],
 		"dateAdded": 1581466476,
-		"dateLastModified": 1584188881
+		"dateLastModified": 1585422724
 	},
 	"trap": [
 		{
@@ -92,7 +92,7 @@
 			"trapHazType": "MAG",
 			"entries": [
 				"This trap appears in 10-foot wide and smaller corridors. Stone arms are carved into the walls. A character notices subtle movement in the arms with a DC 15 Wisdom ({@skill Perception}) check. Creatures wearing a special amulet designed by the trap's maker can move through the corridor without triggering the trap.",
-				"When a creature has moved to the center of the corridor, the trap is triggered. At the start of the round the arms make attack rolls with a {@atk 5|+5 bonus}, grasping at all creatures adjacent to the walls of the corridor. A successful attack deals 11 ({@dice 2d10}) bludgeoning damage to a creature and it is {@condition grappled} by the arms (escape DC 14). While grappled in this way the creature is also {@condition restrained}.",
+				"When a creature has moved to the center of the corridor, the trap is triggered. At the start of the round the arms make attack rolls with a {@hit 5|+5 bonus}, grasping at all creatures adjacent to the walls of the corridor. A successful attack deals 11 ({@dice 2d10}) bludgeoning damage to a creature and it is {@condition grappled} by the arms (escape DC 14). While grappled in this way the creature is also {@condition restrained}.",
 				"Dealing 10 damage to the arms grasping a creature with a single attack or spell causes the arms to let go of that creature (AC 17)."
 			]
 		},
@@ -158,7 +158,7 @@
 			"trapHazType": "MECH",
 			"entries": [
 				"A large scythe drops from the ceiling and swings back and forth in a line 5 feet wide and 20 feet long when a hidden pressure plate in the room is pressed. Any weight of more than 20 pounds placed on the pressure plate triggers the trap. The pressure plate can be spotted with a DC 15 Wisdom ({@skill Perception}) check. A character studying the area can determine the pressure plate is a slightly different color than the rest of the floor with a DC 15 Intelligence ({@skill Investigation}) check and that the ceiling holds the outline of a trapdoor (from which the trap's blade springs forth) with a DC 20 Intelligence ({@skill Investigation}) check. Wedging an {@item iron spike|phb} or other object under the pressure plate prevents the trap from activating and attempting to open the compartment in the ceiling results in the trap activating.",
-				"Once the trap is triggered it acts at the start of every round. The scythe makes an attack roll against creatures in its path with a {@atk 7|+7 bonus} to attack. On a hit the attack deals 33 ({@dice 6d10}) slashing damage.",
+				"Once the trap is triggered it acts at the start of every round. The scythe makes an attack roll against creatures in its path with a {@hit 7|+7 bonus} to attack. On a hit the attack deals 33 ({@dice 6d10}) slashing damage.",
 				"Some pressure plates are triggered to activate multiple pendulum scythes in a room or hall each of which runs along a different line and gets to make its own attacks at the start of the round."
 			]
 		},
@@ -171,7 +171,7 @@
 				"A nozzle connected to a vial of poison gas is hidden within a chest's lock or in something else that a creature might open. Opening the object without the proper key causes the nozzle to spring out, spraying poison.",
 				"When the trap is triggered the nozzle creates a 15-foot cone of gas originating from the lock. Creatures within the cone must make a DC 15 Constitution saving throw. Creatures who fail take 22 ({@dice 4d10}) poison damage and are {@condition poisoned} for 1 hour. Creatures who succeed take half damage and are not {@condition poisoned}.",
 				"A DC 20 Intelligence ({@skill Investigation}) check allows a character to deduce the trap's presence from alterations made to the lock to accommodate the nozzle and vial. A DC 15 Dexterity check using {@item thieves' tools|phb} disarms the trap, removing the nozzle and gas vial from the lock. Unsuccessfully attempting to pick the lock triggers the trap.",
-				"A DM can choose to have a different kind of {@filter inhaled poison|items|source=null|type=poison|search=inhaled} ({@book Dungeon Master's Guide page 257\u2013258|dmg|8|poisons}) within the lock. The effects and save DC for the poison change as appropriate."
+				"A DM can choose to have a different kind of {@filter inhaled poison|items|source=null|type=poison|search=inhaled} ({@book Dungeon Master's Guide page 257–258|dmg|8|poisons}) within the lock. The effects and save DC for the poison change as appropriate."
 			]
 		},
 		{
@@ -196,7 +196,7 @@
 			"entries": [
 				"This 20-foot-square area has been cursed with a ritual that forms tendrils of pure necrotic energy that hunger to feed on the living. The ritual is powered by an unholy symbol painted or carved into the ground at the center of the area. The tendrils live below the surface of the floor and wait for a living creature to walk into the area before attacking.",
 				"A character notices the trapped area and its immediate surroundings are slightly colder with a DC 10 Wisdom ({@skill Perception}) check. A character trained in {@skill Religion} can determine the meaning of the symbol with a DC 15 Intelligence ({@skill Religion}) check.",
-				"When a creature steps into the area, the tendrils rise from the ground and make an attack roll against that creature with a {@atk 8|+8 bonus}. On a hit the tendrils deal 22 ({@dice 4d10}) necrotic damage and the target is {@condition grappled} (escape DC 15). While {@condition grappled} in this way the target is also {@condition restrained}. The tendrils make new attacks at the start of each round against any creature in the area.",
+				"When a creature steps into the area, the tendrils rise from the ground and make an attack roll against that creature with a {@hit 8|+8 bonus}. On a hit the tendrils deal 22 ({@dice 4d10}) necrotic damage and the target is {@condition grappled} (escape DC 15). While {@condition grappled} in this way the target is also {@condition restrained}. The tendrils make new attacks at the start of each round against any creature in the area.",
 				"Dealing 15 damage to the tendrils grasping a creature with a single attack or spell causes the arms to let go of that creature (AC 15). Dealing any radiant damage to the tendrils causes them to disappear."
 			]
 		},
@@ -208,7 +208,7 @@
 			"entries": [
 				"Hidden behind a wall, this circular saw blade with a 5-foot-radius runs along a track in the wall, floor, or ceiling after a tripwire is activated.",
 				"The tripwire is 3 inches off the ground and stretches between two columns. A successful DC 15 Wisdom ({@skill Perception}) check spots the tripwire or the blades hidden deep within a slot in the walls. A DC 10 Wisdom ({@skill Perception}) check notices the deep grooves in the wall, ceiling, or floor that serve as the saw's track. A DC 15 Dexterity check made with {@item thieves' tools|phb} breaks the tripwire harmlessly. A character without {@item thieves' tools|phb}can attempt this check with disadvantage using any edged weapon or tool. On a failed check the trap triggers.",
-				"Once the trap is activated the saw moves 40 feet along its track at the start of a round. The saw makes an attack roll with a {@atk 6|+6 bonus} against any creature in its path. On a hit the creature takes 11 ({@dice 2d10}) slashing damage. If the saw gets to the end of its track, it switches direction and comes back the other way.",
+				"Once the trap is activated the saw moves 40 feet along its track at the start of a round. The saw makes an attack roll with a {@hit 6|+6 bonus} against any creature in its path. On a hit the creature takes 11 ({@dice 2d10}) slashing damage. If the saw gets to the end of its track, it switches direction and comes back the other way.",
 				"Some tripwires are triggered to activate multiple saws in a room or hall, each of which runs along a different track and gets to make its own attacks at the start of the round."
 			]
 		},


### PR DESCRIPTION
Worth taking a look at whatever script you're using to autocheck homebrew. Found a few erroneous conversions of `{@hit #}` to `{@atk #}`, which produces unintelligible and undesired results. File in question is `trap/James Introcaso; 20 New Traps.json`.