### PR TITLE
Fix inconsistent CRs for better CR filtering

### DIFF
--- a/collection/Modnar's Manual of Multiple Métier.json
+++ b/collection/Modnar's Manual of Multiple Métier.json
@@ -5369,7 +5369,7 @@
 			"languages": [
 				"None (cannot speak / write / read)"
 			],
-			"cr": "¼",
+			"cr": "1/4",
 			"trait": [
 				{
 					"name": "Active Defense",
@@ -5466,7 +5466,7 @@
 			"languages": [
 				"all languages known by its creator"
 			],
-			"cr": "¼",
+			"cr": "1/4",
 			"trait": [
 				{
 					"name": "Low Gear",
@@ -5582,7 +5582,7 @@
 			"languages": [
 				"None (the construct itself cannot speak / write / read)"
 			],
-			"cr": "¼",
+			"cr": "1/4",
 			"trait": [
 				{
 					"name": "Wayfinder",

--- a/creature/Modnar; NPCs.json
+++ b/creature/Modnar; NPCs.json
@@ -19056,7 +19056,7 @@
 			"languages": [
 				"understands the languages but only Marcus (and Princess Clara) can understand it."
 			],
-			"cr": "1 and 125 Xp",
+			"cr": "2",
 			"trait": [
 				{
 					"name": "Home Sick",


### PR DESCRIPTION
If all homebrew is loaded, at present the range of CRs to filter on in the bestiary goes from "1 and 125 Xp" to "¼". This was due to issues in homebrew. The first had "1 and 125 Xp" where it should have been "2", and the other had "¼" where it should have been "1/4".