### PR TITLE
Added 11 cleric subclasses

### DIFF
--- a/subclass/Middle Finger of Vecna; Abyssal Domain.json
+++ b/subclass/Middle Finger of Vecna; Abyssal Domain.json
@@ -1,0 +1,182 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "mfovabyss",
+				"abbreviation": "MFoV",
+				"full": "Middle Finger of Vecna: Abyssal Domain",
+				"authors": [
+					"Middle Finger of Vecna"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "19.02.19",
+				"url": "https://mfov.magehandpress.com/2019/02/abyssal-domain.html",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Abyssal Domain",
+			"shortName": "Abyssal",
+			"class": "Cleric",
+			"source": "mfovabyss",
+			"subclassSpells": [
+				{
+					"name": "Command",
+					"source": "PHB"
+				},
+				{
+					"name": "Inflict Wounds",
+					"source": "PHB"
+				},
+				{
+					"name": "Ray of Enfeeblement",
+					"source": "PHB"
+				},
+				{
+					"name": "Scorching Ray",
+					"source": "PHB"
+				},
+				{
+					"name": "Lightning Bolt",
+					"source": "PHB"
+				},
+				{
+					"name": "Summon Lesser Demons",
+					"source": "XGE"
+				},
+				{
+					"name": "Dominate Beast",
+					"source": "PHB"
+				},
+				{
+					"name": "Summon Greater Demon",
+					"source": "XGE"
+				},
+				{
+					"name": "Enervation",
+					"source": "XGE"
+				},
+				{
+					"name": "Planar Binding",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Abyssal Domain",
+						"entries": [
+							"It is a common misconception that the members of demon-worshiping cults are all mindless slaves, crazed hedonists, or violent murderers. The truth is that many of them are perfectly sane, with dreams of enslaving demons for themselves, rather than the other way around. A select few are even strong enough to do so, rising through the ranks of their cult to become powerful priests and summoners, capable of calling upon armies of fiends and mortals alike to do their bidding.",
+							{
+								"type": "table",
+								"caption": "Abyssal Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell command}, {@spell inflict wounds}"
+									],
+									[
+										"3rd",
+										"{@spell ray of enfeeblement}, {@spell scorching ray}"
+									],
+									[
+										"5th",
+										"{@spell lightning bolt}, {@spell summon lesser demons|xge}"
+									],
+									[
+										"7th",
+										"{@spell dominate beast}, {@spell summon greater demon|xge}"
+									],
+									[
+										"9th",
+										"{@spell enervation|xge}, {@spell planar binding}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Blood Sacrifice",
+								"entries": [
+									"When you choose this domain at 1st level, you can use dark magic to siphon power from dying creatures. Whenever you reduce a hostile creature to 0 hit points, you gain temporary hit points equal to your Wisdom modifier. Furthermore, whenever you reduce a willing creature to 0 hit points, you gain temporary hit points equal to your cleric level plus twice your Wisdom modifier and have advantage on the first attack roll you make in the next minute. Creatures that you have summoned or dominated are always considered to be willing for the purposes of this ability."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Ruthless",
+								"entries": [
+									"Also at 1st level, the experience you have gained dealing with cunning fiends and treacherous cultists equips you well for future conflicts. Whenever you make a contested ability check against a creature, you can add twice your proficiency bonus to the roll."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Dust to Dust",
+								"entries": [
+									"Starting at 2nd level, you can use your Channel Divinity to augment your offensive spells, the better to unleash the infinite chaos of the Abyss on your foes.",
+									"When you cast a spell that deals damage to one or more creatures, you can use your Channel Divinity to add your Wisdom modifier to the damage. Any creature reduced to 0 hit points by this spell is disintegrated into a fine grey dust, along with anything it is wearing or carrying (except for magic items). The creature can be restored to life only by means of a {@spell true resurrection} or a {@spell wish} spell.",
+									"Any Large or smaller nonmagical object or a creation of magical force that would be hit by the spell is also disintegrated."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Binding of the Deep",
+								"entries": [
+									"At 6th level, you can use your Channel Divinity to chain demons to your will. When you cast a spell that summons demons, you present your holy symbol and use your Channel Divinity to bind them. Any demons bound in this way cannot break free from your control, and are never hostile towards you or your allies. The binding ends when you die."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Potent Spellcasting",
+								"entries": [
+									"At 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Demonic Ascendancy",
+								"entries": [
+									"When you reach 17th level, you infuse your soul with demonic energy, gaining immense power. You have resistance to cold, fire and lightning damage, and gain telepathy with a range of 120 feet."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Middle Finger of Vecna; Destruction Domain.json
+++ b/subclass/Middle Finger of Vecna; Destruction Domain.json
@@ -1,0 +1,181 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "mfovdestruction",
+				"abbreviation": "MFoV",
+				"full": "Middle Finger of Vecna: Destruction Domain",
+				"authors": [
+					"Middle Finger of Vecna"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "3.05.16",
+				"url": "https://mfov.magehandpress.com/2015/12/destruction-domain.html",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Destruction Domain",
+			"shortName": "Destruction",
+			"class": "Cleric",
+			"source": "mfovdestruction",
+			"subclassSpells": [
+				{
+					"name": "Burning Hands",
+					"source": "PHB"
+				},
+				{
+					"name": "Witch Bolt",
+					"source": "PHB"
+				},
+				{
+					"name": "Flame Blade",
+					"source": "PHB"
+				},
+				{
+					"name": "Scorching Ray",
+					"source": "PHB"
+				},
+				{
+					"name": "Lightning Bolt",
+					"source": "PHB"
+				},
+				{
+					"name": "Fireball",
+					"source": "PHB"
+				},
+				{
+					"name": "Blight",
+					"source": "PHB"
+				},
+				{
+					"name": "Wall of Fire",
+					"source": "PHB"
+				},
+				{
+					"name": "Cloudkill",
+					"source": "PHB"
+				},
+				{
+					"name": "Cone of Cold",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Destruction Domain",
+						"entries": [
+							"Some gods revel only in the crushing of walls and the burning of cities. The gods of destruction - such as Bane, Erythnul, Sirrion, and Maglubiyet - train their clerics to oppose the forces of creation. These deities need not be evil, but have a strong tendency toward chaos and enforcing the eternal cycle of death and rebirth.",
+							"Clerics who follow gods of destruction often have a deep personal connection with their chosen deity. In some cases, they were spared from destruction in order to wreak it upon others; in others, they have pleaded with the god for priesthood to destroy a single foe; other still simply worship their god out of fear.",
+							{
+								"type": "table",
+								"caption": "Destruction Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell burning hands}, {@spell witch bolt}"
+									],
+									[
+										"3rd",
+										"{@spell flame blade}, {@spell scorching ray}"
+									],
+									[
+										"5th",
+										"{@spell lightning bolt}, {@spell fireball}"
+									],
+									[
+										"7th",
+										"{@spell blight}, {@spell wall of fire}"
+									],
+									[
+										"9th",
+										"{@spell cloudkill}, {@spell cone of cold}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Bonus Proficiencies",
+								"entries": [
+									"At 1st level, you gain proficiency with one {@filter martial melee weapon|items|source=null|category=basic|type=martial weapon;melee weapon=sand} and one {@filter martial ranged weapon|items|source=null|category=basic|type=martial weapon;ranged weapon=sand} of your choice."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Devastation Initiate",
+								"entries": [
+									"At 1st level, you learn two {@filter evocation cantrips|spells|level=0|school=E} of your choice which count as cleric cantrips for you."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Ruin",
+								"entries": [
+									"By 2nd level, as a bonus action, you can visit destruction on a single creature you can see within 60 feet. This creature must make a Constitution saving throw. On a failed save, the creature's Armor Class is reduced by 4 for 1 minute, or is reduced by 2 on a successful save."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Havoc Spell",
+								"entries": [
+									"Starting at 6th level, when you deal damage to a creature with a spell, you can expend one cleric spell slot to deal bonus radiant damage to one creature that took damage from the spell. The extra damage is {@damage 2d6} for a 1st-level spell slot, plus {@dice 1d6} for each spell level higher than 1st, to a maximum of {@dice 5d6}."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Potent Spellcasting",
+								"entries": [
+									"At 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Baneful Spell",
+								"entries": [
+									"Beginning at 17th level, when you cast a cleric spell that deals damage, it ignores damage resistances. If a creature is immune to a damage dealt by your spell, it is treated as only having resistance against it. Additionally, your spells deal double damage against objects."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Middle Finger of Vecna; Dread Domain.json
+++ b/subclass/Middle Finger of Vecna; Dread Domain.json
@@ -1,0 +1,190 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "mfovdread",
+				"abbreviation": "MFoV",
+				"full": "Dread Domain",
+				"authors": [
+					"Middle Finger of Vecna"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "22.11.17",
+				"url": "https://mfov.magehandpress.com/2017/11/dread-domain.html?view=magazine",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Dread Domain",
+			"shortName": "Dread",
+			"class": "Cleric",
+			"source": "mfovdread",
+			"subclassSpells": [
+				{
+					"name": "Disguise Self",
+					"source": "PHB"
+				},
+				{
+					"name": "False Life",
+					"source": "PHB"
+				},
+				{
+					"name": "Detect Thoughts",
+					"source": "PHB"
+				},
+				{
+					"name": "See Invisibility",
+					"source": "PHB"
+				},
+				{
+					"name": "Fear",
+					"source": "PHB"
+				},
+				{
+					"name": "Slow",
+					"source": "PHB"
+				},
+				{
+					"name": "Greater Invisibility",
+					"source": "PHB"
+				},
+				{
+					"name": "Phantasmal Killer",
+					"source": "PHB"
+				},
+				{
+					"name": "Antilife Shell",
+					"source": "PHB"
+				},
+				{
+					"name": "Dream",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Dread Domain",
+						"entries": [
+							"Dread dwells deep within the heart of every man, a gloom that darkens the visage of the brave, and reduces cowards to outright terror. Dread is mankind's oldest and strongest emotion, and so it empowers sinister, antediluvian gods which thrive in the darkness. Clerics of Dread can seize the lingering anxiety within one's soul and drive it to terror, showing others their deepest fears and simply letting their psyche do its work.",
+							"Gods of the Dread Domain are Erebus, the Shadow Interminable, Somber, the Mourning God, and the Shroud, God of Death and Secrets.",
+							{
+								"type": "table",
+								"caption": "Dread Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell disguise self}, {@spell false life}"
+									],
+									[
+										"3rd",
+										"{@spell detect thoughts}, {@spell see invisibility}"
+									],
+									[
+										"5th",
+										"{@spell fear}, {@spell slow}"
+									],
+									[
+										"7th",
+										"{@spell greater invisibility}, {@spell phantasmal killer}"
+									],
+									[
+										"9th",
+										"{@spell antilife shell}, {@spell dream}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Bonus Proficiencies",
+								"entries": [
+									"When you choose this domain at 1st level, you have proficiency with {@filter martial weapons|items|source=null|category=basic|type=martial weapon} and {@filter heavy armor|items|source=null|category=basic|type=heavy armor}."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Frightful Visage",
+								"entries": [
+									"Also at 1st level, you can use your action to stare into the depths of a creature's soul, revealing flickering nightmares in your eyes. Choose a creature within 30 feet that you can see and that can also see you to make a Wisdom saving throw against your cleric spell save DC. On a failed save, the target is {@condition frightened} of you and can't move until the end of your next turn.",
+									"You can use this ability a number of times equal to your Wisdom modifier (a minimum of once) and regain all expended uses when you finish a long rest. When you reach 17th level in this class, you can use this ability at will."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Grim Exemplar",
+								"entries": [
+									"Starting at 2nd level, you can utter a prayer as a bonus action to become an envoy of dread. You gain the following benefits for 1 minute:",
+									{
+										"type": "list",
+										"items": [
+									"Your weapon attacks deal additional psychic damage equal to your Wisdom modifier.",
+									"Once on each of your turns, while you are in dim light or darkness, you can turn {@condition invisible} as a bonus action. This invisibility ends at the end of your turn, or when you make an attack roll or cast a spell. While invisible as a result of this feature, you move silently, regardless of the armor you are wearing.",
+									"You add double your proficiency bonus to any Charisma ({@skill Intimidation}) check you make."
+									    ]
+									}
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Heart of Terror",
+								"entries": [
+									"Starting at 6th level, your soul is intoxicated by the fear that your deity invokes. You can't be {@condition frightened}. In addition, any creature frightened by you is considered to be under the effects of the {@spell bane} spell for as long as they are frightened."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Divine Strike",
+								"entries": [
+									"At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra {@damage 1d8} psychic damage to the target. When you reach 14th level, the extra damage increases to {@dice 2d8}."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Aura of Dread",
+								"entries": [
+									"Starting at 17th level, you emanate an aura of sheer terror and dread. When you use your Frightful Visage ability, you affect any number of creatures that you choose within 30 feet of you. In addition to the normal effects on a failed save, creatures take {@damage 4d10} psychic damage, or half as much on a successful save."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Middle Finger of Vecna; Dream Domain.json
+++ b/subclass/Middle Finger of Vecna; Dream Domain.json
@@ -1,0 +1,174 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "mfovdream",
+				"abbreviation": "MFoV",
+				"full": "Dream Domain",
+				"authors": [
+					"Middle Finger of Vecna"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "23.01.16",
+				"url": "https://mfov.magehandpress.com/2016/01/dream-domain.html",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Dream Domain",
+			"shortName": "Dream",
+			"class": "Cleric",
+			"source": "mfovdream",
+			"subclassSpells": [
+				{
+					"name": "Charm Person",
+					"source": "PHB"
+				},
+				{
+					"name": "Sleep",
+					"source": "PHB"
+				},
+				{
+					"name": "Detect Thoughts",
+					"source": "PHB"
+				},
+				{
+					"name": "Phantasmal Force",
+					"source": "PHB"
+				},
+				{
+					"name": "Hypnotic Pattern",
+					"source": "PHB"
+				},
+				{
+					"name": "Speak with Dead",
+					"source": "PHB"
+				},
+				{
+					"name": "Confusion",
+					"source": "PHB"
+				},
+				{
+					"name": "Phantasmal Killer",
+					"source": "PHB"
+				},
+				{
+					"name": "Awaken",
+					"source": "PHB"
+				},
+				{
+					"name": "Dream",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Dream Domain",
+						"entries": [
+							"Understanding your dreams is to peek into a wider reality, occupied by spaces and beings scarcely imaginable to the waking mind. Clerics of Dreams venerate nameless, ancient gods that slumber unseen, whose very dreams send ripples throughout the multiverse. They feel the presence of these beings in their own dreams, and are unshakable in their conviction that they will one day awaken.",
+							"You understand that there is precious little difference between the visions we have when asleep and the wishes that consume us while awake, for the world that we live in is but a dream that we share. Ultimately, the power of one's dreams can supplant reality, for the two are not so different.",
+							{
+								"type": "table",
+								"caption": "Dream Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell charm person}, {@spell sleep}"
+									],
+									[
+										"3rd",
+										"{@spell detect thoughts}, {@spell phantasmal force}"
+									],
+									[
+										"5th",
+										"{@spell hypnotic pattern}, {@spell speak with dead}"
+									],
+									[
+										"7th",
+										"{@spell confusion}, {@spell phantasmal killer}"
+									],
+									[
+										"9th",
+										"{@spell awaken}, {@spell dream}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Dreamtelling",
+								"entries": [
+									"At 1st level, you can interpret the symbolism of a dream to learn what sort of fears, concerns, or prophecy inspired it. If a dream originates due to fear or stress on the part of the dreamer, you can gain insight into its reasoning, its emotional state, and something that looms large in its mind (such as something it worries over, loves, or hates.) If the dream is divine in origin, the dreamtelling acts as a {@spell commune} spell, with the question asked relating to a great fear or concern of the dreamer. After interpreting the dreams of a creature, you have advantage on Charisma checks you make against it for 1 hour."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Slumber",
+								"entries": [
+									"Starting at 2nd level, you can use your Channel Divinity as an action to force a creature you can see within 60 feet to fall into a deep magical sleep. This creature must make a Wisdom saving throw or fall {@condition unconscious} for up to 1 minute. Undead and creatures immune to being charmed automatically succeed this saving throw. The creature can reattempt this saving throw with advantage when it takes damage."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Living Nightmare",
+								"entries": [
+									"By 6th level, when you place a creature into a slumber, they toss and turn in the anguish of a fever dream. When a creature that is unconscious due to your Slumber feature begins its turn, you can choose for it to take {@damage 3d6} psychic damage. It does not reattempt its saving throw due to this damage. You do not kill the creature due to this damage; you can only reduce it to 1 hit point."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Potent Spellcasting",
+								"entries": [
+									"Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Dreamwalk",
+								"entries": [
+									"By 17th level, you can step through the world of dreams. In a ritual requiring 1 minute of concentration, choose a creature known to you that is currently sleeping on the same plane as you. You can become a messenger in the creature's dreams, as per the spell {@spell dream}, though you cannot make the messenger appear monstrous and terrifying. You can then teleport to the creature's bedside."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Middle Finger of Vecna; Peace Domain.json
+++ b/subclass/Middle Finger of Vecna; Peace Domain.json
@@ -1,0 +1,180 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "mfovpeace",
+				"abbreviation": "MFoV",
+				"full": "Peace Domain",
+				"authors": [
+					"Middle Finger of Vecna"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "06.01.16",
+				"url": "https://mfov.magehandpress.com/2016/01/peace-domain.html",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Peace Domain",
+			"shortName": "Peace",
+			"class": "Cleric",
+			"source": "mfovpeace",
+			"subclassSpells": [
+				{
+					"name": "Charm Person",
+					"source": "PHB"
+				},
+				{
+					"name": "Sanctuary",
+					"source": "PHB"
+				},
+				{
+					"name": "Calm Emotions",
+					"source": "PHB"
+				},
+				{
+					"name": "Hold Person",
+					"source": "PHB"
+				},
+				{
+					"name": "Protection from Energy",
+					"source": "PHB"
+				},
+				{
+					"name": "Tongues",
+					"source": "PHB"
+				},
+				{
+					"name": "Confusion",
+					"source": "PHB"
+				},
+				{
+					"name": "Freedom of Movement",
+					"source": "PHB"
+				},
+				{
+					"name": "Dominate Person",
+					"source": "PHB"
+				},
+				{
+					"name": "Dispel Evil and Good",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Peace Domain",
+						"entries": [
+							"Clerics of peace venerate the ideal of harmony, and search for nonviolent solutions to worldly problems whenever possible. However, they are not strictly pacifists. If a situation proves too dire, or if all other options are exhausted, these clerics may use violence, especially if it protects someone in need. Gods of this domain - including Eldath, Rao, and Majere - are almost exclusively good, as are their clerics.",
+							{
+								"type": "table",
+								"caption": "Peace Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell charm person}, {@spell sanctuary}"
+									],
+									[
+										"3rd",
+										"{@spell calm emotions}, {@spell hold person}"
+									],
+									[
+										"5th",
+										"{@spell protection from energy}, {@spell tongues}"
+									],
+									[
+										"7th",
+										"{@spell confusion}, {@spell freedom of movement}"
+									],
+									[
+										"9th",
+										"{@spell dominate person}, {@spell dispel evil and good}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Censure Evil",
+								"entries": [
+									"When you select this domain at 1st level, you can channel holy power from the divine planes to censure evil creatures. Your Turn Undead and Destroy Undead features also effect fey and fiends."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Pacifying Voice",
+								"entries": [
+									"At 1st level, you can magically speak in a booming voice, commanding attention and authority. You gain a bonus of half your proficiency bonus when you make a {@skill Persuasion} check to command other creatures. This benefit stacks with your proficiency bonus if you are already proficient in Persuasion."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Peacebond",
+								"entries": [
+									"Starting at 2nd level, as an action, you can pacify nearby creatures. Each creature within 30 feet of you must make a Wisdom saving throw. On a failed save, the creature's weapons and ammunition become locked in their sheaths, quivers, or holsters for 1 minute. During this time, a creature may only free their weapon with a DC 18 Strength check."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Impede Aggressor",
+								"entries": [
+									"At 6th level, as a reaction when a creature that you can see attacks a creature that has not yet taken a turn in combat, you can cause that attack roll to be made at disadvantage."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Divine Strike",
+								"entries": [
+									"At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra {@damage 1d8} radiant damage. When you reach 14th level, the extra radiant damage increases to {@damage 2d8}."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Pacifism",
+								"entries": [
+									"Beginning at 17th level, as an action you can create an aura of pure pacifism for up to 1 minute. Each creature within 15 feet of you makes attack rolls with disadvantage. On your turn, you must spend your action maintaining this effect, otherwise it ends. After using this feature, you must compete a long rest before using it again."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Middle Finger of Vecna; Pestilence Domain.json
+++ b/subclass/Middle Finger of Vecna; Pestilence Domain.json
@@ -1,0 +1,184 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "mfovpestilence",
+				"abbreviation": "MFoV",
+				"full": "Pestilence Domain",
+				"authors": [
+					"Middle Finger of Vecna"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "28.07.16",
+				"url": "https://mfov.magehandpress.com/2016/07/pestilence-domain.html",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Pestilence Domain",
+			"shortName": "Pestilence",
+			"class": "Cleric",
+			"source": "mfovpestilence",
+			"subclassSpells": [
+				{
+					"name": "Bane",
+					"source": "PHB"
+				},
+				{
+					"name": "Detect Poison and Disease",
+					"source": "PHB"
+				},
+				{
+					"name": "Blindness/Deafness",
+					"source": "PHB"
+				},
+				{
+					"name": "Protection from Poison",
+					"source": "PHB"
+				},
+				{
+					"name": "Bestow Curse",
+					"source": "PHB"
+				},
+				{
+					"name": "Remove Curse",
+					"source": "PHB"
+				},
+				{
+					"name": "Confusion",
+					"source": "PHB"
+				},
+				{
+					"name": "Blight",
+					"source": "PHB"
+				},
+				{
+					"name": "Contagion",
+					"source": "PHB"
+				},
+				{
+					"name": "Insect Plague",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Pestilence Domain",
+						"entries": [
+							"You worship gods who favor corruption and plague, the Domain of Pestilence, for, though you are ravaged by disease, it does not harm you. Like a virus, you move through the population, spreading your Festering Faith to all who will listen. Unlike a virus, there is no immune system from the Festering Faith, only complete acceptance.",
+							{
+								"type": "table",
+								"caption": "Pestilence Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell bane}, {@spell detect poison and disease}"
+									],
+									[
+										"3rd",
+										"{@spell blindness/deafness}, {@spell protection from poison}"
+									],
+									[
+										"5th",
+										"{@spell bestow curse}, {@spell remove curse}"
+									],
+									[
+										"7th",
+										"{@spell confusion}, {@spell blight}"
+									],
+									[
+										"9th",
+										"{@spell contagion}, {@spell insect plague}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Body of Plague",
+								"entries": [
+									"By 1st level, you have been in such close proximity to vectors of plague that you are immune to disease and being {@condition poisoned}. Additionally, you have proficiency with heavy armor."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Tumor",
+								"entries": [
+									"Starting at 1st level, your body sequesters its toxins in a bulbous protrusion. When a creature within 5 feet hits you with an attack, you can use your reaction to try to poison the creature with the tumor. The creature must make a Constitution saving throw or be {@condition poisoned} for 1 minute. The creature can reattempt this saving throw at the end of each of its turns, ending the effect on a success.",
+									"After using this ability, you must complete a short or long rest before using it again."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Infection",
+								"entries": [
+									"At 2nd level, your divinity carries disease. You can use your action to touch a creature within your reach, which must make a Constitution saving throw, and suffers one of the following diseases of your choice for one minute on a failed save. Since this ability induces a natural disease in its target, any effect that removes a disease or otherwise ameliorates a disease’s effects apply to it.",
+									"{@b Bloodmore}. The creature bleeds freely. Whenever the creature takes bludgeoning, piercing, or slashing damage, it takes an additional {@damage 1d8} damage.",
+									"{@b Deadleg}. The creature's legs stiffen and its movement slows. The creature can move a maximum of 15 feet or half its movement speed on its turn, whichever is lower, on its turn.",
+									"{@b Slaying Fever}. Frothing at the mouth with rage, the creature must use its action to attack a creature adjacent to it. If there is no such creature, the creature must move to the nearest creature it can see."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Fester",
+								"entries": [
+									"Starting at 6th level, whenever you deal necrotic or radiant damage, you can change the damage type to poison. In addition, you ignore damage resistance to poison damage. Creatures you target with spells or abilities are not immune to being diseased or {@condition poisoned}. Instead, a creature that is immune to disease or poison makes a saving throw against your effect with advantage."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Divine Strike",
+								"entries": [
+									"At 8th level, you gain the ability to infuse your weapon strikes with toxicity. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra {@damage 1d8} poison damage to the target. When you reach 14th level, the extra damage increases to {@damage 2d8}."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Viral Infection",
+								"entries": [
+									"At 17th level, when you use Infection, the target also has disadvantage on ability checks and saving throws using one ability score of your choice. Additionally, any time a target of Infection is within 5 feet of another creature, you can choose for the infection to jump to it. The creature must make a Constitution saving throw or be infected by the same disease as the target for 1 minute."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Middle Finger of Vecna; Travel Domain (Redux).json
+++ b/subclass/Middle Finger of Vecna; Travel Domain (Redux).json
@@ -1,0 +1,182 @@
+{
+  "_meta": {
+    "sources": [
+      {
+        "json": "mfovtravelredux",
+        "abbreviation": "MFoV",
+        "full": "Travel Domain (Redux)",
+        "authors": [
+          "Middle Finger of Vecna"
+        ],
+        "convertedBy": [
+          "EldritchTiefling"
+        ],
+        "version": "12.02.17",
+        "url": "https://mfov.magehandpress.com/2017/02/travel-domain-redux.html",
+        "targetSchema": "1.0.1"
+      }
+    ],
+    "dateAdded": 1589921529,
+    "dateLastModified": 1589921529
+  },
+  "subclass": [
+    {
+      "name": "Travel Domain (Redux)",
+      "shortName": "Travel",
+      "class": "Cleric",
+      "source": "mfovtravelredux",
+      "subclassSpells": [
+        {
+          "name": "Feather Fall",
+          "source": "PHB"
+        },
+        {
+          "name": "Longstrider",
+          "source": "PHB"
+        },
+        {
+          "name": "Find Steed",
+          "source": "PHB"
+        },
+        {
+          "name": "Misty Step",
+          "source": "PHB"
+        },
+        {
+          "name": "Fly",
+          "source": "PHB"
+        },
+        {
+          "name": "Haste",
+          "source": "PHB"
+        },
+        {
+          "name": "Dimension Door",
+          "source": "PHB"
+        },
+        {
+          "name": "Mordenkainen's Private Sanctum",
+          "source": "PHB"
+        },
+        {
+          "name": "Passwall",
+          "source": "PHB"
+        },
+        {
+          "name": "Teleportation Circle",
+          "source": "PHB"
+        }
+      ],
+      "subclassFeatures": [
+        [
+          {
+            "name": "Travel Domain",
+            "entries": [
+              "The realm of vagabonds, merchants, and adventurers, the gods of the travel domain – including Parcel and Risk in Manifest – are popular among any who frequent the roads or sail the seas. Evangelicals and the traveling priests of inhospitable regions also tend to represent the gods of travel.",
+              {
+                "type": "table",
+                "name": "Travel Domain Spells",
+                "colLabels": [
+                  "Cleric Level",
+                  "Spells"
+                ],
+                "colStyles": [
+                  "col-3 text-center",
+                  "col-9"
+                ],
+                "rows": [
+                  [
+                    "1st",
+                    "{@spell longstrider}, {@spell feather fall}"
+                  ],
+                  [
+                    "3rd",
+                    "{@spell find steed}, {@spell misty step}"
+                  ],
+                  [
+                    "5th",
+                    "{@spell fly}, {@spell haste}"
+                  ],
+                  [
+                    "7th",
+                    "{@spell dimension door}, {@spell mordenkainen's private sanctum}"
+                  ],
+                  [
+                    "9th",
+                    "{@spell passwall}, {@spell teleportation circle}"
+                  ]
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Bonus Proficiencies",
+                "entries": [
+                  " When you choose this domain at 1st level, you gain proficiency with four finesse or ranged weapons of your choice. Additionally, you learn the {@spell message} cantrip."
+                ]
+              },
+              {
+                "type": "entries",
+                "name": "Trailblazer",
+                "entries": [
+                  "At 1st level, your movement speed increases by 5 feet. This movement bonus increases by 5 feet at 8th level (10 feet), and again at 14th level (15 feet).",
+                  "Additionally, moving through nonmagical difficult terrain costs you no extra movement, and you have advantage on saving throws against spells that restrict movement, such as {@spell entangle} or {@spell hold person}."
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "entries": [
+              {
+                "type": "entries",
+                "name": "Channel Divinity: Tail Wind",
+                "entries": [
+                  "Starting at 2nd level, as a bonus action, you can use your Channel Divinity to grant up to 5 creatures that you can see within 60 feet you choose a temporary boost of speed. For the next hour, the base movement speed of each creature affected increases by 10 feet."
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "entries": [
+              {
+                "type": "entries",
+                "name": "Freedom of the Road",
+                "entries": [
+                  "At 6th level, as a bonus action, you can speak a prayer to the winds to clear your path of adversaries. Each creature that you choose within 20 feet of you must make a Strength saving throw or be pushed 15 feet away from you and knocked {@condition prone}. Creatures that are Huge or larger have advantage on this saving throw.",
+                  "You can use this feature a number of times equal to your Wisdom modifier (a minimum of 1). You regain all uses of this feature when you finish a short or long rest."
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "entries": [
+              {
+                "name": "Divine Smite",
+                "entries": [
+                  "At 8th level, you gain the ability to infuse your weapon strikes with extra kinetic energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra {@damage 1d8} force damage to the target. When you reach 14th level, the extra damage increases to {@dice 2d8}."
+                ]
+              }
+            ]
+          }
+        ],
+        [
+          {
+            "entries": [
+              {
+                "name": "Nomad",
+                "entries": [
+                  "At 17th level, you are more at home on the road than anywhere else. Opportunity attacks made against you automatically miss."
+                ]
+              }
+            ]
+          }
+        ]
+      ]
+    }
+  ]
+}

--- a/subclass/SwordMeow; Wind Domain.json
+++ b/subclass/SwordMeow; Wind Domain.json
@@ -1,0 +1,190 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "winddomain",
+				"abbreviation": "Brew",
+				"full": "Wind Domain",
+				"authors": [
+					"SwordMeow"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "09.09.18",
+				"url": "https://drive.google.com/file/d/16tfcYJ9yvH5fPgNOXASOhQpKNCbLL_3i/view",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589918247,
+		"dateLastModified": 1589918247
+	},
+	"subclass": [
+		{
+			"name": "Wind Domain",
+			"shortName": "Wind",
+			"class": "Cleric",
+			"source": "winddomain",
+			"subclassSpells": [
+				{
+					"name": "Longstrider",
+					"source": "PHB"
+				},
+				{
+					"name": "Zephyr Strike",
+					"source": "XGE"
+				},
+				{
+					"name": "Gust of Wind",
+					"source": "PHB"
+				},
+				{
+					"name": "Warding Wind",
+					"source": "XGE"
+				},
+				{
+					"name": "Fly",
+					"source": "PHB"
+				},
+				{
+					"name": "Wind Wall",
+					"source": "PHB"
+				},
+				{
+					"name": "Dimension Door",
+					"source": "PHB"
+				},
+				{
+					"name": "Find Greater Steed",
+					"source": "XGE"
+				},
+				{
+					"name": "Control Winds",
+					"source": "XGE"
+				},
+				{
+					"name": "Steel Wind Strike",
+					"source": "XGE"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Wind Domain",
+						"entries": [
+							"The gods of the wind —including Auril, Fharlanghn, Zeboim, and The Traveler— value less attachment to places and people, and emphasize wanderlust and the following of one’s own heart and life. “I go where the wind takes me” is an often said phrase by adventurers, but none embody this as much as clerics of the wind domain. They seek to be truly free, casting off worries and domain. They seek to be truly free, casting off worries and downtrodden ties, embracing the beauty of following the wind.",
+							{
+								"type": "table",
+								"caption": "Wind Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell longstrider}, {@spell zephyr strike|XGE}"
+									],
+									[
+										"3rd",
+										"{@spell gust of wind}, {@spell warding wind|XGE}"
+									],
+									[
+										"5th",
+										"{@spell fly}, {@spell wind wall}"
+									],
+									[
+										"7th",
+										"{@spell dimension door}, {@spell find greater steed|XGE}"
+									],
+									[
+										"9th",
+										"{@spell control winds|XGE}, {@spell steel wind strike|XGE}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Hand of the Wild Wind",
+								"entries": [
+									"At 1st level, you gain the {@spell gust|xge} cantrip. The spell has a number of changes for you when you cast it:",
+									{
+										"type": "list",
+										"items": [
+									"It has a range of 60 feet.",
+									"You can choose Large or smaller creatures.",
+									"If a creature fails the Strength saving throw against being pushed, you can also magically deal {@damage 1d8} bludgeoning damage. This damage increases to {@dice 2d8} at 5th level, {@dice 3d8} at 11th, and {@dice 4d8} at 17th.",
+									"Instead of pushing a creature away when you deal damage, you can let the wild wind guide it. The creature moves 5 feet in a direction decided by the first d8 you roll for damage, instead of pushing it away from you. You can add your proficiency bonus to the result."
+									    ]
+									}
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Protection of the Great Gale",
+								"entries": [
+									"Also at 1st level, the wind swirls around you in protection. While you are not wearing armor, your AC equals 10 + your Dexterity modifier + your Wisdom modifier."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Arm of the Bracing Breeze",
+								"entries": [
+									"Starting at 2nd level, you can use your Channel Divinity to bring down a torrent of wind, forcing foes back or forwards with a mighty barrage of air.",
+									"As an action, you present your holy symbol and choose a circle with a radius of 15 feet within 30 feet of you. Any fire not created by a magical effect is extinguished, be it burning a creature or an object. Additionally, each Huge or smaller hostile creature in the circle must make a Strength saving throw. A creature is pushed or pulled (your choice when you use this feature) 10 feet towards or away from the center of the circle and knocked prone on a failed saving throw, or 5 feet on a successful one."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Grasp of the Carefree Cyclone",
+								"entries": [
+									"Beginning at 6th level, you can cast {@spell feather fall} at will, without expending a spell slot."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Potent Spellcasting",
+								"entries": [
+									"Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Wrath of the Terrifying Tornado",
+								"entries": [
+									"At 17th level, you can cast {@spell investiture of wind|XGE} as a bonus action. When you have its benefits, your flying speed is increased to 90 feet, you can cast {@spell gust|xge} as a bonus action, and you have advantage on Strength and Dexterity saving throws."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Valerion; Liberation Domain.json
+++ b/subclass/Valerion; Liberation Domain.json
@@ -1,0 +1,182 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "liberationdomain",
+				"abbreviation": "Brew",
+				"full": "Liberation Domain",
+				"authors": [
+					"/u/Valerion"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "3.2",
+				"url": "https://www.gmbinder.com/share/-LJL6V0eRCzMS7vkBpwZ/-LMO0qpj85f9GJBE-2go",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1589914515,
+		"dateLastModified": 1589914515
+	},
+	"subclass": [
+		{
+			"name": "Liberation Domain",
+			"shortName": "Liberation",
+			"class": "Cleric",
+			"source": "liberationdomain",
+			"subclassSpells": [
+				{
+					"name": "Longstrider",
+					"source": "PHB"
+				},
+				{
+					"name": "Sanctuary",
+					"source": "PHB"
+				},
+				{
+					"name": "Calm Emotions",
+					"source": "PHB"
+				},
+				{
+					"name": "Misty Step",
+					"source": "PHB"
+				},
+				{
+					"name": "Beacon of Hope",
+					"source": "PHB"
+				},
+				{
+					"name": "Remove Curse",
+					"source": "PHB"
+				},
+				{
+					"name": "Aura of Purity",
+					"source": "PHB"
+				},
+				{
+					"name": "Freedom of Movement",
+					"source": "PHB"
+				},
+				{
+					"name": "Dispel Evil and Good",
+					"source": "PHB"
+				},
+				{
+					"name": "Greater Restoration",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Liberation Domain",
+						"entries": [
+							"Gods and Goddesses of liberty -Libertas, Eleutheria, Haku, Lliira, and others- value freedom, change, self realization, and revolution. Clerics of the liberation domain frequently act as agents of change in kingdoms and communities, bringing new ideas and promoting forward progress against the status quo.",
+							{
+								"type": "table",
+								"caption": "Liberation Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell longstrider}, {@spell sanctuary}"
+									],
+									[
+										"3rd",
+										"{@spell calm emotions}, {@spell misty step}"
+									],
+									[
+										"5th",
+										"{@spell beacon of hope}, {@spell remove curse}"
+									],
+									[
+										"7th",
+										"{@spell aura of purity}, {@spell freedom of movement}"
+									],
+									[
+										"9th",
+										"{@spell dispel evil and good}, {@spell greater restoration}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Bonus Proficiencies",
+								"entries": [
+									"At 1st level, you gain proficiency with martial weapons. You also become proficient in two languages of your choice."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Freedom's Grace",
+								"entries": [
+									"Also at 1st level, you can move with divine speed to assist your allies. When a friendly creature within thirty feet of you that you can see is hit with an attack, you can use your reaction to move up to ten feet in their direction. This movement does not provoke attacks of opportunity.",
+									"You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Indomitable Spirit",
+								"entries": [
+									"Starting at 2nd level, you can use your Channel Divinity to empower your allies to resist the will of your foes. As an action, you present your Holy Symbol, and any ally within 30 feet may repeat a failed saving throw with advantage to end an on-going spell, magical effect, or condition."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Share Blessing",
+								"entries": [
+									"Beginning at 6th level, when you cast a spell targeting yourself, you can also affect a willing creature with the spell if they are within 30 feet of you. The spell level can be no higher than your proficiency bonus.",
+									"You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Divine Strike",
+								"entries": [
+									"At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra {@damage 1d8} radiant damage to the target. When you reach 14th level, the extra damage increases to {@dice 2d8}."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Righteous Rally",
+								"entries": [
+									"At 17th level, you become a symbol of resolve on the battlefield. As an action, you present your holy symbol and empower your allies. For one minute, whenever a friendly creature within 30 feet of you takes damage from a melee attack, they can use their reaction to shove their attacker five feet, and they gain advantage on the Strength ({@skill Athletics}) check. If they succeed on their check, they break free of any grapples and can make a single melee weapon attack. Once you use this feature, you can't use it again until you finish a short or long rest."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}

--- a/subclass/Vampirebagel; Dragon Domain.json
+++ b/subclass/Vampirebagel; Dragon Domain.json
@@ -1,0 +1,258 @@
+{
+ 	"_meta": {
+    	"sources": [
+    		{
+        		"json": "dragondomain",
+        		"abbreviation": "Brew",
+        		"full": "Dragon Domain",
+        		"authors": [
+          		"u/VampireBagel_"
+        		],
+        		"convertedBy": [
+		        "EldritchTiefling"
+		    	],
+        		"version": "20.03.19",
+        		"url": "https://drive.google.com/file/d/0B0igDzJwCf3eRXlkZkdsYVhtVXc/view",
+        		"targetSchema": "1.0.1"
+    		}
+    	],
+    	"dateAdded": 1589914515,
+    	"dateLastModified": 1589914515
+	},
+  		"subclass": [
+    		{
+      			"name": "Dragon Domain",
+      			"shortName": "Dragon",
+      			"class": "Cleric",
+      			"source": "dragondomain",
+      			"subclassSpells": [
+	        		{
+	         			"name": "Absorb Elements",
+	          			"source": "PHB"
+	        		},
+	       			{
+	          			"name": "Identify",
+	          			"source": "PHB"
+	        		},
+	        		{
+	         			"name": "Alter Self",
+	          			"source": "PHB"
+	        		},
+	        		{
+	          			"name": "Dragon's Breath",
+	         			"source": "PHB"
+	        		},
+	        		{
+			            "name": "Elemental Weapon",
+			            "source": "PHB"
+			        },
+			        {
+			            "name": "Fear",
+			            "source": "PHB"
+			        },
+			        {
+			            "name": "Leomund's Secret Chest",
+			            "source": "PHB"
+			        },
+			        {
+			            "name": "Mordenkainen's Private Sanctum",
+			            "source": "PHB"
+			        },
+			        {
+			            "name": "Legend Lore",
+			            "source": "PHB"
+			        },
+			        {
+			            "name": "Reincarnate",
+			            "source": "PHB"
+			        }
+			    ],
+	        "subclassFeatures": [
+	        	[
+	          		{
+			            "name": "Dragon Domain",
+			            "entries": [
+			              "Mighty creatures of awesome size and primal magics, dragons have inspired awe in the common folk for eons - sometimes being worshipped like gods, other times worshipped as gods: Bahamut the platinum dragon, Tiamat the rainbow wrym and Sardior the flawless. These god like beings imbue a fraction of their power unto their most devout followers.",
+			              	{
+				                "type": "table",
+				                "caption": "Dragon Domain Spells",
+				                "colLabels": [
+				                  "Cleric Level",
+				                  "Spells"
+				                ],
+				                "colStyles": [
+				                  "col-3 text-center",
+				                  "col-9"
+				                ],
+	                			"rows": [
+					                [
+					                    "1st",
+					                    "{@spell absorb elements|xge}, {@spell identify}"
+					                ],
+					                  [
+					                    "3rd",
+					                    "{@spell alter self}, {@spell dragon's breath|xge}"
+					                ],
+					                [
+					                    "5th",
+					                    "{@spell elemental weapon}, {@spell fear}"
+					                ],
+					                [
+					                    "7th",
+					                    "{@spell Leomund's secret chest}, {@spell Mordenkainen's private sanctum}"
+					                ],
+					                [
+					                    "9th",
+					                    "{@spell legend lore}, {@spell reincarnate}*"
+					                ]
+	                			],
+	                			"footnotes": [
+	                  				"*The target is always reincarnated as a Dragonborn"
+	                			]
+	              			},
+				            {
+				                "type": "entries",
+				                "name": "Bonus Proficiency",
+				                "entries": [
+				                  "At 1st level, you gain proficiency with martial weapons and heavy armour."
+				                ]
+				            },
+				            {
+				                "type": "entries",
+				                "name": "Dragon's Eye",
+				                "entries": [
+				                  "Also at 1st level, the cunning sight of your god has been passed onto you, You gain proficiency in the {@skill Perception} skill. Your proficiency bonus is doubled for any ability check that uses this skill."
+				                ]
+				            },
+	              {
+	                "type": "entries",
+	                "name": "Draconic Gift",
+	                "entries": [
+	                  "Choose a Dragon type from the Draconic Gift table. The damage type, breath weapon and colour associated with each dragon is used by features you gain later.",
+	                  {
+	                    "type": "table",
+	                    "colLabels": [
+	                      "Dragon",
+	                      "Damage Type",
+	                      "Breath Weapon"
+	                    ],
+	                    "colStyles": [
+	                      "col-2",
+	                      "col-3 text-center",
+	                      "col-7"
+	                    ],
+	                    "rows": [
+	                      [
+	                        "Black",
+	                        "Acid",
+	                        "5 by 30 ft. line (Dex Save)"
+	                      ],
+	                      [
+	                        "Blue",
+	                        "Lightning",
+	                        "5 by 30 ft. line (Dex Save)"
+	                      ],
+	                      [
+	                        "Brass",
+	                        "Fire",
+	                        "5 by 30 ft. line (Dex Save)"
+	                      ],
+	                      [
+	                        "Bronze",
+	                        "Lightning",
+	                        "5 by 30 ft. line (Dex Save)"
+	                      ],
+	                      [
+	                        "Copper",
+	                        "Acid",
+	                        "5 by 30 ft. line (Dex Save)"
+	                      ],
+	                      [
+	                        "Gold",
+	                        "Fire",
+	                        "15 ft. cone (Dex save)"
+	                      ],
+	                      [
+	                        "Green",
+	                        "Poison",
+	                        "15 ft. cone (Con save)"
+	                      ],
+	                      [
+	                        "Red",
+	                        "Fire",
+	                        "15 ft. cone (Dex save)"
+	                      ],
+	                      [
+	                        "Silver",
+	                        "Cold",
+	                        "15 ft. cone (Con save)"
+	                      ],
+	                      [
+	                        "White",
+	                        "Cold",
+	                        "15 ft. cone (Con save)"
+	                      ]
+	                    ]
+	                  }
+	                ]
+	              }
+	            ]
+	          }
+	        ],
+	        [
+	          {
+	            "entries": [
+	              {
+	                "type": "entries",
+	                "name": "Channel Divinity: Heart Of The Dragon",
+	                "entries": [
+	                  "At 2nd level, as an action, you can present your holy symbol and channel the draconic might of your gods into a destructive exhalation of energy. Your Draconic Gift determines the size, shape, and damage type of the exhalation.",
+	                  "When you use your breath weapon, each creature in the area of the exhalation must make a saving throw, the type of which is determined by your draconic gift. A creature takes {@dice 3d8} + your cleric level damage on a failed save, and half as much damage on a successful one."
+	                ]
+	              }
+	            ]
+	          }
+	        ],
+	        [
+	          {
+	            "entries": [
+	              {
+	                "type": "entries",
+	                "name": "Channel Divinity: Winged Form",
+	                "entries": [
+	                  "At 6th level, as a bonus action you may present your holy symbol and gain the gift of flight. A pair of dragon wings sprout from your back, granting you a flying speed equal to your current speed, your wings last for 1 minute before receding into your body.",
+	                  "You can't manifest your wings while wearing armor unless the armor is made to accommodate them, and clothing not made to accommodate your wings might be destroyed when you manifest them."
+	                ]
+	              }
+	            ]
+	          }
+	        ],
+	        [
+	          {
+	            "entries": [
+	              {
+	                "name": "Divine Strike",
+	                "entries": [
+	                  "At 8th level, you gain the ability to infuse your weapon strikes with divine energy. Once on each of your turns when you hit a creature with a weapon attack, you can cause the attack to deal an extra {@damage 1d8} damage type on the draconic gift table to the target. When you reach 14th level, the extra damage increases to {@damage 2d8}."
+	                ]
+	              }
+	            ]
+	          }
+	        ],
+	        [
+	          {
+	            "entries": [
+	              {
+	                "name": "Heart of the Dragon",
+	                "entries": [
+	                  "At 17th level, your gods have granted you a loyal draconic steed as a gift for your service. As an action, you can summon a dragon of your type, as per the {@spell find steed} spell. This dragon has the statistics of a {@creature Wyvern}, except its Intelligence and Charisma are 12, it has immunity to your dragon's damage type, and it lacks the Multiattack and Stinger actions.",
+	                  "Once you've summoned your dragon, you can't do so again until you finish a long rest."
+	                ]
+	              }
+	            ]
+	          }
+	        ]
+	      ]
+	    }
+	]
+}

--- a/subclass/zeek0; Ruin Domain.json
+++ b/subclass/zeek0; Ruin Domain.json
@@ -16,7 +16,8 @@
 				"targetSchema": "1.0.1"
 			}
 		],
-		"dateAdded": 1570573654
+		"dateAdded": 1589914515,
+		"dateLastModified": 1589914515 
 	},
 	"subclass": [
 		{

--- a/subclass/zeek0; Ruin Domain.json
+++ b/subclass/zeek0; Ruin Domain.json
@@ -1,0 +1,179 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "ruindomain",
+				"abbreviation": "Brew",
+				"full": "Ruin Domain",
+				"authors": [
+					"zeek0"
+				],
+				"convertedBy": [
+					"EldritchTiefling"
+				],
+				"version": "21.02.19",
+				"url": "https://drive.google.com/file/d/1n74fDG0Oo20-buFl0OIdtHpqpXEpkr0v/view",
+				"targetSchema": "1.0.1"
+			}
+		],
+		"dateAdded": 1570573654
+	},
+	"subclass": [
+		{
+			"name": "Ruin Domain",
+			"shortName": "Ruin",
+			"class": "Cleric",
+			"source": "ruindomain",
+			"subclassSpells": [
+				{
+					"name": "Bane",
+					"source": "PHB"
+				},
+				{
+					"name": "Dissonant Whispers",
+					"source": "PHB"
+				},
+				{
+					"name": "Ray of Enfeeblement",
+					"source": "PHB"
+				},
+				{
+					"name": "Shatter",
+					"source": "PHB"
+				},
+				{
+					"name": "Bestow Curse",
+					"source": "PHB"
+				},
+				{
+					"name": "Dispel Magic",
+					"source": "PHB"
+				},
+				{
+					"name": "Confusion",
+					"source": "PHB"
+				},
+				{
+					"name": "Blight",
+					"source": "PHB"
+				},
+				{
+					"name": "Contagion",
+					"source": "PHB"
+				},
+				{
+					"name": "Destructive Wave",
+					"source": "PHB"
+				}
+			],
+			"subclassFeatures": [
+				[
+					{
+						"name": "Ruin Domain",
+						"entries": [
+							"Ruin is more and less than physical annihilation - something ruined has been left without value or is otherwise perverted. Gods of ruin — such as Barbatorum, The Devourer, Talos, Tharizdun, and Shiva — are agents of destruction and dissolution. They seek a more permanent state of decline in the world; that forces of destruction should always howl against the forces of creation. Followers of these gods may wish for only devastation of some object, idea, or system with no designs of creation. Others wish for a future of growth and uplift, but know that their part is only to precipitate loss and defeat.",
+							{
+								"type": "table",
+								"caption": "Ruin Domain Spells",
+								"colLabels": [
+									"Cleric Level",
+									"Spells"
+								],
+								"colStyles": [
+									"col-3 text-center",
+									"col-9"
+								],
+								"rows": [
+									[
+										"1st",
+										"{@spell bane}, {@spell dissonant whispers}"
+									],
+									[
+										"3rd",
+										"{@spell ray of enfeeblement}, {@spell shatter}"
+									],
+									[
+										"5th",
+										"{@spell bestow curse}, {@spell dispel magic}"
+									],
+									[
+										"7th",
+										"{@spell confusion}, {@spell blight}"
+									],
+									[
+										"9th",
+										"{@spell contagion}, {@spell destructive wave}"
+									]
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Destruction",
+								"entries": [
+									"At 1st level, your god imbues your magic with greater powers to demolish and destroy. Damage you deal to objects with spells is doubled."
+								]
+							},
+							{
+								"type": "entries",
+								"name": "Dissolution",
+								"entries": [
+									"Also at 1st level, you are blessed with greater abilities to dissolve social and civil bonds. You gain proficiency in {@skill Deception}, and your proficiency bonus is doubled for any ability check you make that uses this skill."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Beget Entropy",
+								"entries": [
+									"Starting at 2nd level, you can use your channel divinity to create a field of accelerated entropy. As an action, you present your holy symbol and invoke the natural powers of reduction and fragmentation. For one minute, enemy creatures within 60 feet gain half the number of hit points or temporary hit points they would otherwise gain. In addition, when a creature or object within range takes damage you can use your reaction to cause them to take an additional amount of force damage equal to {@dice 1d8} + half your cleric level (rounded down)."
+                                ]
+                            }        		
+                        ]            	
+                    }                    			
+				],
+				[
+					{
+						"entries": [
+							{
+								"type": "entries",
+								"name": "Channel Divinity: Disruption",
+								"entries": [
+									"At 6th level, you may use your channel divinity to bring low your enemies' abilities of creation, thought, and deed. As a bonus action, you present your holy symbol and each enemy creature within 30 feet must make a Wisdom saving throw against your spell save DC. On a failed save, a target immediately loses concentration and has disadvantage on ability checks for one minute. At the end of each of its turns, an affected creature can make another Wisdom saving throw. On a success, the effect ends."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Potent Spellcasting",
+								"entries": [
+									"Starting at 8th level, you add your Wisdom modifier to the damage you deal with any cleric cantrip."
+								]
+							}
+						]
+					}
+				],
+				[
+					{
+						"entries": [
+							{
+								"name": "Cripple and Despoil",
+								"entries": [
+									"At 17th level, you can fracture and shatter the power of your enemies. When a creature within 30 feet would use a spell, action, or ability to deal damage, you can use your reaction to force the enemy creature to make a Constitution saving throw against your spell save DC. On a failed save that damage is negated, and damage caused by that spell, action, or ability is halved for 24 hours. If the damage source is a weapon it is sundered in this way until it is repaired, unless it is an artifact. On a successful save that damage is halved, with no lingering effects. Once you use this feature, you can't use it again until you finish a short or long rest."
+								]
+							}
+						]
+					}
+				]
+			]
+		}
+	]
+}


### PR DESCRIPTION
Added to the subclasses folder:

Vampirebagel; Dragon Domain.json 
Valerion; Liberation Domain.json 
SwordMeow; Wind Domain.json |
Middle Finger of Vecna; Travel Domain (Redux).json 
Middle Finger of Vecna; Pestilence Domain.json 
Middle Finger of Vecna; Peace Domain.json 
Middle Finger of Vecna; Dream Domain.json 
Middle Finger of Vecna; Dread Domain.json 
Middle Finger of Vecna; Destruction Domain.json 
Middle Finger of Vecna; Abyssal Domain.json

