### PR TITLE
Changelog

### DIFF
--- a/subclass/Middle Finger of Vecna; Chronomancy Update.json
+++ b/subclass/Middle Finger of Vecna; Chronomancy Update.json
@@ -8,16 +8,20 @@
 				"authors": [
 					"Middle Finger of Vecna"
 				],
+				"convertedBy": [
+					"Anonymous",
+					"ldsmadman"
+				],
 				"full": "Chronomancy Update",
 				"url": "http://mfov.magehandpress.com/p/blog-page.html",
-				"version": "2017.02.24"
+				"version": "2020.05.23"
 			}
 		],
 		"optionalFeatureTypes": {
 			"Pact": "Pact Boon"
 		},
 		"dateAdded": 1545342498,
-		"dateLastModified": 1545342498
+		"dateLastModified": 1590260403
 	},
 	"subclass": [
 		{
@@ -72,7 +76,7 @@
 								"entries": [
 									"By 14th level, you are experienced at hunting colossal creatures with weapons of the same scale.",
 									"You can construct a massive weapon with 1 week of work requiring twice the normal weapon's price in gold, or you can commission one from a blacksmith for a comparable price. You have proficiency in a massive weapon if you have proficiency in its normal counterpart.",
-									"Massive weapons deal twice the number of damage dice as their normal counterparts. When you score a critical hit using a massive weapon against a creature, it must make a Constitution saving throw (DC = 8 + your Strength modifier + your proficiency bonus) or be stunned until the beginning of your next turn. While you are raging, you may attack with massive weapons normally. Otherwise, you may only attack with a massive weapon once each turn."
+									"Massive weapons deal twice the number of damage dice as their normal counterparts. When you score a critical hit using a massive weapon against a creature, it must make a Constitution saving throw (DC = 8 + your Strength modifier + your proficiency bonus) or be {@condition stunned} until the beginning of your next turn. While you are raging, you may attack with massive weapons normally. Otherwise, you may only attack with a massive weapon once each turn."
 								]
 							}
 						]
@@ -255,7 +259,7 @@
 							{
 								"name": "Grandfather Paradox",
 								"entries": [
-									"At 14th level, your knowledge of the future allows you to exploit some of the rules of spacetime. As an action, you can cause that creature to make an Intelligence saving throw. On a failed save, you goad the creature into causing a paradox. For {@dice 1d6} rounds the creature is incapacitated, locked between two opposing states while the paradox sorts itself out. The creature is unaffected on a successful save. Once you use this feature, you can't use it again until you finish a long rest."
+									"At 14th level, your knowledge of the future allows you to exploit some of the rules of spacetime. As an action, you can cause that creature to make an Intelligence saving throw. On a failed save, you goad the creature into causing a paradox. For {@dice 1d6} rounds the creature is {@condition incapacitated}, locked between two opposing states while the paradox sorts itself out. The creature is unaffected on a successful save. Once you use this feature, you can't use it again until you finish a long rest."
 								]
 							}
 						]
@@ -499,6 +503,9 @@
 			"entries": [
 				"Choose a willing creature that you can see within range. During its next turn, the target gains an additional action. That action can be used only to take the {@action Attack} (one weapon attack only), {@action Dash}, {@action Disengage}, {@action Hide}, or {@action Use an Object} action."
 			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -508,7 +515,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -565,7 +572,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -573,6 +580,9 @@
 			},
 			"miscTags": [
 				"SGT"
+			],
+			"areaTags": [
+				"ST"
 			]
 		},
 		{
@@ -608,6 +618,12 @@
 				"A creature you touch must succeed on a Wisdom saving throw or become cursed indefinitely. While under the influence of this curse, the target ages at twice their normal rate, becoming two days older for every day that passes. In addition, they have disadvantage on all Strength checks and saving throws.",
 				"A {@spell remove curse} spell ends this effect."
 			],
+			"areaTags": [
+				"ST"
+			],
+			"savingThrow": [
+				"wisdom"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -617,12 +633,15 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
-			}
+			},
+			"miscTags": [
+				"PRM"
+			]
 		},
 		{
 			"name": "Curse of Youth",
@@ -663,8 +682,8 @@
 			},
 			"entries": [
 				"This spell reverses time for a creature that you can see within range until it becomes a helpless baby. An unwilling creature must make a Wisdom saving throw to avoid the effect. Shapechangers and creatures that do not experience infancy automatically succeed on this saving throw.",
-				"If the target drops to 0 hit points, it reverts back to its ‘normal' age, and excess damage carries over to its normal form. As long as the excess damage doesn't reduce the creature's normal form to 0 hit points, it isn't knocked unconscious.",
-				"The target retains all of its game statistics except its base movement speed and hit points, which are changed to 10 feet and half of the target's maximum, respectively. It cannot take any actions, bonus actions or reactions, cannot cast spells and cannot communicate, except by crying (a person using the spell comprehend languages or similar abilities can interpret such crying to gain a rough understanding of the baby's emotional state). While under the effects of this spell, the target is prone and cannot stand up without the help of an adult.",
+				"If the target drops to 0 hit points, it reverts back to its ‘normal' age, and excess damage carries over to its normal form. As long as the excess damage doesn't reduce the creature's normal form to 0 hit points, it isn't knocked {@condition unconscious}.",
+				"The target retains all of its game statistics except its base movement speed and hit points, which are changed to 10 feet and half of the target's maximum, respectively. It cannot take any actions, bonus actions or reactions, cannot cast spells and cannot communicate, except by crying (a person using the spell {@spell comprehend languages} or similar abilities can interpret such crying to gain a rough understanding of the baby's emotional state). While under the effects of this spell, the target is {@condition prone} and cannot stand up without the help of an adult.",
 				"The target's gear is unaffected by this spell; it will likely fall off the target due to being vastly oversized."
 			],
 			"entriesHigherLevel": [
@@ -675,6 +694,15 @@
 					]
 				}
 			],
+			"conditionInflict": [
+				"prone"
+			],
+			"savingThrow": [
+				"wisdom"
+			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -684,14 +712,15 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
 			},
 			"miscTags": [
-				"SGT"
+				"SGT",
+				"SCL"
 			]
 		},
 		{
@@ -728,6 +757,12 @@
 			"entries": [
 				"You briefly rewind the thoughts a creature of your choice that you can see within range. The target must succeed on a Wisdom saving throw. A creature that took no actions on its previous turn automatically succeeds this saving throw. On a failed save, the target on its next turn must repeat the actions it performed in its previous turn. It can use its reaction as normal; it is not forced to repeat a reaction it made previously. If the situation has changed in such a way that the subject can't take the same actions again, the subject stands still and takes no actions or bonus actions for 1 round."
 			],
+			"savingThrow": [
+				"wisdom"
+			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -737,7 +772,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					},
@@ -791,6 +826,12 @@
 			"entries": [
 				"You briefly slow time for a creature of your choice that you can see within range. The target must succeed on a Wisdom saving throw or be moved to last place in the initiative order from the beginning of the next round onwards."
 			],
+			"savingThrow": [
+				"wisdom"
+			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -800,7 +841,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -859,15 +900,12 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
-			},
-			"miscTags": [
-				"SGT"
-			]
+			}
 		},
 		{
 			"name": "Enhance Reflexes",
@@ -917,6 +955,10 @@
 					]
 				}
 			],
+			"areaTags": [
+				"ST",
+				"MT"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -926,14 +968,15 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
 			},
 			"miscTags": [
-				"SGT"
+				"SGT",
+				"SCL"
 			]
 		},
 		{
@@ -957,7 +1000,10 @@
 			"components": {
 				"v": true,
 				"s": true,
-				"m": "a quartz crystal worth at least 100 gp"
+				"m": {
+					"text": "a quartz crystal worth at least 100 gp",
+					"cost": 10000
+				}
 			},
 			"duration": [
 				{
@@ -970,6 +1016,12 @@
 			"entries": [
 				"You point your finger and fire a pale blue ray at a Small or smaller nonmangical object that you can see within range. Make a ranged spell attack against the target. On a hit, the target is erased from time.",
 				"No trace remains of the erased object and the memory any creature (except the caster) that knew of its existence is altered to reflect the fact that the object never existed. If anything else in the world would not make sense in the absence of the object, history is re-written to explain it. The DM determines the new version of events. Generally, this spell makes the smallest possible change that would provide a plausible explanation."
+			],
+			"areaTags": [
+				"ST"
+			],
+			"spellAttack": [
+				"R"
 			],
 			"entriesHigherLevel": [
 				{
@@ -988,14 +1040,16 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
 			},
 			"miscTags": [
-				"SGT"
+				"SGT",
+				"SCL",
+				"PRM"
 			]
 		},
 		{
@@ -1035,7 +1089,13 @@
 			},
 			"entries": [
 				"You touch a willing creature. Until the spell ends, the target gains a superhuman ability to dodge attacks. The target's AC becomes 22, if it were lower, regardless of what kind of armor it is wearing.",
-				"This spell puts enormous strain on the target's body. After the spell ends, the target gains one level of exhaustion."
+				"This spell puts enormous strain on the target's body. After the spell ends, the target gains one level of {@condition exhaustion}."
+			],
+			"conditionInflict": [
+				"exhaustion"
+			],
+			"areaTags": [
+				"ST"
 			],
 			"classes": {
 				"fromClassList": [],
@@ -1046,7 +1106,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					},
@@ -1083,7 +1143,10 @@
 			"components": {
 				"v": true,
 				"s": true,
-				"m": "an hourglass and a glass eye worth at least 100gp"
+				"m": {
+					"text": "an hourglass and a glass eye worth at least 100gp",
+					"cost": 10000
+				}
 			},
 			"duration": [
 				{
@@ -1100,7 +1163,7 @@
 				"chronomancy": true
 			},
 			"entries": [
-				"You cast your senses back in time to perceive your current location as it was at some point in the past, including any events that were happening at that time. You must specify the exact time you wish to see, which cannot be more than 100 years ago. When viewing the past, it appears dreamlike and shadowy, but you are able to discern detail and hear conversation as normal, and any special senses you possess (such as darkvision) also work as normal.",
+				"You cast your senses back in time to perceive your current location as it was at some point in the past, including any events that were happening at that time. You must specify the exact time you wish to see, which cannot be more than 100 years ago. When viewing the past, it appears dreamlike and shadowy, but you are able to discern detail and hear conversation as normal, and any special senses you possess (such as {@sense darkvision}) also work as normal.",
 				"While perceiving the past, you can look in any direction, but you cannot move or speak and are unable to sense your present surroundings."
 			],
 			"entriesHigherLevel": [
@@ -1111,6 +1174,15 @@
 					]
 				}
 			],
+			"savingThrow": [
+				"wisdom"
+			],
+			"miscTags": [
+				"SCL"
+			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1120,7 +1192,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					},
@@ -1177,6 +1249,9 @@
 			"entries": [
 				"Choose a willing creature that you can see within range. Until the spell ends, the target's speed is tripled, it gains a +3 bonus to AC, it has advantage on Dexterity saving throws, and it gains an additional action on each of its turns. That action can be used only to take the {@action Attack} (one weapon attack only), {@action Dash}, {@action Disengage}, {@action Hide}, or {@action Use an Object} action."
 			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1186,7 +1261,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1237,6 +1312,13 @@
 				"If the creature attempts to cast a spell with a casting time of 1 action, roll a {@dice d20}. On a 16 or higher, the spell doesn't take effect until the creature's next turn, and the creature must use its action on that turn to complete the spell. If it can't, the spell is wasted. If the creature uses nonmagical wings to fly, it is unable to fly while under the influence of this spell. If it is airborne when the spell is cast, it lands safely at the start of its next turn.",
 				"A creature affected by this spell makes another Wisdom saving throw at the end of its turn. On a successful save, the effect ends for it."
 			],
+			"savingThrow": [
+				"wisdom"
+			],
+			"areaTags": [
+				"C",
+				"MT"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1246,7 +1328,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1294,7 +1376,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1348,6 +1430,9 @@
 				},
 				"You cannot damage or destroy a machine using this spell."
 			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1357,7 +1442,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1416,6 +1501,9 @@
 					]
 				}
 			],
+			"areaTags": [
+				"MT"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1425,14 +1513,15 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
 			},
 			"miscTags": [
-				"SGT"
+				"SGT",
+				"SCL"
 			]
 		},
 		{
@@ -1475,6 +1564,9 @@
 			"entries": [
 				"Choose up to three willing creatures that you can see within range. Until the spell ends, the targets' speeds are tripled, they gain a +3 bonus to AC, have advantage on Dexterity saving throws, and it gain an additional action on each of their turns. That action can be used only to take the {@action Attack} (one weapon attack only), {@action Dash}, {@action Disengage}, {@action Hide}, or {@action Use an Object} action."
 			],
+			"areaTags": [
+				"MT"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1484,7 +1576,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1532,9 +1624,9 @@
 					"type": "list",
 					"items": [
 						"Make an Intelligence check to remember information about something.",
-						"Make a Wisdom (Perception) check.",
-						"Take the Hide action.",
-						"Deploy a bag of caltrops.",
+						"Make a {@skill Perception|Wisdom (Perception)} check.",
+						"Take the {@action Hide} action.",
+						"Deploy a {@item caltrops (bag of 20)|phb|bag of caltrops}.",
 						"Draw or stow weapons and shields."
 					]
 				}
@@ -1548,7 +1640,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1575,7 +1667,11 @@
 			"components": {
 				"v": true,
 				"s": true,
-				"m": "gold dust worth at least 500gp, which the spell consumes"
+				"m": {
+					"text": "gold dust worth at least 500gp, which the spell consumes",
+					"consumed": true,
+					"cost": 50000
+				}
 			},
 			"duration": [
 				{
@@ -1589,6 +1685,9 @@
 			"entries": [
 				"You perform a long, complex ritual on another creature, reducing its apparent age by {@dice 3d10} years, to a minimum of 13 years. This effect does not extend the creature's lifespan."
 			],
+			"areaTags": [
+				"ST"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1598,7 +1697,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1651,6 +1750,13 @@
 					]
 				}
 			],
+			"areaTags": [
+				"ST",
+				"MT"
+			],
+			"miscTags": [
+				"SCL"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1660,7 +1766,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1713,6 +1819,9 @@
 					]
 				}
 			],
+			"savingThrow": [
+				"constitution"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1722,14 +1831,19 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
 			},
+			"areaTags": [
+				"ST",
+				"MT"
+			],
 			"miscTags": [
-				"SGT"
+				"SGT",
+				"SCL"
 			]
 		},
 		{
@@ -1752,7 +1866,10 @@
 			"components": {
 				"v": true,
 				"s": true,
-				"m": "a diamond hourglass filled with tiny gemstones or pearl dust, worth at least 45,000gp"
+				"m": {
+					"text": "a diamond hourglass filled with tiny gemstones or pearl dust, worth at least 45,000gp",
+					"cost": 4500000
+				}
 			},
 			"duration": [
 				{
@@ -1771,7 +1888,10 @@
 			"entries": [
 				"You create a transparent, spherical demiplane centered on yourself with a radius of 10 feet. Time within this demiplane passes significantly faster than time outside, allowing you to experience 24 hours of time while those outside only experience 1 hour.",
 				"No material can pass into or out of the demiplane, and no spell or effect created on one side of it can affect the other side.",
-				"If any creatures other than yourself and you familiar (if you have one) would be caught within the area of this spell, the spell fails."
+				"If any creatures other than yourself and your familiar (if you have one) would be caught within the area of this spell, the spell fails."
+			],
+			"areaTags": [
+				"S"
 			],
 			"classes": {
 				"fromClassList": [],
@@ -1782,7 +1902,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1825,9 +1945,16 @@
 				{
 					"name": "At Higher Levels",
 					"entries": [
-						"When you cast this spell using a spell slot of 6th level or higher, the healing increases by {@dice 1d4} for each slot level above 5th."
+						"When you cast this spell using a spell slot of 6th level or higher, the healing increases by {@scaledice 7d4|5-9|1d4} for each slot level above 5th."
 					]
 				}
+			],
+			"miscTags": [
+				"HL",
+				"SCL"
+			],
+			"areaTags": [
+				"ST"
 			],
 			"classes": {
 				"fromClassList": [],
@@ -1838,7 +1965,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
@@ -1880,6 +2007,15 @@
 				"Choose a creature that you can see within range. If the target has 150 hit points or fewer, it is {@condition paralyzed} and frozen in time, unaware of its surroundings. Otherwise, the spell has no effect.",
 				"The target must make a Wisdom saving throw at the end of each of its turns. On a successful save, this paralysis effect ends."
 			],
+			"areaTags": [
+				"ST"
+			],
+			"savingThrow": [
+				"wisdom"
+			],
+			"conditionInflict": [
+				"paralyzed"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -1889,14 +2025,15 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}
 				]
 			},
 			"miscTags": [
-				"SGT"
+				"SGT",
+				"PRM"
 			]
 		},
 		{
@@ -1934,8 +2071,11 @@
 				"chronomancy": true
 			},
 			"entries": [
-				"This spell enchants a physical missile, such as an arrow, bolt or sling bullet so that it freezes in time and space. You may reposition the missile as part of the action to cast the spell, and the spell may be used on magical or otherwise enchanted missiles.",
+				"This spell enchants a physical missile, such as an {@item arrow|phb}, {@item crossbow bolt|phb|bolt} or {@item sling bullet|phb} so that it freezes in time and space. You may reposition the missile as part of the action to cast the spell, and the spell may be used on magical or otherwise enchanted missiles.",
 				"The missile remains frozen in place until either a creature passes within 60 feet in front of it, something touches it, a strong wind blows upon it, the enchantment is dispelled or the duration ends. At that point, the missile moves suddenly, as if it was just fired or thrown. If a creature is in the line of fire, the missile makes an attack which adds your spell attack bonus to the attack roll, and does the basic damage of whatever missile type was used (missiles that vary by launcher use the highest possible damage dice)."
+			],
+			"areaTags": [
+				"ST"
 			],
 			"classes": {
 				"fromClassList": [],
@@ -1946,7 +2086,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					},
@@ -1984,7 +2124,10 @@
 			"components": {
 				"v": true,
 				"s": true,
-				"m": "a pair of hourglasses, worth at least 100gp each"
+				"m": {
+					"text": "a pair of hourglasses, worth at least 100gp each",
+					"cost": 20000
+				}
 			},
 			"duration": [
 				{
@@ -2013,6 +2156,9 @@
 					]
 				}
 			],
+			"areaTags": [
+				"C"
+			],
 			"classes": {
 				"fromClassList": [],
 				"fromSubclass": [
@@ -2022,7 +2168,7 @@
 							"source": "PHB"
 						},
 						"subclass": {
-							"name": "The Chronomancer",
+							"name": "Chronomancer",
 							"source": "MFOV:CP1"
 						}
 					}


### PR DESCRIPTION
Class Packs:
 - Prehistoric Warrior (barbarian subclass), Illiterate Intuition feature: updated description to be dynamic
 - Prehistoric Warrior (barbarian subclass), Massive Weapon Fighting feature: added @condition tag to "stunned"
 - The Future You (warlock subclass), Grandfather Paradox feature: added @condition tag to "incapacitated"

Spells:
 - Fixed the broken links in the spells for the Chronomancer subclass
 - Updated spell descriptions to be more dynamic
 - Added spell metadata (spell areas, scaling dice rolls, material costs, conditions inflicted, etc.) 
 - Temporal Bubble spell: Fixed typo ("you familiar" to "your familiar")
 - Erase spell: Fixed type ("nonmangical" to "nonmagical")