### PR TITLE
Update - v0.2

### DIFF
--- a/spell/Jessica Wolfman; The (Not Really) Complete Tome of Spells.json
+++ b/spell/Jessica Wolfman; The (Not Really) Complete Tome of Spells.json
@@ -1,16066 +1,17089 @@
 {
-	"_meta": {
-		"sources": [
-			{
-				"json": "NRCToS",
-				"abbreviation": "NRCToS",
-				"full": "The (Not Really) Complete Tome of Spells",
-				"url": "https://drive.google.com/file/d/0B0Qx4NeOkTzTZzhIQW1BdF9NM2c/view",
-				"version": "",
-				"authors": [
-					"Jessica Wolfman"
-				],
-				"convertedBy": [
-					"ldsmadman"
-				]
-			}
-		],
-		"dateAdded": 1590440677,
-		"dateLastModified": 1590440677
-	},
-	"monster": [
-		{
-			"name": "Colossus",
-			"shortName": "colossus",
-			"source": "NRCToS",
-			"page": 303,
-			"size": "G",
-			"type": "construct",
-			"alignment": [
-				"U"
-			],
-			"ac": [
-				{
-					"ac": 18,
-					"from": [
-						"natural armor"
-					]
-				}
-			],
-			"hp": {
-				"formula": "20d20 + 100",
-				"average": 310
-			},
-			"speed": {
-				"walk": 0
-			},
-			"str": 28,
-			"dex": 8,
-			"con": 20,
-			"int": 1,
-			"wis": 5,
-			"cha": 1,
-			"senses": [
-				"truesight (blind beyond this radius) 120 ft."
-			],
-			"passive": 7,
-			"resist": [
-				{
-					"resist": [
-						"bludgeoning",
-						"piercing",
-						"slashing"
-					],
-					"note": "from nonmagical weapons",
+  "_meta": {
+    "sources": [
+      {
+        "json": "NRCToS",
+        "abbreviation": "NRCToS",
+        "full": "The (Not Really) Complete Tome of Spells",
+        "url": "https://drive.google.com/file/d/0B0Qx4NeOkTzTZzhIQW1BdF9NM2c/view",
+        "version": "",
+        "authors": [
+          "Jessica Wolfman"
+        ],
+        "convertedBy": [
+          "ldsmadman"
+        ]
+      }
+    ],
+    "dateAdded": 1590440677,
+    "dateLastModified": 1596193416
+  },
+  "monster": [
+    {
+      "name": "Colossus",
+      "shortName": "colossus",
+      "source": "NRCToS",
+      "page": 303,
+      "size": "G",
+      "type": "construct",
+      "alignment": [
+        "U"
+      ],
+      "ac": [
+        {
+          "ac": 18,
+          "from": [
+            "natural armor"
+          ]
+        }
+      ],
+      "hp": {
+        "formula": "20d20 + 100",
+        "average": 310
+      },
+      "speed": {
+        "walk": 0
+      },
+      "str": 28,
+      "dex": 8,
+      "con": 20,
+      "int": 1,
+      "wis": 5,
+      "cha": 1,
+      "senses": [
+        "truesight (blind beyond this radius) 120 ft."
+      ],
+      "passive": 7,
+      "resist": [
+        {
+          "resist": [
+            "bludgeoning",
+            "piercing",
+            "slashing"
+          ],
+          "note": "from nonmagical weapons",
 					"cond": true
-				}
-			],
-			"conditionImmune": [
-				"blinded",
-				"charmed",
-				"deafened",
-				"exhaustion",
-				"frightened",
-				"petrified",
-				"poisoned",
-				"prone",
-				"stunned",
-				"unconscious"
-			],
-			"cr": "18",
-			"trait": [
-				{
-					"name": "Immutable Form",
-					"entries": [
-						"The colossus is immune to any spell or effect that would alter its form."
-					]
-				},
-				{
-					"name": "Siege Monster",
-					"entries": [
-						"The colossus deals double damage to objects and structures."
-					]
-				},
-				{
-					"name": "Magic Resistance",
-					"entries": [
-						"The colossus has advantage on saving throws against spells and other magical effects."
-					]
-				}
-			],
-			"action": [
-				{
-					"name": "Slam",
-					"entries": [
-						"{@atk mw} {@hit 15} to hit, reach 20 ft., one target. {@h}48 ({@damage 6d12 + 9}) bludgeoning damage."
-					]
-				}
-			],
-			"fluff": {
-				"entries": [
-					"Can be summoned/created by the {@spell rising colossus|nrctos} spell."
-				]
-			},
-			"traitTags": [
-				"Immutable Form",
-				"Magic Resistance",
-				"Siege Monster"
-			],
-			"senseTags": [
-				"U"
-			],
-			"damageTags": [
-				"B"
-			],
-			"miscTags": [
-				"MW",
-				"RCH"
-			],
-			"uniqueId": "2c8754ac208bc0f5dbec82bfa4dde5e6"
-		}
-	],
-	"spell": [
-		{
-			"name": "Aalldam's Waterspray",
-			"source": "NRCToS",
-			"page": 63,
-			"level": 3,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "line",
-				"distance": {
-					"type": "feet",
-					"amount": 50
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a beaker of water"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a high-pressure line of water, 50 feet long and 10 feet wide, which gushes out from your hands. All creatures within the area must make a Strength saving throw. A creature takes {@damage 4d8} bludgeoning damage and is knocked {@condition prone} on a failed saving throw, or half as much damage and remains standing on a successful one.",
-				"This spell can also be used to put out fires in a 20-foot cube centered on your target."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, you inflict an additional {@scaledice 4d8|3-9|1d8} damage for each slot level above 3rd."
-					]
-				}
-			],
-			"damageInflict": [
-				"bludgeoning"
-			],
-			"conditionInflict": [
-				"prone"
-			],
-			"savingThrow": [
-				"strength"
-			],
-			"areaTags": [
-				"C",
-				"L"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Coast"
-						}
-					}
-				]
-			},
-			"uniqueId": "7405c4779050442aaf33606983eca3d6"
-		},
-		{
-			"name": "Absorb Strength",
-			"source": "NRCToS",
-			"page": 63,
-			"level": 5,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "one ounce of meat"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Book of Vile Darkness}",
-				"You eat at least an ounce of fresh, raw meat from a once-living creature (beast, dragon, giant, humanoid, or monstrosity). You then gain a bonus to your Strength and Constitution equal to that creature's ability modifier for those attributes. For instance, if you eat the flesh of an owlbear (Strength 20, Constitution 17), you gain a +5 bonus to Strength and +3 bonus to Constitution. If the creature doesn't have a positive modifier for one of the attributes, you gain no bonus to your own corresponding attribute."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Fiend",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "82152d4a5872df9d4679b7e0fb54c66a"
-		},
-		{
-			"name": "Acid Fog",
-			"source": "NRCToS",
-			"page": 63,
-			"level": 5,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "powdered dried peas"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You create a 20-foot-radius sphere of fog centered on a point within range. The sphere spreads around corners, and its area is heavily obscured.",
-				"The area inside the fog is thick and cloying, and acts as difficult terrain. The fogs are also highly acidic. Each round a creature ends its turn in the fog, it takes {@damage 3d10} acid damage. It lasts for the duration or until a strong wind (20 miles per hour or more) disperses it.",
-				"If a target takes at least 10 points of damage and is wearing nonmagical armor, the armor's AC is permanently reduced by one level of effectiveness. If the armor is reduced to AC 10, it is destroyed. A spell such as {@spell repair|NRCToS} (q.v.) will fix the damage and restore the armor to its normal strength."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 6th level or higher, the radius of the fog increases by 10 feet for each slot level above 5th."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"S"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Swamp"
-						}
-					}
-				]
-			},
-			"uniqueId": "7c303ceb9325f6fa5c79c7283a540ab7"
-		},
-		{
-			"name": "Repair",
-			"source": "NRCToS",
-			"page": 299,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"An inanimate object you touch regains a number of hit points equal to {@dice 1d8} + your spellcasting ability modifier. This spell can be used to heal undead and constructs as well."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 2nd level or higher, the healing increases by {@scaledice 1d8|1-9|1d8} for each slot level above 1st."
-					]
-				}
-			],
-			"miscTags": [
-				"HL"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "59455d29026dad2799eec959b52339aa"
-		},
-		{
-			"name": "Acidball",
-			"source": "NRCToS",
-			"page": 64,
-			"level": 4,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 150
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a tiny ball of bat guano and caustic soda"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A yellowish blob of light flashes from your pointing finger to a point you choose within range and splashes outwards, drenching everyone nearby with droplets of acid. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes {@damage 8d6} acid damage on a failed save, or half as much damage on a successful one."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 5th level or higher, the damage increases by {@scaledice 8d6|4-9|1d6} for each slot level above 4th."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"areaTags": [
-				"S"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "aa5948540b05cba179c435f5c70faae1"
-		},
-		{
-			"name": "Acid Storm",
-			"source": "NRCToS",
-			"page": 64,
-			"level": 7,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 150
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"A storm made of gelatinous, acidic droplets appears in a location you choose within range. The area of the storm consists of up to ten 10-foot cubes, which you can arrange as you wish. Each cube must have at least once face adjacent to the face of another cube.",
-				"Each creature in the area must make a Dexterity saving throw. A creature takes {@damage 8d6} acid damage on a failed save, or half as much damage on a successful one, each round that the creature ends its turn in the storm and for one round afterwards. If a target takes at least 10 points of damage and is wearing nonmagical armor, the armor's AC is permanently reduced by one level of effectiveness. If the armor is reduced to AC 10, it is destroyed. A spell such as {@spell repair|NRCToS} (q.v.) will fix the damage and restore the armor to its normal strength."
-			],
-			"damageInflict": [
-				"acid"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"C"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "18271ac29afbbf8a0034c31c7485950d"
-		},
-		{
-			"name": "Acid Lash",
-			"source": "NRCToS",
-			"page": 64,
-			"level": 3,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "three drops of an acidic liquid"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a glowing line of vivid purple force that lashes out at your command towards a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes {@damage 4d10} acid damage and if the creature is Large or smaller, you pull it up to 10 feet closer to you."
-			],
-			"damageInflict": [
-				"acid"
-			],
-			"spellAttack": [
-				"M"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "e03268daa845491158b0752a75f9fb5f"
-		},
-		{
-			"name": "Acid Hands",
-			"source": "NRCToS",
-			"page": 64,
-			"level": 1,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 15
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"As you hold your hands with thumbs touching and fingers spread, a thin sheet of corrosive liquid shoots forth from your outstretched fingertips. Each creature in a 15-foot cone must make a Dexterity saving throw. A creature takes {@damage 3d8} acid damage on a failed save, or half as much on a successful one."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 2nd level or higher, the damage increases by {@scaledice 3d8|1-9|1d8} for each slot level above 1st."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Great Old One",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "69ab5c65b3a1d11d4e4342a2da9da3ee"
-		},
-		{
-			"name": "Aggressive Thundercloud",
-			"source": "NRCToS",
-			"page": 65,
-			"level": 2,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of wood that has been struck by lightning"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You summon a storm cloud that fits in a 5-foot square; it doesn't fill its space. It hovers 10 feet above the ground, but you can command it to rise to 20 feet or sink to ground level; no action is required by you. When you cast the spell and as a bonus action on your subsequent turns, you can move the cloud up to 20 feet and then direct it to send a thunderbolt at a single target within 10 feet of it. The target must make a Dexterity saving throw, taking {@damage 4d6} lightning damage on a failed save and no damage on a successful one. Anything within the cloud is lightly obscured, and it provides dim light to a 5-foot radius around it."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level or higher spell slot, you inflict an additional {@scaledice 4d6|2-9|1d6} damage for each slot level above 2nd."
-					]
-				}
-			],
-			"damageInflict": [
-				"lightning"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"areaTags": [
-				"Q"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Tempest",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Mountain"
-						}
-					}
-				]
-			},
-			"uniqueId": "de3efc2f94bf8866466c47864c92f008",
+        }
+      ],
+      "conditionImmune": [
+        "blinded",
+        "charmed",
+        "deafened",
+        "exhaustion",
+        "frightened",
+        "petrified",
+        "poisoned",
+        "prone",
+        "stunned",
+        "unconscious"
+      ],
+      "cr": "18",
+      "trait": [
+        {
+          "name": "Immutable Form",
+          "entries": [
+            "The colossus is immune to any spell or effect that would alter its form."
+          ]
+        },
+        {
+          "name": "Siege Monster",
+          "entries": [
+            "The colossus deals double damage to objects and structures."
+          ]
+        },
+        {
+          "name": "Magic Resistance",
+          "entries": [
+            "The colossus has advantage on saving throws against spells and other magical effects."
+          ]
+        }
+      ],
+      "action": [
+        {
+          "name": "Slam",
+          "entries": [
+            "{@atk mw} {@hit 15} to hit, reach 20 ft., one target. {@h}48 ({@damage 6d12 + 9}) bludgeoning damage."
+          ]
+        }
+      ],
+      "fluff": {
+        "entries": [
+          "Can be summoned/created by the {@spell rising colossus|nrctos} spell."
+        ]
+      },
+      "traitTags": [
+        "Immutable Form",
+        "Magic Resistance",
+        "Siege Monster"
+      ],
+      "senseTags": [
+        "U"
+      ],
+      "damageTags": [
+        "B"
+      ],
+      "miscTags": [
+        "MW",
+        "RCH"
+      ],
+      "uniqueId": "2c8754ac208bc0f5dbec82bfa4dde5e6"
+    }
+  ],
+  "spell": [
+    {
+      "name": "Aalldam's Waterspray",
+      "source": "NRCToS",
+      "page": 63,
+      "level": 3,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "line",
+        "distance": {
+          "type": "feet",
+          "amount": 50
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a beaker of water"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a high-pressure line of water, 50 feet long and 10 feet wide, which gushes out from your hands. All creatures within the area must make a Strength saving throw. A creature takes {@damage 4d8} bludgeoning damage and is knocked {@condition prone} on a failed saving throw, or half as much damage and remains standing on a successful one.",
+        "This spell can also be used to put out fires in a 20-foot cube centered on your target."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, you inflict an additional {@scaledice 4d8|3-9|1d8} damage for each slot level above 3rd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "bludgeoning"
+      ],
+      "conditionInflict": [
+        "prone"
+      ],
+      "savingThrow": [
+        "strength"
+      ],
+      "areaTags": [
+        "C",
+        "L"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Coast"
+            }
+          }
+        ]
+      },
+      "uniqueId": "7405c4779050442aaf33606983eca3d6"
+    },
+    {
+      "name": "Absorb Strength",
+      "source": "NRCToS",
+      "page": 63,
+      "level": 5,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "one ounce of meat"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Book of Vile Darkness}",
+        "You eat at least an ounce of fresh, raw meat from a once-living creature (beast, dragon, giant, humanoid, or monstrosity). You then gain a bonus to your Strength and Constitution equal to that creature's ability modifier for those attributes. For instance, if you eat the flesh of an owlbear (Strength 20, Constitution 17), you gain a +5 bonus to Strength and +3 bonus to Constitution. If the creature doesn't have a positive modifier for one of the attributes, you gain no bonus to your own corresponding attribute."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Fiend",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "82152d4a5872df9d4679b7e0fb54c66a"
+    },
+    {
+      "name": "Acid Fog",
+      "source": "NRCToS",
+      "page": 63,
+      "level": 5,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "powdered dried peas"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You create a 20-foot-radius sphere of fog centered on a point within range. The sphere spreads around corners, and its area is heavily obscured.",
+        "The area inside the fog is thick and cloying, and acts as difficult terrain. The fogs are also highly acidic. Each round a creature ends its turn in the fog, it takes {@damage 3d10} acid damage. It lasts for the duration or until a strong wind (20 miles per hour or more) disperses it.",
+        "If a target takes at least 10 points of damage and is wearing nonmagical armor, the armor's AC is permanently reduced by one level of effectiveness. If the armor is reduced to AC 10, it is destroyed. A spell such as {@spell repair|NRCToS} (q.v.) will fix the damage and restore the armor to its normal strength."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 6th level or higher, the radius of the fog increases by 10 feet for each slot level above 5th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "S"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Swamp"
+            }
+          }
+        ]
+      },
+      "uniqueId": "7c303ceb9325f6fa5c79c7283a540ab7"
+    },
+    {
+      "name": "Repair",
+      "source": "NRCToS",
+      "page": 299,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "An inanimate object you touch regains a number of hit points equal to {@dice 1d8} + your spellcasting ability modifier. This spell can be used to heal undead and constructs as well."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 2nd level or higher, the healing increases by {@scaledice 1d8|1-9|1d8} for each slot level above 1st."
+          ]
+        }
+      ],
+      "miscTags": [
+        "HL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "59455d29026dad2799eec959b52339aa"
+    },
+    {
+      "name": "Acidball",
+      "source": "NRCToS",
+      "page": 64,
+      "level": 4,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 150
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a tiny ball of bat guano and caustic soda"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A yellowish blob of light flashes from your pointing finger to a point you choose within range and splashes outwards, drenching everyone nearby with droplets of acid. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes {@damage 8d6} acid damage on a failed save, or half as much damage on a successful one."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 5th level or higher, the damage increases by {@scaledice 8d6|4-9|1d6} for each slot level above 4th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "areaTags": [
+        "S"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "aa5948540b05cba179c435f5c70faae1"
+    },
+    {
+      "name": "Acid Storm",
+      "source": "NRCToS",
+      "page": 64,
+      "level": 7,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 150
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "A storm made of gelatinous, acidic droplets appears in a location you choose within range. The area of the storm consists of up to ten 10-foot cubes, which you can arrange as you wish. Each cube must have at least once face adjacent to the face of another cube.",
+        "Each creature in the area must make a Dexterity saving throw. A creature takes {@damage 8d6} acid damage on a failed save, or half as much damage on a successful one, each round that the creature ends its turn in the storm and for one round afterwards. If a target takes at least 10 points of damage and is wearing nonmagical armor, the armor's AC is permanently reduced by one level of effectiveness. If the armor is reduced to AC 10, it is destroyed. A spell such as {@spell repair|NRCToS} (q.v.) will fix the damage and restore the armor to its normal strength."
+      ],
+      "damageInflict": [
+        "acid"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "C"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "18271ac29afbbf8a0034c31c7485950d"
+    },
+    {
+      "name": "Acid Lash",
+      "source": "NRCToS",
+      "page": 64,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "three drops of an acidic liquid"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a glowing line of vivid purple force that lashes out at your command towards a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes {@damage 4d10} acid damage and if the creature is Large or smaller, you pull it up to 10 feet closer to you."
+      ],
+      "damageInflict": [
+        "acid"
+      ],
+      "spellAttack": [
+        "M"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "e03268daa845491158b0752a75f9fb5f"
+    },
+    {
+      "name": "Acid Hands",
+      "source": "NRCToS",
+      "page": 64,
+      "level": 1,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 15
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "As you hold your hands with thumbs touching and fingers spread, a thin sheet of corrosive liquid shoots forth from your outstretched fingertips. Each creature in a 15-foot cone must make a Dexterity saving throw. A creature takes {@damage 3d8} acid damage on a failed save, or half as much on a successful one."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 2nd level or higher, the damage increases by {@scaledice 3d8|1-9|1d8} for each slot level above 1st."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Great Old One",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "69ab5c65b3a1d11d4e4342a2da9da3ee"
+    },
+    {
+      "name": "Aggressive Thundercloud",
+      "source": "NRCToS",
+      "page": 65,
+      "level": 2,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of wood that has been struck by lightning"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You summon a storm cloud that fits in a 5-foot square; it doesn't fill its space. It hovers 10 feet above the ground, but you can command it to rise to 20 feet or sink to ground level; no action is required by you. When you cast the spell and as a bonus action on your subsequent turns, you can move the cloud up to 20 feet and then direct it to send a thunderbolt at a single target within 10 feet of it. The target must make a Dexterity saving throw, taking {@damage 4d6} lightning damage on a failed save and no damage on a successful one. Anything within the cloud is lightly obscured, and it provides dim light to a 5-foot radius around it."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level or higher spell slot, you inflict an additional {@scaledice 4d6|2-9|1d6} damage for each slot level above 2nd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "lightning"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "areaTags": [
+        "Q"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Tempest",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Mountain"
+            }
+          }
+        ]
+      },
+      "uniqueId": "de3efc2f94bf8866466c47864c92f008",
 			"miscTags": [
 				"SMN"
 			]
-		},
-		{
-			"name": "Age Object",
-			"source": "NRCToS",
-			"page": 65,
-			"level": 5,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a flask of seawater and a piece of coal"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You age a nonmagical item of Large size or smaller at a rate of 5 years per round you concentrate. The actual effect depends on the nature of the item\u2014iron and steel will rust and corrode, masonry will crack and weaken, wood will rot away to nothing, and so on. This inflicts {@damage 3d6} force damage each round."
-			],
-			"damageInflict": [
-				"force"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "4ae7e775ffe2ff93bc56f15fa1d61fe2"
-		},
-		{
-			"name": "Age Animal",
-			"source": "NRCToS",
-			"page": 65,
-			"level": 5,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"This spell ages any beast, dragon, or monstrosity with an Intelligence of 4 or less at a rate of 1 year per round you concentrate. It may make a Constitution saving throw each round to resist. On a success, it is not affected during that round."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "1b4f8adf094d02e104a14a75b5a718b8"
-		},
-		{
-			"name": "Adhesion",
-			"source": "NRCToS",
-			"page": 65,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of powdered horse's hoof"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You bring together two solid, inanimate objects, which become stuck together. It requires a Strength (Athletics) ability check, made at disadvantage, to pry them apart (DC equal to your spell save DC)."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level spell slot, you increase the duration to 3 hours. When you cast it with a 3rd-level spell slot, you increase the duration to 8 hours. When you cast it with a 4th-level or higher spell slot, you increase the duration to 12 hours."
-					]
-				}
-			],
-			"opposedCheck": [
-				"strength",
-				"intelligence"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "802d48643724f24bb29f88403ee2d250"
-		},
-		{
-			"name": "Adamantine Weapon",
-			"source": "NRCToS",
-			"page": 65,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of diamond powder"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You transform your own cudgel, mace, staff, or other bludgeoning weapon into one made of pure elemental adamantine. It does an additional {@damage 1d12} bludgeoning damage on a successful hit."
-			],
-			"damageInflict": [
-				"bludgeoning"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "War",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Mountain"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Crown",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "1dd362298e6c2fdc46513d17d60c3786"
-		},
-		{
-			"name": "Agra's Ambush",
-			"source": "NRCToS",
-			"page": 66,
-			"level": 3,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a handful of roughly-ground glass"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You provide protection for yourself or one willing creature against unwanted mental intrusion. The trap will be triggered if a protected creature be affected by a spell or effect that would sense its emotions, read its thoughts, or put the {@condition charmed} condition on it. The attacker must make a Wisdom saving throw. The attacker takes {@damage 3d10} psychic damage on a failed saving throw, or half as much damage on a successful one. In either case, you are alerted as to the potential intrusion.",
-				"Once this spell has been triggered, it ends."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, the trap inflicts another {@scaledice 3d10|3-9|1d10} damage per slot level above 3rd."
-					]
-				}
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "ccd0f9edbcf117d60bb4b23edd00c1fd"
-		},
-		{
-			"name": "Agitate Wounds",
-			"source": "NRCToS",
-			"page": 66,
-			"level": 3,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of salt"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You choose one creature that you see within range that has recently been injured by an edged weapon (i.e., not at full hit points and not yet been treated with a {@item healer's kit|phb}, a curative {@filter potion|items|type=potion}, or with {@filter healing magic|spells|miscellaneous=healing}), or by another attack that caused bleeding. This spell will cause the wounds to open and bleed profusely. The target takes {@damage 2d6} damage and must make a Constitution saving throw. On a success, the target takes no more damage. On a failure, the target takes another {@damage 1d4} damage each round until the wound is treated."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"HL",
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Vengeance",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Oathbreaker",
-							"source": "DMG"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Fiend",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "d587f8412a08e6fba9dadf0cac22c1c9"
-		},
-		{
-			"name": "Aging",
-			"source": "NRCToS",
-			"page": 66,
-			"level": 8,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a black opal worth at least 500 gp",
-					"cost": 50000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A sickly gray bolt of energy shoots out from your outstretched hand towards a creature within range. Make a ranged spell attack. On a hit, the target must make a Constitution saving throw. The target takes {@damage 6d10} necrotic damage and instantly ages that many years on a failed saving throw, or half as much damage and years on a successful one. In either case, the creature is also knocked {@condition unconscious} for 1 minute. If the target dies from this damage, it is considered to have died of old age and can only be brought back through a {@spell wish}.",
-				"The aging is permanent unless reversed with a {@spell greater restoration} spell. The aging has no game affects unless the DM determines that the target has been pushed into old age, in which case the subject suffers from one level of {@condition exhaustion}, which is permanent until the aging has been reversed.",
-				"Celestials, constructs, elementals, fey, fiends, undead, and any other sort of creature that doesn't age is immune to this spell."
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "5438708526f1b12ca3601e9d0f6c6023"
-		},
-		{
-			"name": "Ahrvar's Forgery",
-			"source": "NRCToS",
-			"page": 67,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a sample of the handwriting to be copied"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"When you cast this spell, you gain the ability to perfectly mimic one person's handwriting for the next ten minutes."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Trickery",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "8a5aa9b505761711722297b6f223e8be"
-		},
-		{
-			"name": "Airboat",
-			"source": "NRCToS",
-			"page": 67,
-			"level": 8,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "miles",
-					"amount": 5
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 12
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You must be outside to cast this spell. You point to a cloud, which immediately descends towards you and changes shape until it becomes a ship made of clouds. You determine its shape (caravel, dragon-galley, rowboat, etc.), but that has no bearing on its performance.",
-				"You and up to eight other creatures of your choice may board the airboat, which flies at a speed of 100 feet under your telepathic command. You are considered to have proficiency with the airboat. While captaining the boat, you have resistance to lightning and thunder damage and are immune to harm caused by nonmagical winds. The airboat has an AC of 13 and 100 hit points."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When cast with a 9th-level spell slot, you may bring up to sixteen other creatures onboard with you."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "d861f3d13a0a0c68c7a011275b3c6c21"
-		},
-		{
-			"name": "Airy Water",
-			"source": "NRCToS",
-			"page": 67,
-			"level": 5,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "sphere",
-				"distance": {
-					"type": "feet",
-					"amount": 20
-				}
-			},
-			"components": {
-				"s": true,
-				"m": "a handful of salt"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Stormwrack}",
-				"You turn the water in a 20-foot bubble around you turns into a frothy substance that can be breathed as easily as air. In addition, movement is easier through {@i airy water}\u2014a creature's swimming speed increases by 20 feet and Strength (Athletics) checks made in order to swim are made at advantage, and boats traveling in a patch of {@i airy water} have their speed increased by 25%."
-			],
-			"areaTags": [
-				"S"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Coast"
-						}
-					}
-				]
-			},
-			"uniqueId": "80eb16af529b33c1cabdce4c77110f73"
-		},
-		{
-			"name": "Alcoreax's Icetrail",
-			"source": "NRCToS",
-			"page": 67,
-			"level": 4,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a steel pin and a cup of water"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You tap the ground at your feet and a wave of ice 10 feet high and 20 feet wide appears on the ground and begins to snake forward, leaving a sheet of ice in its wake. The wave moves at a rate of 30 feet in a straight line, but at the beginning of each of your turns, you may direct it to turn and move in a different direction at a 45- or 90-degree angle.",
-				"A creature standing in the area when the ice enters its space will be caught by the icy wave and will be {@condition restrained} by it (escape DC equal to your spell save DC). A {@condition restrained} creature will begin to suffocate, as per the {@book suffocation rules|PHB|8|Suffocating} in the {@i Player's Handbook}, page 183. Magical fire will melt the wave without harming the creatures trapped by it.",
-				"A creature who enters the area with the sheet of ice or ends its turn there must succeed on a Dexterity saving throw to avoid slipping on the ice and falling {@condition prone}. The ice sheet counts as difficult terrain. In addition, the air up to 10 feet above the ice sheet is so cold that each creature that ends its turn in that area take {@damage 3d8} cold damage."
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"areaTags": [
-				"W"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Arctic"
-						}
-					}
-				]
-			},
-			"uniqueId": "deae3324b8c5328b169181548fc8bf8b"
-		},
-		{
-			"name": "Allegro",
-			"source": "NRCToS",
-			"page": 68,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 20
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a tail feather from a bird of prey"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1,
-						"upTo": true
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You and up to eight allies within 20 feet of you have their walking speed doubled for the duration of this spell."
-			],
-			"miscTags": [
-				"HL"
-			],
-			"areaTags": [
-				"R"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "6a2f8caf221aa4b4f8a1ec0cb3bb0f78"
-		},
-		{
-			"name": "Alpha's Chill of the Void",
-			"source": "NRCToS",
-			"page": 68,
-			"level": 4,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of ice"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You bring forth a wave of airless, supernaturally-intense cold in a 60-foot cone. All creatures in the area take {@damage 6d6} cold damage and one level of {@condition exhaustion} as the air is sucked from their lungs. There is no saving throw. Creatures that don't need to breathe take no {@condition exhaustion}.",
-				"All normal vegetation of Medium size or smaller in the area dies, and larger vegetation has a 50 percent chance of dying. Plant creatures are no more susceptible than other living beings are. Normal (non-magical) fires in the area are immediately snuffed and standing water instantly freezes."
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Great Old One",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "57609fa118fbe4b43dbad38630832cd2"
-		},
-		{
-			"name": "Alpha's Blue Blaze",
-			"source": "NRCToS",
-			"page": 68,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You cause blue flames and purple acid to fan forth from your outstretched hand in a 60-foot cone. All creatures in that area must make a Dexterity saving throw. A creature takes {@damage 4d8} fire damage and {@damage 4d8} acid damage on a failed saving throw, or half as much on a successful one."
-			],
-			"damageInflict": [
-				"acid",
-				"fire"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "16f84928577e3b846bfaba0a072382d0"
-		},
-		{
-			"name": "Allergy Field",
-			"source": "NRCToS",
-			"page": 68,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of ragweed"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You choose a point within range that you can see and fill it with a 10-foot cube of pollen. All creatures within that area must make a Constitution saving throw against poison or suffer disadvantage on all attack rolls and skill checks for the next minute due to uncontrollable sneezing and watering eyes. A creature may make a new saving throw at the start of each of its turns, ending the effect on a success. A wind of at least 5 miles per hour will blow the pollen away and end the spell."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"C"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "a4873a085d75b2f0fd2699947f3286b3"
-		},
-		{
-			"name": "Rising Rot",
-			"source": "NRCToS",
-			"page": 303,
-			"level": 6,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a handful of mold spores"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You hold up your hand and a thin beam of sickly green-brown light shoots out and automatically strikes one living, corporeal creature within range you can see. Mold and gangrenous patches begin to form on its body. At the beginning of each of its turns, the creature must make a Constitution saving throw. It takes {@damage 2d8} poison damage and {@damage 2d8} necrotic damage on a failed saving throw, or half as much damage on a successful one. This continues until the target is reduced to 0 hit points or has successfully saved three times. The saves do not need to be consecutive."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 7th-level or higher spell slot, it inflicts an additional {@scaledice 2d8|6-9|1d8} poison damage and {@scaledice 2d8|6-9|1d8} necrotic damage for each slot level above 6th."
-					]
-				}
-			],
-			"damageInflict": [
-				"necrotic",
-				"poison"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "7454d028c7372d49e76db1964cc3c7e2"
-		},
-		{
-			"name": "Alpha's Hunting Hound",
-			"source": "NRCToS",
-			"page": 69,
-			"level": 1,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of meat"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You summon a fey spirit that takes the form of a white and red {@creature mastiff}. It is identical to the {@creature mastiff} from the {@i Monster Manual} (page 332), save that its {@skill Perception} skill bonus is +5. It is friendly to you and your companions. Roll initiative for it, as it has its own turns. It will obey any commands that you issue. If you don't issue commands to it, it will defend itself from hostile creatures, but otherwise takes no actions. The {@creature mastiff} disappears when it drops to 0 hit points or when the spell ends."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level or higher spell slot, you conjure one additional hound for each slot level above 1st."
-					]
-				}
-			],
-			"miscTags": [
-				"SMN"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Ancients",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "c0a6c066bc1be4d318988b9159c768f4"
-		},
-		{
-			"name": "Alpha's Heat Lightning",
-			"source": "NRCToS",
-			"page": 69,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a short glass rod, a bit of fur, and a bit or iron or lodestone"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You call down a bolt of purplish-red lightning, which strikes a single creature you can see within range. Make a ranged spell attack to hit. On a success, that creature takes {@damage 4d10} fire damage and {@damage 4d10} lightning damage. If the creature is wearing nonmagical metallic armor or carrying a metallic weapon, the creature takes an additional {@damage 1d10} lightning damage. The lightning will also set combustibles on fire."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 6th-level or higher spell slot, you inflict an additional {@scaledice 4d10 + 4d10|5-9|1d10} lightning damage for each slot level above 5th."
-					]
-				}
-			],
-			"damageInflict": [
-				"fire",
-				"lightning"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Grassland"
-						}
-					}
-				]
-			},
-			"uniqueId": "42b256127039dd11c0c0ee66e0822ddb"
-		},
-		{
-			"name": "Alpha's Comet",
-			"source": "NRCToS",
-			"page": 69,
-			"level": 7,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a ball of pitch mixed with sulfur and phosphorus"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a sphere of flaming rock with a tail of noxious, superheated gasses. This unerringly strikes one target you can see within range, causing {@damage 4d8} bludgeoning damage and {@damage 4d8} fire damage. In addition, all creatures within 5 feet of the target must make a Dexterity saving throw, taking {@damage 4d8} fire damage on a failed roll or half as much on a successful one.",
-				"Finally, all creatures within 10 feet of the target, including the target (if the target is a creature), must make a Constitution saving throw against poison. On a failed save, the creature is spends its action that turn retching and reeling, takes {@damage 2d8} poison damage, and is {@condition poisoned} for 1 minute. Creatures that don't need to breathe or are immune to poison automatically succeed on this saving throw. The gasses disperse after 1 round."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 8th-level or higher spell slot, you inflict an additional {@dice 1d8} bludgeoning, fire, and poison damage for each spell slot above 7th."
-					]
-				}
-			],
-			"damageInflict": [
-				"bludgeoning",
-				"fire",
-				"poison"
-			],
-			"conditionInflict": [
-				"poisoned"
-			],
-			"savingThrow": [
-				"constitution",
-				"dexterity"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST",
-				"R",
-				"Q"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "119a608ddbe97aae090e4a656cd0cda0"
-		},
-		{
-			"name": "Alpha's Moonlight",
-			"source": "NRCToS",
-			"page": 70,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a moonstone"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A 30-foot-radius circle of soft, blue-gray light shines down from above, centered on a point you choose within range. In this area, all color is washed out; creatures in that area cannot discern color and can only see in shades of gray. Creatures who have the trait Sunlight Sensitivity are not affected by sunlight while in this area; creatures who take damage from sunlight only take half the normal amount of damage.",
-				"While in this area, infected lycanthropes must make a Wisdom saving throw to avoid being forced to transform.",
-				"If you cast this spell on yourself, the area moves with you. Otherwise, it is stationary."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Forest"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Archfey",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "fad19b44821bea35b0c05c9ff2a0c2c8"
-		},
-		{
-			"name": "Alpha's Rolling Thunder",
-			"source": "NRCToS",
-			"page": 70,
-			"level": 3,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You throw your hands skyward and a tremendous clap of thunder sounds directly overhead. All creatures within 30 feet must make a Constitution saving throw. A creature takes {@damage 5d6} thunder damage and is knocked {@condition prone} on a failed saving throw, or half as much damage and is not knocked {@condition prone} on a successful one. In addition, regardless of the saving throw, a creature is {@condition deafened} until the end of its next turn."
-			],
-			"damageInflict": [
-				"thunder"
-			],
-			"conditionInflict": [
-				"deafened",
-				"prone"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"areaTags": [
-				"R"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Tempest",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Coast"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Mountain"
-						}
-					}
-				]
-			},
-			"uniqueId": "a739873985128de69fb2ca5030e7623e"
-		},
-		{
-			"name": "Alpha's Rainbow Beam",
-			"source": "NRCToS",
-			"page": 70,
-			"level": 2,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a clear gem or crystal prism worth at least 50 gp",
-					"cost": 5000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You draw forth a beam of elemental light and fire it at a creature you can see within range. Make a ranged spell attack to hit. You may attempt a DC 13 Intelligence (Arcana) check to choose the beam's color; otherwise, it is randomly determined. You may not attempt to create a multihued beam. The beam does {@damage 3d10} damage of a type determined by its color; the target may make a Dexterity saving throw for half damage. Roll a {@dice d8} to determine the color.",
-				{
-					"type": "table",
-					"colLabels": [
-						"{@dice d8}",
-						"Beam's Color"
-					],
-					"colStyles": [
-						"col-1 text-center",
-						"col-11"
-					],
-					"rows": [
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 1,
-									"pad": false
-								}
-							},
-							"Red (force damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 2
-								}
-							},
-							"Orange (fire damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 3
-								}
-							},
-							"Yellow (acid damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 4
-								}
-							},
-							"Green (poison damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 5
-								}
-							},
-							"Blue (lightning damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 6
-								}
-							},
-							"Indigo (cold damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 7
-								}
-							},
-							"Violet (radiant damage)"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"exact": 8
-								}
-							},
-							"Multihued; roll twice and ignore further rolls of 8."
-						]
-					]
-				},
-				"The beam stops once it hits a solid object, even if that object is transparent."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level spell slot or higher, it does an additional {@scaledice 3d10|2-9|1d8} damage per slot level above 2nd."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid",
-				"cold",
-				"fire",
-				"force",
-				"lightning",
-				"poison",
-				"radiant"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Light",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "d4589db67790a3c278d0b4e15d1eb180"
-		},
-		{
-			"name": "Alpha's Starlight Citadel",
-			"source": "NRCToS",
-			"page": 71,
-			"level": 7,
-			"school": "C",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a star sapphire worth at least 1,000 gp and a small steel carving of a tower",
-					"cost": 100000
-				}
-			},
-			"duration": [
-				{
-					"type": "special"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a citadel out of a magical metal that is midnight blue with silvery accent in color. It is identical in shape, size, and layout to {@item Daern's instant fortress}, although it slowly coalesces instead of suddenly growing and thus does not cause damage to creatures who cannot get out of the way. The door opens on your command and on the command of up to 10 others that you designate when casting the spell.",
-				"This spell can only be cast at night and will last until touched by the first rays of direct sunlight."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "84f248fa37cc0f4a15e57259277e6ef9"
-		},
-		{
-			"name": "Alpha's Sparkle Beam",
-			"source": "NRCToS",
-			"page": 71,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You draw upon the Positive Plane and call forth a cone filled with shining motes of silver and gold light. All creatures in a 10-foot cone must make a Constitution saving throw or be {@condition blinded} until the end of their next turn. A creature with the Sunlight Sensitivity trait has disadvantage on this roll.",
-				"Undead, fiends, and creatures of any type native to the Shadowfell take {@dice 1d6} + your spellcasting ability modifier in radiant damage. Creatures of types other than those listed above do not take damage from this spell, but they might still be {@condition blinded}.",
-				"This spell's damage increases by {@damage 1d6} when you reach 5th level ({@damage 2d6} + your modifier), 11th level ({@damage 3d6} + your modifier), and 17th level ({@damage 4d6} + your modifier)."
-			],
-			"scalingLevelDice": {
-				"label": "radiant damage",
-				"scaling": {
-					"1": "1d6",
-					"5": "2d6",
-					"11": "3d6",
-					"17": "4d6"
-				}
-			},
-			"damageInflict": [
-				"radiant"
-			],
-			"conditionInflict": [
-				"blinded"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"opposedCheck": [
-				"constitution"
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "3e282a0a25467095c42c753488ccce48"
-		},
-		{
-			"name": "Alpha's Spark Shower",
-			"source": "NRCToS",
-			"page": 71,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 15
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a bit of fur, glass, and copper"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You extend your arms and a sheet of sizzling purple sparks shoot forth from your hands. Each creature in a 15-foot cone must make a Dexterity saving throw. A creature takes {@damage 1d6} lightning damage on a failed saving throw, or half as much on a successful one. A creature wearing metal armor has disadvantage on this roll.",
-				"This spell does additional damage when you reach 5th level ({@damage 2d6}), 11th level ({@damage 3d6}), and 17th level ({@damage 4d6})."
-			],
-			"damageInflict": [
-				"lightning"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "7f2d59f9dc447a830e276c4b0fafdf7c"
-		},
-		{
-			"name": "Alpha's Shadowfire",
-			"source": "NRCToS",
-			"page": 71,
-			"level": 4,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a black opal worth at least 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A streak of black and green flame erupts from your hands and strikes a point you choose within range. Make a ranged spell attack to hit. On a success, your target takes {@damage 3d10} fire damage plus {@damage 3d10} necrotic damage."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"For each spell slot of 5th level or higher, you inflict an additional {@dice 1d10} fire or {@damage 1d10} necrotic damage (your choice) per slot level above 4th."
-					]
-				}
-			],
-			"damageInflict": [
-				"fire",
-				"necrotic"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "551e37918deaef3cd23c01427a321032"
-		},
-		{
-			"name": "Alter Instrument",
-			"source": "NRCToS",
-			"page": 73,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium} and The Great Net Spellbook",
-				"You may transform one {@filter musical instrument|items|type=instrument} into another one of similar size (up to 50% larger or smaller) with which you are familiar; you don't need to be proficient in its use, however. The instrument remains in this shape for as long as you are touching it. If you put it down for more than 1 minute, it reverts to its normal shape. It also reverts back if someone else attempts to play it.",
-				"The spell's duration increases to 1 hour when you reach 5th level and 8 hours when you reach 11th level.",
-				"You can instead use this spell to perfectly tune an instrument you touch. This effect is permanent, although the instrument may eventually fall out of tune anyway."
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "e1e8ca8ea2c8ce34dfe942947f588818"
-		},
-		{
-			"name": "Alpha's Starshield",
-			"source": "NRCToS",
-			"page": 72,
-			"level": 5,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a black sapphire and a star sapphire, each worth at least 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You are enveloped in a nearly skin-tight magical shield that looks like a moonless night sky. While this spell is in effect, you are immune to radiant damage and to being {@condition blinded}. You are also advantage on any saving throw to resist spells that uses light or color to blind, charm, confuse, or damage you. You can see through magical darkness and gain {@sense darkvision} to 60 feet; if you already have darkvision, it expands an additional 30 feet. Finally, you also gain advantage on all {@skill Stealth|Dexterity (Stealth)} rolls when in dim light or darkness."
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "dea49978f5a0db281a65db16d4b3b516"
-		},
-		{
-			"name": "Alter Animal Intelligence",
-			"source": "NRCToS",
-			"page": 72,
-			"level": 3,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a dried fish, piece of brain coral, and rare herbs worth 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Prayerbook",
-				"You cause one aberration, beast, dragon, monstrosity, or ooze with an Intelligence of 4 or less to gain 2 points of Intelligence permanently. The creature must make a Constitution saving throw when you cast this spell, whether or not the creature is willing. On a failure, the spell still succeeds but the creature takes {@damage 4d10} psychic damage as its brain is painfully altered.",
-				"You may cast this spell on a creature multiple times, raising its intelligence by 2 each time, to a maximum of 10. This does not grant the creature the ability to speak, nor does it secure the creature's friendship for you.",
-				"You may cast this spell on a normal plant, giving it an Intelligence of 2 (or more, if you cast this spell multiple times), but this doesn't give it mobility beyond what it already has."
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "fc668c3c7c6657b3c7ebb52f54949626"
-		},
-		{
-			"name": "Alter Beast",
-			"source": "NRCToS",
-			"page": 72,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "two strands of gold twisted together to form a double helix, worth 10 gp",
-					"cost": 1000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You may sculpt part of a beast's body as you wish. For instance, you could change paws or hooves into hands, make a quadruped walk upright, alter a creature's mouth and larynx to make it capable of speech, and so on. The DM will determine if there are any changes to its attributes due to the change. The creature must make a Constitution saving throw when you cast this spell, whether or not the creature is willing. On a failure, the spell still succeeds but the creature takes {@damage 5d10} force damage as its body is painfully altered.",
-				"You may only make one change with each casting of this spell, although the change can be complex (such as rearranging a quadruped's hips and legs so it becomes a biped), but you may cast this spell on a single creature multiple times. You can't increase a creature's intelligence with this spell, nor can you add body parts (such as additional limbs); you may remove parts, however. The changes you make are permanent and might be passed down to any offspring it may have."
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "1482189b932bdc0fd06bdefff8498a2b"
-		},
-		{
-			"name": "Blades of Fury",
-			"source": "NRCToS",
-			"page": 95,
-			"level": 3,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a miniature longsword"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You summon five illusory flying {@item longsword|phb|longswords}, which you set to duel other creatures within range. When you cast the spell and as a bonus action on your subsequent turns, you can move a sword up to 30 feet and cause it to attack a new target.",
-				"Your swords attack using your spell attack modifier. On a hit, the sword inflicts {@damage 1d8} slashing damage. Each time a target is struck by a sword, it may make an Intelligence saving throw. On a success, the target becomes aware that the sword is an illusion, which causes the sword to vanish. If another creature is told that the swords are illusions or sees one vanish, that creature has advantage on its next saving throw.",
-				"If a creature is reduced to 0 hit points by these illusory blades, they instead drop to 1 hit point and fall {@condition unconscious}."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a spell slot of 6th level or higher, you summon one additional sword per slot level above 5th."
-					]
-				}
-			],
-			"damageInflict": [
-				"slashing"
-			],
-			"savingThrow": [
-				"intelligence"
-			],
-			"miscTags": [
-				"SCL",
-				"SMN"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "f79e3afa5feaabb8e48e2fe153068c5e"
-		},
-		{
-			"name": "Blacksteel",
-			"source": "NRCToS",
-			"page": 95,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"One weapon you touch becomes completely matte-black and utterly silent\u2014it makes no noise when being drawn, when striking someone even if it hits armor, or when dropped."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "fd898ac86ab6e2fe7e6083c15d17a2af"
-		},
-		{
-			"name": "Bliss",
-			"source": "NRCToS",
-			"page": 97,
-			"level": 2,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"One creature within range that you can see must make a Wisdom saving throw or fall into a trance of intense pleasure; for the duration of the spell, the creature is {@condition incapacitated}. The creature may make a new saving throw at the end of each of its turns, ending the effect on success.",
-				"This spell has potential for addiction and is debilitating with frequent use. If a creature is subjected to this spell three times in a 24-hour period, it must make a Wisdom saving throw. On a failure, it takes {@damage 1d10} psychic damage and its hit point total is reduced by that amount. This hit point reduction lasts for 1 week or until a spell such as greater restoration is cast on it. Until its hit point total has been restored, it can't make a saving throw to resist the spell, but must still make a Wisdom saving throw to avoid taking psychic damage."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 3rd-level or higher spell slot, the spell no longer requires concentration. If you cast this spell with a 5th-level or higher spell slot, the duration increases to 10 minutes."
-					]
-				}
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"conditionInflict": [
-				"incapacitated"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"HL",
-				"SCL",
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "36ef3ad6be259f44dd3c4318c4312011"
-		},
-		{
-			"name": "Drawmij's Breath of Life",
-			"source": "NRCToS",
-			"page": 161,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "bonus action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 100
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You endow yourself and up eight other allies with the ability to hold your breath for twice as long as normal."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "a7b7d539453d8e2deaf76ff2e9cc5703"
-		},
-		{
-			"name": "Drawmij's Instant Exit",
-			"source": "NRCToS",
-			"page": 161,
-			"level": 3,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a miniature silver door decorated worth 500 gp",
-					"cost": 50000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You open an extradimensional door in a wall or other flat surface that remains open for one round. When the door closes, you and anyone else who pass through the door are teleported to a completely random location within 250 yards. You will be let out on a flat surface capable of supporting your weight, but there is no guarantee that this place will otherwise be safe. You cannot control who uses the door."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "414beb4b269c50b0b4c5e2bde4a7d496"
-		},
-		{
-			"name": "Drawmij's Light Step",
-			"source": "NRCToS",
-			"page": 161,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a bit of cat fur and a duck's feather"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You or one willing creature you touch is granted a the ability to walk at a normal pace without leaving tracks or disturbing the ground below it. The creature can also walk across relatively calm fluids, such as the surface of a lake, as if it was difficult terrain."
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Archfey",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "8324abc8fbfecc5aa6f5cadc77c09008"
-		},
-		{
-			"name": "Drawmij's Scent Mask",
-			"source": "NRCToS",
-			"page": 161,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a scentless flower"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"One creature you touch is rendered scentless and cannot be tracked by smell.",
-				"This spell can be cast on a creature that attacks through scent, such as a skunk or troglodyte. That creature may make a Constitution saving throw to resist. On a failure, it cannot use this attack for the duration."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "35323bc0c38b6dc6d538370f70a869db"
-		},
-		{
-			"name": "Drawmij's Swift Mount",
-			"source": "NRCToS",
-			"page": 162,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a hare's foot or a bit of cheetah's fur"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You touch a trained riding beast, dragon, or monstrosity that has an Intelligence of 4 or less, or on a riding beast summoned with the {@spell find steed} spell, and its movement is doubled for the duration of the spell. If you overload the animal, it automatically cancels this spell. You cannot cast this spell on that creature again until it has taken a short or long rest."
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Grassland"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Crown",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "cd8d3b80e0431d3351f51ea0410fd3f7"
-		},
-		{
-			"name": "Dread Word",
-			"source": "NRCToS",
-			"page": 162,
-			"level": 3,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Book of Vile Darkness}",
-				"You speak a word from an ancient language so foul that one creature within range that you can see takes {@damage 3d10} psychic damage and its hit point total is reduced by half that amount. There is no saving throw allowed. Hit point reduction lasts until the creature takes a short or long rest. This spell does not work on {@condition deafened} creatures.",
-				"Due to the incredible evil of the spell, non-evil spellcasters take 5 points of psychic damage each time they cast this spell."
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Oathbreaker",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "e139c74bf4be13c35b4756ea0bfe7a2c"
-		},
-		{
-			"name": "Dream Feast",
-			"source": "NRCToS",
-			"page": 162,
-			"level": 2,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": true
-			},
-			"duration": [
-				{
-					"type": "special"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You must cast this on a willing target. The next time that creature sleeps (which must be within 8 hours of you casting this spell), it will dream of eating all of its favorite foods. When it wakes up, the creature will be sated, as if it had eaten a full meal. The target must sleep for at least two hours for this spell to take effect. A creature can't benefit from this spell again until it has eaten at least two actual meals."
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Life",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "a48b4e5ce68b0b05a94f1e7c9aec02f0"
-		},
-		{
-			"name": "Dream Sight",
-			"source": "NRCToS",
-			"page": 162,
-			"level": 3,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "special"
-			},
-			"components": {
-				"s": true,
-				"m": {
-					"text": "incense worth at least 5 gp",
-					"cost": 500
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Oriental Adventures}",
-				"You fall into a deep sleep and your spirit leaves your body and travels ethereally and invisibly. You gain a flying speed of 90 feet. You can pass through solid objects and creatures as if they were difficult terrain; you take {@damage 1d10} force damage if you end your turn inside an object. While in this form, you gain truesight to 30 feet. You are blocked by any spell or effect that blocks ethereal creatures and can be seen by creatures with {@sense truesight} or that are using {@spell true seeing}. You are immune to all nonmagical damage. You cannot speak, attack, cast spells, or perform any action while in this form other than moving and observing.",
-				"When the spell is over, or if your body is disturbed in any way, your spirit instantly returns and you wake up. If you took damage in any way while in spirit form, you retain that damage upon awakening."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, your speed increases by 30 feet for each slot level above 3rd."
-					]
-				}
-			],
-			"damageInflict": [
-				"force"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "8c5ea5b2028d31c31e8004ef2647ca42"
-		},
-		{
-			"name": "Drenal's Stone Flame",
-			"source": "NRCToS",
-			"page": 163,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a mix of fine sand and sugar, which is thrown in the air"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You point to an open flame no larger than a torch. The flame turns into a brightly-glowing stone that is cool to the touch and that can be picked up and carried without harm. It continues to shed as much light as it did before it was transformed.",
-				"When the spell expires, the stone reverts to normal flame and will burn whatever it is touching. If the stone is shattered, the flame is extinguished."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "0b92dbdf1154ee39071b3bd5aecab79f"
-		},
-		{
-			"name": "Drought",
-			"source": "NRCToS",
-			"page": 163,
-			"level": 3,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 300
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a dried rat and a pinch of salt"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You spend an hour meditating and the area around you becomes much drier than before. If the land was wet and swampy, the water drains away. If it was a field or forest, the ground withers to dust and the vegetation begins to die within a few days. This spell doesn't work if cast on an area with more than a foot of standing water.",
-				"A particular plot of land can only be affected by this spell once per season, and the effects last until the end of the current growing season."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Desert"
-						}
-					}
-				]
-			},
-			"uniqueId": "f26c1d7dc73650bac168ae4587794114"
-		},
-		{
-			"name": "Druidcraft (New Variants)",
-			"source": "NRCToS",
-			"page": 163,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"These are new variants of the spell {@spell druidcraft} that appears in the {@book Player's Handbook|phb} (page 236).",
-				{
-					"type": "list",
-					"items": [
-						"You perfectly mimic one animal or bird call. This does not give you the ability to speak with the animal, but does allow you to mimic the creature's mating calls, territorial howls, warning growls, and so on, with enough accuracy to fool that creature.",
-						"You place a magical mark on a natural inanimate object. The mark instantly understandable to other creatures that know this spell. The mark can only convey simple concepts, such as \"fresh water is nearby\" or \"warning: nesting monsters.\" The mark lasts until the end of the season or until you dispel it.",
-						"You command one {@filter beast of CR 0|bestiary|challenge rating=[&0;&0]|type=beast}. The command must be of no more than two or three words (\"sit,\" \"attack him\"). The creature will obey you to the best of its ability.",
-						"You completely heal a Tiny plant of all damage and disease.",
-						"You cause a picked fruit (or vegetable, seed, or nut) to become unblemished, free from parasites, and healthy to eat. If it's unripe or too ripe, you cause it to become perfectly ripe.",
-						"You ask a {@filter beast of CR 1 or lower|bestiary|challenge rating=[&0;&1]|type=beast} to perform a simple, non-combat-related task for you. The beast will obey you as long as it's physically capable of performing the task, it can't potentially harm it, and it takes no longer than 1 minute to complete."
-					]
-				}
-			],
-			"miscTags": [
-				"HL"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Fighter",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcane Archer",
-							"source": "XGE"
-						}
-					}
-				]
-			},
-			"uniqueId": "19b98edbb3b513374253679d5019e955"
-		},
-		{
-			"name": "Spring",
-			"source": "NRCToS",
-			"page": 334,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a small forked stick, which is thrust into the ground"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You create a temporary freshwater spring that flows at a rate of {@dice 2d6} gallons per minute. In a desert or an area under drought conditions, it only produces {@dice 1d4} gallons per minute."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Nature",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Desert"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Ancients",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "c128d3085f8005aaec49785e5be959ad"
-		},
-		{
-			"name": "Demonstar",
-			"source": "NRCToS",
-			"page": 149,
-			"level": 8,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 90
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a golden star"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a small golden star and throw it at a fiend you see within range. You must make a ranged spell attack to hit. On a success, the star attaches itself to the fiend. At the beginning of each of its turns, the fiend must make a Constitution saving throw. It takes {@damage 12d6} force damage and is {@condition paralyzed} until the end of its turn on a failed saving throw, or half as much damage and is not {@condition paralyzed} on a successful save. If the fiend makes a successful saving throw three times, the spell ends. The successes don't need to be consecutive."
-			],
-			"damageInflict": [
-				"force"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "3918dd1f41df9689c19a083a342d820f"
-		},
-		{
-			"name": "Depress Resistance",
-			"source": "NRCToS",
-			"page": 149,
-			"level": 4,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a broken iron rod"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You target one creature you can see within range, and that creature must make a Wisdom saving throw. If it fails and it has Magic Resistance, it loses that trait for the duration. If it doesn't have Magic Resistance, it has disadvantage on saving throws against spells and magical effects for the duration."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "e3242a8b0b0de4b8bb25b8fe29b105d8"
-		},
-		{
-			"name": "Detect Charm",
-			"source": "NRCToS",
-			"page": 149,
-			"level": 2,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "the crushed petals of a bleeding-heart flower"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You look into the eyes of a target and can see if that creature is under a magical charm or under any similar spell (this includes any spell that does not function if the target is immune to charm, such as suggestion). This spell does not reveal what sort of charm the target is under or who placed the charm on that person. You can examine one person per round."
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					},
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Knowledge",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "fb55390b445a7a6d439b218f668a1274"
-		},
-		{
-			"name": "Detect Harmony",
-			"source": "NRCToS",
-			"page": 149,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "sphere",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a scroll on which prayers have been written in exotic inks worth at least 10 gp",
-					"cost": 1000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You gain understanding of the balance of good, evil, law, chaos, naturalness, and unnaturalness there is in a 60-foot-radius sphere around you. The information you receive is vague (\"there are many unnatural things\" or \"there is much randomness and little order\") and don't reveal the exact nature or cause of the imbalance."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Ancients",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "fd18ed4519bcadf7101e140d6ec85da9"
-		},
-		{
-			"name": "Detect Metals and Minerals",
-			"source": "NRCToS",
-			"page": 150,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "sphere",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a small magnet, a vial of weak acid, and a small sample of the desired material"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"For the duration, you sense the presence of a single type of ore, mineral deposit, or worked metal you specify within range. You will learn how far away it is, and roughly how much of it is there."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "35e858cdd835f9177e3e16b4d52a3f7f"
-		},
-		{
-			"name": "Detect Secret Passages and Portals",
-			"source": "NRCToS",
-			"page": 150,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"For the duration, you can sense the presence of secret doors, compartments, and so on that have been deliberately constructed to escape detection within range. You do not gain any understanding of how to open them. This spell does not detect traps or other hidden objects that can harm you."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "e4f3da38027931d0f0b0183e72af0bb9"
-		},
-		{
-			"name": "Detect Spellcasting",
-			"source": "NRCToS",
-			"page": 150,
-			"level": 4,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a pinch of powdered gemstone worth 10 gp",
-					"cost": 1000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You become aware of other spells currently being cast or activated within a 120-foot radius of you. You do not become aware of what spell it is or where, precisely, it originates from, although you gain a general sense of its direction (\"to the west\"). However, you may make a DC 12 check using your spellcasting ability to determine what the spell's level, school, or type (arcane or divine)."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "733073f6afad62e41b0d6a07745c3582"
-		},
-		{
-			"name": "Detonate",
-			"source": "NRCToS",
-			"page": 150,
-			"level": 3,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a burning coal and an eagle's feather"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You cause one nonmagical, inanimate object of Medium-size or smaller (or a Medium-sized piece of a larger object) you can see within range to explode. Fragile items (as per the {@i Dungeon Master's Guide}, {@table Object Hit Points|dmg|page 246}) are automatically affected. If you target a resilient object, make a {@dice d20} roll, adding your spellcasting ability modifier. On a roll of 10 or higher, it explodes.",
-				"The object itself takes {@damage 5d10} force damage. All creatures within 10 feet of it must make a Dexterity saving throw. A creature takes {@damage 3d6} fire damage and {@damage 3d6} piercing damage and is knocked {@condition prone} on a failed saving throw, or half as much damage and remains standing on a successful save. The fire ignites flammable objects in the area that aren't being worn or carried."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a spell slot of 4th-level or higher, you inflict an additional {@damage 1d10} damage to the object and {@damage 1d6} fire and {@damage 1d6} piercing damage for each slot level above 3rd."
-					]
-				}
-			],
-			"damageInflict": [
-				"fire",
-				"force",
-				"piercing"
-			],
-			"conditionInflict": [
-				"prone"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
+    },
+    {
+      "name": "Age Object",
+      "source": "NRCToS",
+      "page": 65,
+      "level": 5,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a flask of seawater and a piece of coal"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You age a nonmagical item of Large size or smaller at a rate of 5 years per round you concentrate. The actual effect depends on the nature of the item\u2014iron and steel will rust and corrode, masonry will crack and weaken, wood will rot away to nothing, and so on. This inflicts {@damage 3d6} force damage each round."
+			],
+      "damageInflict": [
+        "force"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "4ae7e775ffe2ff93bc56f15fa1d61fe2"
+    },
+    {
+      "name": "Age Animal",
+      "source": "NRCToS",
+      "page": 65,
+      "level": 5,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "This spell ages any beast, dragon, or monstrosity with an Intelligence of 4 or less at a rate of 1 year per round you concentrate. It may make a Constitution saving throw each round to resist. On a success, it is not affected during that round."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "1b4f8adf094d02e104a14a75b5a718b8"
+    },
+    {
+      "name": "Adhesion",
+      "source": "NRCToS",
+      "page": 65,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of powdered horse's hoof"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You bring together two solid, inanimate objects, which become stuck together. It requires a Strength (Athletics) ability check, made at disadvantage, to pry them apart (DC equal to your spell save DC)."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level spell slot, you increase the duration to 3 hours. When you cast it with a 3rd-level spell slot, you increase the duration to 8 hours. When you cast it with a 4th-level or higher spell slot, you increase the duration to 12 hours."
+          ]
+        }
+      ],
+      "opposedCheck": [
+        "strength",
+        "intelligence"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "802d48643724f24bb29f88403ee2d250"
+    },
+    {
+      "name": "Adamantine Weapon",
+      "source": "NRCToS",
+      "page": 65,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of diamond powder"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You transform your own cudgel, mace, staff, or other bludgeoning weapon into one made of pure elemental adamantine. It does an additional {@damage 1d12} bludgeoning damage on a successful hit."
+      ],
+      "damageInflict": [
+        "bludgeoning"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "War",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Mountain"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Crown",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "1dd362298e6c2fdc46513d17d60c3786"
+    },
+    {
+      "name": "Agra's Ambush",
+      "source": "NRCToS",
+      "page": 66,
+      "level": 3,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a handful of roughly-ground glass"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You provide protection for yourself or one willing creature against unwanted mental intrusion. The trap will be triggered if a protected creature be affected by a spell or effect that would sense its emotions, read its thoughts, or put the {@condition charmed} condition on it. The attacker must make a Wisdom saving throw. The attacker takes {@damage 3d10} psychic damage on a failed saving throw, or half as much damage on a successful one. In either case, you are alerted as to the potential intrusion.",
+        "Once this spell has been triggered, it ends."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, the trap inflicts another {@scaledice 3d10|3-9|1d10} damage per slot level above 3rd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "ccd0f9edbcf117d60bb4b23edd00c1fd"
+    },
+    {
+      "name": "Agitate Wounds",
+      "source": "NRCToS",
+      "page": 66,
+      "level": 3,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of salt"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You choose one creature that you see within range that has recently been injured by an edged weapon (i.e., not at full hit points and not yet been treated with a {@item healer's kit|phb}, a curative {@filter potion|items|type=potion}, or with {@filter healing magic|spells|miscellaneous=healing}), or by another attack that caused bleeding. This spell will cause the wounds to open and bleed profusely. The target takes {@damage 2d6} damage and must make a Constitution saving throw. On a success, the target takes no more damage. On a failure, the target takes another {@damage 1d4} damage each round until the wound is treated."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "HL",
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Vengeance",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Oathbreaker",
+              "source": "DMG"
+            }
+          },
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Fiend",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "d587f8412a08e6fba9dadf0cac22c1c9"
+    },
+    {
+      "name": "Aging",
+      "source": "NRCToS",
+      "page": 66,
+      "level": 8,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a black opal worth at least 500 gp",
+          "cost": 50000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A sickly gray bolt of energy shoots out from your outstretched hand towards a creature within range. Make a ranged spell attack. On a hit, the target must make a Constitution saving throw. The target takes {@damage 6d10} necrotic damage and instantly ages that many years on a failed saving throw, or half as much damage and years on a successful one. In either case, the creature is also knocked {@condition unconscious} for 1 minute. If the target dies from this damage, it is considered to have died of old age and can only be brought back through a {@spell wish}.",
+        "The aging is permanent unless reversed with a {@spell greater restoration} spell. The aging has no game affects unless the DM determines that the target has been pushed into old age, in which case the subject suffers from one level of {@condition exhaustion}, which is permanent until the aging has been reversed.",
+        "Celestials, constructs, elementals, fey, fiends, undead, and any other sort of creature that doesn't age is immune to this spell."
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "5438708526f1b12ca3601e9d0f6c6023"
+    },
+    {
+      "name": "Ahrvar's Forgery",
+      "source": "NRCToS",
+      "page": 67,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a sample of the handwriting to be copied"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "When you cast this spell, you gain the ability to perfectly mimic one person's handwriting for the next ten minutes."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "8a5aa9b505761711722297b6f223e8be"
+    },
+    {
+      "name": "Airboat",
+      "source": "NRCToS",
+      "page": 67,
+      "level": 8,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "miles",
+          "amount": 5
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 12
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You must be outside to cast this spell. You point to a cloud, which immediately descends towards you and changes shape until it becomes a ship made of clouds. You determine its shape (caravel, dragon-galley, rowboat, etc.), but that has no bearing on its performance.",
+        "You and up to eight other creatures of your choice may board the airboat, which flies at a speed of 100 feet under your telepathic command. You are considered to have proficiency with the airboat. While captaining the boat, you have resistance to lightning and thunder damage and are immune to harm caused by nonmagical winds. The airboat has an AC of 13 and 100 hit points."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When cast with a 9th-level spell slot, you may bring up to sixteen other creatures onboard with you."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "d861f3d13a0a0c68c7a011275b3c6c21"
+    },
+    {
+      "name": "Airy Water",
+      "source": "NRCToS",
+      "page": 67,
+      "level": 5,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "sphere",
+        "distance": {
+          "type": "feet",
+          "amount": 20
+        }
+      },
+      "components": {
+        "s": true,
+        "m": "a handful of salt"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Stormwrack}",
+        "You turn the water in a 20-foot bubble around you turns into a frothy substance that can be breathed as easily as air. In addition, movement is easier through {@i airy water}\u2014a creature's swimming speed increases by 20 feet and Strength (Athletics) checks made in order to swim are made at advantage, and boats traveling in a patch of {@i airy water} have their speed increased by 25%."
+      ],
+      "areaTags": [
+        "S"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Coast"
+            }
+          }
+        ]
+      },
+      "uniqueId": "80eb16af529b33c1cabdce4c77110f73"
+    },
+    {
+      "name": "Alcoreax's Icetrail",
+      "source": "NRCToS",
+      "page": 67,
+      "level": 4,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a steel pin and a cup of water"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You tap the ground at your feet and a wave of ice 10 feet high and 20 feet wide appears on the ground and begins to snake forward, leaving a sheet of ice in its wake. The wave moves at a rate of 30 feet in a straight line, but at the beginning of each of your turns, you may direct it to turn and move in a different direction at a 45- or 90-degree angle.",
+        "A creature standing in the area when the ice enters its space will be caught by the icy wave and will be {@condition restrained} by it (escape DC equal to your spell save DC). A {@condition restrained} creature will begin to suffocate, as per the {@book suffocation rules|PHB|8|Suffocating} in the {@i Player's Handbook}, page 183. Magical fire will melt the wave without harming the creatures trapped by it.",
+        "A creature who enters the area with the sheet of ice or ends its turn there must succeed on a Dexterity saving throw to avoid slipping on the ice and falling {@condition prone}. The ice sheet counts as difficult terrain. In addition, the air up to 10 feet above the ice sheet is so cold that each creature that ends its turn in that area take {@damage 3d8} cold damage."
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "areaTags": [
+        "W"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Arctic"
+            }
+          }
+        ]
+      },
+      "uniqueId": "deae3324b8c5328b169181548fc8bf8b"
+    },
+    {
+      "name": "Allegro",
+      "source": "NRCToS",
+      "page": 68,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 20
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a tail feather from a bird of prey"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1,
+            "upTo": true
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You and up to eight allies within 20 feet of you have their walking speed doubled for the duration of this spell."
+      ],
+      "miscTags": [
+        "HL"
+      ],
+      "areaTags": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "6a2f8caf221aa4b4f8a1ec0cb3bb0f78"
+    },
+    {
+      "name": "Alpha's Chill of the Void",
+      "source": "NRCToS",
+      "page": 68,
+      "level": 4,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of ice"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You bring forth a wave of airless, supernaturally-intense cold in a 60-foot cone. All creatures in the area take {@damage 6d6} cold damage and one level of {@condition exhaustion} as the air is sucked from their lungs. There is no saving throw. Creatures that don't need to breathe take no {@condition exhaustion}.",
+        "All normal vegetation of Medium size or smaller in the area dies, and larger vegetation has a 50 percent chance of dying. Plant creatures are no more susceptible than other living beings are. Normal (non-magical) fires in the area are immediately snuffed and standing water instantly freezes."
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Great Old One",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "57609fa118fbe4b43dbad38630832cd2"
+    },
+    {
+      "name": "Alpha's Blue Blaze",
+      "source": "NRCToS",
+      "page": 68,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause blue flames and purple acid to fan forth from your outstretched hand in a 60-foot cone. All creatures in that area must make a Dexterity saving throw. A creature takes {@damage 4d8} fire damage and {@damage 4d8} acid damage on a failed saving throw, or half as much on a successful one."
+      ],
+      "damageInflict": [
+        "acid",
+        "fire"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "16f84928577e3b846bfaba0a072382d0"
+    },
+    {
+      "name": "Allergy Field",
+      "source": "NRCToS",
+      "page": 68,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of ragweed"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You choose a point within range that you can see and fill it with a 10-foot cube of pollen. All creatures within that area must make a Constitution saving throw against poison or suffer disadvantage on all attack rolls and skill checks for the next minute due to uncontrollable sneezing and watering eyes. A creature may make a new saving throw at the start of each of its turns, ending the effect on a success. A wind of at least 5 miles per hour will blow the pollen away and end the spell."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "C"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "a4873a085d75b2f0fd2699947f3286b3"
+    },
+    {
+      "name": "Rising Rot",
+      "source": "NRCToS",
+      "page": 303,
+      "level": 6,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a handful of mold spores"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You hold up your hand and a thin beam of sickly green-brown light shoots out and automatically strikes one living, corporeal creature within range you can see. Mold and gangrenous patches begin to form on its body. At the beginning of each of its turns, the creature must make a Constitution saving throw. It takes {@damage 2d8} poison damage and {@damage 2d8} necrotic damage on a failed saving throw, or half as much damage on a successful one. This continues until the target is reduced to 0 hit points or has successfully saved three times. The saves do not need to be consecutive."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 7th-level or higher spell slot, it inflicts an additional {@scaledice 2d8|6-9|1d8} poison damage and {@scaledice 2d8|6-9|1d8} necrotic damage for each slot level above 6th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "necrotic",
+        "poison"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "7454d028c7372d49e76db1964cc3c7e2"
+    },
+    {
+      "name": "Alpha's Hunting Hound",
+      "source": "NRCToS",
+      "page": 69,
+      "level": 1,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of meat"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You summon a fey spirit that takes the form of a white and red {@creature mastiff}. It is identical to the {@creature mastiff} from the {@i Monster Manual} (page 332), save that its {@skill Perception} skill bonus is +5. It is friendly to you and your companions. Roll initiative for it, as it has its own turns. It will obey any commands that you issue. If you don't issue commands to it, it will defend itself from hostile creatures, but otherwise takes no actions. The {@creature mastiff} disappears when it drops to 0 hit points or when the spell ends."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, you conjure one additional hound for each slot level above 1st."
+          ]
+        }
+      ],
+      "miscTags": [
+        "SMN"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Ancients",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "c0a6c066bc1be4d318988b9159c768f4"
+    },
+    {
+      "name": "Alpha's Heat Lightning",
+      "source": "NRCToS",
+      "page": 69,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a short glass rod, a bit of fur, and a bit or iron or lodestone"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You call down a bolt of purplish-red lightning, which strikes a single creature you can see within range. Make a ranged spell attack to hit. On a success, that creature takes {@damage 4d10} fire damage and {@damage 4d10} lightning damage. If the creature is wearing nonmagical metallic armor or carrying a metallic weapon, the creature takes an additional {@damage 1d10} lightning damage. The lightning will also set combustibles on fire."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 6th-level or higher spell slot, you inflict an additional {@scaledice 4d10 + 4d10|5-9|1d10} lightning damage for each slot level above 5th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "fire",
+        "lightning"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Grassland"
+            }
+          }
+        ]
+      },
+      "uniqueId": "42b256127039dd11c0c0ee66e0822ddb"
+    },
+    {
+      "name": "Alpha's Comet",
+      "source": "NRCToS",
+      "page": 69,
+      "level": 7,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a ball of pitch mixed with sulfur and phosphorus"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a sphere of flaming rock with a tail of noxious, superheated gasses. This unerringly strikes one target you can see within range, causing {@damage 4d8} bludgeoning damage and {@damage 4d8} fire damage. In addition, all creatures within 5 feet of the target must make a Dexterity saving throw, taking {@damage 4d8} fire damage on a failed roll or half as much on a successful one.",
+        "Finally, all creatures within 10 feet of the target, including the target (if the target is a creature), must make a Constitution saving throw against poison. On a failed save, the creature is spends its action that turn retching and reeling, takes {@damage 2d8} poison damage, and is {@condition poisoned} for 1 minute. Creatures that don't need to breathe or are immune to poison automatically succeed on this saving throw. The gasses disperse after 1 round."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 8th-level or higher spell slot, you inflict an additional {@dice 1d8} bludgeoning, fire, and poison damage for each spell slot above 7th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "bludgeoning",
+        "fire",
+        "poison"
+      ],
+      "conditionInflict": [
+        "poisoned"
+      ],
+      "savingThrow": [
+        "constitution",
+        "dexterity"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST",
+        "R",
+        "Q"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "119a608ddbe97aae090e4a656cd0cda0"
+    },
+    {
+      "name": "Alpha's Moonlight",
+      "source": "NRCToS",
+      "page": 70,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a moonstone"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A 30-foot-radius circle of soft, blue-gray light shines down from above, centered on a point you choose within range. In this area, all color is washed out; creatures in that area cannot discern color and can only see in shades of gray. Creatures who have the trait Sunlight Sensitivity are not affected by sunlight while in this area; creatures who take damage from sunlight only take half the normal amount of damage.",
+        "While in this area, infected lycanthropes must make a Wisdom saving throw to avoid being forced to transform.",
+        "If you cast this spell on yourself, the area moves with you. Otherwise, it is stationary."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Forest"
+            }
+          },
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Archfey",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "fad19b44821bea35b0c05c9ff2a0c2c8"
+    },
+    {
+      "name": "Alpha's Rolling Thunder",
+      "source": "NRCToS",
+      "page": 70,
+      "level": 3,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You throw your hands skyward and a tremendous clap of thunder sounds directly overhead. All creatures within 30 feet must make a Constitution saving throw. A creature takes {@damage 5d6} thunder damage and is knocked {@condition prone} on a failed saving throw, or half as much damage and is not knocked {@condition prone} on a successful one. In addition, regardless of the saving throw, a creature is {@condition deafened} until the end of its next turn."
+      ],
+      "damageInflict": [
+        "thunder"
+      ],
+      "conditionInflict": [
+        "deafened",
+        "prone"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "areaTags": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Tempest",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Coast"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Mountain"
+            }
+          }
+        ]
+      },
+      "uniqueId": "a739873985128de69fb2ca5030e7623e"
+    },
+    {
+      "name": "Alpha's Rainbow Beam",
+      "source": "NRCToS",
+      "page": 70,
+      "level": 2,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a clear gem or crystal prism worth at least 50 gp",
+          "cost": 5000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You draw forth a beam of elemental light and fire it at a creature you can see within range. Make a ranged spell attack to hit. You may attempt a DC 13 Intelligence (Arcana) check to choose the beam's color; otherwise, it is randomly determined. You may not attempt to create a multihued beam. The beam does {@damage 3d10} damage of a type determined by its color; the target may make a Dexterity saving throw for half damage. Roll a {@dice d8} to determine the color.",
+        {
+          "type": "table",
+          "colLabels": [
+            "{@dice d8}",
+            "Beam's Color"
+          ],
+          "colStyles": [
+            "col-1 text-center",
+            "col-11"
+          ],
+          "rows": [
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 1,
+                  "pad": false
+                }
+              },
+              "Red (force damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 2
+                }
+              },
+              "Orange (fire damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 3
+                }
+              },
+              "Yellow (acid damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 4
+                }
+              },
+              "Green (poison damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 5
+                }
+              },
+              "Blue (lightning damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 6
+                }
+              },
+              "Indigo (cold damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 7
+                }
+              },
+              "Violet (radiant damage)"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "exact": 8
+                }
+              },
+              "Multihued; roll twice and ignore further rolls of 8."
+            ]
+          ]
+        },
+        "The beam stops once it hits a solid object, even if that object is transparent."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level spell slot or higher, it does an additional {@scaledice 3d10|2-9|1d8} damage per slot level above 2nd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid",
+        "cold",
+        "fire",
+        "force",
+        "lightning",
+        "poison",
+        "radiant"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Light",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "d4589db67790a3c278d0b4e15d1eb180"
+    },
+    {
+      "name": "Alpha's Starlight Citadel",
+      "source": "NRCToS",
+      "page": 71,
+      "level": 7,
+      "school": "C",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a star sapphire worth at least 1,000 gp and a small steel carving of a tower",
+          "cost": 100000
+        }
+      },
+      "duration": [
+        {
+          "type": "special"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a citadel out of a magical metal that is midnight blue with silvery accent in color. It is identical in shape, size, and layout to {@item Daern's instant fortress}, although it slowly coalesces instead of suddenly growing and thus does not cause damage to creatures who cannot get out of the way. The door opens on your command and on the command of up to 10 others that you designate when casting the spell.",
+        "This spell can only be cast at night and will last until touched by the first rays of direct sunlight."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "84f248fa37cc0f4a15e57259277e6ef9"
+    },
+    {
+      "name": "Alpha's Sparkle Beam",
+      "source": "NRCToS",
+      "page": 71,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You draw upon the Positive Plane and call forth a cone filled with shining motes of silver and gold light. All creatures in a 10-foot cone must make a Constitution saving throw or be {@condition blinded} until the end of their next turn. A creature with the Sunlight Sensitivity trait has disadvantage on this roll.",
+        "Undead, fiends, and creatures of any type native to the Shadowfell take {@dice 1d6} + your spellcasting ability modifier in radiant damage. Creatures of types other than those listed above do not take damage from this spell, but they might still be {@condition blinded}.",
+        "This spell's damage increases by {@damage 1d6} when you reach 5th level ({@damage 2d6} + your modifier), 11th level ({@damage 3d6} + your modifier), and 17th level ({@damage 4d6} + your modifier)."
+      ],
+      "scalingLevelDice": {
+        "label": "radiant damage",
+        "scaling": {
+          "1": "1d6",
+          "5": "2d6",
+          "11": "3d6",
+          "17": "4d6"
+        }
+      },
+      "damageInflict": [
+        "radiant"
+      ],
+      "conditionInflict": [
+        "blinded"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "opposedCheck": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "3e282a0a25467095c42c753488ccce48"
+    },
+    {
+      "name": "Alpha's Spark Shower",
+      "source": "NRCToS",
+      "page": 71,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 15
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a bit of fur, glass, and copper"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You extend your arms and a sheet of sizzling purple sparks shoot forth from your hands. Each creature in a 15-foot cone must make a Dexterity saving throw. A creature takes {@damage 1d6} lightning damage on a failed saving throw, or half as much on a successful one. A creature wearing metal armor has disadvantage on this roll.",
+        "This spell does additional damage when you reach 5th level ({@damage 2d6}), 11th level ({@damage 3d6}), and 17th level ({@damage 4d6})."
+      ],
+      "damageInflict": [
+        "lightning"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "7f2d59f9dc447a830e276c4b0fafdf7c"
+    },
+    {
+      "name": "Alpha's Shadowfire",
+      "source": "NRCToS",
+      "page": 71,
+      "level": 4,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a black opal worth at least 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A streak of black and green flame erupts from your hands and strikes a point you choose within range. Make a ranged spell attack to hit. On a success, your target takes {@damage 3d10} fire damage plus {@damage 3d10} necrotic damage."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "For each spell slot of 5th level or higher, you inflict an additional {@dice 1d10} fire or {@damage 1d10} necrotic damage (your choice) per slot level above 4th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "fire",
+        "necrotic"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "551e37918deaef3cd23c01427a321032"
+    },
+    {
+      "name": "Alter Instrument",
+      "source": "NRCToS",
+      "page": 73,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium} and The Great Net Spellbook",
+        "You may transform one {@filter musical instrument|items|type=instrument} into another one of similar size (up to 50% larger or smaller) with which you are familiar; you don't need to be proficient in its use, however. The instrument remains in this shape for as long as you are touching it. If you put it down for more than 1 minute, it reverts to its normal shape. It also reverts back if someone else attempts to play it.",
+        "The spell's duration increases to 1 hour when you reach 5th level and 8 hours when you reach 11th level.",
+        "You can instead use this spell to perfectly tune an instrument you touch. This effect is permanent, although the instrument may eventually fall out of tune anyway."
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "e1e8ca8ea2c8ce34dfe942947f588818"
+    },
+    {
+      "name": "Alpha's Starshield",
+      "source": "NRCToS",
+      "page": 72,
+      "level": 5,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a black sapphire and a star sapphire, each worth at least 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You are enveloped in a nearly skin-tight magical shield that looks like a moonless night sky. While this spell is in effect, you are immune to radiant damage and to being {@condition blinded}. You are also advantage on any saving throw to resist spells that uses light or color to blind, charm, confuse, or damage you. You can see through magical darkness and gain {@sense darkvision} to 60 feet; if you already have darkvision, it expands an additional 30 feet. Finally, you also gain advantage on all {@skill Stealth|Dexterity (Stealth)} rolls when in dim light or darkness."
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "dea49978f5a0db281a65db16d4b3b516"
+    },
+    {
+      "name": "Alter Animal Intelligence",
+      "source": "NRCToS",
+      "page": 72,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a dried fish, piece of brain coral, and rare herbs worth 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Prayerbook",
+        "You cause one aberration, beast, dragon, monstrosity, or ooze with an Intelligence of 4 or less to gain 2 points of Intelligence permanently. The creature must make a Constitution saving throw when you cast this spell, whether or not the creature is willing. On a failure, the spell still succeeds but the creature takes {@damage 4d10} psychic damage as its brain is painfully altered.",
+        "You may cast this spell on a creature multiple times, raising its intelligence by 2 each time, to a maximum of 10. This does not grant the creature the ability to speak, nor does it secure the creature's friendship for you.",
+        "You may cast this spell on a normal plant, giving it an Intelligence of 2 (or more, if you cast this spell multiple times), but this doesn't give it mobility beyond what it already has."
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "fc668c3c7c6657b3c7ebb52f54949626"
+    },
+    {
+      "name": "Alter Beast",
+      "source": "NRCToS",
+      "page": 72,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "two strands of gold twisted together to form a double helix, worth 10 gp",
+          "cost": 1000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You may sculpt part of a beast's body as you wish. For instance, you could change paws or hooves into hands, make a quadruped walk upright, alter a creature's mouth and larynx to make it capable of speech, and so on. The DM will determine if there are any changes to its attributes due to the change. The creature must make a Constitution saving throw when you cast this spell, whether or not the creature is willing. On a failure, the spell still succeeds but the creature takes {@damage 5d10} force damage as its body is painfully altered.",
+        "You may only make one change with each casting of this spell, although the change can be complex (such as rearranging a quadruped's hips and legs so it becomes a biped), but you may cast this spell on a single creature multiple times. You can't increase a creature's intelligence with this spell, nor can you add body parts (such as additional limbs); you may remove parts, however. The changes you make are permanent and might be passed down to any offspring it may have."
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "1482189b932bdc0fd06bdefff8498a2b"
+    },
+    {
+      "name": "Blades of Fury",
+      "source": "NRCToS",
+      "page": 95,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a miniature longsword"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You summon five illusory flying {@item longsword|phb|longswords}, which you set to duel other creatures within range. When you cast the spell and as a bonus action on your subsequent turns, you can move a sword up to 30 feet and cause it to attack a new target.",
+        "Your swords attack using your spell attack modifier. On a hit, the sword inflicts {@damage 1d8} slashing damage. Each time a target is struck by a sword, it may make an Intelligence saving throw. On a success, the target becomes aware that the sword is an illusion, which causes the sword to vanish. If another creature is told that the swords are illusions or sees one vanish, that creature has advantage on its next saving throw.",
+        "If a creature is reduced to 0 hit points by these illusory blades, they instead drop to 1 hit point and fall {@condition unconscious}."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a spell slot of 6th level or higher, you summon one additional sword per slot level above 5th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "slashing"
+      ],
+      "savingThrow": [
+        "intelligence"
+      ],
+      "miscTags": [
+        "SCL",
+        "SMN"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "f79e3afa5feaabb8e48e2fe153068c5e"
+    },
+    {
+      "name": "Blacksteel",
+      "source": "NRCToS",
+      "page": 95,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "One weapon you touch becomes completely matte-black and utterly silent\u2014it makes no noise when being drawn, when striking someone even if it hits armor, or when dropped."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "fd898ac86ab6e2fe7e6083c15d17a2af"
+    },
+    {
+      "name": "Bliss",
+      "source": "NRCToS",
+      "page": 97,
+      "level": 2,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "One creature within range that you can see must make a Wisdom saving throw or fall into a trance of intense pleasure; for the duration of the spell, the creature is {@condition incapacitated}. The creature may make a new saving throw at the end of each of its turns, ending the effect on success.",
+        "This spell has potential for addiction and is debilitating with frequent use. If a creature is subjected to this spell three times in a 24-hour period, it must make a Wisdom saving throw. On a failure, it takes {@damage 1d10} psychic damage and its hit point total is reduced by that amount. This hit point reduction lasts for 1 week or until a spell such as greater restoration is cast on it. Until its hit point total has been restored, it can't make a saving throw to resist the spell, but must still make a Wisdom saving throw to avoid taking psychic damage."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 3rd-level or higher spell slot, the spell no longer requires concentration. If you cast this spell with a 5th-level or higher spell slot, the duration increases to 10 minutes."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "conditionInflict": [
+        "incapacitated"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "HL",
 				"SCL",
 				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b0f96bdd0b4cbfe36eca8321c6a56eab"
-		},
-		{
-			"name": "Déjà Vu",
-			"source": "NRCToS",
-			"page": 148,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a timekeeping device of any sort worth at least 100 gp, which is consumed",
-					"consumed": true,
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A creature you can see is sent back in time to the place where it was exactly 24 hours ago (do not take planetary rotation into account). An unwilling creature may make a Wisdom saving throw to resist. If another creature or object is in the location you send it to, it will appear in the nearest empty space. If the creature was on a different plane at that time, the spell fails."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 7th-level or higher spell slot, you transport the creature back an additional 24 hours for each slot level above 6th."
-					]
-				}
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"SCL",
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "36ef3ad6be259f44dd3c4318c4312011"
+    },
+    {
+      "name": "Drawmij's Breath of Life",
+      "source": "NRCToS",
+      "page": 161,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "bonus action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 100
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You endow yourself and up eight other allies with the ability to hold your breath for twice as long as normal."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "a7b7d539453d8e2deaf76ff2e9cc5703"
+    },
+    {
+      "name": "Drawmij's Instant Exit",
+      "source": "NRCToS",
+      "page": 161,
+      "level": 3,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a miniature silver door decorated worth 500 gp",
+          "cost": 50000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You open an extradimensional door in a wall or other flat surface that remains open for one round. When the door closes, you and anyone else who pass through the door are teleported to a completely random location within 250 yards. You will be let out on a flat surface capable of supporting your weight, but there is no guarantee that this place will otherwise be safe. You cannot control who uses the door."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "414beb4b269c50b0b4c5e2bde4a7d496"
+    },
+    {
+      "name": "Drawmij's Light Step",
+      "source": "NRCToS",
+      "page": 161,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a bit of cat fur and a duck's feather"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You or one willing creature you touch is granted a the ability to walk at a normal pace without leaving tracks or disturbing the ground below it. The creature can also walk across relatively calm fluids, such as the surface of a lake, as if it was difficult terrain."
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Archfey",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "8324abc8fbfecc5aa6f5cadc77c09008"
+    },
+    {
+      "name": "Drawmij's Scent Mask",
+      "source": "NRCToS",
+      "page": 161,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a scentless flower"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "One creature you touch is rendered scentless and cannot be tracked by smell.",
+        "This spell can be cast on a creature that attacks through scent, such as a skunk or troglodyte. That creature may make a Constitution saving throw to resist. On a failure, it cannot use this attack for the duration."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "35323bc0c38b6dc6d538370f70a869db"
+    },
+    {
+      "name": "Drawmij's Swift Mount",
+      "source": "NRCToS",
+      "page": 162,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a hare's foot or a bit of cheetah's fur"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You touch a trained riding beast, dragon, or monstrosity that has an Intelligence of 4 or less, or on a riding beast summoned with the {@spell find steed} spell, and its movement is doubled for the duration of the spell. If you overload the animal, it automatically cancels this spell. You cannot cast this spell on that creature again until it has taken a short or long rest."
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Grassland"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Crown",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "cd8d3b80e0431d3351f51ea0410fd3f7"
+    },
+    {
+      "name": "Dread Word",
+      "source": "NRCToS",
+      "page": 162,
+      "level": 3,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Book of Vile Darkness}",
+        "You speak a word from an ancient language so foul that one creature within range that you can see takes {@damage 3d10} psychic damage and its hit point total is reduced by half that amount. There is no saving throw allowed. Hit point reduction lasts until the creature takes a short or long rest. This spell does not work on {@condition deafened} creatures.",
+        "Due to the incredible evil of the spell, non-evil spellcasters take 5 points of psychic damage each time they cast this spell."
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Oathbreaker",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "e139c74bf4be13c35b4756ea0bfe7a2c"
+    },
+    {
+      "name": "Dream Feast",
+      "source": "NRCToS",
+      "page": 162,
+      "level": 2,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": true
+      },
+      "duration": [
+        {
+          "type": "special"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You must cast this on a willing target. The next time that creature sleeps (which must be within 8 hours of you casting this spell), it will dream of eating all of its favorite foods. When it wakes up, the creature will be sated, as if it had eaten a full meal. The target must sleep for at least two hours for this spell to take effect. A creature can't benefit from this spell again until it has eaten at least two actual meals."
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Life",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "a48b4e5ce68b0b05a94f1e7c9aec02f0"
+    },
+    {
+      "name": "Dream Sight",
+      "source": "NRCToS",
+      "page": 162,
+      "level": 3,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "special"
+      },
+      "components": {
+        "s": true,
+        "m": {
+          "text": "incense worth at least 5 gp",
+          "cost": 500
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Oriental Adventures}",
+        "You fall into a deep sleep and your spirit leaves your body and travels ethereally and invisibly. You gain a flying speed of 90 feet. You can pass through solid objects and creatures as if they were difficult terrain; you take {@damage 1d10} force damage if you end your turn inside an object. While in this form, you gain truesight to 30 feet. You are blocked by any spell or effect that blocks ethereal creatures and can be seen by creatures with {@sense truesight} or that are using {@spell true seeing}. You are immune to all nonmagical damage. You cannot speak, attack, cast spells, or perform any action while in this form other than moving and observing.",
+        "When the spell is over, or if your body is disturbed in any way, your spirit instantly returns and you wake up. If you took damage in any way while in spirit form, you retain that damage upon awakening."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, your speed increases by 30 feet for each slot level above 3rd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "8c5ea5b2028d31c31e8004ef2647ca42"
+    },
+    {
+      "name": "Drenal's Stone Flame",
+      "source": "NRCToS",
+      "page": 163,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a mix of fine sand and sugar, which is thrown in the air"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You point to an open flame no larger than a torch. The flame turns into a brightly-glowing stone that is cool to the touch and that can be picked up and carried without harm. It continues to shed as much light as it did before it was transformed.",
+        "When the spell expires, the stone reverts to normal flame and will burn whatever it is touching. If the stone is shattered, the flame is extinguished."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "0b92dbdf1154ee39071b3bd5aecab79f"
+    },
+    {
+      "name": "Drought",
+      "source": "NRCToS",
+      "page": 163,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 300
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a dried rat and a pinch of salt"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You spend an hour meditating and the area around you becomes much drier than before. If the land was wet and swampy, the water drains away. If it was a field or forest, the ground withers to dust and the vegetation begins to die within a few days. This spell doesn't work if cast on an area with more than a foot of standing water.",
+        "A particular plot of land can only be affected by this spell once per season, and the effects last until the end of the current growing season."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Desert"
+            }
+          }
+        ]
+      },
+      "uniqueId": "f26c1d7dc73650bac168ae4587794114"
+    },
+    {
+      "name": "Druidcraft (New Variants)",
+      "source": "NRCToS",
+      "page": 163,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "These are new variants of the spell {@spell druidcraft} that appears in the {@book Player's Handbook|phb} (page 236).",
+        {
+          "type": "list",
+          "items": [
+            "You perfectly mimic one animal or bird call. This does not give you the ability to speak with the animal, but does allow you to mimic the creature's mating calls, territorial howls, warning growls, and so on, with enough accuracy to fool that creature.",
+            "You place a magical mark on a natural inanimate object. The mark instantly understandable to other creatures that know this spell. The mark can only convey simple concepts, such as \"fresh water is nearby\" or \"warning: nesting monsters.\" The mark lasts until the end of the season or until you dispel it.",
+            "You command one {@filter beast of CR 0|bestiary|challenge rating=[&0;&0]|type=beast}. The command must be of no more than two or three words (\"sit,\" \"attack him\"). The creature will obey you to the best of its ability.",
+            "You completely heal a Tiny plant of all damage and disease.",
+            "You cause a picked fruit (or vegetable, seed, or nut) to become unblemished, free from parasites, and healthy to eat. If it's unripe or too ripe, you cause it to become perfectly ripe.",
+            "You ask a {@filter beast of CR 1 or lower|bestiary|challenge rating=[&0;&1]|type=beast} to perform a simple, non-combat-related task for you. The beast will obey you as long as it's physically capable of performing the task, it can't potentially harm it, and it takes no longer than 1 minute to complete."
+          ]
+        }
+      ],
+      "miscTags": [
+        "HL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Fighter",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcane Archer",
+              "source": "XGE"
+            }
+          }
+        ]
+      },
+      "uniqueId": "19b98edbb3b513374253679d5019e955"
+    },
+    {
+      "name": "Spring",
+      "source": "NRCToS",
+      "page": 334,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a small forked stick, which is thrust into the ground"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You create a temporary freshwater spring that flows at a rate of {@dice 2d6} gallons per minute. In a desert or an area under drought conditions, it only produces {@dice 1d4} gallons per minute."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Nature",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Desert"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Ancients",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "c128d3085f8005aaec49785e5be959ad"
+    },
+    {
+      "name": "Demonstar",
+      "source": "NRCToS",
+      "page": 149,
+      "level": 8,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 90
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a golden star"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a small golden star and throw it at a fiend you see within range. You must make a ranged spell attack to hit. On a success, the star attaches itself to the fiend. At the beginning of each of its turns, the fiend must make a Constitution saving throw. It takes {@damage 12d6} force damage and is {@condition paralyzed} until the end of its turn on a failed saving throw, or half as much damage and is not {@condition paralyzed} on a successful save. If the fiend makes a successful saving throw three times, the spell ends. The successes don't need to be consecutive."
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "3918dd1f41df9689c19a083a342d820f"
+    },
+    {
+      "name": "Depress Resistance",
+      "source": "NRCToS",
+      "page": 149,
+      "level": 4,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a broken iron rod"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You target one creature you can see within range, and that creature must make a Wisdom saving throw. If it fails and it has Magic Resistance, it loses that trait for the duration. If it doesn't have Magic Resistance, it has disadvantage on saving throws against spells and magical effects for the duration."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "e3242a8b0b0de4b8bb25b8fe29b105d8"
+    },
+    {
+      "name": "Detect Charm",
+      "source": "NRCToS",
+      "page": 149,
+      "level": 2,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "the crushed petals of a bleeding-heart flower"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You look into the eyes of a target and can see if that creature is under a magical charm or under any similar spell (this includes any spell that does not function if the target is immune to charm, such as suggestion). This spell does not reveal what sort of charm the target is under or who placed the charm on that person. You can examine one person per round."
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          },
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Knowledge",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "fb55390b445a7a6d439b218f668a1274"
+    },
+    {
+      "name": "Detect Harmony",
+      "source": "NRCToS",
+      "page": 149,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "sphere",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a scroll on which prayers have been written in exotic inks worth at least 10 gp",
+          "cost": 1000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You gain understanding of the balance of good, evil, law, chaos, naturalness, and unnaturalness there is in a 60-foot-radius sphere around you. The information you receive is vague (\"there are many unnatural things\" or \"there is much randomness and little order\") and don't reveal the exact nature or cause of the imbalance."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Ancients",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "fd18ed4519bcadf7101e140d6ec85da9"
+    },
+    {
+      "name": "Detect Metals and Minerals",
+      "source": "NRCToS",
+      "page": 150,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "sphere",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a small magnet, a vial of weak acid, and a small sample of the desired material"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "For the duration, you sense the presence of a single type of ore, mineral deposit, or worked metal you specify within range. You will learn how far away it is, and roughly how much of it is there."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "35e858cdd835f9177e3e16b4d52a3f7f"
+    },
+    {
+      "name": "Detect Secret Passages and Portals",
+      "source": "NRCToS",
+      "page": 150,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "For the duration, you can sense the presence of secret doors, compartments, and so on that have been deliberately constructed to escape detection within range. You do not gain any understanding of how to open them. This spell does not detect traps or other hidden objects that can harm you."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "e4f3da38027931d0f0b0183e72af0bb9"
+    },
+    {
+      "name": "Detect Spellcasting",
+      "source": "NRCToS",
+      "page": 150,
+      "level": 4,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a pinch of powdered gemstone worth 10 gp",
+          "cost": 1000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You become aware of other spells currently being cast or activated within a 120-foot radius of you. You do not become aware of what spell it is or where, precisely, it originates from, although you gain a general sense of its direction (\"to the west\"). However, you may make a DC 12 check using your spellcasting ability to determine what the spell's level, school, or type (arcane or divine)."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "733073f6afad62e41b0d6a07745c3582"
+    },
+    {
+      "name": "Detonate",
+      "source": "NRCToS",
+      "page": 150,
+      "level": 3,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a burning coal and an eagle's feather"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause one nonmagical, inanimate object of Medium-size or smaller (or a Medium-sized piece of a larger object) you can see within range to explode. Fragile items (as per the {@i Dungeon Master's Guide}, {@table Object Hit Points|dmg|page 246}) are automatically affected. If you target a resilient object, make a {@dice d20} roll, adding your spellcasting ability modifier. On a roll of 10 or higher, it explodes.",
+        "The object itself takes {@damage 5d10} force damage. All creatures within 10 feet of it must make a Dexterity saving throw. A creature takes {@damage 3d6} fire damage and {@damage 3d6} piercing damage and is knocked {@condition prone} on a failed saving throw, or half as much damage and remains standing on a successful save. The fire ignites flammable objects in the area that aren't being worn or carried."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a spell slot of 4th-level or higher, you inflict an additional {@damage 1d10} damage to the object and {@damage 1d6} fire and {@damage 1d6} piercing damage for each slot level above 3rd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "fire",
+        "force",
+        "piercing"
+      ],
+      "conditionInflict": [
+        "prone"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SCL",
 				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "34686f26f77afc72536acbf5c37ab462"
-		},
-		{
-			"name": "Demand",
-			"source": "NRCToS",
-			"page": 148,
-			"level": 7,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "unlimited"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a short piece of copper wire"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"This spell functions as the {@spell sending} spell, in that you can send a message of twenty-five words or fewer to a creature with which you are familiar. However, this spell also contains a {@spell suggestion}, as per that spell. This {@i suggestion} lasts for 8 hours and does not require concentration.",
-				"The recipient must make a Wisdom saving throw or become subject to the {@i suggestion}. The {@i demand} is understood even if you don't share a language with the subject or if the subject has no language."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "169c7578cde56a8c72f77482dde75a78"
-		},
-		{
-			"name": "Befoul",
-			"source": "NRCToS",
-			"page": 90,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Ravenloft}, {@i Gazetteer Volume V} (Sword & Sorcery)",
-				"Up to 10 pounds of organic, non-living matter is aged by 1 day with each casting of this spell. If you cast this spell on an object that weighs more than 10 pounds, only part of it will be aged. However, you can cast this spell multiple times on an object, aging all of it over the course of numerous castings, or part of it while leaving the rest untouched.",
-				"The object is aged by 1 week when you reach 5th level, 1 month when you reach 11th level, and 3 months when you reach 17th level."
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "c7f55e2e37f52a798af5a5930e7a76d4"
-		},
-		{
-			"name": "Bearhug",
-			"source": "NRCToS",
-			"page": 90,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a bit of bear fur"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You gain the ability to bear hug a creature up to one size category larger or smaller than you. If you successfully make an unarmed attack, you can grapple that creature (escape DC is equal to your spell save DC). As long as the grapple remains in effect, that target is {@condition restrained}. At the start of each of your turns, you may constrict, doing {@dice 2d12} + your Strength modifier in bludgeoning damage. While grappling someone, you cannot use your hands or arms for any other purpose."
-			],
-			"conditionInflict": [
-				"restrained"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "379ba53e5bcf002dd7e49606e8100781"
-		},
-		{
-			"name": "Bloodbridge",
-			"source": "NRCToS",
-			"page": 100,
-			"level": 0,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "two golden needles"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You touch two creatures and draw blood out from one (the \"donor\"), channel it through yourself, and infuse it into the other (the \"recipient\"). The donor then loses a number of hit points equal to {@dice 1d6} + your spellcasting ability modifier and the recipient gains that number of hit points, up to its normal maximum. The donor does not need to be willing and may make a Dexterity or Strength saving throw to evade or escape your grasp. This spell has no effect on constructs, elementals, oozes, plants, undead, and other creatures that lack blood."
-			],
-			"savingThrow": [
-				"strength"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "53e2188dbdc437621e07a332ec44e55e"
-		},
-		{
-			"name": "Candletrick",
-			"source": "NRCToS",
-			"page": 109,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You light a candle or lantern\u2014any source of light that has a wick (as opposed to torches). For the duration of the spell, this flame cannot be extinguished by nonmagical means. If the flame is snuffed out, it will automatically relight itself."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "00e8110dd579aff5d3032f023574a1b1"
-		},
-		{
-			"name": "Cook",
-			"source": "NRCToS",
-			"page": 124,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "enough food for one or two meals, a pinch of tinder, a small dab of sulfur, and 1 gold piece",
-					"cost": 100
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"This automatically transforms prepared but raw ingredients into a decent-quality meal for two, provided that the ingredients are fit to be eaten. This spell cannot be used on living beings, plant matter that has not been picked, or on an animal's unbutchered carcass. This also removes natural toxins (such as bacteria that would cause food poisoning) from the food, but it will not remove deliberately-placed poisons or contaminants such as shards of glass."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 3rd level or higher, you can prepare food for two additional people for each spell slot above 2nd level. You must provide ingredients for the additional meals."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "53f2f070300088d065fffa3b48a8022d"
-		},
-		{
-			"name": "Copy",
-			"source": "NRCToS",
-			"page": 125,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You hold a blank sheet of paper, a book with empty pages, or another similar material over a document and this spell produces a perfect copy. Each casting of this spell will duplicate a standard 8 inch × 10 inch quarto size.",
-				"Attempts to copy magical text of any sort will automatically fail. If you copy a text-based trap (such as a {@spell symbol}), you set the trap off."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "df6d83ad1ae702eb93c339f85f5c4ac5"
-		},
-		{
-			"name": "Command Hair",
-			"source": "NRCToS",
-			"page": 118,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Prayerbook",
-				"You may cause the hair of a willing target to grow up to one foot, be cut or shaved off, and style itself in any manner you choose.",
-				"You may also cause the hair to act like a prehensile tentacle, under the control of the hair's owner. The hair has Strength 6 (-2) and Dexterity 9 (-1) and while it performs all combat-related actions at disadvantage, it can do other things such as grabbing items, picking locks, untying ropes, and so forth at no penalty."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level or higher spell slot, the hair has a +1 bonus to Strength and Dexterity for each slot level above 1st."
-					]
-				}
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "8ce2a54edaf4b2a2e393d34af1be8e8a"
-		},
-		{
-			"name": "Comfort",
-			"source": "NRCToS",
-			"page": 118,
-			"level": 1,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You sing a pleasant song and all allies within range will cease feeling pain, heat, cold, hunger, thirst, or {@condition exhaustion}, as long as those feelings were produced naturally and not induced by magic or through combat. Thus, you could make someone feel wide awake after being up all night, but not one that had been struck by a {@spell ray of fatigue|dapc} (q.v.).",
-				"This spell does not negate or prevent the targets from normal damage through the elements, {@book starvation|phb|8|food and water|0}, etc.; it merely prevents the targets from feeling the effects."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "503aa99b59a08dff34434744b9a8295b"
-		},
-		{
-			"name": "Consume Likeness",
-			"source": "NRCToS",
-			"page": 122,
-			"level": 6,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "one ounce of meat, which is consumed",
-					"consumed": true
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Book of Vile Darkness}",
-				"You consume an ounce of raw flesh from a creature of the same type and size category as yourself, and your form changes to perfectly match the way that creature looked when alive (you may also cast this using meat from a still-living creature). This change is permanent but is also primarily cosmetic. You gain none of the original creature's attributes, abilities, or knowledge. However, it the creature had gills and had the amphibious or limited amphibious trait, you also gain the ability to breathe underwater. You can also gain up to one additional pair of limbs, if the original creature had extra limbs; likewise, if you were missing a limb and the original creature was not, you regrow that limb\u2014however, if the original creature was missing a limb (and not from the way it was killed), you also lose that limb. When you die, you resume your true form."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "79afb33e8a31f8fd5398ce1b0b90a891"
-		},
-		{
-			"name": "Confuse Self",
-			"source": "NRCToS",
-			"page": 120,
-			"level": 1,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "reaction",
-					"condition": "taken when you detect someone trying to read your mind"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You become utterly and completely confused. You are {@condition incapacitated} for the duration, but you are also immune to being {@condition charmed} or {@condition frightened} and to having your mind or emotions read or mind controlled. You are also immune to all mundane attempts to persuade or intimidate you."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Great Old One",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "cef63bd4d2c5d33756b7ba06ebc2a92d"
-		},
-		{
-			"name": "Compass",
-			"source": "NRCToS",
-			"page": 119,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a brass bowl filled with water, an iron needle, and a cork"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "week",
-						"amount": 1
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You use the pin, cork, and brass bowl to make a simple compass. However, instead of pointing to magnetic north, the needle points towards any destination you choose, as long as you know for certain that destination exists. For instance, you could set it to point towards your home port or a major city, but not to the rumored location of a long-lost dungeon.",
-				"The spell ends if the water is drained from the bowl or the cork or needle is removed."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "bef99a8cf7f9f6838a01294ad6faf6cf"
-		},
-		{
-			"name": "Music of the Spheres",
-			"source": "NRCToS",
-			"page": 268,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "three ribbons, one, four, and nine inches long that made from fine silver thread and worth 100 gp each",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"Utterly beautiful cosmic music begins playing around you. All creatures within range except for you and your allies become so distracted by the music and must make a Wisdom saving throw or be at disadvantage on all attacks against you, and at all attempts to resist any effect that would charm them."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"areaTags": [
-				"S"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "0d4a1e2f4d4fb6b51a6b26ac9b1a8a07"
-		},
-		{
-			"name": "Nap",
-			"source": "NRCToS",
-			"page": 270,
-			"level": 2,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of pillow stuffing, a feather, and a pebble"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"One willing creature you touch takes a short rest which is as refreshing as a long rest, and gives the creature all the benefits of a long rest. A creature can only be affected by this spell once every 24 hours.",
-				"Creatures that are immune to {@condition exhaustion} cannot be affected by this spell."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Life",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "574403cd9b0991044d4aa230391fbe53"
-		},
-		{
-			"name": "Notice",
-			"source": "NRCToS",
-			"page": 275,
-			"level": 0,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You put yourself in a trance for a few seconds, and when you emerge, you are highly aware of your surroundings. Until the end of your next turn, you have advantage on your {@skill Perception|Wisdom (Perception)} check. While you are in this trance, you are deaf and blind as to your own surroundings."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "1dce86173b5aa58114f48eaaa534c10e"
-		},
-		{
-			"name": "Orison",
-			"source": "NRCToS",
-			"page": 281,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "special"
-				}
-			],
-			"entries": [
-				"The most basic prayers that an acolyte learns, orisons are used to hone the spellcasting ability of priests. You create one of the following effects within range:",
-				{
-					"type": "list",
-					"items": [
-						"You cause mundane pain and nausea to lessen for up to 1 hour, or heal one creature other than yourself of {@dice 1d4} hit points of damage. Once you heal a creature with this spell, you cannot use this spell again on that creature until both you and the target have taken a short or long rest.",
-						"You bless a meal (food to be shared by two to four individuals), and roll a {@dice d4}. Add that number to any saving throw to avoid being {@condition poisoned} by that meal or drink.",
-						"You light a candle and hold it; as long as it is in your hand, it cannot be extinguished by any nonmagical means.",
-						"You offer up a quick prayer (along the lines of \"give me strength!\" or \"don't let me fail!\"). The GM secretly rolls {@dice 2d20} and records the better of the two rolls. At some point during the next hour, you may choose to replace your roll with that roll, for good or for ill.",
-						"You cause one creature you see within range to gain a +1 bonus to their attack or saving throw until the end of its next turn.",
-						"You cause one creature you see within range to suffer a -1 penalty to its attack or saving throw until the end of its next turn.",
-						"You cause one creature you touch to gain a +2 bonus to a single Charisma skill check."
-					]
-				}
-			],
-			"miscTags": [
-				"HL"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "6927eecc9e5583cf859af5782c5dbdb7"
-		},
-		{
-			"name": "Pilpin's Orchestra",
-			"source": "NRCToS",
-			"page": 286,
-			"level": 3,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "miniature golden instruments worth 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You summon anywhere from 4 to 50 musical instruments, which will play any piece or pieces of music for which you have provided sheet music. You may control the music's volume at will; no action is required by you.",
-				"The instruments will play exactly as musical notation dictates (a true musical aficionado will determine that the performance is a bit lackluster, but most people won't notice). You may choose to conduct the orchestra yourself, if you wish to alter the music in some manner."
-			],
-			"miscTags": [
-				"SMN"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "57d9a6568fc2a93d9f5c50b40f0981b4"
-		},
-		{
-			"name": "Obedience",
-			"source": "NRCToS",
-			"page": 277,
-			"level": 6,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a golden circlet, necklace, or bracelet worth at least 1,000 gp",
-					"cost": 100000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You place a circlet, necklace, or bracelet on any corporeal creature that is not a celestial, elemental, fey, fiend, or undead and that has an Intelligence of 5 or more, and then cast the spell. The creature makes a Wisdom saving throw. On a failure, the creature is bound by the circlet and cannot remove it.",
-				"At any time, you may say a password, established when you cast the spell, and activate the circlet. For each round the circlet is activated, the creature suffers {@damage 1d10} psychic damage and must make a Constitution saving throw or be {@condition stunned} until the end of its next turn due to the incredible pain. When you cast the spell, you may specify up to 7 other creatures who can use the password to activate the circlet. If the creature, or anyone else, attempts to remove the circlet, it will activate for 1 round. You may deactivate and remove the circlet at any time. A dispel magic, remove curse, or wish spell also will remove it."
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			"savingThrow": [
-				"constitution",
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "99cd29da137726f38400b1b549c984b6"
-		},
-		{
-			"name": "Crier's Boon",
-			"source": "NRCToS",
-			"page": 130,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of vellum rolled into a cone"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One willing creature you touch gains the ability to speak loudly and clearly; that creature can makes itself be heard up to 200 feet away, regardless of background noise."
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "a3ed19eb451ae140bd168c36c612b2a5"
-		},
-		{
-			"name": "Fertility",
-			"source": "NRCToS",
-			"page": 185,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a seed"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "week",
-						"amount": 1
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You touch a willing creature or any beast or monstrosity with an Intelligence of 4 or lower. For the duration, that creature becomes incredibly fertile. The creature is all but guaranteed to become pregnant or sire offspring with its next mating. You may not use this spell on yourself, although you can use it on your partner."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Life",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "43f56fb3bd56d9be1a1c2adbe62c89d5"
-		},
-		{
-			"name": "Prestidigitation (New Variants)",
-			"source": "NRCToS",
-			"page": 290,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1,
-						"upTo": true
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook, {@i Wizard's Spell Compendium}, {@i Priest's Spell Compendium}, and Pathfinder (via d20pfsrd.com)",
-				"These are new variants of the spell {@spell prestidigitation} that appears in the {@book Player's Handbook|phb}, pg. 267.",
-				{
-					"type": "list",
-					"items": [
-						"You cause a page of a book to appear blank for 1 hour.",
-						"You cause a glowing green arrow to appear; it will point in a cardinal direction you choose for 1 round.",
-						"You can cause one creature you touch to become sterile for one hour. This use of {@i prestidigitation} is instantly countered by the spell {@spell fertility|nrctos} (q.v.).",
-						"You count the number of objects of one type that are no smaller than a grain of rice that are within a single pile or container, or that are in a 5-yard square.",
-						"Sort small objects (none of which may be heavier than half an ounce) into discrete piles based on one criterion of your choice (such as color or shape).",
-						"You touch a plate of food or cup of drink and learn its quality: rotten, poor, average, good, or gourmet. This does not reveal the existence of poison or other contaminants.",
-						"Your hair or beard is neatly trimmed by 1/2 inch, or grows by 1/2 inch.",
-						"You shape a Medium-sized or smaller patch of nonmagical smoke or fog into any shape you wish, although you're incapable of fine detail. You can even cause it to move slightly.",
-						"You make an object waterproof for the duration, although fully immersing it in liquid for 1 minute or more will end the spell.",
-						"You create an umbrella of magical force. You can choose its appearance or make it {@condition invisible}.",
-						"You can alter the pitch, tone, and accent of your voice. You can even give yourself a slight speech impediment (such as a minor lisp or stutter) of change your voice so you sound like a member of a different race or sex."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "4c1ac98d71f4c81e9ecb040d5963c49e"
-		},
-		{
-			"name": "Anonymous Interaction",
-			"source": "NRCToS",
-			"page": 80,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "special"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You cast this spell on a creature with whom you are having a conversation, and that creature will forget all but the most general information about you and what you spoke about, unless it first makes an Intelligence saving throw. For instance, if you cast this spell on a town guard and question her about a rash of mysterious murders that had recently occurred, and that guard was later asked about you and failed her save, she will remember nothing specific about the event. (\"A male human... maybe elf? And he definitely had hair. Except...maybe it was a woman? Oh, and she was asking about stuff that was going on around here. Hmm... did I remember to tell him about the harvest festival next week?\") Creatures who are immune to being {@condition charmed} are immune to this spell."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level or higher spell slot, you may affect one other target per slot level above 2nd."
-					]
-				}
-			],
-			"savingThrow": [
-				"intelligence"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Trickery",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "3bf852e9d8a46fb6a25b44f128feb0f5"
-		},
-		{
-			"name": "Diction",
-			"source": "NRCToS",
-			"page": 152,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "sphere",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a writing instrument, ink, and something to write on"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You animate a pen or other writing instrument and it will begin to write any words that are spoken within ten feet of you. The words will appear in a language you can read. For languages you don't know, it will write the words phonetically but won't translate. No other details will be given, although emphasis will be noted. If there is more than one speaker, it will begin a new paragraph for each one. If you supply multiple colors of ink, you can also direct it to switch colors with different speakers.",
-				"If a spell with verbal components is cast in the area, it will be recorded as a string of meaningless symbols. Command words for magical items, however, will be recorded.",
-				"The spell's range will increase when you reach 5th level (15 feet), 11th level (20 feet), and 17th level (30 feet)."
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "2716da978ccb580bf06afcedccd24c2b"
-		},
-		{
-			"name": "Dig",
-			"source": "NRCToS",
-			"page": 152,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 100
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a miniature shovel and bucket"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"This spell digs a hole 5 feet wide and 5 feet deep in a single round. In each subsequent round, you can choose to make the hole wider by five feet or deeper by five feet. You may dig through nonmagical, unworked earth, sand, mud, gravel, or loose rocks, but not through solid rock.",
-				"This spell can also be used to inflict damage against {@creature earth elemental|mm|earth elementals} and constructs made of earth or clay. The target {@creature earth elemental} must make a Constitution saving throw. The target takes {@damage 3d10} force damage on a failed saving throw, or half as much damage on a successful one."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, you may dig through solid, unworked rock."
-					]
-				}
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Mountain"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Underdark"
-						}
-					}
-				]
-			},
-			"uniqueId": "7f247f5379d56f4fcfc0fe10263639db"
-		},
-		{
-			"name": "Dimensional Anchor",
-			"source": "NRCToS",
-			"page": 152,
-			"level": 4,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You fire a ray of emerald energy at one creature within range. You must make a ranged spell attack to hit. If you are successful, the target is bound by a magical net that blocks all forms of extradimensional travel. While trapped by the spell, the affected creature cannot use spells or magical effects such as {@spell astral projection}, {@spell blink}, {@spell dimension door}, {@spell Drawmij's instant exit|nrctos} (q.v.), {@spell etherealness}, {@spell gate}, {@spell maze}, {@spell misty step}, {@spell plane shift}, or {@spell teleport}, or use {@spell gate|phb|gates} and {@spell teleportation circle|phb|teleportation circles}. It also prevents creatures from using native abilities, such as a {@creature blink dog}'s or {@creature balor}'s teleportation.",
-				"This spell is ineffective against creatures that are already ethereal or astral, nor does it prevent extradimensional perception or attack. It does not stop summoned creatures from vanishing when the spell that summoned them ends."
-			],
-			"spellAttack": [
-				"R"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "88b27beb1dc2431fddf83d1d738a7dca"
-		},
-		{
-			"name": "Dirge of Discord",
-			"source": "NRCToS",
-			"page": 154,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of ashes"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You play jarring music and up to 6 creatures you see within range are forced to make a Wisdom saving throw. Those who fail have disadvantage on all attack rolls and Dexterity ability checks and saving throws and have their speed reduced to half-normal."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"areaTags": [
-				"MT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "d8aeddc33093acf23aea37a2463d8ade"
-		},
-		{
-			"name": "Disarm",
-			"source": "NRCToS",
-			"page": 154,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a minor telekinetic burst of force and aim it at a weapon or other object held in a target's hand. The target must make a Dexterity saving throw with a +2 bonus or drop the weapon.",
-				"This spell becomes harder to resist when you reach 5th level (no bonus), 11th level (-2 penalty), and 17th level (-4 penalty)."
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "493953ca7eb5381eff75de16be7b2aa5"
-		},
-		{
-			"name": "Disbelief",
-			"source": "NRCToS",
-			"page": 154,
-			"level": 8,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You convince yourself or a creature you touch that as many as four objects or creatures of Huge size or smaller simply do not exist. Unwilling creatures may make an Intelligence saving throw to resist. The objects and creatures cannot harm or hinder you in any way, nor you can take any action against them. You can pass through a disbelieved creature or object as if it was difficult terrain and take {@damage 1d10} force damage if you end your turn inside one."
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"intelligence"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "57c1d805e16ca3911805625c2c98885b"
-		},
-		{
-			"name": "Disease",
-			"source": "NRCToS",
-			"page": 154,
-			"level": 4,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "week",
-						"amount": 4
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"This spell creates a long-lasting illusion of a terrible disease on one creature you see within range, unless that creature succeeds at an Intelligence saving throw. The illusion causes the appearance of unsightly boils and lesions, patches of gangrene, hemorrhaging, swelling, and so on. The disease has no actual true effect but convinces the target that it does\u2014the target has a -2 penalty on all Constitution and Dexterity saving throws for the duration.",
-				"The changes wrought by this spell fail to hold up under physical inspection. For example, the target could appear to be covered with weeping pustules but someone touching it would feel its normal skin.",
-				"Any spell that dispels illusions will automatically end the effect. If the target is given strong evidence that it isn't actually ill, it may make a new saving throw, ending the effect on a success."
-			],
-			"savingThrow": [
-				"dexterity",
-				"intelligence"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "49c33ada9cb7d512cd8a4e248ce5eef6"
-		},
-		{
-			"name": "Camouflage",
-			"source": "NRCToS",
-			"page": 109,
-			"level": 1,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"Your skin, clothing, and other belongings you are carrying shift in color as you move, allowing you to blend into your background. You have advantage on all Dexterity ({@skill Stealth}) ability checks while this spell is active."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "c0835ba2096e93056809699d413f4e1b"
-		},
-		{
-			"name": "Call Society",
-			"source": "NRCToS",
-			"page": 109,
-			"level": 3,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "miles",
-					"amount": 5
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a badge, letter, or other symbol of membership"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You point in a direction and cast this spell to alert other members of an organization you belong to, such as a Mages' or Merchants' Guild, that you require aid. An illusory (and obviously magical) bird springs into being and will fly in that direction. You may record a message of no more than 25 words in the bird before it leaves.",
-				"The bird will fly in a straight line in the direction you choose to a maximum distance of 5 miles. If it passes within 1 mile of a fellow member of your organization it will divert its flight to meet that individual. When it approaches within 10 feet of its target, it will relay its message and then vanish. The target will also gain a brief mental image of the path the bird traveled and your location. If the bird travels the full five miles without sensing a co-member, it dissipates."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 3rd level or higher, the range increases by one mile for every slot level above 2nd."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Crown",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "c5d73cb0d9b5683866c06cff610298bb"
-		},
-		{
-			"name": "Buzzing Bee",
-			"source": "NRCToS",
-			"page": 108,
-			"level": 1,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 100
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a dab of honey"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You conjure a magical bee that hums and buzzes in the ears of one creature you can see within range. The bee has a flying speed of 180 feet and invariably recognizes its target, even if the target moves into total darkness, turns {@condition invisible}, or {@spell polymorph|phb|polymorphs} into a different form.",
-				"While this bee is in existence, its target must make a concentration saving throw when casting a spell, or each round when concentrating on one, and is at disadvantage on all Dexterity ({@skill Stealth}) skill rolls."
-			],
-			"miscTags": [
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b0f96bdd0b4cbfe36eca8321c6a56eab"
+    },
+    {
+      "name": "Déjà Vu",
+      "source": "NRCToS",
+      "page": 148,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a timekeeping device of any sort worth at least 100 gp, which is consumed",
+          "consumed": true,
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A creature you can see is sent back in time to the place where it was exactly 24 hours ago (do not take planetary rotation into account). An unwilling creature may make a Wisdom saving throw to resist. If another creature or object is in the location you send it to, it will appear in the nearest empty space. If the creature was on a different plane at that time, the spell fails."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 7th-level or higher spell slot, you transport the creature back an additional 24 hours for each slot level above 6th."
+          ]
+        }
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SCL",
 				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "c97a6f509d7d3c5616111ea82ad8bf75"
-		},
-		{
-			"name": "Call",
-			"source": "NRCToS",
-			"page": 108,
-			"level": 9,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "special"
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a miniature wax statue of the target"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You call a specific intelligent by name, and if that target is on the same plane as you, then it becomes aware of your call and may choose to accept or reject it. If the target accepts, it is instantly teleported to any safe location within 30 feet of you. If there are no safe spaces within 30 feet, the spell fails."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "dcd22daa099cbcd66bdfe1b26d3ba2f6"
-		},
-		{
-			"name": "Coalthirst's Universal Mindbender",
-			"source": "NRCToS",
-			"page": 116,
-			"level": 9,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "rare incense worth at least 1,000 gp",
-					"cost": 100000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You completely rewrite the target creature's entire personality. With each casting, may change a number of major behaviors equal to twice your spellcasting attribute modifier. If the creature is unwilling, then it may attempt to resist each major change you make.",
-				"A major changes is one that adds, removes, or completely alters memories, beliefs, or opinions it has about an individual, organization, or concept, especially if it has a great deal of intellectual or emotional significance to the target. You may also change a creature's alignment in this manner.",
-				"For instance, you can alter a paladin's memories so that where she once remembered the high priest of her homeland as being a fair and just man, she now remembers him slaughtering peasants for fun and as sacrifices to dark gods. You can cause cool-headed assassin to become sickened by the thought of harming another and turn herself and her entire guild over to the law for just punishment. Or you can make a dull and retiring peasant believe that he is the Chosen One and cause him to immediately begin rallying people to join his cause to try to issue in a new world order. Any of these things would act as an example of a single major change.",
-				"You may change any number of minor behaviors, such as nervous habits and unconscious mannerisms, personality quirks, trivial memories, or opinions on inconsequential matters. For instance, you can cause a target to become a teetotaler (or to begin drinking more heavily), to stop spitting and belching in public, or to forget about that one time the baker overcharged him. A minor change such as this is automatic and cannot be resisted.",
-				"This spell cannot be used to alter attributes or remove or grant abilities, but can be used to make the target attempt to gain new abilities or refuse to use existing one."
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "f89db505f087659b38a814dc187fc4dd"
-		},
-		{
-			"name": "Glyph of Revealing",
-			"source": "NRCToS",
-			"page": 202,
-			"level": 5,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "ink made out of the juice of crushed eyebright flowers, white chalk, and powdered quartz"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You inscribe a special rune on a flat, horizontal surface. All other magical runes, marks, glyphs, symbols, and other forms of written magic become visible, allowing them to be read or identified without being accidentally triggered."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Knowledge",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "c1f07c94fc8731c9ed014f13cf838439"
-		},
-		{
-			"name": "Glyph of Warding (New Variants)",
-			"source": "NRCToS",
-			"page": 202,
-			"level": 3,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "incense and powdered diamond worth at least 200 gp, which the spell consumes",
-					"cost": 20000,
-					"consume": true
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent",
-					"ends": [
-						"dispel",
-						"trigger"
-					]
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook and {@i Priest's Spell Compendium}",
-				"These are new variants of the spell {@spell glyph of warding} that appears in the {@book Player's Handbook|phb} (page 245).",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Necromantic Runes",
-									"entries": [
-										"When this rune is triggered, a violent explosion of energy from the Negative Plane strikes the creature who disturbed it. The creature must make a Dexterity saving throw. It takes {@damage 4d8} necrotic damage on a failed save, or half as much damage on a successful one, and its hit point total is reduced by that amount. This hit point reduction lasts until the creature takes a short or long rest."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Sepia Snake Sigil",
-									"entries": [
-										"When triggered, a magical snake made of glimmering brown force springs into being and attacks the nearest living creature (other than you) within 10 feet of it, using your spell attack modifier. On a hit, it engulfs the target in a shimmering amber field of force. On the creature's next turn, it may attempt to escape the field (escape DC equal to your spell save DC). If unsuccessful, the target is {@condition restrained} and {@condition incapacitated}. These conditions remain for 8 hours, until you release the {@condition restrained} creature, or a {@spell dispel magic} spell is cast on it. While in the amber field, the creature does not age or need to eat, drink, breathe, or sleep."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"conditionInflict": [
-				"restrained",
-				"incapacitated"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"S"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "c2b6c032190fbacab1eff581058b86ae"
-		},
-		{
-			"name": "Gnat Swarm",
-			"source": "NRCToS",
-			"page": 202,
-			"level": 0,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Prayerbook",
-				"You conjure a swarm of biting gnats around a single target within range you can see. The target must make a Wisdom saving throw or be distracted until the end of its next turn. It will have disadvantage on all attack rolls and ability checks until then."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "34686f26f77afc72536acbf5c37ab462"
+    },
+    {
+      "name": "Demand",
+      "source": "NRCToS",
+      "page": 148,
+      "level": 7,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "unlimited"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a short piece of copper wire"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "This spell functions as the {@spell sending} spell, in that you can send a message of twenty-five words or fewer to a creature with which you are familiar. However, this spell also contains a {@spell suggestion}, as per that spell. This {@i suggestion} lasts for 8 hours and does not require concentration.",
+        "The recipient must make a Wisdom saving throw or become subject to the {@i suggestion}. The {@i demand} is understood even if you don't share a language with the subject or if the subject has no language."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "169c7578cde56a8c72f77482dde75a78"
+    },
+    {
+      "name": "Befoul",
+      "source": "NRCToS",
+      "page": 90,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Ravenloft}, {@i Gazetteer Volume V} (Sword & Sorcery)",
+        "Up to 10 pounds of organic, non-living matter is aged by 1 day with each casting of this spell. If you cast this spell on an object that weighs more than 10 pounds, only part of it will be aged. However, you can cast this spell multiple times on an object, aging all of it over the course of numerous castings, or part of it while leaving the rest untouched.",
+        "The object is aged by 1 week when you reach 5th level, 1 month when you reach 11th level, and 3 months when you reach 17th level."
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "c7f55e2e37f52a798af5a5930e7a76d4"
+    },
+    {
+      "name": "Bearhug",
+      "source": "NRCToS",
+      "page": 90,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a bit of bear fur"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You gain the ability to bear hug a creature up to one size category larger or smaller than you. If you successfully make an unarmed attack, you can grapple that creature (escape DC is equal to your spell save DC). As long as the grapple remains in effect, that target is {@condition restrained}. At the start of each of your turns, you may constrict, doing {@dice 2d12} + your Strength modifier in bludgeoning damage. While grappling someone, you cannot use your hands or arms for any other purpose."
+      ],
+      "conditionInflict": [
+        "restrained"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "379ba53e5bcf002dd7e49606e8100781"
+    },
+    {
+      "name": "Bloodbridge",
+      "source": "NRCToS",
+      "page": 100,
+      "level": 0,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "two golden needles"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You touch two creatures and draw blood out from one (the \"donor\"), channel it through yourself, and infuse it into the other (the \"recipient\"). The donor then loses a number of hit points equal to {@dice 1d6} + your spellcasting ability modifier and the recipient gains that number of hit points, up to its normal maximum. The donor does not need to be willing and may make a Dexterity or Strength saving throw to evade or escape your grasp. This spell has no effect on constructs, elementals, oozes, plants, undead, and other creatures that lack blood."
+      ],
+      "savingThrow": [
+        "strength"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "53e2188dbdc437621e07a332ec44e55e"
+    },
+    {
+      "name": "Candletrick",
+      "source": "NRCToS",
+      "page": 109,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You light a candle or lantern\u2014any source of light that has a wick (as opposed to torches). For the duration of the spell, this flame cannot be extinguished by nonmagical means. If the flame is snuffed out, it will automatically relight itself."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "00e8110dd579aff5d3032f023574a1b1"
+    },
+    {
+      "name": "Cook",
+      "source": "NRCToS",
+      "page": 124,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "enough food for one or two meals, a pinch of tinder, a small dab of sulfur, and 1 gold piece",
+          "cost": 100
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "This automatically transforms prepared but raw ingredients into a decent-quality meal for two, provided that the ingredients are fit to be eaten. This spell cannot be used on living beings, plant matter that has not been picked, or on an animal's unbutchered carcass. This also removes natural toxins (such as bacteria that would cause food poisoning) from the food, but it will not remove deliberately-placed poisons or contaminants such as shards of glass."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 3rd level or higher, you can prepare food for two additional people for each spell slot above 2nd level. You must provide ingredients for the additional meals."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "53f2f070300088d065fffa3b48a8022d"
+    },
+    {
+      "name": "Copy",
+      "source": "NRCToS",
+      "page": 125,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You hold a blank sheet of paper, a book with empty pages, or another similar material over a document and this spell produces a perfect copy. Each casting of this spell will duplicate a standard 8 inch × 10 inch quarto size.",
+        "Attempts to copy magical text of any sort will automatically fail. If you copy a text-based trap (such as a {@spell symbol}), you set the trap off."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "df6d83ad1ae702eb93c339f85f5c4ac5"
+    },
+    {
+      "name": "Command Hair",
+      "source": "NRCToS",
+      "page": 118,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Prayerbook",
+        "You may cause the hair of a willing target to grow up to one foot, be cut or shaved off, and style itself in any manner you choose.",
+        "You may also cause the hair to act like a prehensile tentacle, under the control of the hair's owner. The hair has Strength 6 (-2) and Dexterity 9 (-1) and while it performs all combat-related actions at disadvantage, it can do other things such as grabbing items, picking locks, untying ropes, and so forth at no penalty."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, the hair has a +1 bonus to Strength and Dexterity for each slot level above 1st."
+          ]
+        }
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "8ce2a54edaf4b2a2e393d34af1be8e8a"
+    },
+    {
+      "name": "Comfort",
+      "source": "NRCToS",
+      "page": 118,
+      "level": 1,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You sing a pleasant song and all allies within range will cease feeling pain, heat, cold, hunger, thirst, or {@condition exhaustion}, as long as those feelings were produced naturally and not induced by magic or through combat. Thus, you could make someone feel wide awake after being up all night, but not one that had been struck by a {@spell ray of fatigue|dapc} (q.v.).",
+        "This spell does not negate or prevent the targets from normal damage through the elements, {@book starvation|phb|8|food and water|0}, etc.; it merely prevents the targets from feeling the effects."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "503aa99b59a08dff34434744b9a8295b"
+    },
+    {
+      "name": "Consume Likeness",
+      "source": "NRCToS",
+      "page": 122,
+      "level": 6,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "one ounce of meat, which is consumed",
+          "consumed": true
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Book of Vile Darkness}",
+        "You consume an ounce of raw flesh from a creature of the same type and size category as yourself, and your form changes to perfectly match the way that creature looked when alive (you may also cast this using meat from a still-living creature). This change is permanent but is also primarily cosmetic. You gain none of the original creature's attributes, abilities, or knowledge. However, it the creature had gills and had the amphibious or limited amphibious trait, you also gain the ability to breathe underwater. You can also gain up to one additional pair of limbs, if the original creature had extra limbs; likewise, if you were missing a limb and the original creature was not, you regrow that limb\u2014however, if the original creature was missing a limb (and not from the way it was killed), you also lose that limb. When you die, you resume your true form."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "79afb33e8a31f8fd5398ce1b0b90a891"
+    },
+    {
+      "name": "Confuse Self",
+      "source": "NRCToS",
+      "page": 120,
+      "level": 1,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "reaction",
+          "condition": "taken when you detect someone trying to read your mind"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You become utterly and completely confused. You are {@condition incapacitated} for the duration, but you are also immune to being {@condition charmed} or {@condition frightened} and to having your mind or emotions read or mind controlled. You are also immune to all mundane attempts to persuade or intimidate you."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Great Old One",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "cef63bd4d2c5d33756b7ba06ebc2a92d"
+    },
+    {
+      "name": "Compass",
+      "source": "NRCToS",
+      "page": 119,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a brass bowl filled with water, an iron needle, and a cork"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "week",
+            "amount": 1
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You use the pin, cork, and brass bowl to make a simple compass. However, instead of pointing to magnetic north, the needle points towards any destination you choose, as long as you know for certain that destination exists. For instance, you could set it to point towards your home port or a major city, but not to the rumored location of a long-lost dungeon.",
+        "The spell ends if the water is drained from the bowl or the cork or needle is removed."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "bef99a8cf7f9f6838a01294ad6faf6cf"
+    },
+    {
+      "name": "Music of the Spheres",
+      "source": "NRCToS",
+      "page": 268,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "three ribbons, one, four, and nine inches long that made from fine silver thread and worth 100 gp each",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "Utterly beautiful cosmic music begins playing around you. All creatures within range except for you and your allies become so distracted by the music and must make a Wisdom saving throw or be at disadvantage on all attacks against you, and at all attempts to resist any effect that would charm them."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "areaTags": [
+        "S"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "0d4a1e2f4d4fb6b51a6b26ac9b1a8a07"
+    },
+    {
+      "name": "Nap",
+      "source": "NRCToS",
+      "page": 270,
+      "level": 2,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of pillow stuffing, a feather, and a pebble"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "One willing creature you touch takes a short rest which is as refreshing as a long rest, and gives the creature all the benefits of a long rest. A creature can only be affected by this spell once every 24 hours.",
+        "Creatures that are immune to {@condition exhaustion} cannot be affected by this spell."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Life",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "574403cd9b0991044d4aa230391fbe53"
+    },
+    {
+      "name": "Notice",
+      "source": "NRCToS",
+      "page": 275,
+      "level": 0,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You put yourself in a trance for a few seconds, and when you emerge, you are highly aware of your surroundings. Until the end of your next turn, you have advantage on your {@skill Perception|Wisdom (Perception)} check. While you are in this trance, you are deaf and blind as to your own surroundings."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "1dce86173b5aa58114f48eaaa534c10e"
+    },
+    {
+      "name": "Orison",
+      "source": "NRCToS",
+      "page": 281,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "special"
+        }
+      ],
+      "entries": [
+        "The most basic prayers that an acolyte learns, orisons are used to hone the spellcasting ability of priests. You create one of the following effects within range:",
+        {
+          "type": "list",
+          "items": [
+            "You cause mundane pain and nausea to lessen for up to 1 hour, or heal one creature other than yourself of {@dice 1d4} hit points of damage. Once you heal a creature with this spell, you cannot use this spell again on that creature until both you and the target have taken a short or long rest.",
+            "You bless a meal (food to be shared by two to four individuals), and roll a {@dice d4}. Add that number to any saving throw to avoid being {@condition poisoned} by that meal or drink.",
+            "You light a candle and hold it; as long as it is in your hand, it cannot be extinguished by any nonmagical means.",
+            "You offer up a quick prayer (along the lines of \"give me strength!\" or \"don't let me fail!\"). The GM secretly rolls {@dice 2d20} and records the better of the two rolls. At some point during the next hour, you may choose to replace your roll with that roll, for good or for ill.",
+            "You cause one creature you see within range to gain a +1 bonus to their attack or saving throw until the end of its next turn.",
+            "You cause one creature you see within range to suffer a -1 penalty to its attack or saving throw until the end of its next turn.",
+            "You cause one creature you touch to gain a +2 bonus to a single Charisma skill check."
+          ]
+        }
+      ],
+      "miscTags": [
+        "HL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "6927eecc9e5583cf859af5782c5dbdb7"
+    },
+    {
+      "name": "Pilpin's Orchestra",
+      "source": "NRCToS",
+      "page": 286,
+      "level": 3,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "miniature golden instruments worth 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You summon anywhere from 4 to 50 musical instruments, which will play any piece or pieces of music for which you have provided sheet music. You may control the music's volume at will; no action is required by you.",
+        "The instruments will play exactly as musical notation dictates (a true musical aficionado will determine that the performance is a bit lackluster, but most people won't notice). You may choose to conduct the orchestra yourself, if you wish to alter the music in some manner."
+      ],
+      "miscTags": [
+        "SMN"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "57d9a6568fc2a93d9f5c50b40f0981b4"
+    },
+    {
+      "name": "Obedience",
+      "source": "NRCToS",
+      "page": 277,
+      "level": 6,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a golden circlet, necklace, or bracelet worth at least 1,000 gp",
+          "cost": 100000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You place a circlet, necklace, or bracelet on any corporeal creature that is not a celestial, elemental, fey, fiend, or undead and that has an Intelligence of 5 or more, and then cast the spell. The creature makes a Wisdom saving throw. On a failure, the creature is bound by the circlet and cannot remove it.",
+        "At any time, you may say a password, established when you cast the spell, and activate the circlet. For each round the circlet is activated, the creature suffers {@damage 1d10} psychic damage and must make a Constitution saving throw or be {@condition stunned} until the end of its next turn due to the incredible pain. When you cast the spell, you may specify up to 7 other creatures who can use the password to activate the circlet. If the creature, or anyone else, attempts to remove the circlet, it will activate for 1 round. You may deactivate and remove the circlet at any time. A dispel magic, remove curse, or wish spell also will remove it."
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "savingThrow": [
+        "constitution",
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "99cd29da137726f38400b1b549c984b6"
+    },
+    {
+      "name": "Crier's Boon",
+      "source": "NRCToS",
+      "page": 130,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of vellum rolled into a cone"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One willing creature you touch gains the ability to speak loudly and clearly; that creature can makes itself be heard up to 200 feet away, regardless of background noise."
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "a3ed19eb451ae140bd168c36c612b2a5"
+    },
+    {
+      "name": "Fertility",
+      "source": "NRCToS",
+      "page": 185,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a seed"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "week",
+            "amount": 1
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You touch a willing creature or any beast or monstrosity with an Intelligence of 4 or lower. For the duration, that creature becomes incredibly fertile. The creature is all but guaranteed to become pregnant or sire offspring with its next mating. You may not use this spell on yourself, although you can use it on your partner."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Life",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "43f56fb3bd56d9be1a1c2adbe62c89d5"
+    },
+    {
+      "name": "Prestidigitation (New Variants)",
+      "source": "NRCToS",
+      "page": 290,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1,
+            "upTo": true
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook, {@i Wizard's Spell Compendium}, {@i Priest's Spell Compendium}, and Pathfinder (via d20pfsrd.com)",
+        "These are new variants of the spell {@spell prestidigitation} that appears in the {@book Player's Handbook|phb}, pg. 267.",
+        {
+          "type": "list",
+          "items": [
+            "You cause a page of a book to appear blank for 1 hour.",
+            "You cause a glowing green arrow to appear; it will point in a cardinal direction you choose for 1 round.",
+            "You can cause one creature you touch to become sterile for one hour. This use of {@i prestidigitation} is instantly countered by the spell {@spell fertility|nrctos} (q.v.).",
+            "You count the number of objects of one type that are no smaller than a grain of rice that are within a single pile or container, or that are in a 5-yard square.",
+            "Sort small objects (none of which may be heavier than half an ounce) into discrete piles based on one criterion of your choice (such as color or shape).",
+            "You touch a plate of food or cup of drink and learn its quality: rotten, poor, average, good, or gourmet. This does not reveal the existence of poison or other contaminants.",
+            "Your hair or beard is neatly trimmed by 1/2 inch, or grows by 1/2 inch.",
+            "You shape a Medium-sized or smaller patch of nonmagical smoke or fog into any shape you wish, although you're incapable of fine detail. You can even cause it to move slightly.",
+            "You make an object waterproof for the duration, although fully immersing it in liquid for 1 minute or more will end the spell.",
+            "You create an umbrella of magical force. You can choose its appearance or make it {@condition invisible}.",
+            "You can alter the pitch, tone, and accent of your voice. You can even give yourself a slight speech impediment (such as a minor lisp or stutter) of change your voice so you sound like a member of a different race or sex."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "4c1ac98d71f4c81e9ecb040d5963c49e"
+    },
+    {
+      "name": "Anonymous Interaction",
+      "source": "NRCToS",
+      "page": 80,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "special"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You cast this spell on a creature with whom you are having a conversation, and that creature will forget all but the most general information about you and what you spoke about, unless it first makes an Intelligence saving throw. For instance, if you cast this spell on a town guard and question her about a rash of mysterious murders that had recently occurred, and that guard was later asked about you and failed her save, she will remember nothing specific about the event. (\"A male human... maybe elf? And he definitely had hair. Except...maybe it was a woman? Oh, and she was asking about stuff that was going on around here. Hmm... did I remember to tell him about the harvest festival next week?\") Creatures who are immune to being {@condition charmed} are immune to this spell."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level or higher spell slot, you may affect one other target per slot level above 2nd."
+          ]
+        }
+      ],
+      "savingThrow": [
+        "intelligence"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "3bf852e9d8a46fb6a25b44f128feb0f5"
+    },
+    {
+      "name": "Diction",
+      "source": "NRCToS",
+      "page": 152,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "sphere",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a writing instrument, ink, and something to write on"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You animate a pen or other writing instrument and it will begin to write any words that are spoken within ten feet of you. The words will appear in a language you can read. For languages you don't know, it will write the words phonetically but won't translate. No other details will be given, although emphasis will be noted. If there is more than one speaker, it will begin a new paragraph for each one. If you supply multiple colors of ink, you can also direct it to switch colors with different speakers.",
+        "If a spell with verbal components is cast in the area, it will be recorded as a string of meaningless symbols. Command words for magical items, however, will be recorded.",
+        "The spell's range will increase when you reach 5th level (15 feet), 11th level (20 feet), and 17th level (30 feet)."
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "2716da978ccb580bf06afcedccd24c2b"
+    },
+    {
+      "name": "Dig",
+      "source": "NRCToS",
+      "page": 152,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 100
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a miniature shovel and bucket"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "This spell digs a hole 5 feet wide and 5 feet deep in a single round. In each subsequent round, you can choose to make the hole wider by five feet or deeper by five feet. You may dig through nonmagical, unworked earth, sand, mud, gravel, or loose rocks, but not through solid rock.",
+        "This spell can also be used to inflict damage against {@creature earth elemental|mm|earth elementals} and constructs made of earth or clay. The target {@creature earth elemental} must make a Constitution saving throw. The target takes {@damage 3d10} force damage on a failed saving throw, or half as much damage on a successful one."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, you may dig through solid, unworked rock."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Mountain"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Underdark"
+            }
+          }
+        ]
+      },
+      "uniqueId": "7f247f5379d56f4fcfc0fe10263639db"
+    },
+    {
+      "name": "Dimensional Anchor",
+      "source": "NRCToS",
+      "page": 152,
+      "level": 4,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You fire a ray of emerald energy at one creature within range. You must make a ranged spell attack to hit. If you are successful, the target is bound by a magical net that blocks all forms of extradimensional travel. While trapped by the spell, the affected creature cannot use spells or magical effects such as {@spell astral projection}, {@spell blink}, {@spell dimension door}, {@spell Drawmij's instant exit|nrctos} (q.v.), {@spell etherealness}, {@spell gate}, {@spell maze}, {@spell misty step}, {@spell plane shift}, or {@spell teleport}, or use {@spell gate|phb|gates} and {@spell teleportation circle|phb|teleportation circles}. It also prevents creatures from using native abilities, such as a {@creature blink dog}'s or {@creature balor}'s teleportation.",
+        "This spell is ineffective against creatures that are already ethereal or astral, nor does it prevent extradimensional perception or attack. It does not stop summoned creatures from vanishing when the spell that summoned them ends."
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "88b27beb1dc2431fddf83d1d738a7dca"
+    },
+    {
+      "name": "Dirge of Discord",
+      "source": "NRCToS",
+      "page": 154,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of ashes"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You play jarring music and up to 6 creatures you see within range are forced to make a Wisdom saving throw. Those who fail have disadvantage on all attack rolls and Dexterity ability checks and saving throws and have their speed reduced to half-normal."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "areaTags": [
+        "MT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "d8aeddc33093acf23aea37a2463d8ade"
+    },
+    {
+      "name": "Disarm",
+      "source": "NRCToS",
+      "page": 154,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a minor telekinetic burst of force and aim it at a weapon or other object held in a target's hand. The target must make a Dexterity saving throw with a +2 bonus or drop the weapon.",
+        "This spell becomes harder to resist when you reach 5th level (no bonus), 11th level (-2 penalty), and 17th level (-4 penalty)."
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "493953ca7eb5381eff75de16be7b2aa5"
+    },
+    {
+      "name": "Disbelief",
+      "source": "NRCToS",
+      "page": 154,
+      "level": 8,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You convince yourself or a creature you touch that as many as four objects or creatures of Huge size or smaller simply do not exist. Unwilling creatures may make an Intelligence saving throw to resist. The objects and creatures cannot harm or hinder you in any way, nor you can take any action against them. You can pass through a disbelieved creature or object as if it was difficult terrain and take {@damage 1d10} force damage if you end your turn inside one."
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "intelligence"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "57c1d805e16ca3911805625c2c98885b"
+    },
+    {
+      "name": "Disease",
+      "source": "NRCToS",
+      "page": 154,
+      "level": 4,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "week",
+            "amount": 4
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "This spell creates a long-lasting illusion of a terrible disease on one creature you see within range, unless that creature succeeds at an Intelligence saving throw. The illusion causes the appearance of unsightly boils and lesions, patches of gangrene, hemorrhaging, swelling, and so on. The disease has no actual true effect but convinces the target that it does\u2014the target has a -2 penalty on all Constitution and Dexterity saving throws for the duration.",
+        "The changes wrought by this spell fail to hold up under physical inspection. For example, the target could appear to be covered with weeping pustules but someone touching it would feel its normal skin.",
+        "Any spell that dispels illusions will automatically end the effect. If the target is given strong evidence that it isn't actually ill, it may make a new saving throw, ending the effect on a success."
+      ],
+      "savingThrow": [
+        "dexterity",
+        "intelligence"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "49c33ada9cb7d512cd8a4e248ce5eef6"
+    },
+    {
+      "name": "Camouflage",
+      "source": "NRCToS",
+      "page": 109,
+      "level": 1,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "Your skin, clothing, and other belongings you are carrying shift in color as you move, allowing you to blend into your background. You have advantage on all Dexterity ({@skill Stealth}) ability checks while this spell is active."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "c0835ba2096e93056809699d413f4e1b"
+    },
+    {
+      "name": "Call Society",
+      "source": "NRCToS",
+      "page": 109,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "miles",
+          "amount": 5
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a badge, letter, or other symbol of membership"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You point in a direction and cast this spell to alert other members of an organization you belong to, such as a Mages' or Merchants' Guild, that you require aid. An illusory (and obviously magical) bird springs into being and will fly in that direction. You may record a message of no more than 25 words in the bird before it leaves.",
+        "The bird will fly in a straight line in the direction you choose to a maximum distance of 5 miles. If it passes within 1 mile of a fellow member of your organization it will divert its flight to meet that individual. When it approaches within 10 feet of its target, it will relay its message and then vanish. The target will also gain a brief mental image of the path the bird traveled and your location. If the bird travels the full five miles without sensing a co-member, it dissipates."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 3rd level or higher, the range increases by one mile for every slot level above 2nd."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Crown",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "c5d73cb0d9b5683866c06cff610298bb"
+    },
+    {
+      "name": "Buzzing Bee",
+      "source": "NRCToS",
+      "page": 108,
+      "level": 1,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 100
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a dab of honey"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You conjure a magical bee that hums and buzzes in the ears of one creature you can see within range. The bee has a flying speed of 180 feet and invariably recognizes its target, even if the target moves into total darkness, turns {@condition invisible}, or {@spell polymorph|phb|polymorphs} into a different form.",
+        "While this bee is in existence, its target must make a concentration saving throw when casting a spell, or each round when concentrating on one, and is at disadvantage on all Dexterity ({@skill Stealth}) skill rolls."
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "c97a6f509d7d3c5616111ea82ad8bf75"
+    },
+    {
+      "name": "Call",
+      "source": "NRCToS",
+      "page": 108,
+      "level": 9,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "special"
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a miniature wax statue of the target"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You call a specific intelligent by name, and if that target is on the same plane as you, then it becomes aware of your call and may choose to accept or reject it. If the target accepts, it is instantly teleported to any safe location within 30 feet of you. If there are no safe spaces within 30 feet, the spell fails."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "dcd22daa099cbcd66bdfe1b26d3ba2f6"
+    },
+    {
+      "name": "Coalthirst's Universal Mindbender",
+      "source": "NRCToS",
+      "page": 116,
+      "level": 9,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "rare incense worth at least 1,000 gp",
+          "cost": 100000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You completely rewrite the target creature's entire personality. With each casting, may change a number of major behaviors equal to twice your spellcasting attribute modifier. If the creature is unwilling, then it may attempt to resist each major change you make.",
+        "A major changes is one that adds, removes, or completely alters memories, beliefs, or opinions it has about an individual, organization, or concept, especially if it has a great deal of intellectual or emotional significance to the target. You may also change a creature's alignment in this manner.",
+        "For instance, you can alter a paladin's memories so that where she once remembered the high priest of her homeland as being a fair and just man, she now remembers him slaughtering peasants for fun and as sacrifices to dark gods. You can cause cool-headed assassin to become sickened by the thought of harming another and turn herself and her entire guild over to the law for just punishment. Or you can make a dull and retiring peasant believe that he is the Chosen One and cause him to immediately begin rallying people to join his cause to try to issue in a new world order. Any of these things would act as an example of a single major change.",
+        "You may change any number of minor behaviors, such as nervous habits and unconscious mannerisms, personality quirks, trivial memories, or opinions on inconsequential matters. For instance, you can cause a target to become a teetotaler (or to begin drinking more heavily), to stop spitting and belching in public, or to forget about that one time the baker overcharged him. A minor change such as this is automatic and cannot be resisted.",
+        "This spell cannot be used to alter attributes or remove or grant abilities, but can be used to make the target attempt to gain new abilities or refuse to use existing one."
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "f89db505f087659b38a814dc187fc4dd"
+    },
+    {
+      "name": "Glyph of Revealing",
+      "source": "NRCToS",
+      "page": 202,
+      "level": 5,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "ink made out of the juice of crushed eyebright flowers, white chalk, and powdered quartz"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You inscribe a special rune on a flat, horizontal surface. All other magical runes, marks, glyphs, symbols, and other forms of written magic become visible, allowing them to be read or identified without being accidentally triggered."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Knowledge",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "c1f07c94fc8731c9ed014f13cf838439"
+    },
+    {
+      "name": "Glyph of Warding (New Variants)",
+      "source": "NRCToS",
+      "page": 202,
+      "level": 3,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "incense and powdered diamond worth at least 200 gp, which the spell consumes",
+          "cost": 20000,
+          "consume": true
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent",
+          "ends": [
+            "dispel",
+            "trigger"
+          ]
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook and {@i Priest's Spell Compendium}",
+        "These are new variants of the spell {@spell glyph of warding} that appears in the {@book Player's Handbook|phb} (page 245).",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Necromantic Runes",
+                  "entries": [
+                    "When this rune is triggered, a violent explosion of energy from the Negative Plane strikes the creature who disturbed it. The creature must make a Dexterity saving throw. It takes {@damage 4d8} necrotic damage on a failed save, or half as much damage on a successful one, and its hit point total is reduced by that amount. This hit point reduction lasts until the creature takes a short or long rest."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Sepia Snake Sigil",
+                  "entries": [
+                    "When triggered, a magical snake made of glimmering brown force springs into being and attacks the nearest living creature (other than you) within 10 feet of it, using your spell attack modifier. On a hit, it engulfs the target in a shimmering amber field of force. On the creature's next turn, it may attempt to escape the field (escape DC equal to your spell save DC). If unsuccessful, the target is {@condition restrained} and {@condition incapacitated}. These conditions remain for 8 hours, until you release the {@condition restrained} creature, or a {@spell dispel magic} spell is cast on it. While in the amber field, the creature does not age or need to eat, drink, breathe, or sleep."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "conditionInflict": [
+        "restrained",
+        "incapacitated"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "S"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "c2b6c032190fbacab1eff581058b86ae"
+    },
+    {
+      "name": "Gnat Swarm",
+      "source": "NRCToS",
+      "page": 202,
+      "level": 0,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Prayerbook",
+        "You conjure a swarm of biting gnats around a single target within range you can see. The target must make a Wisdom saving throw or be distracted until the end of its next turn. It will have disadvantage on all attack rolls and ability checks until then."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "afa5fde3bff14fbeac65c2614387306b"
+    },
+    {
+      "name": "Godly Protection",
+      "source": "NRCToS",
+      "page": 202,
+      "level": 4,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Prayerbook",
+        "Divine light illuminates all of your allies within range, provided those allies are not engaging in any action other than joining you in prayer. After you have cast the spell, they may resume their normal activities.",
+        "For the spell's duration, your allies are immune to being {@condition frightened} or {@condition charmed} and will have advantage on any one type of roll of your choosing: either all attack rolls, saving throws, or ability checks."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "21d50e8debbefc3a2b2369f42842270d"
+    },
+    {
+      "name": "Dheryth's Energy Cloak",
+      "source": "NRCToS",
+      "page": 151,
+      "level": 5,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a miniature shield"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You surround yourself with a multicolored cloak of energy. While this spell is in effect, you are immune to force damage and cannot be harmed or hindered in any way by spells that create, manipulate, or grapple or restrain with magical force, including (but not limited to) {@spell Bigby's hand}, {@spell Darklight's stapling spikes|nrctos} (q.v.), {@spell disarm|nrctos} (q.v.), {@spell forcecage}, {@spell Otiluke's resilient sphere}, {@spell sarcophagus of death|nrctos} (q.v.), {@spell wall of force}, or {@spell wingbind|nrctos} (q.v.).",
+        "In addition, you have a +2 bonus to your armor class."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "c796e4e968d04f6f972c5cf77822e02d"
+    },
+    {
+      "name": "Dheryth's Energy Globe",
+      "source": "NRCToS",
+      "page": 151,
+      "level": 6,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true,
+        "m": {
+          "text": "a gemstone worth at least 20 gp, which is consumed in the casting of the spell",
+          "cost": 2000,
+          "consume": true
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You turn a gem into a minute gateway to the Positive Plane; you may then throw it (range 15/30), drop it, hide it somewhere, and so on. At the end of the next round, the gem explodes. All creatures within 10 feet of the gem must make a Dexterity saving throw. A creature takes {@damage 11d6} radiant damage on a failed saving throw, or half as much damage on a successful one."
+      ],
+      "damageInflict": [
+        "radiant"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "511941e966bd1151faae611d64464c66"
+    },
+    {
+      "name": "Diamond Spray",
+      "source": "NRCToS",
+      "page": 151,
+      "level": 4,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "diamond dust worth at least 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Book of Exalted Deeds}",
+        "You blow the diamond dust at your targets and a 60-foot cone of diamond shards blasts outwards. All aberrations, fiends, and undead in the area must make a Dexterity saving throw. A creature takes {@damage 7d6} piercing damage on a failed saving throw, or half as much damage on a successful one. This bypasses resistance to piercing damage. In addition, the creature is {@condition stunned} for 1 minute. It may make a Wisdom saving throw at the beginning of each of its turns, ending the effect on a success."
+      ],
+      "damageResist": [
+        "piercing"
+      ],
+      "damageImmune": [
+        "piercing"
+      ],
+      "damageVulnerable": [
+        "piercing"
+      ],
+      "damageInflict": [
+        "piercing"
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "savingThrow": [
+        "dexterity",
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "592eb35f05641cf3b504bdb75f945b98"
+    },
+    {
+      "name": "Diamondblade",
+      "source": "NRCToS",
+      "page": 151,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a diamond worth at least 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One bladed weapon you touch becomes incredibly sharp. You may then use the weapon or give it to someone else; you are considered to have proficiency with it.",
+        "The sword grants +3 to hit and damage. If you roll a 20, you inflict an additional {@damage 4d10} slashing damage and an additional {@damage 1d10} damage on each of the target's next 3 turns due to excessive bleeding."
+      ],
+      "damageInflict": [
+        "slashing"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "908e7e8c0d90447ac9ac09fc8c55791a"
+    },
+    {
+      "name": "Darklight's Stapling Spikes",
+      "source": "NRCToS",
+      "page": 141,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a small iron spike"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 24,
+            "upTo": true
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a dozen bolts of force which you direct at one Small- to Large-sized creature you see within range. That creature must make a Dexterity saving throw. On a failure, the spikes pin that creature to ground or to the nearest wall, restraining it but causing no damage. The escape DC is equal to your spell save DC, but if the creature attempts to escape, then the spikes sharpen, causing {@damage 2d4} force damage whether the attempt is successful or not.",
+        "The spikes fade away if the target successfully escapes them or when 24 hours have passed, whichever comes first."
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "93a5fcf29a163d32095e97859ab9754e"
+    },
+    {
+      "name": "Scratch",
+      "source": "NRCToS",
+      "page": 310,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause one creature within range to suffer from an intensely annoying itch. That creature must make an Intelligence saving throw or spend its next turn scratching desperately. If you attempt to use this on a creature a second time in less than 1 minute, that creature has advantage on its saving throw."
+      ],
+      "savingThrow": [
+        "intelligence"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "85a3c1a10fb876d762a7123ea21825a1"
+    },
+    {
+      "name": "Sarcophagus of Death",
+      "source": "NRCToS",
+      "page": 306,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a fragment of a sarcophagus"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "A coffin-shaped rectangle of force forms around one target you can see within range. That target must make a Dexterity saving throw to avoid being trapped inside.",
+        "The sarcophagus is completely airtight and cannot be broken from the inside. A creature inside will begin to {@book suffocate |phb|8|suffocating|0}(Player's Handbook, page 183) unless it has a way of providing itself with air or doesn't need to breathe. On the outside, it is a physical object that has AC 15, hit points equal to your hit point maximum, and resistance to all forms of damage. If it drops to 0 hit points, the spell ends."
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Death",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "e22a92a3008493cf62c4e369da3e5b2d"
+    },
+    {
+      "name": "Wingbind",
+      "source": "NRCToS",
+      "page": 368,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 400
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a web of force that wraps around the wings and body of any one flying creature within range. The creature is {@condition grappled} (escape DC equal to your spell save DC) and {@condition restrained} as long as the grapple remains."
+      ],
+      "conditionInflict": [
+        "grappled"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Grassland"
+            }
+          }
+        ]
+      },
+      "uniqueId": "9bf3553703590b675f8421dd30ef26a8"
+    },
+    {
+      "name": "Elonia's Glamer",
+      "source": "NRCToS",
+      "page": 169,
+      "level": 1,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of ruby dust and a pinch of chalk dust"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You subtly change the appearance of yourself or one other humanoid, making that person more or less attractive. This does not make that person look like someone else. If you make the target more attractive, the target's skin clearer and smoother, their teeth straighter and whiter, and their hair thicker and more lustrous. For the duration, the target has advantage on Charisma ({@skill Persuasion}) skill checks designed to elicit positive reactions. If you make the target more unattractive, the target will appear lackluster, grungy, and unkempt. It will have disadvantage on the above-mentioned {@skill Persuasion} checks. An unwilling target may make a Wisdom saving throw to resist."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Archfey",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "2cd148e9ceaa19226325e2ada7e690b7"
+    },
+    {
+      "name": "Empathy",
+      "source": "NRCToS",
+      "page": 169,
+      "level": 0,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You look at one target within range and learn which of the following emotions, if any, the target is feeling most prominently, and whether the emotion is being felt weakly, moderately, or strongly:",
+        {
+          "type": "table",
+          "colStyles": [
+            "col-4 text-center",
+            "col-4 text-center",
+            "col-4 text-center"
+          ],
+          "rows": [
+            [
+              "anger",
+              "happiness",
+              "optimism"
+            ],
+            [
+              "anticipation",
+              "hatred",
+              "pain"
+            ],
+            [
+              "anxiety",
+              "hostility",
+              "panic"
+            ],
+            [
+              "curiosity",
+              "horror",
+              "pleasure"
+            ],
+            [
+              "desire",
+              "hunger/thirst",
+              "shame"
+            ],
+            [
+              "disgust",
+              "love",
+              "sorrow"
+            ],
+            [
+              "distress",
+              "lust",
+              "surprise"
+            ],
+            [
+              "fatigue",
+              "fear",
+              "uneasiness"
+            ],
+            [
+              "guilt",
+              "need",
+              "wonder"
+            ]
+          ]
+        },
+        "This spell does not reveal the cause of the emotion or any other information about it. A creature that is aware that you are or might be attempting to contact its mind may attempt to make an Intelligence saving throw to resist; otherwise, there is no saving throw.",
+        "If you target an aberration, celestial, elemental, fey, or fiend, and that target is feeling an emotion strongly, you must make a DC 13 Wisdom saving throw. If you fail, the alien nature of that creature's mind overwhelms you and you take {@damage 1d10} psychic damage. This spell doesn't work on constructs or undead, even intelligent, free-willed ones."
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "savingThrow": [
+        "intelligence",
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "78d990a5f1c1e670e0a1d9f31cce3e91"
+    },
+    {
+      "name": "Encrypt",
+      "source": "NRCToS",
+      "page": 169,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of dust or fluff and a feather"
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You render one message of 100 words or less permanently unreadable by everyone save you and one other specific creature named when you cast the spell. This message remains indecipherable even to spells such as {@spell comprehend languages}, although a {@spell dispel magic} will remove the encryption. This message may be written on any media you wish and you do not have to be the original writer of the message."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, you may encrypt an additional 100 words per slot level above 3rd."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b2b04cd11ef89946349db7c973a7b778"
+    },
+    {
+      "name": "Gem Record (Write)",
+      "source": "NRCToS",
+      "page": 196,
+      "level": 2,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a flawless gemstone worth at least 10 gp",
+          "cost": 1000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "You use this spell to record information inside a gemstone or to read information that was recorded by another. This spell is permanent, although destroying the gemstone will destroy the information, and the {@i gem record} can be erased by a {@spell dispel magic} or {@spell erase|nrctos} (q.v.).",
+        "You may specify up to three other individuals who may also freely read the {@i gem record}. All others must cast this spell on the gemstone to be able to read it. You may cast protective spells such as {@spell glyph of warding} on the gemstone in the same way you would cast it on a book.",
+        "The gemstone must be flawless for this spell to work. If the gem is slightly damaged (or is re-cut by a jeweler) after information has been recorded in it, roll a {@dice d20}. On a 1, the information you want has been permanently lost. If the gem has been badly damaged or altered, the information has been lost on a roll of 1-10. If the gemstone has been shattered or pulverized, the information has been permanently lost.",
+        "You may use the {@spell copy|nrctos} spell (q.v.) on the {@i gem record}, but it will only produce a copy on paper or parchment, not into another gemstone. You can use spells such as {@spell encrypt|nrctos} (q.v.) or {@spell mistaken missive|nrctos} (q.v.) on the {@i gem record} as well.",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Gem Write",
+                  "entries": [
+                    "You record information inside of a gemstone. You may speak into it or hold the gem above a written record while casting this spell and it will copy the writing. It will record static images but cannot record moving images. You may use the gem to record spells, but that turns it into a spellbook; you cannot use a {@i gem record} as a spell scroll.",
+                    "For every 50 gp the gem costs, you can record up to 1,000 words or one spell level. You only have to pay half the normal cost of inscribing a spell when you record it in a {@i gem record}. When you cast this version of the spell, the casting time is 1 minute per 1,000 words or spell level. You may cast this spell on multiple occasions until the gem is \"filled.\""
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "53cdf9822f1de033b6d4f4d261ca42ce"
+    },
+    {
+      "name": "Gem Record (Read)",
+      "source": "NRCToS",
+      "page": 196,
+      "level": 2,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a drop of your blood",
+          "cost": 1000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "You use this spell to record information inside a gemstone or to read information that was recorded by another. This spell is permanent, although destroying the gemstone will destroy the information, and the {@i gem record} can be erased by a {@spell dispel magic} or {@spell erase|nrctos} (q.v.).",
+        "You may specify up to three other individuals who may also freely read the {@i gem record}. All others must cast this spell on the gemstone to be able to read it. You may cast protective spells such as {@spell glyph of warding} on the gemstone in the same way you would cast it on a book.",
+        "The gemstone must be flawless for this spell to work. If the gem is slightly damaged (or is re-cut by a jeweler) after information has been recorded in it, roll a {@dice d20}. On a 1, the information you want has been permanently lost. If the gem has been badly damaged or altered, the information has been lost on a roll of 1-10. If the gemstone has been shattered or pulverized, the information has been permanently lost.",
+        "You may use the {@spell copy|nrctos} spell (q.v.) on the {@i gem record}, but it will only produce a copy on paper or parchment, not into another gemstone. You can use spells such as {@spell encrypt|nrctos} (q.v.) or {@spell mistaken missive|nrctos} (q.v.) on the {@i gem record} as well.",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Gem Read",
+                  "entries": [
+                    "You may read a {@i gem record} that was created by another caster. If the information was recorded verbally, you will \"hear\" the recorder's voice in your mind. If it was copied from a text, you will mentally \"see\" the words and will have to read them; this takes as long as it would normally take to read from a book. You do not have to start from the beginning of the text; if you think about the topic or the specific section you wish to see, the {@i gem} will skip ahead to that point. This effectively gives you a search function. The recorded text is revealed mentally to you; it cannot be broadcast to be heard or read by multiple people at once.",
+                    "When you cast this version of the spell, the casting time is 1 round, plus the length of time it takes to listen to or read the information, to a maximum of one hour. If you lose your concentration, the spell ends."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "938686ac45b4b036d83614f9d90a1bc6"
+    },
+    {
+      "name": "Genocide",
+      "source": "NRCToS",
+      "page": 197,
+      "level": 9,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 400
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You speak the name of a species of living creature (such as \"goblinoids\" or \"hippogriff\") and point to a member of that species that you can see within range. The creature must have a CR of 8 or less. A bolt of glowing black energy leaps from your hand to that creature, which must make a Constitution saving throw. It takes 100 necrotic damage on a failed saving throw, or half as much on a successful one.",
+        "The following round, tendrils of energy leap from that creature to all other creatures of that type that are within 60 feet of it. Those creatures must also make Constitution saving throws. A creature takes 50 necrotic damage on a failed saving throw, or half as much on a successful one."
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST",
+        "MT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "57f65d78a9e5fade4d564a3477fb41c5"
+    },
+    {
+      "name": "Mistaken Missive",
+      "source": "NRCToS",
+      "page": 266,
+      "level": 2,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "three drops of ink"
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You cast this spell on up to ten pages of text. Over the course of a week, the text will slowly change.",
+        "On the first day, it will become faint, as if the writer was running out of ink. On the second through fourth days, the words become gibberish\u2014the text is aligned in groups of letters and punctuation, but nearly all the words are meaningless. On the fifth day, the letters have become real words, but the sentences make no sense. On the sixth day, and thereafter, the message is coherent but conveys the exact opposite of the original meaning."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "7153f57382ce914f1cf83571e317b014"
+    },
+    {
+      "name": "Erase",
+      "source": "NRCToS",
+      "page": 173,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You remove any writing you see, leaving the surface it was on unmarked (even if the words were carved in stone). It will erase up to 1,000 words at a time and automatically erases nonmagical writings.",
+        "If you are attempting to remove magical writing, including spell scrolls and magical traps such as {@spell glyph of warding} or {@spell symbol}, you must make an ability check using your spellcasting ability. The DC equals 10 + the spell's level. On a successful check, the writing is erased. If you fail, and the magical writing is actually a trap, the trap goes off.",
+        "This spell does not work on illusory writing, such as that produced by {@spell illusory script}, as that writing isn't real."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "c2cf02df013202925f916860f08f4028"
+    },
+    {
+      "name": "Puppeteer",
+      "source": "NRCToS",
+      "page": 294,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 160
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "Silvery strings fly out from your hand towards a creature you can see within your range and attach to it; a moment later, they fade from view. The target may make a Wisdom saving throw to resist. If the creature fails, it is forced to mimic your actions exactly, although it looks awkward and ineffective, and the creature has disadvantage on all Strength- and Dexterity-based actions you make it take. You cannot make it perform any action it cannot physically do.",
+        "If you attempt to force it into taking a suicidal action or one in direct opposition to its interests or alignment, it may make another saving throw, ending the effect on a success."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "053adc76528d4655e95340ef6f68a6bf"
+    },
+    {
+      "name": "Power Word Attention",
+      "source": "NRCToS",
+      "page": 289,
+      "level": 1,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You utter a word of power (or whistle very loudly) that compels all creatures within a 60-foot radius of you to pay complete and utter attention to you for 1 round. A creature that is involved in a life-or-death situation may make an Intelligence saving throw to resist. {@condition Deafened} creatures are immune to this spell."
+      ],
+      "savingThrow": [
+        "intelligence"
+      ],
+      "areaTags": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "69975a178e16a3091b861b6916ac69ac"
+    },
+    {
+      "name": "Power Word Banish",
+      "source": "NRCToS",
+      "page": 289,
+      "level": 9,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You utter a word of great power that forces one elemental, fiend, or celestial that you can see within range to immediately return to its home plane. If the creature has a CR of 15 or more, it may make a Wisdom saving throw to resist."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "4ccd2b626e810132338de2ff13922d80"
+    },
+    {
+      "name": "Power Word Blind",
+      "source": "NRCToS",
+      "page": 289,
+      "level": 8,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You point to one creature you can see within range and shout out a magic word. If the creature you choose has 50 hit points or fewer, it goes permanently {@condition blinded|phb|blind}. If it has up to 100 hit points, it goes blind for 1 day. If it has more than 100 hit points, the spell has no effect.",
+        "All creatures within 10 feet of the creature you pointed out are permanently {@condition blinded} if they have 25 hit points or fewer, or are {@condition blinded} for 1 day if they have up to 50 hit points."
+      ],
+      "miscTags": [
+        "PRM",
 				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "afa5fde3bff14fbeac65c2614387306b"
-		},
-		{
-			"name": "Godly Protection",
-			"source": "NRCToS",
-			"page": 202,
-			"level": 4,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Prayerbook",
-				"Divine light illuminates all of your allies within range, provided those allies are not engaging in any action other than joining you in prayer. After you have cast the spell, they may resume their normal activities.",
-				"For the spell's duration, your allies are immune to being {@condition frightened} or {@condition charmed} and will have advantage on any one type of roll of your choosing: either all attack rolls, saving throws, or ability checks."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "21d50e8debbefc3a2b2369f42842270d"
-		},
-		{
-			"name": "Dheryth's Energy Cloak",
-			"source": "NRCToS",
-			"page": 151,
-			"level": 5,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a miniature shield"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You surround yourself with a multicolored cloak of energy. While this spell is in effect, you are immune to force damage and cannot be harmed or hindered in any way by spells that create, manipulate, or grapple or restrain with magical force, including (but not limited to) {@spell Bigby's hand}, {@spell Darklight's stapling spikes|nrctos} (q.v.), {@spell disarm|nrctos} (q.v.), {@spell forcecage}, {@spell Otiluke's resilient sphere}, {@spell sarcophagus of death|nrctos} (q.v.), {@spell wall of force}, or {@spell wingbind|nrctos} (q.v.).",
-				"In addition, you have a +2 bonus to your armor class."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "c796e4e968d04f6f972c5cf77822e02d"
-		},
-		{
-			"name": "Dheryth's Energy Globe",
-			"source": "NRCToS",
-			"page": 151,
-			"level": 6,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true,
-				"m": {
-					"text": "a gemstone worth at least 20 gp, which is consumed in the casting of the spell",
-					"cost": 2000,
-					"consume": true
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You turn a gem into a minute gateway to the Positive Plane; you may then throw it (range 15/30), drop it, hide it somewhere, and so on. At the end of the next round, the gem explodes. All creatures within 10 feet of the gem must make a Dexterity saving throw. A creature takes {@damage 11d6} radiant damage on a failed saving throw, or half as much damage on a successful one."
-			],
-			"damageInflict": [
-				"radiant"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "511941e966bd1151faae611d64464c66"
-		},
-		{
-			"name": "Diamond Spray",
-			"source": "NRCToS",
-			"page": 151,
-			"level": 4,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "diamond dust worth at least 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Book of Exalted Deeds}",
-				"You blow the diamond dust at your targets and a 60-foot cone of diamond shards blasts outwards. All aberrations, fiends, and undead in the area must make a Dexterity saving throw. A creature takes {@damage 7d6} piercing damage on a failed saving throw, or half as much damage on a successful one. This bypasses resistance to piercing damage. In addition, the creature is {@condition stunned} for 1 minute. It may make a Wisdom saving throw at the beginning of each of its turns, ending the effect on a success."
-			],
-			"damageResist": [
-				"piercing"
-			],
-			"damageImmune": [
-				"piercing"
-			],
-			"damageVulnerable": [
-				"piercing"
-			],
-			"damageInflict": [
-				"piercing"
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			"savingThrow": [
-				"dexterity",
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "592eb35f05641cf3b504bdb75f945b98"
-		},
-		{
-			"name": "Diamondblade",
-			"source": "NRCToS",
-			"page": 151,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a diamond worth at least 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One bladed weapon you touch becomes incredibly sharp. You may then use the weapon or give it to someone else; you are considered to have proficiency with it.",
-				"The sword grants +3 to hit and damage. If you roll a 20, you inflict an additional {@damage 4d10} slashing damage and an additional {@damage 1d10} damage on each of the target's next 3 turns due to excessive bleeding."
-			],
-			"damageInflict": [
-				"slashing"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "908e7e8c0d90447ac9ac09fc8c55791a"
-		},
-		{
-			"name": "Darklight's Stapling Spikes",
-			"source": "NRCToS",
-			"page": 141,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a small iron spike"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 24,
-						"upTo": true
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a dozen bolts of force which you direct at one Small- to Large-sized creature you see within range. That creature must make a Dexterity saving throw. On a failure, the spikes pin that creature to ground or to the nearest wall, restraining it but causing no damage. The escape DC is equal to your spell save DC, but if the creature attempts to escape, then the spikes sharpen, causing {@damage 2d4} force damage whether the attempt is successful or not.",
-				"The spikes fade away if the target successfully escapes them or when 24 hours have passed, whichever comes first."
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "93a5fcf29a163d32095e97859ab9754e"
-		},
-		{
-			"name": "Scratch",
-			"source": "NRCToS",
-			"page": 310,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You cause one creature within range to suffer from an intensely annoying itch. That creature must make an Intelligence saving throw or spend its next turn scratching desperately. If you attempt to use this on a creature a second time in less than 1 minute, that creature has advantage on its saving throw."
-			],
-			"savingThrow": [
-				"intelligence"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "85a3c1a10fb876d762a7123ea21825a1"
-		},
-		{
-			"name": "Sarcophagus of Death",
-			"source": "NRCToS",
-			"page": 306,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a fragment of a sarcophagus"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"A coffin-shaped rectangle of force forms around one target you can see within range. That target must make a Dexterity saving throw to avoid being trapped inside.",
-				"The sarcophagus is completely airtight and cannot be broken from the inside. A creature inside will begin to {@book suffocate |phb|8|suffocating|0}(Player's Handbook, page 183) unless it has a way of providing itself with air or doesn't need to breathe. On the outside, it is a physical object that has AC 15, hit points equal to your hit point maximum, and resistance to all forms of damage. If it drops to 0 hit points, the spell ends."
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Death",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "e22a92a3008493cf62c4e369da3e5b2d"
-		},
-		{
-			"name": "Wingbind",
-			"source": "NRCToS",
-			"page": 368,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 400
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a web of force that wraps around the wings and body of any one flying creature within range. The creature is {@condition grappled} (escape DC equal to your spell save DC) and {@condition restrained} as long as the grapple remains."
-			],
-			"conditionInflict": [
-				"grappled"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Grassland"
-						}
-					}
-				]
-			},
-			"uniqueId": "9bf3553703590b675f8421dd30ef26a8"
-		},
-		{
-			"name": "Elonia's Glamer",
-			"source": "NRCToS",
-			"page": 169,
-			"level": 1,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of ruby dust and a pinch of chalk dust"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You subtly change the appearance of yourself or one other humanoid, making that person more or less attractive. This does not make that person look like someone else. If you make the target more attractive, the target's skin clearer and smoother, their teeth straighter and whiter, and their hair thicker and more lustrous. For the duration, the target has advantage on Charisma ({@skill Persuasion}) skill checks designed to elicit positive reactions. If you make the target more unattractive, the target will appear lackluster, grungy, and unkempt. It will have disadvantage on the above-mentioned {@skill Persuasion} checks. An unwilling target may make a Wisdom saving throw to resist."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Archfey",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "2cd148e9ceaa19226325e2ada7e690b7"
-		},
-		{
-			"name": "Empathy",
-			"source": "NRCToS",
-			"page": 169,
-			"level": 0,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You look at one target within range and learn which of the following emotions, if any, the target is feeling most prominently, and whether the emotion is being felt weakly, moderately, or strongly:",
-				{
-					"type": "table",
-					"colStyles": [
-						"col-4 text-center",
-						"col-4 text-center",
-						"col-4 text-center"
-					],
-					"rows": [
-						[
-							"anger",
-							"happiness",
-							"optimism"
-						],
-						[
-							"anticipation",
-							"hatred",
-							"pain"
-						],
-						[
-							"anxiety",
-							"hostility",
-							"panic"
-						],
-						[
-							"curiosity",
-							"horror",
-							"pleasure"
-						],
-						[
-							"desire",
-							"hunger/thirst",
-							"shame"
-						],
-						[
-							"disgust",
-							"love",
-							"sorrow"
-						],
-						[
-							"distress",
-							"lust",
-							"surprise"
-						],
-						[
-							"fatigue",
-							"fear",
-							"uneasiness"
-						],
-						[
-							"guilt",
-							"need",
-							"wonder"
-						]
-					]
-				},
-				"This spell does not reveal the cause of the emotion or any other information about it. A creature that is aware that you are or might be attempting to contact its mind may attempt to make an Intelligence saving throw to resist; otherwise, there is no saving throw.",
-				"If you target an aberration, celestial, elemental, fey, or fiend, and that target is feeling an emotion strongly, you must make a DC 13 Wisdom saving throw. If you fail, the alien nature of that creature's mind overwhelms you and you take {@damage 1d10} psychic damage. This spell doesn't work on constructs or undead, even intelligent, free-willed ones."
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"savingThrow": [
-				"intelligence",
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "78d990a5f1c1e670e0a1d9f31cce3e91"
-		},
-		{
-			"name": "Encrypt",
-			"source": "NRCToS",
-			"page": 169,
-			"level": 3,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of dust or fluff and a feather"
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You render one message of 100 words or less permanently unreadable by everyone save you and one other specific creature named when you cast the spell. This message remains indecipherable even to spells such as {@spell comprehend languages}, although a {@spell dispel magic} will remove the encryption. This message may be written on any media you wish and you do not have to be the original writer of the message."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, you may encrypt an additional 100 words per slot level above 3rd."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b2b04cd11ef89946349db7c973a7b778"
-		},
-		{
-			"name": "Gem Record (Write)",
-			"source": "NRCToS",
-			"page": 196,
-			"level": 2,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a flawless gemstone worth at least 10 gp",
-					"cost": 1000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"You use this spell to record information inside a gemstone or to read information that was recorded by another. This spell is permanent, although destroying the gemstone will destroy the information, and the {@i gem record} can be erased by a {@spell dispel magic} or {@spell erase|nrctos} (q.v.).",
-				"You may specify up to three other individuals who may also freely read the {@i gem record}. All others must cast this spell on the gemstone to be able to read it. You may cast protective spells such as {@spell glyph of warding} on the gemstone in the same way you would cast it on a book.",
-				"The gemstone must be flawless for this spell to work. If the gem is slightly damaged (or is re-cut by a jeweler) after information has been recorded in it, roll a {@dice d20}. On a 1, the information you want has been permanently lost. If the gem has been badly damaged or altered, the information has been lost on a roll of 1-10. If the gemstone has been shattered or pulverized, the information has been permanently lost.",
-				"You may use the {@spell copy|nrctos} spell (q.v.) on the {@i gem record}, but it will only produce a copy on paper or parchment, not into another gemstone. You can use spells such as {@spell encrypt|nrctos} (q.v.) or {@spell mistaken missive|nrctos} (q.v.) on the {@i gem record} as well.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Gem Write",
-									"entries": [
-										"You record information inside of a gemstone. You may speak into it or hold the gem above a written record while casting this spell and it will copy the writing. It will record static images but cannot record moving images. You may use the gem to record spells, but that turns it into a spellbook; you cannot use a {@i gem record} as a spell scroll.",
-										"For every 50 gp the gem costs, you can record up to 1,000 words or one spell level. You only have to pay half the normal cost of inscribing a spell when you record it in a {@i gem record}. When you cast this version of the spell, the casting time is 1 minute per 1,000 words or spell level. You may cast this spell on multiple occasions until the gem is \"filled.\""
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "53cdf9822f1de033b6d4f4d261ca42ce"
-		},
-		{
-			"name": "Gem Record (Read)",
-			"source": "NRCToS",
-			"page": 196,
-			"level": 2,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a drop of your blood",
-					"cost": 1000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"You use this spell to record information inside a gemstone or to read information that was recorded by another. This spell is permanent, although destroying the gemstone will destroy the information, and the {@i gem record} can be erased by a {@spell dispel magic} or {@spell erase|nrctos} (q.v.).",
-				"You may specify up to three other individuals who may also freely read the {@i gem record}. All others must cast this spell on the gemstone to be able to read it. You may cast protective spells such as {@spell glyph of warding} on the gemstone in the same way you would cast it on a book.",
-				"The gemstone must be flawless for this spell to work. If the gem is slightly damaged (or is re-cut by a jeweler) after information has been recorded in it, roll a {@dice d20}. On a 1, the information you want has been permanently lost. If the gem has been badly damaged or altered, the information has been lost on a roll of 1-10. If the gemstone has been shattered or pulverized, the information has been permanently lost.",
-				"You may use the {@spell copy|nrctos} spell (q.v.) on the {@i gem record}, but it will only produce a copy on paper or parchment, not into another gemstone. You can use spells such as {@spell encrypt|nrctos} (q.v.) or {@spell mistaken missive|nrctos} (q.v.) on the {@i gem record} as well.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Gem Read",
-									"entries": [
-										"You may read a {@i gem record} that was created by another caster. If the information was recorded verbally, you will \"hear\" the recorder's voice in your mind. If it was copied from a text, you will mentally \"see\" the words and will have to read them; this takes as long as it would normally take to read from a book. You do not have to start from the beginning of the text; if you think about the topic or the specific section you wish to see, the {@i gem} will skip ahead to that point. This effectively gives you a search function. The recorded text is revealed mentally to you; it cannot be broadcast to be heard or read by multiple people at once.",
-										"When you cast this version of the spell, the casting time is 1 round, plus the length of time it takes to listen to or read the information, to a maximum of one hour. If you lose your concentration, the spell ends."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "938686ac45b4b036d83614f9d90a1bc6"
-		},
-		{
-			"name": "Genocide",
-			"source": "NRCToS",
-			"page": 197,
-			"level": 9,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 400
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You speak the name of a species of living creature (such as \"goblinoids\" or \"hippogriff\") and point to a member of that species that you can see within range. The creature must have a CR of 8 or less. A bolt of glowing black energy leaps from your hand to that creature, which must make a Constitution saving throw. It takes 100 necrotic damage on a failed saving throw, or half as much on a successful one.",
-				"The following round, tendrils of energy leap from that creature to all other creatures of that type that are within 60 feet of it. Those creatures must also make Constitution saving throws. A creature takes 50 necrotic damage on a failed saving throw, or half as much on a successful one."
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST",
-				"MT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "57f65d78a9e5fade4d564a3477fb41c5"
-		},
-		{
-			"name": "Mistaken Missive",
-			"source": "NRCToS",
-			"page": 266,
-			"level": 2,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "three drops of ink"
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You cast this spell on up to ten pages of text. Over the course of a week, the text will slowly change.",
-				"On the first day, it will become faint, as if the writer was running out of ink. On the second through fourth days, the words become gibberish\u2014the text is aligned in groups of letters and punctuation, but nearly all the words are meaningless. On the fifth day, the letters have become real words, but the sentences make no sense. On the sixth day, and thereafter, the message is coherent but conveys the exact opposite of the original meaning."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "7153f57382ce914f1cf83571e317b014"
-		},
-		{
-			"name": "Erase",
-			"source": "NRCToS",
-			"page": 173,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You remove any writing you see, leaving the surface it was on unmarked (even if the words were carved in stone). It will erase up to 1,000 words at a time and automatically erases nonmagical writings.",
-				"If you are attempting to remove magical writing, including spell scrolls and magical traps such as {@spell glyph of warding} or {@spell symbol}, you must make an ability check using your spellcasting ability. The DC equals 10 + the spell's level. On a successful check, the writing is erased. If you fail, and the magical writing is actually a trap, the trap goes off.",
-				"This spell does not work on illusory writing, such as that produced by {@spell illusory script}, as that writing isn't real."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "c2cf02df013202925f916860f08f4028"
-		},
-		{
-			"name": "Puppeteer",
-			"source": "NRCToS",
-			"page": 294,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 160
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"Silvery strings fly out from your hand towards a creature you can see within your range and attach to it; a moment later, they fade from view. The target may make a Wisdom saving throw to resist. If the creature fails, it is forced to mimic your actions exactly, although it looks awkward and ineffective, and the creature has disadvantage on all Strength- and Dexterity-based actions you make it take. You cannot make it perform any action it cannot physically do.",
-				"If you attempt to force it into taking a suicidal action or one in direct opposition to its interests or alignment, it may make another saving throw, ending the effect on a success."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "053adc76528d4655e95340ef6f68a6bf"
-		},
-		{
-			"name": "Power Word Attention",
-			"source": "NRCToS",
-			"page": 289,
-			"level": 1,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You utter a word of power (or whistle very loudly) that compels all creatures within a 60-foot radius of you to pay complete and utter attention to you for 1 round. A creature that is involved in a life-or-death situation may make an Intelligence saving throw to resist. {@condition Deafened} creatures are immune to this spell."
-			],
-			"savingThrow": [
-				"intelligence"
-			],
-			"areaTags": [
-				"R"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "69975a178e16a3091b861b6916ac69ac"
-		},
-		{
-			"name": "Power Word Banish",
-			"source": "NRCToS",
-			"page": 289,
-			"level": 9,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You utter a word of great power that forces one elemental, fiend, or celestial that you can see within range to immediately return to its home plane. If the creature has a CR of 15 or more, it may make a Wisdom saving throw to resist."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "4ccd2b626e810132338de2ff13922d80"
-		},
-		{
-			"name": "Power Word Blind",
-			"source": "NRCToS",
-			"page": 289,
-			"level": 8,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You point to one creature you can see within range and shout out a magic word. If the creature you choose has 50 hit points or fewer, it goes permanently {@condition blinded|phb|blind}. If it has up to 100 hit points, it goes blind for 1 day. If it has more than 100 hit points, the spell has no effect.",
-				"All creatures within 10 feet of the creature you pointed out are permanently {@condition blinded} if they have 25 hit points or fewer, or are {@condition blinded} for 1 day if they have up to 50 hit points."
-			],
-			"miscTags": [
-				"PRM",
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "cf42f9d28a9b90c5e3499959d21cf56b"
-		},
-		{
-			"name": "Power Word Disrupt",
-			"source": "NRCToS",
-			"page": 289,
-			"level": 3,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "reaction",
-					"condition": "taken when another creature begins to cast a spell"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Your word of magical power utterly destroys the concentration of one spellcaster you see within range. It will fail to cast the spell and will lose the spell slot."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Arcana",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "5a823046d38e246a2e7632374a612209"
-		},
-		{
-			"name": "Power Word Fear",
-			"source": "NRCToS",
-			"page": 289,
-			"level": 2,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Your great word of power instills horrifying fear in one creature you can see within range. That creature must succeed on a Wisdom saving throw or drop whatever it is holding and become {@condition frightened}, taking the {@action Dash} option to run away from you for 1 minute. If it ends its turn in a location where it doesn't have line of sight to you, it may make a new saving throw, ending the effect on a success."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Undying",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "9d12657ce8a2234dfbe5d7f9fc28bf51"
-		},
-		{
-			"name": "Possess",
-			"source": "NRCToS",
-			"page": 288,
-			"level": 4,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 500
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a bowl or stick of incense and a figurine of the being to be possessed"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You release your soul from your body and possess another humanoid or beast. That creature must make a Charisma saving throw to resist. If it fails, you take over its body. The target becomes {@condition incapacitated} and {@condition unconscious} and you gain control of it. While in control, you have resistance to all forms of damage that your target takes, except for psychic damage\u2014you take psychic damage as normal and your host takes no damage.",
-				"Your game statistics are replaced by the statistics of the creature, though you retain your alignment and your Intelligence, Wisdom, and Charisma scores. You retain the benefit of your own class features. You do not have ready access to your host's memories. If you wish to gain access to a memory, you must make a Charisma ability check against your target's Charisma.",
-				"You may choose to end the possession at any time. If the body you are in drops to 0 hit points, the possession ends and you must make a Charisma saving throw. You take {@damage 6d8} psychic damage on a failed saving throw, or half as much on a successful one.",
-				"A target is immune to your attempts to possess it for 24 hours after succeeding on the saving throw or the possession ends.",
-				"While you are possessing a target, you are subject to spells such as {@spell dispel evil and good} and {@spell exorcism|nrctos} (q.v.)."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 7th-level spell slot, you may attempt to possess any being, regardless of that creature's type."
-					]
-				}
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"conditionInflict": [
-				"incapacitated",
-				"unconscious"
-			],
-			"savingThrow": [
-				"charisma"
-			],
-			"opposedCheck": [
-				"charisma"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Undying",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "9d12d21829a1aba2c177b26b10fac1c4"
-		},
-		{
-			"name": "Power Drain",
-			"source": "NRCToS",
-			"page": 288,
-			"level": 9,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a black opal worth 1,000 gp",
-					"cost": 100000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You touch a creature and drain its very life force, which you then use to power a spell.",
-				"The creature you touch must make a Constitution saving throw or take {@damage 8d10} necrotic damage and have its hit point total reduced by that amount. That life force is then stored within the opal, and you may use it to gain spell slots, as follows:",
-				{
-					"type": "table",
-					"colLabels": [
-						"Hit Points Drained",
-						"Slot Level"
-					],
-					"colStyles": [
-						"col-6 text-center",
-						"col-6 text-center"
-					],
-					"rows": [
-						[
-							"1-10",
-							"1"
-						],
-						[
-							"11-20",
-							"2"
-						],
-						[
-							"21-30",
-							"3"
-						],
-						[
-							"31-40",
-							"4"
-						],
-						[
-							"41-50",
-							"5"
-						],
-						[
-							"51-60",
-							"6"
-						],
-						[
-							"61-70",
-							"7"
-						],
-						[
-							"71-80",
-							"8"
-						]
-					]
-				},
-				"If you wish, you may choose to use the slot to cast a spell of a lower level.",
-				"If you don't use that energy within 10 minutes of being drained, or the opal is destroyed, the energy dissipates. The target creature will then be able to restore its hit point total after a short or long rest. If you use the energy, the target's hit point total reduction is permanent until a spell such as {@spell greater restoration} is cast upon it."
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "f1e3b613be7da84cbca61f1ceb6c7602",
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "cf42f9d28a9b90c5e3499959d21cf56b"
+    },
+    {
+      "name": "Power Word Disrupt",
+      "source": "NRCToS",
+      "page": 289,
+      "level": 3,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "reaction",
+          "condition": "taken when another creature begins to cast a spell"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Your word of magical power utterly destroys the concentration of one spellcaster you see within range. It will fail to cast the spell and will lose the spell slot."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "5a823046d38e246a2e7632374a612209"
+    },
+    {
+      "name": "Power Word Fear",
+      "source": "NRCToS",
+      "page": 289,
+      "level": 2,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Your great word of power instills horrifying fear in one creature you can see within range. That creature must succeed on a Wisdom saving throw or drop whatever it is holding and become {@condition frightened}, taking the {@action Dash} option to run away from you for 1 minute. If it ends its turn in a location where it doesn't have line of sight to you, it may make a new saving throw, ending the effect on a success."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Undying",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "9d12657ce8a2234dfbe5d7f9fc28bf51"
+    },
+    {
+      "name": "Possess",
+      "source": "NRCToS",
+      "page": 288,
+      "level": 4,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 500
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a bowl or stick of incense and a figurine of the being to be possessed"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You release your soul from your body and possess another humanoid or beast. That creature must make a Charisma saving throw to resist. If it fails, you take over its body. The target becomes {@condition incapacitated} and {@condition unconscious} and you gain control of it. While in control, you have resistance to all forms of damage that your target takes, except for psychic damage\u2014you take psychic damage as normal and your host takes no damage.",
+        "Your game statistics are replaced by the statistics of the creature, though you retain your alignment and your Intelligence, Wisdom, and Charisma scores. You retain the benefit of your own class features. You do not have ready access to your host's memories. If you wish to gain access to a memory, you must make a Charisma ability check against your target's Charisma.",
+        "You may choose to end the possession at any time. If the body you are in drops to 0 hit points, the possession ends and you must make a Charisma saving throw. You take {@damage 6d8} psychic damage on a failed saving throw, or half as much on a successful one.",
+        "A target is immune to your attempts to possess it for 24 hours after succeeding on the saving throw or the possession ends.",
+        "While you are possessing a target, you are subject to spells such as {@spell dispel evil and good} and {@spell exorcism|nrctos} (q.v.)."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 7th-level spell slot, you may attempt to possess any being, regardless of that creature's type."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "conditionInflict": [
+        "incapacitated",
+        "unconscious"
+      ],
+      "savingThrow": [
+        "charisma"
+      ],
+      "opposedCheck": [
+        "charisma"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Undying",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "9d12d21829a1aba2c177b26b10fac1c4"
+    },
+    {
+      "name": "Power Drain",
+      "source": "NRCToS",
+      "page": 288,
+      "level": 9,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a black opal worth 1,000 gp",
+          "cost": 100000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You touch a creature and drain its very life force, which you then use to power a spell.",
+        "The creature you touch must make a Constitution saving throw or take {@damage 8d10} necrotic damage and have its hit point total reduced by that amount. That life force is then stored within the opal, and you may use it to gain spell slots, as follows:",
+        {
+          "type": "table",
+          "colLabels": [
+            "Hit Points Drained",
+            "Slot Level"
+          ],
+          "colStyles": [
+            "col-6 text-center",
+            "col-6 text-center"
+          ],
+          "rows": [
+            [
+              "1-10",
+              "1"
+            ],
+            [
+              "11-20",
+              "2"
+            ],
+            [
+              "21-30",
+              "3"
+            ],
+            [
+              "31-40",
+              "4"
+            ],
+            [
+              "41-50",
+              "5"
+            ],
+            [
+              "51-60",
+              "6"
+            ],
+            [
+              "61-70",
+              "7"
+            ],
+            [
+              "71-80",
+              "8"
+            ]
+          ]
+        },
+        "If you wish, you may choose to use the slot to cast a spell of a lower level.",
+        "If you don't use that energy within 10 minutes of being drained, or the opal is destroyed, the energy dissipates. The target creature will then be able to restore its hit point total after a short or long rest. If you use the energy, the target's hit point total reduction is permanent until a spell such as {@spell greater restoration} is cast upon it."
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "f1e3b613be7da84cbca61f1ceb6c7602",
 			"miscTags": [
 				"HL"
 			]
-		},
-		{
-			"name": "Exorcism",
-			"source": "NRCToS",
-			"page": 177,
-			"level": 1,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a silver bell, a book of prayers, and a blessed candle that must remain lit throughout the ritual"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You attempt to force a ghost, demon, or other such entity to leave the host or object it is possessing. The creature that the entity is possessing must be either willing or {@condition restrained} for you to cast this spell.",
-				"After an hour of reciting liturgy, chanting, waving burning sage around, drawing magic sigils, and so on, the entity must make a saving throw, using the higher of its Charisma, Constitution, or Wisdom. If it succeeds, nothing happens and the spell ends.",
-				"If the entity fails its saving throw, it takes {@damage 2d10} psychic damage and its hit point total is reduced by that amount. It must then make a second saving throw, using the same attribute it used for the first save. If that roll fails, it also loses a number of points from that attribute equal to your spellcasting ability modifier (minimum of 1). Hit point and attribute reduction lasts until one week has passed since the last time you or anyone else attempted to exorcise it.",
-				"If the entity's first saving throw failed (whether or not the second one succeeds or fails), you must make a Constitution saving throw, with a DC equal to 10 + the entity's proficiency bonus + the entity's Charisma attribute modifier. On a failed saving throw, you take {@damage 2d10} psychic damage, and the entity's host takes {@damage 1d10} force damage.",
-				"One casting of this spell will generally only weaken the spirit; it usually requires multiple castings to fully drive it away. If you reduce its hit point total to 10 or less, or any of its attributes to 3 or lower, it will be too weak to remain inside its vessel and will immediately attempt to flee. It cannot attempt to repossess that host for 1 year.",
-				"Note that this spell does not prevent the creature from using any of its own abilities while you are casting it."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level or higher spell slot, you inflict an additional {@scaledice 2d10|1-9|1d10} psychic damage for each slot level above 1st. If you cast this spell with a 6th-level or higher spell slot, the creature has disadvantage on all saving throws. This does not affect the amount of damage you or the entity's host take."
-					]
-				}
-			],
-			"damageInflict": [
-				"force",
-				"psychic"
-			],
-			"savingThrow": [
-				"constitution",
-				"wisdom",
-				"charisma"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "252d08618a9703d52a09777ae88f5d80"
-		},
-		{
-			"name": "Hornung's Random Dispatcher",
-			"source": "NRCToS",
-			"page": 217,
-			"level": 8,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You point to one creature you can see within range. That creature must make an Intelligence saving throw. On a failure, the creature is hurtled into a completely random plane of existence. You have no control over which plane the target ends up going to and it is entirely possible that the target's destination will instantly kill it.",
-				"The GM should roll on the following table to randomly determine the destination.",
-				{
-					"type": "table",
-					"colLabels": [
-						"{@dice d100}",
-						"Plane"
-					],
-					"colStyles": [
-						"col-1-5 text-center",
-						"col-10-5"
-					],
-					"rows": [
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"pad": true,
-									"min": 1,
-									"max": 4
-								}
-							},
-							"The Feywild"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"pad": true,
-									"min": 5,
-									"max": 8
-								}
-							},
-							"The Shadowfell"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"pad": true,
-									"min": 9,
-									"max": 12
-								}
-							},
-							"The Ethereal Plane"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 13,
-									"max": 16
-								}
-							},
-							"The Astral Plane"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 17,
-									"max": 20
-								}
-							},
-							"The Elemental Plane of Air"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 21,
-									"max": 24
-								}
-							},
-							"The Elemental Plane of Earth"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 25,
-									"max": 28
-								}
-							},
-							"The Elemental Plane of Fire"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 29,
-									"max": 32
-								}
-							},
-							"The Elemental Plane of Water"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 33,
-									"max": 36
-								}
-							},
-							"The Blessed Fields of Elysium"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 37,
-									"max": 40
-								}
-							},
-							"The Clockwork Nirvana of Mechanus"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 41,
-									"max": 44
-								}
-							},
-							"The Ever-Changing Chaos of Limbo"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 45,
-									"max": 48
-								}
-							},
-							"The Gray Waste of Hades"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 49,
-									"max": 52
-								}
-							},
-							"The Heroic Domains of Ysgard"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 53,
-									"max": 56
-								}
-							},
-							"The Infinite Battlefield of Acheron"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 57,
-									"max": 60
-								}
-							},
-							"The Infinite Layers of the Abyss"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 61,
-									"max": 64
-								}
-							},
-							"The Nine Hells of Baator"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 65,
-									"max": 68
-								}
-							},
-							"The Olympic Glades of Arborea"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 69,
-									"max": 72
-								}
-							},
-							"The Peaceable Kingdoms of Arcadia"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 73,
-									"max": 76
-								}
-							},
-							"The Seven Heavens of Mount Celestia"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 77,
-									"max": 80
-								}
-							},
-							"The Tarterian Depths of Carceri"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 81,
-									"max": 84
-								}
-							},
-							"The Twin Paradises of Bytopia"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 85,
-									"max": 88
-								}
-							},
-							"The Wilderness of the Beastlands"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 89,
-									"max": 92
-								}
-							},
-							"The Windswept Depths of Pandemonium"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 93,
-									"max": 96
-								}
-							},
-							"The Outlands or the City of Sigil"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 97,
-									"max": 98
-								}
-							},
-							"The Far Realms"
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 99,
-									"max": 100
-								}
-							},
-							"An alternate Prime world"
-						]
-					]
-				}
-			],
-			"savingThrow": [
-				"intelligence"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "7d8a0847abf0412e4435e8329dd20e29"
-		},
-		{
-			"name": "Legerdemain",
-			"source": "NRCToS",
-			"page": 242,
-			"level": 0,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You perform a magic trick, of the sort normally performed by stage magicians.",
-				{
-					"type": "list",
-					"items": [
-						"You change a Tiny creature or object into another one of the same size.",
-						"You hide a creature or object of Huge size or smaller by briefly obscuring it, such as by moving a curtain in front of it, hiding it behind an object, etc. The target is rendered {@condition invisible} as long as it doesn't move more than 5 feet from its initial location. It can still be heard, smelled, and touched, and can be seen with {@sense truesight} or {@sense blindsight}.",
-						"You hide a Tiny creature or object in your palm, up your sleeve, in your hat, etc., even concealing any bulges or sounds it makes. At the same time, you create an illusory duplicate. Physical interaction with the duplicate reveals it to be an illusion, because things can pass through it.",
-						"You summon a Tiny object that is within 10 feet of you into your hand.",
-						"You conjure a harmless, {@filter CR 0 creature|bestiary|challenge rating=0}, such as a mouse, a small swarm of butterflies, a sparrow, and so on, which appears in your hand or within 5 feet of you. This is a real animal, taken from somewhere within 1 mile of you. At the spell's end, you may choose to keep the creature with you, let it go, or send it back to its original location.",
-						"You create a puff of colored smoke. It provides light concealment until the end of your next turn.",
-						"You cause a Small-sized or smaller object made of metal or wood to pass through a similarly-sized object.",
-						"You cut and restore a rope, cloth, belt, or other similar object.",
-						"You turn a picture or paper sculpture of a Tiny-sized creature into a real creature. It will have the same attributes of a normal creature of its type, with the following changes: its Intelligence will be 1, it will have 5 hit points, and it will have disadvantage on all rolls.",
-						"You instantly change into another suit of clothes that you have stored within 10 feet. You can also use this to instantly don light armor (but nothing heavier than that).",
-						"You create a bright flash of light and puff of colorful smoke (your choice of colors). The smoke lasts for 1 round, and during that time you can use your bonus action to use the {@action Hide} action."
-					]
-				}
-			],
-			"conditionInflict": [
-				"invisible"
-			],
-			"miscTags": [
-				"HL",
-				"SMN"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b342cd2fb51e071be3018308d52051ca"
-		},
-		{
-			"name": "Ladder",
-			"source": "NRCToS",
-			"page": 240,
-			"level": 1,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a knot of wood"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a ladder of magical force that is one foot wide and ten feet long. You may place it vertically against a wall, lay it horizontally so it can be used to cross gaps, or have it lean at a 45° angle to be used as a staircase. In any case, the ladder is firmly anchored and will not move once placed."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 2nd level or higher, the ladder increases ten feet in length for each slot level above 1st."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "092ba828f6acc952b2a7520d6374c181"
-		},
-		{
-			"name": "Laeral's Cutting Hand",
-			"source": "NRCToS",
-			"page": 240,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"One of your hands gains a magical cutting edge. The merest touch of your hand will sever nonmagical ropes, sacks, and the like. Unarmed strikes do {@dice 1d12} + your Strength modifier in slashing damage."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level or higher spell slot, you inflict an additional {@scaledice 1d12|1-9|1d12} damage per slot level above 1st."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "d6b79b8d948929d56fdfaab13bdd0039"
-		},
-		{
-			"name": "Laeral's Invisible Blade",
-			"source": "NRCToS",
-			"page": 240,
-			"level": 8,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a bladed weapon, which is consumed in the casting of the spell, and a clear rock crystal",
-					"consume": true
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a magical sword and is {@condition invisible} and inaudible to all creatures other than yourself. Roll initiative for it and it has its own turns\u2014it attacks using your spell attack modifier. It will attack one creature you can see within range. On a hit, the sword inflicts {@damage 8d10} slashing damage.",
-				"The spell ends if the target is ever outside the spell's range or if it has total cover from you."
-			],
-			"damageInflict": [
-				"slashing"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "9256868e36ce80e2da609182b2d8ef09"
-		},
-		{
-			"name": "Last Image",
-			"source": "NRCToS",
-			"page": 240,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"When you touch a corpse and cast this spell, you see a still image of whatever the last thing the corpse saw.",
-				"If the target died due to a gaze attack, you must make a saving throw of the type associated with the attack or suffer the results of the gaze. You have advantage on this roll."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Knowledge",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Undying",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "7336ce940b49c495b9cfca7bbe90955f"
-		},
-		{
-			"name": "Lava Bolt",
-			"source": "NRCToS",
-			"page": 240,
-			"level": 4,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of pumice or obsidian"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You conjure an orb of lava which you hurl at one target within range. Make a ranged spell attack to hit. On a hit, the target takes {@damage 3d8} bludgeoning damage and {@damage 3d8} fire damage. In addition, the target must make a Dexterity saving throw. On a failure, the lava sticks to the target and begins to solidify. The target is {@condition restrained} (escape DC equal to your spell save DC) and takes {@damage 1d8} fire damage at the end of each of its turns for 1 minute.",
-				"While this spell is active, the lava can only be removed by the application of copious amounts of water or with a spell that of 2nd level or higher that inflicts cold-based damage (this spell also inflicts half damage to the target). If the target dies from this spell it becomes completely encased in hardened volcanic rock."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 5th-level or higher spell slot, you inflict an additional {@scaledice 3d8|4-9|1d8} fire damage on initial impact and each round for each slot level above 4th."
-					]
-				}
-			],
-			"damageInflict": [
-				"bludgeoning",
-				"fire"
-			],
-			"conditionInflict": [
-				"restrained"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Mountain"
-						}
-					}
-				]
-			},
-			"uniqueId": "558d37026bdeb600e7f7f651be12527a"
-		},
-		{
-			"name": "Leaf into Dagger",
-			"source": "NRCToS",
-			"page": 241,
-			"level": 0,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a normal leaf"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You transform any tree leaf into a magical dagger that does {@dice 1d4} + your spellcasting ability modifier in piercing damage. You cannot be harmed by this blade and should you drop it, it instantly becomes a leaf again."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "9b8673e801eb8241395f8220ebf24e5c"
-		},
-		{
-			"name": "Iceball",
-			"source": "NRCToS",
-			"page": 222,
-			"level": 3,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 150
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a tiny ball of bat guano and powdered glass"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A bright blue-white streak flashes from your pointing finger to a point you choose within range and then explodes into small shards of ice. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes {@damage 3d6} bludgeoning damage and {@damage 4d6} cold damage on a failed save, or half as much damage on a successful one. In either case, the targets are also {@condition stunned} until the end of their next turn."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 4th level or higher, the cold damage increases by {@scaledice 4d6|3-9|1d6} for each slot level above 3rd."
-					]
-				}
-			],
-			"damageInflict": [
-				"bludgeoning",
-				"cold"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "967edb66fb176a5c19cda4f9c57b5e89"
-		},
-		{
-			"name": "Idea",
-			"source": "NRCToS",
-			"page": 222,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a gold coin, which is consumed in the casting",
-					"consume": true
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You flip the coin in the area while thinking of your problem and the coin vanishes. You then gain advantage on a single {@skill Arcana}, {@skill History}, {@skill Insight}, {@skill Investigation}, {@skill Medicine}, {@skill Nature}, {@skill Performance}, {@skill Religion}, or {@skill Survival} ability check needed to solve the problem.",
-				"If the problem is one that doesn't require a skill roll to solve (but instead requires role-playing), the DM will give you a strong hint as to the solution."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b481b02ab048d74738bf1b46d2b02c6b"
-		},
-		{
-			"name": "Ill Omen",
-			"source": "NRCToS",
-			"page": 222,
-			"level": 0,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You curse a target with bad luck. It must succeed on a Wisdom saving throw or be at disadvantage on all rolls until the end of its next turn. You may only curse a particular target with this spell once until you have finished a short or long rest."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "56e9b38ad66b0faa6b49c6ab484a98f8"
-		},
-		{
-			"name": "Illusory Feast",
-			"source": "NRCToS",
-			"page": 222,
-			"level": 5,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 400
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of food"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You conjure a phantasmal image of delicious-looking food and drink. All creatures within 30 feet of it must make a Wisdom saving throw. On a failure, a target will stop what it is doing and attempt to eat the food; the food appears to be exactly the type the target likes and exists only in its mind. A target may attempt a new saving throw at the beginning of each of its turns, ending the effect on a success. If a target is attacked, the spell automatically ends for that creature, but not for anyone else affected by the spell. Creatures that do not eat are immune to this spell."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Trickery",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "5e9462e3712fe0416529ab79e88e1206"
-		},
-		{
-			"name": "Layla's Morning-After Kiss",
-			"source": "NRCToS",
-			"page": 241,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You kiss an {@condition unconscious} or sleeping creature's skin (although you do not need to kiss its lips) and it makes a Wisdom saving throw. If it fails, it permanently forgets everything that happened up to 1 hour before it fell asleep.",
-				"The memory can be recovered by use of the {@spell hypnosis|nrctos} (q.v.) spell."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Trickery",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "3076ea4afcc3236ea4c3a95716d22a7b"
-		},
-		{
-			"name": "Hypnosis",
-			"source": "NRCToS",
-			"page": 219,
-			"level": 5,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 10
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a small, shiny object on a string"
-			},
-			"duration": [
-				{
-					"type": "special"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You attempt to beguile a creature with an Intelligence of 5 or higher that you can see and that in return can see your eyes; it must also be able to understand your language and must be either willing or {@condition restrained}. The creature must make a Wisdom saving throw; if it fails, it is {@condition charmed} by you. This spell has several functions; you must choose which one you will use when you cast the spell.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Deprogramming",
-									"entries": [
-										"If the target is suffering from the {@condition charmed} condition, you may release the target from that effect. You can also use this to deprogram a creature suffering from non-magical brainwashing."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Memory Recovery",
-									"entries": [
-										"If the target's memories had been altered or erased, either through mundane means (including both normal forgetfulness and brainwashing) or by the {@spell modify memory} or similar spell, you restore the original memory."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Phantasmal Harm",
-									"entries": [
-										"You can cause the target to believe that it is being harmed. Each round, for a number of rounds equal to twice your spellcasting ability modifier, you may inflict {@dice 1d10}, {@dice 2d10}, or {@damage 3d10} psychic damage (you may choose how severe the \"damage\" is). If the target falls to 0 hit points or lower, it may make a Wisdom saving throw. If it succeeds, it instead drops to 1 hit point and falls {@condition unconscious}."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Rejuvenation",
-									"entries": [
-										"You can remove 1 level of {@condition exhaustion} from the target. You may only use this version of the spell on a creature once each day."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Suggestion",
-									"entries": [
-										"You implant a suggestion, as per the spell, into the creature's subconscious, with the following changes: the suggestion lasts for 1 week and you can ask the target to perform an action that is self-destructive or that violates its alignment. If you do so, however, the target may make a second saving throw when the suggestion is triggered; if it succeeds, it will snap out of it. Once the creature has completed your suggestion, it will have no conscious memory of its actions. The memory can be recovered using the memory recovery version of this spell.",
-										"If you cast this version of {@i hypnosis} on your target every day for a week, the suggestion will last for 1 month. If you cast it every day for a month, the suggestion will last for a year."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Truth-Telling",
-									"entries": [
-										"You may ask the target a number of questions equal to twice your spell attack modifier. The target will answer them truthfully, although not necessarily fully or coherently."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"conditionInflict": [
-				"charmed"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"HL",
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "66838736cc94894ba9e48c282ee10770"
-		},
-		{
-			"name": "Augment Artistry",
-			"source": "NRCToS",
-			"page": 84,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a scroll bearing a piece of epic poetry"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You or a willing target gains proficiency with one form of artisan's tools. If the target already has proficiency in the desired tools, then that target may use double its proficiency bonus."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 4th-level or higher spell slot, the target gains triple its proficiency bonus."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Ancients",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "27e7a90922a8a9218f96d1e70306397a"
-		},
-		{
-			"name": "Augment Familiar",
-			"source": "NRCToS",
-			"page": 84,
-			"level": 2,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"For the spell's duration, you grant your familiar or animal companion 10 temporary hit points, resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons, and advantage on all saving throws."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level or higher spell slot, you grant the creature an additional 5 temporary hit points per spell slot above 2nd."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "f5258fb21b262f308b2e2a11d8460142",
+    },
+    {
+      "name": "Exorcism",
+      "source": "NRCToS",
+      "page": 177,
+      "level": 1,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a silver bell, a book of prayers, and a blessed candle that must remain lit throughout the ritual"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You attempt to force a ghost, demon, or other such entity to leave the host or object it is possessing. The creature that the entity is possessing must be either willing or {@condition restrained} for you to cast this spell.",
+        "After an hour of reciting liturgy, chanting, waving burning sage around, drawing magic sigils, and so on, the entity must make a saving throw, using the higher of its Charisma, Constitution, or Wisdom. If it succeeds, nothing happens and the spell ends.",
+        "If the entity fails its saving throw, it takes {@damage 2d10} psychic damage and its hit point total is reduced by that amount. It must then make a second saving throw, using the same attribute it used for the first save. If that roll fails, it also loses a number of points from that attribute equal to your spellcasting ability modifier (minimum of 1). Hit point and attribute reduction lasts until one week has passed since the last time you or anyone else attempted to exorcise it.",
+        "If the entity's first saving throw failed (whether or not the second one succeeds or fails), you must make a Constitution saving throw, with a DC equal to 10 + the entity's proficiency bonus + the entity's Charisma attribute modifier. On a failed saving throw, you take {@damage 2d10} psychic damage, and the entity's host takes {@damage 1d10} force damage.",
+        "One casting of this spell will generally only weaken the spirit; it usually requires multiple castings to fully drive it away. If you reduce its hit point total to 10 or less, or any of its attributes to 3 or lower, it will be too weak to remain inside its vessel and will immediately attempt to flee. It cannot attempt to repossess that host for 1 year.",
+        "Note that this spell does not prevent the creature from using any of its own abilities while you are casting it."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, you inflict an additional {@scaledice 2d10|1-9|1d10} psychic damage for each slot level above 1st. If you cast this spell with a 6th-level or higher spell slot, the creature has disadvantage on all saving throws. This does not affect the amount of damage you or the entity's host take."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "force",
+        "psychic"
+      ],
+      "savingThrow": [
+        "constitution",
+        "wisdom",
+        "charisma"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "252d08618a9703d52a09777ae88f5d80"
+    },
+    {
+      "name": "Hornung's Random Dispatcher",
+      "source": "NRCToS",
+      "page": 217,
+      "level": 8,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You point to one creature you can see within range. That creature must make an Intelligence saving throw. On a failure, the creature is hurtled into a completely random plane of existence. You have no control over which plane the target ends up going to and it is entirely possible that the target's destination will instantly kill it.",
+        "The GM should roll on the following table to randomly determine the destination.",
+        {
+          "type": "table",
+          "colLabels": [
+            "{@dice d100}",
+            "Plane"
+          ],
+          "colStyles": [
+            "col-1-5 text-center",
+            "col-10-5"
+          ],
+          "rows": [
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "pad": true,
+                  "min": 1,
+                  "max": 4
+                }
+              },
+              "The Feywild"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "pad": true,
+                  "min": 5,
+                  "max": 8
+                }
+              },
+              "The Shadowfell"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "pad": true,
+                  "min": 9,
+                  "max": 12
+                }
+              },
+              "The Ethereal Plane"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 13,
+                  "max": 16
+                }
+              },
+              "The Astral Plane"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 17,
+                  "max": 20
+                }
+              },
+              "The Elemental Plane of Air"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 21,
+                  "max": 24
+                }
+              },
+              "The Elemental Plane of Earth"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 25,
+                  "max": 28
+                }
+              },
+              "The Elemental Plane of Fire"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 29,
+                  "max": 32
+                }
+              },
+              "The Elemental Plane of Water"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 33,
+                  "max": 36
+                }
+              },
+              "The Blessed Fields of Elysium"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 37,
+                  "max": 40
+                }
+              },
+              "The Clockwork Nirvana of Mechanus"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 41,
+                  "max": 44
+                }
+              },
+              "The Ever-Changing Chaos of Limbo"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 45,
+                  "max": 48
+                }
+              },
+              "The Gray Waste of Hades"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 49,
+                  "max": 52
+                }
+              },
+              "The Heroic Domains of Ysgard"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 53,
+                  "max": 56
+                }
+              },
+              "The Infinite Battlefield of Acheron"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 57,
+                  "max": 60
+                }
+              },
+              "The Infinite Layers of the Abyss"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 61,
+                  "max": 64
+                }
+              },
+              "The Nine Hells of Baator"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 65,
+                  "max": 68
+                }
+              },
+              "The Olympic Glades of Arborea"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 69,
+                  "max": 72
+                }
+              },
+              "The Peaceable Kingdoms of Arcadia"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 73,
+                  "max": 76
+                }
+              },
+              "The Seven Heavens of Mount Celestia"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 77,
+                  "max": 80
+                }
+              },
+              "The Tarterian Depths of Carceri"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 81,
+                  "max": 84
+                }
+              },
+              "The Twin Paradises of Bytopia"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 85,
+                  "max": 88
+                }
+              },
+              "The Wilderness of the Beastlands"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 89,
+                  "max": 92
+                }
+              },
+              "The Windswept Depths of Pandemonium"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 93,
+                  "max": 96
+                }
+              },
+              "The Outlands or the City of Sigil"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 97,
+                  "max": 98
+                }
+              },
+              "The Far Realms"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 99,
+                  "max": 100
+                }
+              },
+              "An alternate Prime world"
+            ]
+          ]
+        }
+      ],
+      "savingThrow": [
+        "intelligence"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "7d8a0847abf0412e4435e8329dd20e29"
+    },
+    {
+      "name": "Legerdemain",
+      "source": "NRCToS",
+      "page": 242,
+      "level": 0,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You perform a magic trick, of the sort normally performed by stage magicians.",
+        {
+          "type": "list",
+          "items": [
+            "You change a Tiny creature or object into another one of the same size.",
+            "You hide a creature or object of Huge size or smaller by briefly obscuring it, such as by moving a curtain in front of it, hiding it behind an object, etc. The target is rendered {@condition invisible} as long as it doesn't move more than 5 feet from its initial location. It can still be heard, smelled, and touched, and can be seen with {@sense truesight} or {@sense blindsight}.",
+            "You hide a Tiny creature or object in your palm, up your sleeve, in your hat, etc., even concealing any bulges or sounds it makes. At the same time, you create an illusory duplicate. Physical interaction with the duplicate reveals it to be an illusion, because things can pass through it.",
+            "You summon a Tiny object that is within 10 feet of you into your hand.",
+            "You conjure a harmless, {@filter CR 0 creature|bestiary|challenge rating=0}, such as a mouse, a small swarm of butterflies, a sparrow, and so on, which appears in your hand or within 5 feet of you. This is a real animal, taken from somewhere within 1 mile of you. At the spell's end, you may choose to keep the creature with you, let it go, or send it back to its original location.",
+            "You create a puff of colored smoke. It provides light concealment until the end of your next turn.",
+            "You cause a Small-sized or smaller object made of metal or wood to pass through a similarly-sized object.",
+            "You cut and restore a rope, cloth, belt, or other similar object.",
+            "You turn a picture or paper sculpture of a Tiny-sized creature into a real creature. It will have the same attributes of a normal creature of its type, with the following changes: its Intelligence will be 1, it will have 5 hit points, and it will have disadvantage on all rolls.",
+            "You instantly change into another suit of clothes that you have stored within 10 feet. You can also use this to instantly don light armor (but nothing heavier than that).",
+            "You create a bright flash of light and puff of colorful smoke (your choice of colors). The smoke lasts for 1 round, and during that time you can use your bonus action to use the {@action Hide} action."
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "invisible"
+      ],
+      "miscTags": [
+        "HL",
+        "SMN"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b342cd2fb51e071be3018308d52051ca"
+    },
+    {
+      "name": "Ladder",
+      "source": "NRCToS",
+      "page": 240,
+      "level": 1,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a knot of wood"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a ladder of magical force that is one foot wide and ten feet long. You may place it vertically against a wall, lay it horizontally so it can be used to cross gaps, or have it lean at a 45° angle to be used as a staircase. In any case, the ladder is firmly anchored and will not move once placed."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 2nd level or higher, the ladder increases ten feet in length for each slot level above 1st."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "092ba828f6acc952b2a7520d6374c181"
+    },
+    {
+      "name": "Laeral's Cutting Hand",
+      "source": "NRCToS",
+      "page": 240,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "One of your hands gains a magical cutting edge. The merest touch of your hand will sever nonmagical ropes, sacks, and the like. Unarmed strikes do {@dice 1d12} + your Strength modifier in slashing damage."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, you inflict an additional {@scaledice 1d12|1-9|1d12} damage per slot level above 1st."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "d6b79b8d948929d56fdfaab13bdd0039"
+    },
+    {
+      "name": "Laeral's Invisible Blade",
+      "source": "NRCToS",
+      "page": 240,
+      "level": 8,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a bladed weapon, which is consumed in the casting of the spell, and a clear rock crystal",
+          "consume": true
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a magical sword and is {@condition invisible} and inaudible to all creatures other than yourself. Roll initiative for it and it has its own turns\u2014it attacks using your spell attack modifier. It will attack one creature you can see within range. On a hit, the sword inflicts {@damage 8d10} slashing damage.",
+        "The spell ends if the target is ever outside the spell's range or if it has total cover from you."
+      ],
+      "damageInflict": [
+        "slashing"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "9256868e36ce80e2da609182b2d8ef09"
+    },
+    {
+      "name": "Last Image",
+      "source": "NRCToS",
+      "page": 240,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "When you touch a corpse and cast this spell, you see a still image of whatever the last thing the corpse saw.",
+        "If the target died due to a gaze attack, you must make a saving throw of the type associated with the attack or suffer the results of the gaze. You have advantage on this roll."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Knowledge",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Undying",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "7336ce940b49c495b9cfca7bbe90955f"
+    },
+    {
+      "name": "Lava Bolt",
+      "source": "NRCToS",
+      "page": 240,
+      "level": 4,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of pumice or obsidian"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You conjure an orb of lava which you hurl at one target within range. Make a ranged spell attack to hit. On a hit, the target takes {@damage 3d8} bludgeoning damage and {@damage 3d8} fire damage. In addition, the target must make a Dexterity saving throw. On a failure, the lava sticks to the target and begins to solidify. The target is {@condition restrained} (escape DC equal to your spell save DC) and takes {@damage 1d8} fire damage at the end of each of its turns for 1 minute.",
+        "While this spell is active, the lava can only be removed by the application of copious amounts of water or with a spell that of 2nd level or higher that inflicts cold-based damage (this spell also inflicts half damage to the target). If the target dies from this spell it becomes completely encased in hardened volcanic rock."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 5th-level or higher spell slot, you inflict an additional {@scaledice 3d8|4-9|1d8} fire damage on initial impact and each round for each slot level above 4th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "bludgeoning",
+        "fire"
+      ],
+      "conditionInflict": [
+        "restrained"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Mountain"
+            }
+          }
+        ]
+      },
+      "uniqueId": "558d37026bdeb600e7f7f651be12527a"
+    },
+    {
+      "name": "Leaf into Dagger",
+      "source": "NRCToS",
+      "page": 241,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a normal leaf"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You transform any tree leaf into a magical dagger that does {@dice 1d4} + your spellcasting ability modifier in piercing damage. You cannot be harmed by this blade and should you drop it, it instantly becomes a leaf again."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "9b8673e801eb8241395f8220ebf24e5c"
+    },
+    {
+      "name": "Iceball",
+      "source": "NRCToS",
+      "page": 222,
+      "level": 3,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 150
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a tiny ball of bat guano and powdered glass"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A bright blue-white streak flashes from your pointing finger to a point you choose within range and then explodes into small shards of ice. Each creature in a 20-foot-radius sphere centered on that point must make a Dexterity saving throw. A target takes {@damage 3d6} bludgeoning damage and {@damage 4d6} cold damage on a failed save, or half as much damage on a successful one. In either case, the targets are also {@condition stunned} until the end of their next turn."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 4th level or higher, the cold damage increases by {@scaledice 4d6|3-9|1d6} for each slot level above 3rd."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "bludgeoning",
+        "cold"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "967edb66fb176a5c19cda4f9c57b5e89"
+    },
+    {
+      "name": "Idea",
+      "source": "NRCToS",
+      "page": 222,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a gold coin, which is consumed in the casting",
+          "consume": true
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You flip the coin in the area while thinking of your problem and the coin vanishes. You then gain advantage on a single {@skill Arcana}, {@skill History}, {@skill Insight}, {@skill Investigation}, {@skill Medicine}, {@skill Nature}, {@skill Performance}, {@skill Religion}, or {@skill Survival} ability check needed to solve the problem.",
+        "If the problem is one that doesn't require a skill roll to solve (but instead requires role-playing), the DM will give you a strong hint as to the solution."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b481b02ab048d74738bf1b46d2b02c6b"
+    },
+    {
+      "name": "Ill Omen",
+      "source": "NRCToS",
+      "page": 222,
+      "level": 0,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You curse a target with bad luck. It must succeed on a Wisdom saving throw or be at disadvantage on all rolls until the end of its next turn. You may only curse a particular target with this spell once until you have finished a short or long rest."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "56e9b38ad66b0faa6b49c6ab484a98f8"
+    },
+    {
+      "name": "Illusory Feast",
+      "source": "NRCToS",
+      "page": 222,
+      "level": 5,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 400
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of food"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You conjure a phantasmal image of delicious-looking food and drink. All creatures within 30 feet of it must make a Wisdom saving throw. On a failure, a target will stop what it is doing and attempt to eat the food; the food appears to be exactly the type the target likes and exists only in its mind. A target may attempt a new saving throw at the beginning of each of its turns, ending the effect on a success. If a target is attacked, the spell automatically ends for that creature, but not for anyone else affected by the spell. Creatures that do not eat are immune to this spell."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "5e9462e3712fe0416529ab79e88e1206"
+    },
+    {
+      "name": "Layla's Morning-After Kiss",
+      "source": "NRCToS",
+      "page": 241,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You kiss an {@condition unconscious} or sleeping creature's skin (although you do not need to kiss its lips) and it makes a Wisdom saving throw. If it fails, it permanently forgets everything that happened up to 1 hour before it fell asleep.",
+        "The memory can be recovered by use of the {@spell hypnosis|nrctos} (q.v.) spell."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "3076ea4afcc3236ea4c3a95716d22a7b"
+    },
+    {
+      "name": "Hypnosis",
+      "source": "NRCToS",
+      "page": 219,
+      "level": 5,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a small, shiny object on a string"
+      },
+      "duration": [
+        {
+          "type": "special"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You attempt to beguile a creature with an Intelligence of 5 or higher that you can see and that in return can see your eyes; it must also be able to understand your language and must be either willing or {@condition restrained}. The creature must make a Wisdom saving throw; if it fails, it is {@condition charmed} by you. This spell has several functions; you must choose which one you will use when you cast the spell.",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Deprogramming",
+                  "entries": [
+                    "If the target is suffering from the {@condition charmed} condition, you may release the target from that effect. You can also use this to deprogram a creature suffering from non-magical brainwashing."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Memory Recovery",
+                  "entries": [
+                    "If the target's memories had been altered or erased, either through mundane means (including both normal forgetfulness and brainwashing) or by the {@spell modify memory} or similar spell, you restore the original memory."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Phantasmal Harm",
+                  "entries": [
+                    "You can cause the target to believe that it is being harmed. Each round, for a number of rounds equal to twice your spellcasting ability modifier, you may inflict {@dice 1d10}, {@dice 2d10}, or {@damage 3d10} psychic damage (you may choose how severe the \"damage\" is). If the target falls to 0 hit points or lower, it may make a Wisdom saving throw. If it succeeds, it instead drops to 1 hit point and falls {@condition unconscious}."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Rejuvenation",
+                  "entries": [
+                    "You can remove 1 level of {@condition exhaustion} from the target. You may only use this version of the spell on a creature once each day."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Suggestion",
+                  "entries": [
+                    "You implant a suggestion, as per the spell, into the creature's subconscious, with the following changes: the suggestion lasts for 1 week and you can ask the target to perform an action that is self-destructive or that violates its alignment. If you do so, however, the target may make a second saving throw when the suggestion is triggered; if it succeeds, it will snap out of it. Once the creature has completed your suggestion, it will have no conscious memory of its actions. The memory can be recovered using the memory recovery version of this spell.",
+                    "If you cast this version of {@i hypnosis} on your target every day for a week, the suggestion will last for 1 month. If you cast it every day for a month, the suggestion will last for a year."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Truth-Telling",
+                  "entries": [
+                    "You may ask the target a number of questions equal to twice your spell attack modifier. The target will answer them truthfully, although not necessarily fully or coherently."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "conditionInflict": [
+        "charmed"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "HL",
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "66838736cc94894ba9e48c282ee10770"
+    },
+    {
+      "name": "Augment Artistry",
+      "source": "NRCToS",
+      "page": 84,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a scroll bearing a piece of epic poetry"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You or a willing target gains proficiency with one form of artisan's tools. If the target already has proficiency in the desired tools, then that target may use double its proficiency bonus."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 4th-level or higher spell slot, the target gains triple its proficiency bonus."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Ancients",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "27e7a90922a8a9218f96d1e70306397a"
+    },
+    {
+      "name": "Augment Familiar",
+      "source": "NRCToS",
+      "page": 84,
+      "level": 2,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "For the spell's duration, you grant your familiar or animal companion 10 temporary hit points, resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons, and advantage on all saving throws."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level or higher spell slot, you grant the creature an additional 5 temporary hit points per spell slot above 2nd."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "f5258fb21b262f308b2e2a11d8460142",
 			"miscTags": [
 				"THP"
 			]
-		},
-		{
-			"name": "Augmenting Wall",
-			"source": "NRCToS",
-			"page": 84,
-			"level": 4,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 100
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You create a nearly-invisible wall, up to 10 feet high and 30 feet long, of shimmering energy. Choose from acid, cold, fire, force, or lightning damage when you cast this spell. Any weapon thrown or fired through your side of the wall emerge from the other side imbued with that energy and inflict an additional {@damage 1d10} damage of that type to its target, should it hit. This has no effect on melee weapons or on creatures who pass through the wall, nor does it enhance spells that pass through it. It will enhance magical missiles and thrown weapons, however. The wall does not block vision."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 5th-level or higher spell slot, thrown and missile weapons inflict an additional {@scaledice 1d10|4-9|1d10} damage per slot level above 4th."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid",
-				"cold",
-				"fire",
-				"force",
-				"lightning"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "aa629ed6ab585a92e2bb41036a76d565"
-		},
-		{
-			"name": "Aura of Protection",
-			"source": "NRCToS",
-			"page": 84,
-			"level": 1,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A bright aura surrounds you. While under the protection of this spell, you take 1 less point of damage from any attack by a bludgeoning, piercing, or slashing nonmagical weapon."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level spell slot, you subtract 2 points of damage from any nonmagical bludgeoning, piercing, or slashing nonmagical weapons. When you cast this spell with a 5th-level spell slot, you subtract 3 points from attacks by magical weapons as well."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Devotion",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "55e3ba67a4752e6ca8724ea7483aa62e"
-		},
-		{
-			"name": "Autopsy",
-			"source": "NRCToS",
-			"page": 85,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You touch a corpse that has been dead no longer than 1 week and learn what truly killed it. You do not gain any other information (such as the identity of the killer), but the spell will reveal if the cause of death was magical."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a higher-level spell slot, you may receive information from an older corpse:",
-						{
-							"type": "table",
-							"colLabels": [
-								"Slot Level",
-								"Age of Corpse"
-							],
-							"colStyles": [
-								"col-2-5 text-center",
-								"col-9-5"
-							],
-							"rows": [
-								[
-									"2nd",
-									"1 month"
-								],
-								[
-									"3rd",
-									"6 months"
-								],
-								[
-									"4th",
-									"1 year"
-								],
-								[
-									"5th",
-									"10 years"
-								],
-								[
-									"6th",
-									"50 years"
-								],
-								[
-									"7th",
-									"100 years"
-								],
-								[
-									"8th",
-									"1,000 years"
-								],
-								[
-									"9th",
-									"10,000 years"
-								]
-							]
-						}
-					]
-				}
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Death",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "b84190b300706b46a697376622276522"
-		},
-		{
-			"name": "Awaken Sin",
-			"source": "NRCToS",
-			"page": 86,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"When cast on an evil creature with an Intelligence of 5 or higher, this spell causes feelings of intense guilt and shame to well up in that creature's mind. It must make a Wisdom saving throw or take {@damage 5d10} psychic damage. If this brings the target to 0 hit points, it is instead reduced to 1 hit point and falls {@condition unconscious} instead of dying. Upon waking up, the creature must make a second Wisdom saving throw or have its hit point total reduced by {@dice 3d10}. This reduction remains until a {@spell greater restoration} or similar spell is cast upon it."
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Devotion",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Vengeance",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "dc5ea0f0e786148f6bc147252c6071f0"
-		},
-		{
-			"name": "Backstab Backlash",
-			"source": "NRCToS",
-			"page": 87,
-			"level": 2,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a protective field around you. If someone successfully hits you with a sneak attack, the attack rebounds and your attacker suffers the damage it would have inflicted on you instead."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "902906b9899d864ee5bde8d9077fca51"
-		},
-		{
-			"name": "Bigby's Dexterous Digits",
-			"source": "NRCToS",
-			"page": 92,
-			"level": 2,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a pair of gloves stitched with your name and studded with gems worth at least 500 gp",
-					"cost": 50000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a pair of Tiny hands made of shimmering, translucent force in an unoccupied space that you can see within range.",
-				"The hands are objects that have AC 15 and 5 hit points. If all of the hands created by your spell are destroyed the spell ends. When you cast the spell and as a bonus action on your subsequent turns, you can move the hands up to 30 feet. Roll initiative for the hands as a group, which has its own turns.",
-				"The hands perform various tasks for you; you may choose from the following options:",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Fantastic Fencers",
-									"entries": [
-										"The hands are created holding long, rapier-like blades made of force. They attack using your spell attack modifier, and can attack two different targets at once. On a hit, the target takes {@damage 1d8} force damage.",
-										"You may choose for the {@i fencers} to do nonlethal damage instead, to use as a fencing partner for yourself or another. The wounds it inflicts cause you pain and appear to be real, but vanish when the spell ends, and if the {@i fencers} bring you down to 1 hit point, the spell automatically ends. When you choose to make the {@i fencers} inflict nonlethal damage, the spell's duration increases to 10 minutes."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Feeling Fingers",
-									"entries": [
-										"The hands have a Strength and Dexterity of 8 (-1) but otherwise functions of an {@spell unseen servant}. It also has an amazingly sensitive sense of touch: it has {@skill Perception} +6 and has advantage on all {@skill Perception} checks, allowing it to detect minute cracks and openings. You can choose to use your action to treat the hands as a sensor and feel through them."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Pugnacious Pugilists",
-									"entries": [
-										"The hands are clenched and covered with bandages, as if they belong to a boxer. They attack using your spell attack modifier. On a hit, the target takes {@damage 1d8} bludgeoning damage.",
-										"You may choose for the {@i pugilists} to do nonlethal damage instead, to use as a fencing partner for yourself or another. The wounds it inflicts cause you pain and appear to be real, but vanish when the spell ends, and if the {@i pugilists} bring you down to 1 hit points, the spell automatically ends. When you choose to make the {@i pugilists} inflict nonlethal damage, the spell's duration increases to 10 minutes."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Silencing Hand",
-									"entries": [
-										"The hands fly towards a target you choose within range that you can see. Make a ranged spell attack to hit. On a success, the hands clamp themselves over the target's mouth. They cannot be pulled away and as long as they remain, the target cannot speak and is at disadvantage to all ranged attack. The hands take only half-damage that is dealt to them; the creature to which the hands are attached take the other half."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Strangling Grip",
-									"entries": [
-										"The hands fly towards a Small- or Medium-sized target you choose within range that you can see and grab onto its throat, using your spell attack modifier to attack. On a hit, it does {@damage 2d4} bludgeoning damage and the target is {@condition grappled} (escape DC is equal to your Spell Save DC). Until this grapple ends, the target can't breathe. At the beginning of each of its turns, the hands inflict an additional {@damage 2d4} bludgeoning damage."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"damageInflict": [
-				"bludgeoning",
-				"force"
-			],
-			"conditionInflict": [
-				"grappled"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "2535016a63269b0bbe3f672faf4362bc"
-		},
-		{
-			"name": "Bigby's Bookworm Bane",
-			"source": "NRCToS",
-			"page": 92,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a child-sized glove"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You create a Tiny hand out of shimmering, translucent force. This hand immediately seeks out and destroys bookworms, roaches, mice, and other creatures that eat paper, vellum, parchment, glue, and leather\u2014that is, typical library pests: creatures of Tiny size and no more than 1 hit point. It cannot defend itself, attack anything other than the aforementioned pests, or perform any other actions."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b49b056fed3505317129ac2d4adc6fae"
-		},
-		{
-			"name": "Bite the Hand",
-			"source": "NRCToS",
-			"page": 94,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 50
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You target a creature that has been conjured and cause it to turn on its summoner, provided that individual is present. The creature will attack its summoner to the best of its ability but will perform no other actions for you.",
-				"To succeed in controlling the creature, you must make a successful ability check, using your spellcasting ability, with a DC equal to the summoner's saving throw DC. If you succeed, the creature is under your control, as if you had cast the spell that had conjured it. This spell has no effect on creatures summoned with the {@spell find familiar} or {@spell find steed} spells."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, you may target one additional creature per slot level above 3rd."
-					]
-				}
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "5b3a60b6da778db955847d67e7384112"
-		},
-		{
-			"name": "Blast of Sand",
-			"source": "NRCToS",
-			"page": 96,
-			"level": 4,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of sand"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Sandstorm}",
-				"A cone of course sand sprays out from your outstretched palm with punishing force. All creatures within the area must make a Dexterity saving throw. A creature takes {@damage 7d6} piercing damage on a failed saving throw, or half as much damage on a successful one. {@book Fragile|DMG|8|hit points|0} objects and structures (as per the {@i Dungeon Master's Guide}, page 247) take double damage."
-			],
-			"damageInflict": [
-				"piercing"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Desert"
-						}
-					}
-				]
-			},
-			"uniqueId": "bed3c45fd71cceab9c4dd43a761436db"
-		},
-		{
-			"name": "Bleeding Touch",
-			"source": "NRCToS",
-			"page": 96,
-			"level": 0,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a needle"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You cause a bleeding wound to appear on one living creature you touch. That creature must make a Constitution saving throw. On a failure, it takes an amount of necrotic damage equal to your spellcasting ability at the end of each of its turns for the next three rounds.",
-				"You inflict an additional +2 damage at 5th level, +4 damage at 11th level, and +8 damage at 17th level."
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"SCL"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "28ce89955ea62b25cc8d26d8971b198d"
-		},
-		{
-			"name": "Blessed Abundance",
-			"source": "NRCToS",
-			"page": 96,
-			"level": 4,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You can duplicate up to 10 pounds of inanimate, nonliving animal or vegetable matter. You hold the object you wish to duplicate in one hand while you cast this spell and its double appears in your other hand. Magical items, ores and minerals, and living creatures cannot be affected by this spell."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a slot of 5th level or higher, you can duplicate up to 10 additional pounds per spell slot above 4th."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Life",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "b9cacb00c1c483053ddf8737feb61ddc"
-		},
-		{
-			"name": "Blessed Forgetfulness",
-			"source": "NRCToS",
-			"page": 96,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a few drops of holy water"
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You touch a creature and completely repress one terrible memory it has. An unwilling creature may make a Charisma saving throw to resist. This can negate the effect of a failed {@variantrule Fear and Horror|dmg|fear} or {@variantrule New Ability Scores: Honor and Sanity|dmg|sanity} check (should your game use such things) or simply remove a horrible memory that has no actual game effect. This has no effect on magically-induced or altered memories. You cannot use this spell on yourself. This spell can be reversed with {@spell hypnosis|nrctos} (q.v.)"
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, you may choose to suppress the traumatic nature of the memory while otherwise leaving it intact."
-					]
-				}
-			],
-			"savingThrow": [
-				"charisma"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Archfey",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "27b0a689266353ced850a5ff7b8cbc89"
-		},
-		{
-			"name": "Bladethirst",
-			"source": "NRCToS",
-			"page": 95,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "bonus action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"Your sword or other slashing weapon bursts into unearthly steel-blue flame. Until the end of your turn, you have advantage on all rolls to hit with this weapon and inflict an additional {@damage 1d6} cold damage. The weapon sheds bright light in 10-foot radius and dim light for a further 10 feet."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a spell slot of 2nd level or higher, the amount of cold damage you inflict increases by {@scaledice 1d6|1-9|1d6} for each slot level above 1st."
-					]
-				}
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "War",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Crown",
-							"source": "SCAG"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Vengeance",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "9e74257c824e7b1c5110833e903949c9"
-		},
-		{
-			"name": "Blizzard",
-			"source": "NRCToS",
-			"page": 97,
-			"level": 5,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "five acorns and any gem worth at least 50 gp",
-					"cost": 5000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a blizzard with a radius of 60 feet centered on any point you choose within range. While in this storm, all creatures are lightly obscured, the ground becomes difficult terrain, and a strong wind springs up, extinguishing all nonmagical flames and dispersing all gas-type attacks, including a {@creature Young Green Dragon|mm|green dragon}'s breath weapon and spells such as {@spell cloudkill}.",
-				"In addition, sharp slivers of ice fall. All creatures in the area must make a Constitution saving throw. A creature takes {@damage 6d6} cold damage on a failed saving throw or half as much on a successful one each round that they end their turn inside the blizzard."
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"areaTags": [
-				"Y"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Tempest",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Druid",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Land",
-							"source": "PHB",
-							"subSubclass": "Arctic"
-						}
-					}
-				]
-			},
-			"uniqueId": "b88dd490f54657ba0f82115cef014083"
-		},
-		{
-			"name": "Conceal Item",
-			"source": "NRCToS",
-			"page": 119,
-			"level": 3,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a handful of any kind of gemstone dust"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You render a single inanimate, nonliving object of Small-size or smaller completely undetectable when you hide it on your person. The object must be placed in a bag, hidden underneath your clothing, or otherwise concealed. No amount of searching, even a physical pat-down, will reveal the object, although {@spell true seeing} will reveal its location.",
-				"You may take the object out, at which point it becomes visible, but until the spell's duration is over, it will return to being {@condition invisible} once you return it to hiding."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Trickery",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "06b9c12461b947d30397f679e7349d2f"
-		},
-		{
-			"name": "Condition Protection",
-			"source": "NRCToS",
-			"page": 119,
-			"level": 2,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"While this spell is in effect, you or a willing creature you touch have immunity to one of the following conditions: {@condition blinded}, {@condition charmed}, {@condition deafened}, {@condition frightened}, {@condition incapacitated}, {@condition paralyzed}, {@condition petrified}, {@condition poisoned}, {@condition stunned}, or {@condition unconscious}. If your target is already suffering from one of these conditions, this spell will allow them to make an additional saving throw to recover from it."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, the target becomes immune to one additional condition per slot level above 3rd."
-					]
-				}
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "665baca4404f3665e1340713f4a13a4a"
-		},
-		{
-			"name": "Cone of Acid",
-			"source": "NRCToS",
-			"page": 119,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a citrus fruit"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A jet of bubbling acid erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes {@damage 7d10} acid damage on a failed save, or half as much damage on a successful one. A creature killed by this spell dissolves into a puddle of stinking goo.",
-				"If a target takes at least 10 points of damage and is wearing nonmagical armor, the armor's AC is permanently reduced by one level of effectiveness. If the armor is reduced to AC 10, it is destroyed. A spell such as {@spell repair|nrctos} (q.v.) will fix the damage and restore the armor to its normal strength."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 6th level or higher, the damage increases by {@scaledice 7d10|5-9|1d10} for each slot level above 5th."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "8eaa3161aac7610718b868039ac7ef61"
-		},
-		{
-			"name": "Cone of Fire",
-			"source": "NRCToS",
-			"page": 120,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a red garnet"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A cone of white flame erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes {@damage 8d10} fire damage on a failed save, or half as much damage on a successful one. A creature killed by this spell is burned to ashes. This spell sets nonmagical flammable items on fire."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 6th level or higher, the damage increases by {@scaledice 8d10|5-9|1d10} for each slot level above 5th."
-					]
-				}
-			],
-			"damageInflict": [
-				"fire"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "ecf00afb5f38c46124e10cd33d4d8726"
-		},
-		{
-			"name": "Cone of Force",
-			"source": "NRCToS",
-			"page": 120,
-			"level": 5,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a small cone made of quartz worth at least 25 gp",
-					"cost": 2500
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"A cone of green and golden magical force erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes {@damage 8d10} force damage on a failed save, or half as much damage on a successful one. A creature killed by this spell is reduced to dust."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell using a spell slot of 6th level or higher, the damage increases by {@scaledice 8d10|5-9|1d10} for each slot level above 5th."
-					]
-				}
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"areaTags": [
-				"N"
-			],
-			"uniqueId": "abf606c5dac333d675381aec9bdc7ecd"
-		},
-		{
-			"name": "Darkbolt",
-			"source": "NRCToS",
-			"page": 135,
-			"level": 3,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a dead worm or a piece of octopus or squid tentacle"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You create a black, rubbery tentacle that lashes out at your command towards a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes {@damage 5d10} bludgeoning damage and if the creature is Large or smaller, you pull it up to 10 feet closer to you. The tentacle wraps around the target and grapples it (escape DC is equal to your spell save DC).",
-				"Until this grapple ends, the target is {@condition restrained} and you cannot use the {@i darkbolt} on another target. In addition, at the start of each of the target's turns, the {@i darkbolt} squeezes, causing an additional {@damage 3d8} bludgeoning damage. You may release your target as a bonus action."
-			],
-			"damageInflict": [
-				"bludgeoning"
-			],
-			"conditionInflict": [
-				"restrained"
-			],
-			"spellAttack": [
-				"M"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Great Old One",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "36eeb0f2f716055d5feb5d027d74eb22"
-		},
-		{
-			"name": "Darklight's Creeping Curse of Frost",
-			"source": "NRCToS",
-			"page": 136,
-			"level": 9,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a diamond worth at least 1,000 gp",
-					"cost": 100000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You touch a single building and ice begins to slowly spread out from the point you are touching at a rate of 10 feet each minute, until the entire structure is coated with a layer of frost. The ice will even creep under doors and through windows, coating a large amount of the building's interior. This ice is permanent and can only be removed by a {@spell dispel magic} spell cast with at least an 9th-level spell slot. A fire- or heat-based spell will only remove the ice in 5-foot square patch, but unless the entire spell is {@spell dispel magic|phb|dispelled}, the ice will grow back.",
-				"The entire structure will remain at freezing temperature, regardless of ambient temperature. Touching the ice with bare hands or through thin gloves or shoes causes {@damage 1d4} cold damage at the end of each round a creature remains in contact with it. The grounds and floor or the building become difficult terrain. A creature that enters the area or ends its turn there must succeed on a Dexterity saving throw or fall {@condition prone}."
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"conditionInflict": [
-				"prone"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "90a39ceec2c13b838611adb1964350ec"
-		},
-		{
-			"name": "Darklight's Finger of Ice",
-			"source": "NRCToS",
-			"page": 136,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You send a bolt of bitterly cold energy to a creature you can see within range, who must make a Constitution saving throw as the coldness freezes the blood in its veins. It takes {@damage 7d8 + 30} cold damage on a failed saving throw, or half as much damage on a successful one.",
-				"A creature killed by this spell becomes a solid block of ice. Optionally, you may choose to reduce it to 1 hit point and freeze it in a form of stasis. If you choose this, the creature will be {@condition petrified} as ice instead of stone. It will remain encased in ice as long as the temperature remains below 50° F in the immediate area. If the temperature rises above that, the frozen creature will defrost over a period of 1 week. If touched by magically-produced heat, it will defrost in 1 minute. Upon becoming completely defrosted, the creature must immediately make a Constitution saving throw or fall to 0 hit points."
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "0f0cb164704c520c52350c62aadcaead"
-		},
-		{
-			"name": "Darklight's Haywire Hands",
-			"source": "NRCToS",
-			"page": 136,
-			"level": 3,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a length of twisted steel wire"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Two strands of wire erupt from your outstretched hands and strike out at one or two individuals in range that you can see within range. A target must make a Dexterity saving throw or become {@condition grappled} and {@condition restrained} (escape DC equal to your spell save DC). The wires may also be cut; they each have AC 15 and 10 hit points."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 4th-level or higher spell slot, you create one additional wire for each slot level above 3rd. For each additional wire you create, you may target one additional creature. A creature who is {@condition restrained} by two or more wires has disadvantage on its saving throws.",
-						"When you cast this spell with a 6th-level or higher spell slot, the wires have resistance to all forms of damage."
-					]
-				}
-			],
-			"conditionInflict": [
-				"grappled",
-				"restrained"
-			],
-			"savingThrow": [
-				"dexterity"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "47e7587d9a252e5f7d7be28840ef77fd"
-		},
-		{
-			"name": "Darklight's Inexplicable Image",
-			"source": "NRCToS",
-			"page": 137,
-			"level": 2,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a drawing of the illusion you wish to create"
-			},
-			"duration": [
-				{
-					"type": "permanent",
-					"ends": [
-						"trigger"
-					]
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You enchant an inanimate object so that the next person other than yourself who touches it with bare hands triggers it, creating a clear image and sound. You may choose to make the image visible and audible to all or appear only in the triggering creature's mind.",
-				"The image sound can be of anything you wish, but cannot take more than two or three words to describe (\"giggling halfling child\" or \"menacing wraith\"). If you include a message, it cannot be longer than 15 words long. Sound effects (such as the giggling of the illusory halfling) do not count as words. The illusion lasts for no longer than 30 seconds."
-			],
-			"miscTags": [
-				"PRM"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "2570c091f6eeee1efaa9e389f57af971"
-		},
-		{
-			"name": "Darklight's Lightning Web",
-			"source": "NRCToS",
-			"page": 137,
-			"level": 6,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a bit of hide from an electric eel"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You conjure a mass of thick, sticky webbing at a point of your choice within range. The webs fill a 20-foot cube from that point for the duration. The webs are difficult terrain and lightly obscure their area. If the webs aren't anchored between two solid masses (such as walls or trees) or layered across a floor, wall, or ceiling, the conjured web collapses on itself, and the spell ends at the start of your next turn. Webs layered over a flat surface have a depth of 5 feet.",
-				"As soon as the webs are created, they begin to crackle with arcs of electricity. A creature that starts its turn in the webs or that enters them during its turn must make a Dexterity saving throw. On a failure, it is {@condition restrained} (escape DC equal to your spell save DC). At the end of each of its turns, the creature must make a Constitution saving throw. A creature takes {@damage 8d6} lightning damage and is {@condition stunned} until the end of its next turn on a failed saving throw, and suffers no ill effect on a successful save."
-			],
-			"damageInflict": [
-				"lightning"
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			"savingThrow": [
-				"constitution",
-				"dexterity"
-			],
-			"areaTags": [
-				"C"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "32abaef525a08a4b3026de151ce74d2c"
-		},
-		{
-			"name": "Darklight's Planar Weapon",
-			"source": "NRCToS",
-			"page": 137,
-			"level": 6,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You create a 3-foot-long blade of energy drawn from one of the Planes. You are considered proficient in it. The exact effects of the weapon depends on from which plane the energy came. It inflicts {@damage 9d6} damage on a hit; the exact type of damage inflicted by the sword depends on its type.",
-				"You may attempt to choose what sort of blade you produce by making a DC 15 ability check using your spellcasting ability. On a success, you get the blade you wish. Otherwise, the blade you receive is completely random.",
-				{
-					"type": "table",
-					"colLabels": [
-						"{@dice d100}",
-						"Sword Type"
-					],
-					"colStyles": [
-						"col-1-5 text-center",
-						"col-10-5"
-					],
-					"rows": [
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 1,
-									"max": 3,
-									"pad": true
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Abyssal Blade",
-												"entries": [
-													"This blade is made of embers and inflicts {@damage 3d6} acid damage, {@damage 3d6} fire damage, and {@damage 3d6} poison damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 4,
-									"max": 5,
-									"pad": true
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Acheronean Blade",
-												"entries": [
-													"This sword is made of partially-rusted iron and inflicts {@damage 5d6} cold damage and {@damage 4d6} poison damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 6,
-									"max": 9,
-									"pad": true
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Airy Blade",
-												"entries": [
-													"This sword is transparent with swirling streaks of white. It inflicts {@damage 5d6} slashing damage and {@damage 4d6} thunder damage, plus you are surrounded by a cloud of fog 5 feet in radius. You are lightly obscured but your own vision is not hindered."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 10,
-									"max": 12
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Arborean Blade",
-												"entries": [
-													"This sword is made shining bronze and inflicts {@damage 5d6} lightning damage and {@damage 4d6} slashing damage. It inflicts double damage to fiends."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 13,
-									"max": 14
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Arcadian Blade",
-												"entries": [
-													"This sword is made of white gold and inflicts {@damage 4d6} radiant damage and {@damage 5d6} slashing damage. It inflicts double damage to fiends."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 15,
-									"max": 16
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Ashen Blade",
-												"entries": [
-													"This sword is iron-gray and inflicts {@damage 4d6} cold damage and {@damage 5d6} necrotic damage, plus you are surrounded by a cloud of swirling ashes 5 feet in radius. You are lightly obscured but your own vision is not hindered."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 17,
-									"max": 20
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Astral Blade",
-												"entries": [
-													"This sword is made of silver and inflicts {@damage 9d6} force damage. The target's hit point total is reduced by that amount. The reduction lasts until the creature takes a short or long rest. This blade ignores bonuses to magical armor and if you are wielding it on the Astral Plane, then on a natural 20 in severs your foe's silver cord (if it has one)."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 21,
-									"max": 22
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Bestial Blade",
-												"entries": [
-													"This sword is made of thorny wood and inflicts {@damage 3d6} piercing damage, {@damage 3d6} poison damage, and {@damage 3d6} slashing damage. It inflicts double damage to fiends."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 23,
-									"max": 24
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Bytopian Blade",
-												"entries": [
-													"This sword is made of bright beaten iron and inflicts {@damage 6d6} radiant damage and {@damage 3d6} force damage. It inflicts double damage to fiends."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 25,
-									"max": 26
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Carcerian Blade",
-												"entries": [
-													"This sword is made of dully-glowing red stone and inflicts {@damage 6d6} force damage and {@damage 3d6} thunder damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 27,
-									"max": 29
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Celestian Blade",
-												"entries": [
-													"This sword is made of gold and inflicts {@damage 9d6} radiant damage. It inflicts double damage to fiends."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 30,
-									"max": 31
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Concordant Blade",
-												"entries": [
-													"This sword is made of plain steel and inflicts {@damage 9d6} force damage. It inflicts double damage to fiends and celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 32,
-									"max": 33
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Dust Blade",
-												"entries": [
-													"This sword is dull gray-brown and inflicts {@damage 5d6} cold damage and {@damage 4d6} necrotic damage. On a successful hit, your target must make a Constitution saving throw or spend its next turn coughing and choking due to dust in its lungs. Creatures that do not need to breathe are not affected by this."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 34,
-									"max": 37
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Earthen Blade",
-												"entries": [
-													"This sword is gray and brown and inflicts {@damage 9d6} bludgeoning damage. On a successful hit, your target must make a Constitution saving throw or be {@condition petrified} until the end of its next turn due to being temporarily turned to stone."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 38,
-									"max": 40
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Elysium Blade",
-												"entries": [
-													"This sword is made of rose-colored metal and inflicts {@damage 3d6} bludgeoning damage and {@damage 6d6} psychic damage. It inflicts double damage to fiends."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 41,
-									"max": 44
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Ethereal Blade",
-												"entries": [
-													"This sword is made of transparent smoke and inflicts {@damage 9d6} force damage. The target's hit point total is reduced by that amount. The reduction lasts until the creature takes a short or long rest. It inflicts double damage to creatures with the etherealness or ethereal stride abilities."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 45,
-									"max": 47
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Faerie Blade",
-												"entries": [
-													"This blade is made of faintly-glowing, silvery wood and inflicts {@damage 3d6} poison damage and {@damage 6d6} psychic damage. A non-fey creature struck with this blade must make a Constitution saving throw or fall {@condition unconscious} and prone until the end of its next turn."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 48,
-									"max": 51
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Fiery Blade",
-												"entries": [
-													"This sword is made of flames and inflicts {@damage 9d6} fire damage. This also ignites flammable objects that your target is wearing; the target must make a Dexterity saving throw or take an additional {@damage 2d6} fire damage the following round."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 52,
-									"max": 53
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Gehennan Blade",
-												"entries": [
-													"This sword is made of black ice and inflicts {@damage 6d6} cold damage and {@damage 3d6} necrotic damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 54,
-									"max": 56
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Hadean Blade",
-												"entries": [
-													"This sword is made of matte-gray metal and inflicts {@damage 3d6} cold damage, {@damage 3d6} necrotic damage, and {@damage 3d6} psychic damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 57,
-									"max": 59
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Hellish Blade",
-												"entries": [
-													"This sword is made of shards of obsidian and inflicts {@damage 5d6} fire damage and {@damage 4d6} psychic damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 60,
-									"max": 61
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Icy Blade",
-												"entries": [
-													"This sword is shining blue-white and inflicts an {@damage 9d6} damage. On a successful hit, your target must make a Constitution saving throw or be {@condition paralyzed} until the end of its next turn due to being frozen by the intense cold."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 62,
-									"max": 63
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Maddening Blade",
-												"entries": [
-													"This blade is made of dark, corroded metal and is covered with glowing eldritch runes. It inflicts {@damage 9d6} psychic damage and on a successful hit, your target must make a Wisdom saving throw or be confused; a confused creature can't take actions or reactions until the end of its next turn. If the creature dies due to the psychic damage, it instead drops to 1 hit point and falls {@condition unconscious}. When it wakes up, it is inflicted by {@table long-term madness}."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 64,
-									"max": 65
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Magma Blade",
-												"entries": [
-													"This sword is black with glowing red streaks and inflicts {@damage 5d6} fire damage and {@damage 4d6} bludgeoning damage. This also ignites flammable objects that your target is wearing; the target must make a Dexterity saving throw or take an additional {@damage 2d6} fire damage the following round."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 66,
-									"max": 68
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Mechanical Blade",
-												"entries": [
-													"This sword is made of copper with glowing, intricately-etched lines. It does {@damage 9d6} force damage. It inflicts double damage to chaotic creatures."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 69,
-									"max": 70
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Mineral Blade",
-												"entries": [
-													"This sword is made of jagged, multihued crystals and inflicts {@damage 4d6} force damage and {@damage 5d6} slashing damage. On a successful hit, your target must make a Dexterity saving throw or be frozen by the cold and {@condition paralyzed} until the end of its next turn."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 71,
-									"max": 72
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Negative Blade",
-												"entries": [
-													"This sword is pure black. It inflicts {@damage 9d6} necrotic damage, and the target's hit point total is reduced by that amount. If the target dies due to this damage, it rises as an undead of equal or lesser CR in {@dice 1d4} hours. This hit point reduction lasts until {@spell greater restoration} is cast. It inflicts double damage to creatures native to or that drawn energy from the Positive Plane."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 73,
-									"max": 74
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Oozing Blade",
-												"entries": [
-													"This sword is made of constantly-swirling translucent goo and inflicts {@damage 6d6} acid damage and {@damage 3d6} poison damage. On a successful hit, your target must make a Constitution saving throw or be {@condition poisoned} until the end of its next turn."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 75,
-									"max": 76
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Pandemoniacal Blade",
-												"entries": [
-													"This sword is made of smooth black limestone and inflicts {@damage 5d6} psychic damage and {@damage 4d6} thunder damage. It inflicts double damage to celestials."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 77,
-									"max": 78
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Positive Blade",
-												"entries": [
-													"This sword is pure white. It inflicts {@damage 9d6} radiant damage, and if the target dies due to this damage, it explodes. All creatures within 10 feet must make a Dexterity saving throw. A creature takes {@damage 3d6} radiant damage on a failed saving throw, or half as much on a successful one. It inflicts double damage to creatures native to or that drawn energy from the Negative Plane."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 79,
-									"max": 80
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Radiant Blade",
-												"entries": [
-													"This sword is made of brilliant light and inflicts {@damage 9d6} radiant damage. On a successful hit, your target must make a Constitution saving throw or be {@condition blinded} until the end of its next turn."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 81,
-									"max": 82
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Salt Blade",
-												"entries": [
-													"This sword is made of white crystals and inflicts {@damage 3d6} necrotic damage, {@damage 3d6} poison damage, and {@damage 3d6} slashing damage. On a successful hit, your target's hit point total is reduced by the amount of necrotic damage it took. This hit point reduction lasts until the target takes a short or long rest."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 83,
-									"max": 85
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Shadow Blade",
-												"entries": [
-													"This blade is made of shadow and inflicts {@damage 4d6} force damage and {@damage 5d6} psychic damage. You may attack your opponent's shadow, if it has one (this requires a light source that is not directly overhead). The shadow has an AC of 10 plus the creature's Dexterity modifier, but the attack is at disadvantage."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 86,
-									"max": 87
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Smoke Blade",
-												"entries": [
-													"This sword is dark gray and shot through with tiny red sparks, and inflicts {@damage 4d6} fire damage and {@damage 5d6} poison damage, plus you are surrounded by a cloud of thick smoke 5 feet in radius. You are lightly obscured but your own vision is not hindered."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 88,
-									"max": 89
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Steam Blade",
-												"entries": [
-													"This sword is a pale silvery-gray and inflicts {@damage 9d6} fire damage, plus you are surrounded by a cloud of thick fog 5 feet in radius. You are lightly obscured but your own vision is not hindered."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 90,
-									"max": 91
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Vacuum Blade",
-												"entries": [
-													"This sword is black and flecked with stars and inflicts {@damage 9d6} force damage. On a successful hit, your target must make a Constitution saving throw or spend its next turn gasping and choking, attempting to replace the air that has been sucked from its lungs. Creatures that do not need to breathe are not affected by this."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 92,
-									"max": 95
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Watery Blade",
-												"entries": [
-													"This sword is a translucent blue-green and inflicts {@damage 9d6} slashing damage. On a successful hit, your target must make a Constitution saving throw or spend its next turn coughing and choking due to water in its lungs. Creatures that do not need to breathe or that breathe water are not affected by this."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 96,
-									"max": 98
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Xaotic Blade",
-												"entries": [
-													"This sword changes color and form with each movement. It inflicts {@damage 9d6} psychic damage. It inflicts double damage to lawful creatures."
-												]
-											}
-										]
-									}
-								]
-							}
-						],
-						[
-							{
-								"type": "cell",
-								"roll": {
-									"min": 99,
-									"max": 100
-								}
-							},
-							{
-								"type": "entries",
-								"entries": [
-									{
-										"type": "entries",
-										"entries": [
-											{
-												"type": "entries",
-												"name": "Ysgardian Blade",
-												"entries": [
-													"This sword is made of glowing steel and inflicts {@damage 3d6} cold damage, {@damage 3d6} fire damage, and {@damage 3d6} lightning damage."
-												]
-											}
-										]
-									}
-								]
-							}
-						]
-					]
-				}
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 7th-level spell slot, the die type for all damage increases to {@dice d8}. When you cast it with an 8th-level spell slot, the die type increases to {@dice d10}. When you cast it with a 9th-level spell slot, the die type increases to {@dice d12}."
-					]
-				}
-			],
-			"damageInflict": [
-				"acid",
-				"bludgeoning",
-				"cold",
-				"fire",
-				"force",
-				"lightning",
-				"necrotic",
-				"piercing",
-				"poison",
-				"psychic",
-				"radiant",
-				"slashing",
-				"thunder"
-			],
-			"conditionInflict": [
-				"petrified",
-				"unconscious",
-				"prone",
-				"paralyzed",
-				"poisoned",
-				"blinded"
-			],
-			"savingThrow": [
-				"constitution",
-				"dexterity",
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "81346db09a97ea184270f65656ee8d50"
-		},
-		{
-			"name": "Darklight's Tattooed Creature",
-			"source": "NRCToS",
-			"page": 141,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "tattoo inks worth 100 gp and a golden needle worth 50 gp; the inks are consumed when you cast the spell",
-					"cost": 10000,
-					"consume": true
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent",
-					"ends": [
-						"trigger"
-					]
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You touch a living creature and transform it into ink. Only {@filter Large-sized and smaller beasts, dragons, giants, humanoids, monstrosities, and plants|bestiary|type=beast;dragon;giant;humanoid;monstrosity;plant|size=t;s;m;l} may be affected. Shapechangers cannot be affected by this spell and an unwilling creature may make a Wisdom saving throw to resist.",
-				"You must use this ink to create a tattoo on a willing target. If you use it for any other purpose, destroy the ink, or fail to use it within 1 hour, it turns back into the original creature.",
-				"To make an accurate tattoo, you must make a DC 13 Intelligence ability check; if you have proficiency with {@item calligrapher's supplies|phb|calligrapher's tools} or {@item painter's supplies|phb}, you may use that as well. If you fail your roll, the creature will take {@damage 1d10} force damage when reappearing, due to mistakes you made in depicting it accurately. If you roll a 1 when you inscribe the tattoo, the creature instead takes {@damage 5d10} force damage.",
-				"The target may release the creature at any time by touching the tattoo and speaking a command word. This causes the tattoo to vanish and the creature to appear in an empty space within 10 feet of you.",
-				"A tattoo of a Tiny creature takes up one slot, a tattoo of a Small creature takes up two slots, a tattoo of a Medium creature takes up four slots, and a tattoo of a Large creature takes up ten slots.",
-				"A Medium-sized humanoid has one slot on its neck, two on each arm, four on each leg, ten on its back and ten on its chest. A Small-sized humanoid has one slot on its neck and half as many on every other body part. Note that the presence of mundane tattoos does not get in the way of a {@i tattooed creature}, but body slots taken up by other forms of magical tattoos (such as one made with a {@spell create magic tattoo|nrctos} or {@spell Darklight's tattooed item|nrctos} spell (q.v.)) cannot be used by this spell.",
-				"A creature that has been made into a tattoo is effectively in stasis. While affected by this spell, the creature doesn't need to breathe, eat, or drink, and it doesn't age. Divination spells will reveal the tattoo's true nature. When it is released from tattoo form, it has no particular loyalty to you or to the person on whom it was tattooed. However, if that creature had been subject to a spell such as {@spell animal friendship}, {@spell charm person}, or {@spell dominate monster} and had been {@condition charmed}, it will continue to be {@condition charmed} after being released until the duration of the charm has ended."
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"opposedCheck": [
-				"intelligence"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "004afade0c7b44bce28c04c6b3e42cfb"
-		},
-		{
-			"name": "Darklight's Tattooed Item",
-			"source": "NRCToS",
-			"page": 142,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "tattoo inks worth 100 gp and a golden needle worth 50 gp; the inks are consumed when you cast the spell",
-					"cost": 10000,
-					"consume": true
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent",
-					"ends": [
-						"trigger"
-					]
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You touch an inanimate object and transform it into ink. You must use this ink to create a tattoo on a willing target. If you use it for any other purpose, destroy the ink, or fail to use it within 1 hour, it turns back into the original object.",
-				"The target may release the item at any time by touching the tattoo and speaking a command word. This causes the tattoo to vanish and the item to appear in an empty space within 10 feet of you.",
-				"A tattoo of a item of 10 pounds or less takes up one slot, a tattoo of an item of 11-50 pounds takes up two slots, a tattoo of an item 51-150 pounds takes up three slots, a tattoo of an item 151-500 pounds takes up six slots, and a tattoo of an item 501-1,000 pounds takes up 10 slots.",
-				"A Medium-sized humanoid has one slot on its neck, two on each arm, four on each leg, ten on its back and ten on its chest. A Small-sized humanoid has one slot on its neck and half as many on every other body part. Note that the presence of mundane tattoos does not get in the way of a {@i tattooed item}, but body slots taken up by other forms of magical tattoos (such as one made with a {@spell create magic tattoo|nrctos} or {@spell Darklight's tattooed creature|nrctos} spell (q.v.)) cannot be used by this spell."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with an 8th-level spell slot, you may transform an item that weighs up to 2,000 pounds. When you cast this spell with a 9th-level spell slot, you may transform an item that weighs up to 5,000 pounds. These items take up 10 slots each."
-					]
-				}
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "07a92465e00c728a14b1631fcb44b0d8"
-		},
-		{
-			"name": "Create Magic Tattoo",
-			"source": "NRCToS",
-			"page": 127,
-			"level": 3,
-			"school": "T",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "100 gp worth of tattoo inks",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 24
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You tattoo a magical sigil onto a creature, providing protection or aid in some way. To make an accurate tattoo, you must make a DC 13 Intelligence ability check; if you have proficiency with {@item calligrapher's supplies|phb|calligrapher's tools} or {@item painter's supplies|phb}, you may add your proficiency modifier to the roll.",
-				"The effect depends on the spell slot you use to cast this spell and lasts for the duration:",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "3rd-level spell slot",
-									"entries": [
-										"The tattoo takes up one slot and grants one of the following abilities:",
-										{
-											"type": "list",
-											"items": [
-												"+2 bonus on one type of saving throw",
-												"+1 bonus on attacks when using one particular weapon",
-												"+1 bonus to armor class",
-												"5 temporary hit points",
-												"Advantage when using one tool set"
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "5th-level spell slot",
-									"entries": [
-										"The tattoo takes up two slots and grants one of the following abilities:",
-										{
-											"type": "list",
-											"items": [
-												"+2 bonus on three different saving throws",
-												"+2 bonus on attacks and damage when using one particular weapon",
-												"+1 bonus on all attack and damage rolls",
-												"10 temporary hit points",
-												"+10 feet to your speed"
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "7th-level spell slot",
-									"entries": [
-										"The tattoo takes up four slots and grants one of the following abilities:",
-										{
-											"type": "list",
-											"items": [
-												"Advantage on saving throws against magical spells and effects",
-												"Advantage on any three saving throws",
-												"+2 bonus to any attribute",
-												"+3 bonus to armor class",
-												"15 temporary hit points"
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				"A Medium-sized humanoid has one slot on its neck, two on each arm, four on each leg, ten on its back and ten on its chest. A Small-sized humanoid has one slot on its neck, one on each arm, two on each leg, and five on its back and chest. When the spell expires, the tattoo fades away. A creature may have multiple {@i magic tattoos} but they must each be of different types. For instance, a creature could have two magic tattoos cast with a 3rd-level spell slot, with one granting a bonus to attack rolls and one granting a bonus on saving throws. Note that the presence of mundane tattoos does not get in the way of a {@i magic tattoos}, but body slots taken up by other forms of magical tattoos (such as one made with a {@spell Darklight's tattooed creature|nrctos} or {@spell Darklight's tattooed item|nrctos} spell (q.v.)) cannot be used by this spell."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "ec4441352d484e26a92a6048594077e0",
+    },
+    {
+      "name": "Augmenting Wall",
+      "source": "NRCToS",
+      "page": 84,
+      "level": 4,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 100
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You create a nearly-invisible wall, up to 10 feet high and 30 feet long, of shimmering energy. Choose from acid, cold, fire, force, or lightning damage when you cast this spell. Any weapon thrown or fired through your side of the wall emerge from the other side imbued with that energy and inflict an additional {@damage 1d10} damage of that type to its target, should it hit. This has no effect on melee weapons or on creatures who pass through the wall, nor does it enhance spells that pass through it. It will enhance magical missiles and thrown weapons, however. The wall does not block vision."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 5th-level or higher spell slot, thrown and missile weapons inflict an additional {@scaledice 1d10|4-9|1d10} damage per slot level above 4th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid",
+        "cold",
+        "fire",
+        "force",
+        "lightning"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "aa629ed6ab585a92e2bb41036a76d565"
+    },
+    {
+      "name": "Aura of Protection",
+      "source": "NRCToS",
+      "page": 84,
+      "level": 1,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A bright aura surrounds you. While under the protection of this spell, you take 1 less point of damage from any attack by a bludgeoning, piercing, or slashing nonmagical weapon."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level spell slot, you subtract 2 points of damage from any nonmagical bludgeoning, piercing, or slashing nonmagical weapons. When you cast this spell with a 5th-level spell slot, you subtract 3 points from attacks by magical weapons as well."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Devotion",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "55e3ba67a4752e6ca8724ea7483aa62e"
+    },
+    {
+      "name": "Autopsy",
+      "source": "NRCToS",
+      "page": 85,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You touch a corpse that has been dead no longer than 1 week and learn what truly killed it. You do not gain any other information (such as the identity of the killer), but the spell will reveal if the cause of death was magical."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a higher-level spell slot, you may receive information from an older corpse:",
+            {
+              "type": "table",
+              "colLabels": [
+                "Slot Level",
+                "Age of Corpse"
+              ],
+              "colStyles": [
+                "col-2-5 text-center",
+                "col-9-5"
+              ],
+              "rows": [
+                [
+                  "2nd",
+                  "1 month"
+                ],
+                [
+                  "3rd",
+                  "6 months"
+                ],
+                [
+                  "4th",
+                  "1 year"
+                ],
+                [
+                  "5th",
+                  "10 years"
+                ],
+                [
+                  "6th",
+                  "50 years"
+                ],
+                [
+                  "7th",
+                  "100 years"
+                ],
+                [
+                  "8th",
+                  "1,000 years"
+                ],
+                [
+                  "9th",
+                  "10,000 years"
+                ]
+              ]
+            }
+          ]
+        }
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Death",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "b84190b300706b46a697376622276522"
+    },
+    {
+      "name": "Awaken Sin",
+      "source": "NRCToS",
+      "page": 86,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "When cast on an evil creature with an Intelligence of 5 or higher, this spell causes feelings of intense guilt and shame to well up in that creature's mind. It must make a Wisdom saving throw or take {@damage 5d10} psychic damage. If this brings the target to 0 hit points, it is instead reduced to 1 hit point and falls {@condition unconscious} instead of dying. Upon waking up, the creature must make a second Wisdom saving throw or have its hit point total reduced by {@dice 3d10}. This reduction remains until a {@spell greater restoration} or similar spell is cast upon it."
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Devotion",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Vengeance",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "dc5ea0f0e786148f6bc147252c6071f0"
+    },
+    {
+      "name": "Backstab Backlash",
+      "source": "NRCToS",
+      "page": 87,
+      "level": 2,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a protective field around you. If someone successfully hits you with a sneak attack, the attack rebounds and your attacker suffers the damage it would have inflicted on you instead."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "902906b9899d864ee5bde8d9077fca51"
+    },
+    {
+      "name": "Bigby's Dexterous Digits",
+      "source": "NRCToS",
+      "page": 92,
+      "level": 2,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a pair of gloves stitched with your name and studded with gems worth at least 500 gp",
+          "cost": 50000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a pair of Tiny hands made of shimmering, translucent force in an unoccupied space that you can see within range.",
+        "The hands are objects that have AC 15 and 5 hit points. If all of the hands created by your spell are destroyed the spell ends. When you cast the spell and as a bonus action on your subsequent turns, you can move the hands up to 30 feet. Roll initiative for the hands as a group, which has its own turns.",
+        "The hands perform various tasks for you; you may choose from the following options:",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Fantastic Fencers",
+                  "entries": [
+                    "The hands are created holding long, rapier-like blades made of force. They attack using your spell attack modifier, and can attack two different targets at once. On a hit, the target takes {@damage 1d8} force damage.",
+                    "You may choose for the {@i fencers} to do nonlethal damage instead, to use as a fencing partner for yourself or another. The wounds it inflicts cause you pain and appear to be real, but vanish when the spell ends, and if the {@i fencers} bring you down to 1 hit point, the spell automatically ends. When you choose to make the {@i fencers} inflict nonlethal damage, the spell's duration increases to 10 minutes."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Feeling Fingers",
+                  "entries": [
+                    "The hands have a Strength and Dexterity of 8 (-1) but otherwise functions of an {@spell unseen servant}. It also has an amazingly sensitive sense of touch: it has {@skill Perception} +6 and has advantage on all {@skill Perception} checks, allowing it to detect minute cracks and openings. You can choose to use your action to treat the hands as a sensor and feel through them."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Pugnacious Pugilists",
+                  "entries": [
+                    "The hands are clenched and covered with bandages, as if they belong to a boxer. They attack using your spell attack modifier. On a hit, the target takes {@damage 1d8} bludgeoning damage.",
+                    "You may choose for the {@i pugilists} to do nonlethal damage instead, to use as a fencing partner for yourself or another. The wounds it inflicts cause you pain and appear to be real, but vanish when the spell ends, and if the {@i pugilists} bring you down to 1 hit points, the spell automatically ends. When you choose to make the {@i pugilists} inflict nonlethal damage, the spell's duration increases to 10 minutes."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Silencing Hand",
+                  "entries": [
+                    "The hands fly towards a target you choose within range that you can see. Make a ranged spell attack to hit. On a success, the hands clamp themselves over the target's mouth. They cannot be pulled away and as long as they remain, the target cannot speak and is at disadvantage to all ranged attack. The hands take only half-damage that is dealt to them; the creature to which the hands are attached take the other half."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Strangling Grip",
+                  "entries": [
+                    "The hands fly towards a Small- or Medium-sized target you choose within range that you can see and grab onto its throat, using your spell attack modifier to attack. On a hit, it does {@damage 2d4} bludgeoning damage and the target is {@condition grappled} (escape DC is equal to your Spell Save DC). Until this grapple ends, the target can't breathe. At the beginning of each of its turns, the hands inflict an additional {@damage 2d4} bludgeoning damage."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "damageInflict": [
+        "bludgeoning",
+        "force"
+      ],
+      "conditionInflict": [
+        "grappled"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "2535016a63269b0bbe3f672faf4362bc"
+    },
+    {
+      "name": "Bigby's Bookworm Bane",
+      "source": "NRCToS",
+      "page": 92,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a child-sized glove"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You create a Tiny hand out of shimmering, translucent force. This hand immediately seeks out and destroys bookworms, roaches, mice, and other creatures that eat paper, vellum, parchment, glue, and leather\u2014that is, typical library pests: creatures of Tiny size and no more than 1 hit point. It cannot defend itself, attack anything other than the aforementioned pests, or perform any other actions."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b49b056fed3505317129ac2d4adc6fae"
+    },
+    {
+      "name": "Bite the Hand",
+      "source": "NRCToS",
+      "page": 94,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 50
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You target a creature that has been conjured and cause it to turn on its summoner, provided that individual is present. The creature will attack its summoner to the best of its ability but will perform no other actions for you.",
+        "To succeed in controlling the creature, you must make a successful ability check, using your spellcasting ability, with a DC equal to the summoner's saving throw DC. If you succeed, the creature is under your control, as if you had cast the spell that had conjured it. This spell has no effect on creatures summoned with the {@spell find familiar} or {@spell find steed} spells."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, you may target one additional creature per slot level above 3rd."
+          ]
+        }
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "5b3a60b6da778db955847d67e7384112"
+    },
+    {
+      "name": "Blast of Sand",
+      "source": "NRCToS",
+      "page": 96,
+      "level": 4,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of sand"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Sandstorm}",
+        "A cone of course sand sprays out from your outstretched palm with punishing force. All creatures within the area must make a Dexterity saving throw. A creature takes {@damage 7d6} piercing damage on a failed saving throw, or half as much damage on a successful one. {@book Fragile|DMG|8|hit points|0} objects and structures (as per the {@i Dungeon Master's Guide}, page 247) take double damage."
+      ],
+      "damageInflict": [
+        "piercing"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Desert"
+            }
+          }
+        ]
+      },
+      "uniqueId": "bed3c45fd71cceab9c4dd43a761436db"
+    },
+    {
+      "name": "Bleeding Touch",
+      "source": "NRCToS",
+      "page": 96,
+      "level": 0,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a needle"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause a bleeding wound to appear on one living creature you touch. That creature must make a Constitution saving throw. On a failure, it takes an amount of necrotic damage equal to your spellcasting ability at the end of each of its turns for the next three rounds.",
+        "You inflict an additional +2 damage at 5th level, +4 damage at 11th level, and +8 damage at 17th level."
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SCL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "28ce89955ea62b25cc8d26d8971b198d"
+    },
+    {
+      "name": "Blessed Abundance",
+      "source": "NRCToS",
+      "page": 96,
+      "level": 4,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You can duplicate up to 10 pounds of inanimate, nonliving animal or vegetable matter. You hold the object you wish to duplicate in one hand while you cast this spell and its double appears in your other hand. Magical items, ores and minerals, and living creatures cannot be affected by this spell."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a slot of 5th level or higher, you can duplicate up to 10 additional pounds per spell slot above 4th."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Life",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "b9cacb00c1c483053ddf8737feb61ddc"
+    },
+    {
+      "name": "Blessed Forgetfulness",
+      "source": "NRCToS",
+      "page": 96,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a few drops of holy water"
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You touch a creature and completely repress one terrible memory it has. An unwilling creature may make a Charisma saving throw to resist. This can negate the effect of a failed {@variantrule Fear and Horror|dmg|fear} or {@variantrule New Ability Scores: Honor and Sanity|dmg|sanity} check (should your game use such things) or simply remove a horrible memory that has no actual game effect. This has no effect on magically-induced or altered memories. You cannot use this spell on yourself. This spell can be reversed with {@spell hypnosis|nrctos} (q.v.)"
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, you may choose to suppress the traumatic nature of the memory while otherwise leaving it intact."
+          ]
+        }
+      ],
+      "savingThrow": [
+        "charisma"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Archfey",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "27b0a689266353ced850a5ff7b8cbc89"
+    },
+    {
+      "name": "Bladethirst",
+      "source": "NRCToS",
+      "page": 95,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "bonus action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "Your sword or other slashing weapon bursts into unearthly steel-blue flame. Until the end of your turn, you have advantage on all rolls to hit with this weapon and inflict an additional {@damage 1d6} cold damage. The weapon sheds bright light in 10-foot radius and dim light for a further 10 feet."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a spell slot of 2nd level or higher, the amount of cold damage you inflict increases by {@scaledice 1d6|1-9|1d6} for each slot level above 1st."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "War",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Crown",
+              "source": "SCAG"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Vengeance",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "9e74257c824e7b1c5110833e903949c9"
+    },
+    {
+      "name": "Blizzard",
+      "source": "NRCToS",
+      "page": 97,
+      "level": 5,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "five acorns and any gem worth at least 50 gp",
+          "cost": 5000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a blizzard with a radius of 60 feet centered on any point you choose within range. While in this storm, all creatures are lightly obscured, the ground becomes difficult terrain, and a strong wind springs up, extinguishing all nonmagical flames and dispersing all gas-type attacks, including a {@creature Young Green Dragon|mm|green dragon}'s breath weapon and spells such as {@spell cloudkill}.",
+        "In addition, sharp slivers of ice fall. All creatures in the area must make a Constitution saving throw. A creature takes {@damage 6d6} cold damage on a failed saving throw or half as much on a successful one each round that they end their turn inside the blizzard."
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "areaTags": [
+        "Y"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Tempest",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Arctic"
+            }
+          }
+        ]
+      },
+      "uniqueId": "b88dd490f54657ba0f82115cef014083"
+    },
+    {
+      "name": "Conceal Item",
+      "source": "NRCToS",
+      "page": 119,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a handful of any kind of gemstone dust"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You render a single inanimate, nonliving object of Small-size or smaller completely undetectable when you hide it on your person. The object must be placed in a bag, hidden underneath your clothing, or otherwise concealed. No amount of searching, even a physical pat-down, will reveal the object, although {@spell true seeing} will reveal its location.",
+        "You may take the object out, at which point it becomes visible, but until the spell's duration is over, it will return to being {@condition invisible} once you return it to hiding."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "06b9c12461b947d30397f679e7349d2f"
+    },
+    {
+      "name": "Condition Protection",
+      "source": "NRCToS",
+      "page": 119,
+      "level": 2,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "While this spell is in effect, you or a willing creature you touch have immunity to one of the following conditions: {@condition blinded}, {@condition charmed}, {@condition deafened}, {@condition frightened}, {@condition incapacitated}, {@condition paralyzed}, {@condition petrified}, {@condition poisoned}, {@condition stunned}, or {@condition unconscious}. If your target is already suffering from one of these conditions, this spell will allow them to make an additional saving throw to recover from it."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, the target becomes immune to one additional condition per slot level above 3rd."
+          ]
+        }
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "665baca4404f3665e1340713f4a13a4a"
+    },
+    {
+      "name": "Cone of Acid",
+      "source": "NRCToS",
+      "page": 119,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a citrus fruit"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A jet of bubbling acid erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes {@damage 7d10} acid damage on a failed save, or half as much damage on a successful one. A creature killed by this spell dissolves into a puddle of stinking goo.",
+        "If a target takes at least 10 points of damage and is wearing nonmagical armor, the armor's AC is permanently reduced by one level of effectiveness. If the armor is reduced to AC 10, it is destroyed. A spell such as {@spell repair|nrctos} (q.v.) will fix the damage and restore the armor to its normal strength."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 6th level or higher, the damage increases by {@scaledice 7d10|5-9|1d10} for each slot level above 5th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "8eaa3161aac7610718b868039ac7ef61"
+    },
+    {
+      "name": "Cone of Fire",
+      "source": "NRCToS",
+      "page": 120,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a red garnet"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A cone of white flame erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes {@damage 8d10} fire damage on a failed save, or half as much damage on a successful one. A creature killed by this spell is burned to ashes. This spell sets nonmagical flammable items on fire."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 6th level or higher, the damage increases by {@scaledice 8d10|5-9|1d10} for each slot level above 5th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "fire"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "ecf00afb5f38c46124e10cd33d4d8726"
+    },
+    {
+      "name": "Cone of Force",
+      "source": "NRCToS",
+      "page": 120,
+      "level": 5,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a small cone made of quartz worth at least 25 gp",
+          "cost": 2500
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "A cone of green and golden magical force erupts from your hands. Each creature in a 60-foot cone must make a Constitution saving throw. A creature takes {@damage 8d10} force damage on a failed save, or half as much damage on a successful one. A creature killed by this spell is reduced to dust."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell using a spell slot of 6th level or higher, the damage increases by {@scaledice 8d10|5-9|1d10} for each slot level above 5th."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "uniqueId": "abf606c5dac333d675381aec9bdc7ecd"
+    },
+    {
+      "name": "Darkbolt",
+      "source": "NRCToS",
+      "page": 135,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a dead worm or a piece of octopus or squid tentacle"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You create a black, rubbery tentacle that lashes out at your command towards a creature in range. Make a melee spell attack against the target. If the attack hits, the creature takes {@damage 5d10} bludgeoning damage and if the creature is Large or smaller, you pull it up to 10 feet closer to you. The tentacle wraps around the target and grapples it (escape DC is equal to your spell save DC).",
+        "Until this grapple ends, the target is {@condition restrained} and you cannot use the {@i darkbolt} on another target. In addition, at the start of each of the target's turns, the {@i darkbolt} squeezes, causing an additional {@damage 3d8} bludgeoning damage. You may release your target as a bonus action."
+      ],
+      "damageInflict": [
+        "bludgeoning"
+      ],
+      "conditionInflict": [
+        "restrained"
+      ],
+      "spellAttack": [
+        "M"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Great Old One",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "36eeb0f2f716055d5feb5d027d74eb22"
+    },
+    {
+      "name": "Darklight's Creeping Curse of Frost",
+      "source": "NRCToS",
+      "page": 136,
+      "level": 9,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a diamond worth at least 1,000 gp",
+          "cost": 100000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You touch a single building and ice begins to slowly spread out from the point you are touching at a rate of 10 feet each minute, until the entire structure is coated with a layer of frost. The ice will even creep under doors and through windows, coating a large amount of the building's interior. This ice is permanent and can only be removed by a {@spell dispel magic} spell cast with at least an 9th-level spell slot. A fire- or heat-based spell will only remove the ice in 5-foot square patch, but unless the entire spell is {@spell dispel magic|phb|dispelled}, the ice will grow back.",
+        "The entire structure will remain at freezing temperature, regardless of ambient temperature. Touching the ice with bare hands or through thin gloves or shoes causes {@damage 1d4} cold damage at the end of each round a creature remains in contact with it. The grounds and floor or the building become difficult terrain. A creature that enters the area or ends its turn there must succeed on a Dexterity saving throw or fall {@condition prone}."
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "conditionInflict": [
+        "prone"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "90a39ceec2c13b838611adb1964350ec"
+    },
+    {
+      "name": "Darklight's Finger of Ice",
+      "source": "NRCToS",
+      "page": 136,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You send a bolt of bitterly cold energy to a creature you can see within range, who must make a Constitution saving throw as the coldness freezes the blood in its veins. It takes {@damage 7d8 + 30} cold damage on a failed saving throw, or half as much damage on a successful one.",
+        "A creature killed by this spell becomes a solid block of ice. Optionally, you may choose to reduce it to 1 hit point and freeze it in a form of stasis. If you choose this, the creature will be {@condition petrified} as ice instead of stone. It will remain encased in ice as long as the temperature remains below 50° F in the immediate area. If the temperature rises above that, the frozen creature will defrost over a period of 1 week. If touched by magically-produced heat, it will defrost in 1 minute. Upon becoming completely defrosted, the creature must immediately make a Constitution saving throw or fall to 0 hit points."
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "0f0cb164704c520c52350c62aadcaead"
+    },
+    {
+      "name": "Darklight's Haywire Hands",
+      "source": "NRCToS",
+      "page": 136,
+      "level": 3,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a length of twisted steel wire"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Two strands of wire erupt from your outstretched hands and strike out at one or two individuals in range that you can see within range. A target must make a Dexterity saving throw or become {@condition grappled} and {@condition restrained} (escape DC equal to your spell save DC). The wires may also be cut; they each have AC 15 and 10 hit points."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 4th-level or higher spell slot, you create one additional wire for each slot level above 3rd. For each additional wire you create, you may target one additional creature. A creature who is {@condition restrained} by two or more wires has disadvantage on its saving throws.",
+            "When you cast this spell with a 6th-level or higher spell slot, the wires have resistance to all forms of damage."
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "grappled",
+        "restrained"
+      ],
+      "savingThrow": [
+        "dexterity"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "47e7587d9a252e5f7d7be28840ef77fd"
+    },
+    {
+      "name": "Darklight's Inexplicable Image",
+      "source": "NRCToS",
+      "page": 137,
+      "level": 2,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a drawing of the illusion you wish to create"
+      },
+      "duration": [
+        {
+          "type": "permanent",
+          "ends": [
+            "trigger"
+          ]
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You enchant an inanimate object so that the next person other than yourself who touches it with bare hands triggers it, creating a clear image and sound. You may choose to make the image visible and audible to all or appear only in the triggering creature's mind.",
+        "The image sound can be of anything you wish, but cannot take more than two or three words to describe (\"giggling halfling child\" or \"menacing wraith\"). If you include a message, it cannot be longer than 15 words long. Sound effects (such as the giggling of the illusory halfling) do not count as words. The illusion lasts for no longer than 30 seconds."
+      ],
+      "miscTags": [
+        "PRM"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "2570c091f6eeee1efaa9e389f57af971"
+    },
+    {
+      "name": "Darklight's Lightning Web",
+      "source": "NRCToS",
+      "page": 137,
+      "level": 6,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a bit of hide from an electric eel"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You conjure a mass of thick, sticky webbing at a point of your choice within range. The webs fill a 20-foot cube from that point for the duration. The webs are difficult terrain and lightly obscure their area. If the webs aren't anchored between two solid masses (such as walls or trees) or layered across a floor, wall, or ceiling, the conjured web collapses on itself, and the spell ends at the start of your next turn. Webs layered over a flat surface have a depth of 5 feet.",
+        "As soon as the webs are created, they begin to crackle with arcs of electricity. A creature that starts its turn in the webs or that enters them during its turn must make a Dexterity saving throw. On a failure, it is {@condition restrained} (escape DC equal to your spell save DC). At the end of each of its turns, the creature must make a Constitution saving throw. A creature takes {@damage 8d6} lightning damage and is {@condition stunned} until the end of its next turn on a failed saving throw, and suffers no ill effect on a successful save."
+      ],
+      "damageInflict": [
+        "lightning"
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "savingThrow": [
+        "constitution",
+        "dexterity"
+      ],
+      "areaTags": [
+        "C"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "32abaef525a08a4b3026de151ce74d2c"
+    },
+    {
+      "name": "Darklight's Planar Weapon",
+      "source": "NRCToS",
+      "page": 137,
+      "level": 6,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You create a 3-foot-long blade of energy drawn from one of the Planes. You are considered proficient in it. The exact effects of the weapon depends on from which plane the energy came. It inflicts {@damage 9d6} damage on a hit; the exact type of damage inflicted by the sword depends on its type.",
+        "You may attempt to choose what sort of blade you produce by making a DC 15 ability check using your spellcasting ability. On a success, you get the blade you wish. Otherwise, the blade you receive is completely random.",
+        {
+          "type": "table",
+          "colLabels": [
+            "{@dice d100}",
+            "Sword Type"
+          ],
+          "colStyles": [
+            "col-1-5 text-center",
+            "col-10-5"
+          ],
+          "rows": [
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 1,
+                  "max": 3,
+                  "pad": true
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Abyssal Blade",
+                        "entries": [
+                          "This blade is made of embers and inflicts {@damage 3d6} acid damage, {@damage 3d6} fire damage, and {@damage 3d6} poison damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 4,
+                  "max": 5,
+                  "pad": true
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Acheronean Blade",
+                        "entries": [
+                          "This sword is made of partially-rusted iron and inflicts {@damage 5d6} cold damage and {@damage 4d6} poison damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 6,
+                  "max": 9,
+                  "pad": true
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Airy Blade",
+                        "entries": [
+                          "This sword is transparent with swirling streaks of white. It inflicts {@damage 5d6} slashing damage and {@damage 4d6} thunder damage, plus you are surrounded by a cloud of fog 5 feet in radius. You are lightly obscured but your own vision is not hindered."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 10,
+                  "max": 12
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Arborean Blade",
+                        "entries": [
+                          "This sword is made shining bronze and inflicts {@damage 5d6} lightning damage and {@damage 4d6} slashing damage. It inflicts double damage to fiends."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 13,
+                  "max": 14
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Arcadian Blade",
+                        "entries": [
+                          "This sword is made of white gold and inflicts {@damage 4d6} radiant damage and {@damage 5d6} slashing damage. It inflicts double damage to fiends."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 15,
+                  "max": 16
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Ashen Blade",
+                        "entries": [
+                          "This sword is iron-gray and inflicts {@damage 4d6} cold damage and {@damage 5d6} necrotic damage, plus you are surrounded by a cloud of swirling ashes 5 feet in radius. You are lightly obscured but your own vision is not hindered."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 17,
+                  "max": 20
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Astral Blade",
+                        "entries": [
+                          "This sword is made of silver and inflicts {@damage 9d6} force damage. The target's hit point total is reduced by that amount. The reduction lasts until the creature takes a short or long rest. This blade ignores bonuses to magical armor and if you are wielding it on the Astral Plane, then on a natural 20 in severs your foe's silver cord (if it has one)."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 21,
+                  "max": 22
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Bestial Blade",
+                        "entries": [
+                          "This sword is made of thorny wood and inflicts {@damage 3d6} piercing damage, {@damage 3d6} poison damage, and {@damage 3d6} slashing damage. It inflicts double damage to fiends."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 23,
+                  "max": 24
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Bytopian Blade",
+                        "entries": [
+                          "This sword is made of bright beaten iron and inflicts {@damage 6d6} radiant damage and {@damage 3d6} force damage. It inflicts double damage to fiends."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 25,
+                  "max": 26
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Carcerian Blade",
+                        "entries": [
+                          "This sword is made of dully-glowing red stone and inflicts {@damage 6d6} force damage and {@damage 3d6} thunder damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 27,
+                  "max": 29
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Celestian Blade",
+                        "entries": [
+                          "This sword is made of gold and inflicts {@damage 9d6} radiant damage. It inflicts double damage to fiends."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 30,
+                  "max": 31
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Concordant Blade",
+                        "entries": [
+                          "This sword is made of plain steel and inflicts {@damage 9d6} force damage. It inflicts double damage to fiends and celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 32,
+                  "max": 33
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Dust Blade",
+                        "entries": [
+                          "This sword is dull gray-brown and inflicts {@damage 5d6} cold damage and {@damage 4d6} necrotic damage. On a successful hit, your target must make a Constitution saving throw or spend its next turn coughing and choking due to dust in its lungs. Creatures that do not need to breathe are not affected by this."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 34,
+                  "max": 37
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Earthen Blade",
+                        "entries": [
+                          "This sword is gray and brown and inflicts {@damage 9d6} bludgeoning damage. On a successful hit, your target must make a Constitution saving throw or be {@condition petrified} until the end of its next turn due to being temporarily turned to stone."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 38,
+                  "max": 40
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Elysium Blade",
+                        "entries": [
+                          "This sword is made of rose-colored metal and inflicts {@damage 3d6} bludgeoning damage and {@damage 6d6} psychic damage. It inflicts double damage to fiends."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 41,
+                  "max": 44
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Ethereal Blade",
+                        "entries": [
+                          "This sword is made of transparent smoke and inflicts {@damage 9d6} force damage. The target's hit point total is reduced by that amount. The reduction lasts until the creature takes a short or long rest. It inflicts double damage to creatures with the etherealness or ethereal stride abilities."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 45,
+                  "max": 47
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Faerie Blade",
+                        "entries": [
+                          "This blade is made of faintly-glowing, silvery wood and inflicts {@damage 3d6} poison damage and {@damage 6d6} psychic damage. A non-fey creature struck with this blade must make a Constitution saving throw or fall {@condition unconscious} and prone until the end of its next turn."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 48,
+                  "max": 51
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Fiery Blade",
+                        "entries": [
+                          "This sword is made of flames and inflicts {@damage 9d6} fire damage. This also ignites flammable objects that your target is wearing; the target must make a Dexterity saving throw or take an additional {@damage 2d6} fire damage the following round."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 52,
+                  "max": 53
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Gehennan Blade",
+                        "entries": [
+                          "This sword is made of black ice and inflicts {@damage 6d6} cold damage and {@damage 3d6} necrotic damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 54,
+                  "max": 56
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Hadean Blade",
+                        "entries": [
+                          "This sword is made of matte-gray metal and inflicts {@damage 3d6} cold damage, {@damage 3d6} necrotic damage, and {@damage 3d6} psychic damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 57,
+                  "max": 59
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Hellish Blade",
+                        "entries": [
+                          "This sword is made of shards of obsidian and inflicts {@damage 5d6} fire damage and {@damage 4d6} psychic damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 60,
+                  "max": 61
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Icy Blade",
+                        "entries": [
+                          "This sword is shining blue-white and inflicts an {@damage 9d6} damage. On a successful hit, your target must make a Constitution saving throw or be {@condition paralyzed} until the end of its next turn due to being frozen by the intense cold."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 62,
+                  "max": 63
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Maddening Blade",
+                        "entries": [
+                          "This blade is made of dark, corroded metal and is covered with glowing eldritch runes. It inflicts {@damage 9d6} psychic damage and on a successful hit, your target must make a Wisdom saving throw or be confused; a confused creature can't take actions or reactions until the end of its next turn. If the creature dies due to the psychic damage, it instead drops to 1 hit point and falls {@condition unconscious}. When it wakes up, it is inflicted by {@table long-term madness}."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 64,
+                  "max": 65
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Magma Blade",
+                        "entries": [
+                          "This sword is black with glowing red streaks and inflicts {@damage 5d6} fire damage and {@damage 4d6} bludgeoning damage. This also ignites flammable objects that your target is wearing; the target must make a Dexterity saving throw or take an additional {@damage 2d6} fire damage the following round."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 66,
+                  "max": 68
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Mechanical Blade",
+                        "entries": [
+                          "This sword is made of copper with glowing, intricately-etched lines. It does {@damage 9d6} force damage. It inflicts double damage to chaotic creatures."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 69,
+                  "max": 70
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Mineral Blade",
+                        "entries": [
+                          "This sword is made of jagged, multihued crystals and inflicts {@damage 4d6} force damage and {@damage 5d6} slashing damage. On a successful hit, your target must make a Dexterity saving throw or be frozen by the cold and {@condition paralyzed} until the end of its next turn."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 71,
+                  "max": 72
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Negative Blade",
+                        "entries": [
+                          "This sword is pure black. It inflicts {@damage 9d6} necrotic damage, and the target's hit point total is reduced by that amount. If the target dies due to this damage, it rises as an undead of equal or lesser CR in {@dice 1d4} hours. This hit point reduction lasts until {@spell greater restoration} is cast. It inflicts double damage to creatures native to or that drawn energy from the Positive Plane."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 73,
+                  "max": 74
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Oozing Blade",
+                        "entries": [
+                          "This sword is made of constantly-swirling translucent goo and inflicts {@damage 6d6} acid damage and {@damage 3d6} poison damage. On a successful hit, your target must make a Constitution saving throw or be {@condition poisoned} until the end of its next turn."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 75,
+                  "max": 76
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Pandemoniacal Blade",
+                        "entries": [
+                          "This sword is made of smooth black limestone and inflicts {@damage 5d6} psychic damage and {@damage 4d6} thunder damage. It inflicts double damage to celestials."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 77,
+                  "max": 78
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Positive Blade",
+                        "entries": [
+                          "This sword is pure white. It inflicts {@damage 9d6} radiant damage, and if the target dies due to this damage, it explodes. All creatures within 10 feet must make a Dexterity saving throw. A creature takes {@damage 3d6} radiant damage on a failed saving throw, or half as much on a successful one. It inflicts double damage to creatures native to or that drawn energy from the Negative Plane."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 79,
+                  "max": 80
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Radiant Blade",
+                        "entries": [
+                          "This sword is made of brilliant light and inflicts {@damage 9d6} radiant damage. On a successful hit, your target must make a Constitution saving throw or be {@condition blinded} until the end of its next turn."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 81,
+                  "max": 82
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Salt Blade",
+                        "entries": [
+                          "This sword is made of white crystals and inflicts {@damage 3d6} necrotic damage, {@damage 3d6} poison damage, and {@damage 3d6} slashing damage. On a successful hit, your target's hit point total is reduced by the amount of necrotic damage it took. This hit point reduction lasts until the target takes a short or long rest."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 83,
+                  "max": 85
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Shadow Blade",
+                        "entries": [
+                          "This blade is made of shadow and inflicts {@damage 4d6} force damage and {@damage 5d6} psychic damage. You may attack your opponent's shadow, if it has one (this requires a light source that is not directly overhead). The shadow has an AC of 10 plus the creature's Dexterity modifier, but the attack is at disadvantage."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 86,
+                  "max": 87
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Smoke Blade",
+                        "entries": [
+                          "This sword is dark gray and shot through with tiny red sparks, and inflicts {@damage 4d6} fire damage and {@damage 5d6} poison damage, plus you are surrounded by a cloud of thick smoke 5 feet in radius. You are lightly obscured but your own vision is not hindered."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 88,
+                  "max": 89
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Steam Blade",
+                        "entries": [
+                          "This sword is a pale silvery-gray and inflicts {@damage 9d6} fire damage, plus you are surrounded by a cloud of thick fog 5 feet in radius. You are lightly obscured but your own vision is not hindered."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 90,
+                  "max": 91
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Vacuum Blade",
+                        "entries": [
+                          "This sword is black and flecked with stars and inflicts {@damage 9d6} force damage. On a successful hit, your target must make a Constitution saving throw or spend its next turn gasping and choking, attempting to replace the air that has been sucked from its lungs. Creatures that do not need to breathe are not affected by this."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 92,
+                  "max": 95
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Watery Blade",
+                        "entries": [
+                          "This sword is a translucent blue-green and inflicts {@damage 9d6} slashing damage. On a successful hit, your target must make a Constitution saving throw or spend its next turn coughing and choking due to water in its lungs. Creatures that do not need to breathe or that breathe water are not affected by this."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 96,
+                  "max": 98
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Xaotic Blade",
+                        "entries": [
+                          "This sword changes color and form with each movement. It inflicts {@damage 9d6} psychic damage. It inflicts double damage to lawful creatures."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 99,
+                  "max": 100
+                }
+              },
+              {
+                "type": "entries",
+                "entries": [
+                  {
+                    "type": "entries",
+                    "entries": [
+                      {
+                        "type": "entries",
+                        "name": "Ysgardian Blade",
+                        "entries": [
+                          "This sword is made of glowing steel and inflicts {@damage 3d6} cold damage, {@damage 3d6} fire damage, and {@damage 3d6} lightning damage."
+                        ]
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          ]
+        }
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 7th-level spell slot, the die type for all damage increases to {@dice d8}. When you cast it with an 8th-level spell slot, the die type increases to {@dice d10}. When you cast it with a 9th-level spell slot, the die type increases to {@dice d12}."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "acid",
+        "bludgeoning",
+        "cold",
+        "fire",
+        "force",
+        "lightning",
+        "necrotic",
+        "piercing",
+        "poison",
+        "psychic",
+        "radiant",
+        "slashing",
+        "thunder"
+      ],
+      "conditionInflict": [
+        "petrified",
+        "unconscious",
+        "prone",
+        "paralyzed",
+        "poisoned",
+        "blinded"
+      ],
+      "savingThrow": [
+        "constitution",
+        "dexterity",
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "81346db09a97ea184270f65656ee8d50"
+    },
+    {
+      "name": "Darklight's Tattooed Creature",
+      "source": "NRCToS",
+      "page": 141,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "tattoo inks worth 100 gp and a golden needle worth 50 gp; the inks are consumed when you cast the spell",
+          "cost": 10000,
+          "consume": true
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent",
+          "ends": [
+            "trigger"
+          ]
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You touch a living creature and transform it into ink. Only {@filter Large-sized and smaller beasts, dragons, giants, humanoids, monstrosities, and plants|bestiary|type=beast;dragon;giant;humanoid;monstrosity;plant|size=t;s;m;l} may be affected. Shapechangers cannot be affected by this spell and an unwilling creature may make a Wisdom saving throw to resist.",
+        "You must use this ink to create a tattoo on a willing target. If you use it for any other purpose, destroy the ink, or fail to use it within 1 hour, it turns back into the original creature.",
+        "To make an accurate tattoo, you must make a DC 13 Intelligence ability check; if you have proficiency with {@item calligrapher's supplies|phb|calligrapher's tools} or {@item painter's supplies|phb}, you may use that as well. If you fail your roll, the creature will take {@damage 1d10} force damage when reappearing, due to mistakes you made in depicting it accurately. If you roll a 1 when you inscribe the tattoo, the creature instead takes {@damage 5d10} force damage.",
+        "The target may release the creature at any time by touching the tattoo and speaking a command word. This causes the tattoo to vanish and the creature to appear in an empty space within 10 feet of you.",
+        "A tattoo of a Tiny creature takes up one slot, a tattoo of a Small creature takes up two slots, a tattoo of a Medium creature takes up four slots, and a tattoo of a Large creature takes up ten slots.",
+        "A Medium-sized humanoid has one slot on its neck, two on each arm, four on each leg, ten on its back and ten on its chest. A Small-sized humanoid has one slot on its neck and half as many on every other body part. Note that the presence of mundane tattoos does not get in the way of a {@i tattooed creature}, but body slots taken up by other forms of magical tattoos (such as one made with a {@spell create magic tattoo|nrctos} or {@spell Darklight's tattooed item|nrctos} spell (q.v.)) cannot be used by this spell.",
+        "A creature that has been made into a tattoo is effectively in stasis. While affected by this spell, the creature doesn't need to breathe, eat, or drink, and it doesn't age. Divination spells will reveal the tattoo's true nature. When it is released from tattoo form, it has no particular loyalty to you or to the person on whom it was tattooed. However, if that creature had been subject to a spell such as {@spell animal friendship}, {@spell charm person}, or {@spell dominate monster} and had been {@condition charmed}, it will continue to be {@condition charmed} after being released until the duration of the charm has ended."
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "opposedCheck": [
+        "intelligence"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "004afade0c7b44bce28c04c6b3e42cfb"
+    },
+    {
+      "name": "Darklight's Tattooed Item",
+      "source": "NRCToS",
+      "page": 142,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "tattoo inks worth 100 gp and a golden needle worth 50 gp; the inks are consumed when you cast the spell",
+          "cost": 10000,
+          "consume": true
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent",
+          "ends": [
+            "trigger"
+          ]
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You touch an inanimate object and transform it into ink. You must use this ink to create a tattoo on a willing target. If you use it for any other purpose, destroy the ink, or fail to use it within 1 hour, it turns back into the original object.",
+        "The target may release the item at any time by touching the tattoo and speaking a command word. This causes the tattoo to vanish and the item to appear in an empty space within 10 feet of you.",
+        "A tattoo of a item of 10 pounds or less takes up one slot, a tattoo of an item of 11-50 pounds takes up two slots, a tattoo of an item 51-150 pounds takes up three slots, a tattoo of an item 151-500 pounds takes up six slots, and a tattoo of an item 501-1,000 pounds takes up 10 slots.",
+        "A Medium-sized humanoid has one slot on its neck, two on each arm, four on each leg, ten on its back and ten on its chest. A Small-sized humanoid has one slot on its neck and half as many on every other body part. Note that the presence of mundane tattoos does not get in the way of a {@i tattooed item}, but body slots taken up by other forms of magical tattoos (such as one made with a {@spell create magic tattoo|nrctos} or {@spell Darklight's tattooed creature|nrctos} spell (q.v.)) cannot be used by this spell."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with an 8th-level spell slot, you may transform an item that weighs up to 2,000 pounds. When you cast this spell with a 9th-level spell slot, you may transform an item that weighs up to 5,000 pounds. These items take up 10 slots each."
+          ]
+        }
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "07a92465e00c728a14b1631fcb44b0d8"
+    },
+    {
+      "name": "Create Magic Tattoo",
+      "source": "NRCToS",
+      "page": 127,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "100 gp worth of tattoo inks",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 24
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You tattoo a magical sigil onto a creature, providing protection or aid in some way. To make an accurate tattoo, you must make a DC 13 Intelligence ability check; if you have proficiency with {@item calligrapher's supplies|phb|calligrapher's tools} or {@item painter's supplies|phb}, you may add your proficiency modifier to the roll.",
+        "The effect depends on the spell slot you use to cast this spell and lasts for the duration:",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "3rd-level spell slot",
+                  "entries": [
+                    "The tattoo takes up one slot and grants one of the following abilities:",
+                    {
+                      "type": "list",
+                      "items": [
+                        "+2 bonus on one type of saving throw",
+                        "+1 bonus on attacks when using one particular weapon",
+                        "+1 bonus to armor class",
+                        "5 temporary hit points",
+                        "Advantage when using one tool set"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "5th-level spell slot",
+                  "entries": [
+                    "The tattoo takes up two slots and grants one of the following abilities:",
+                    {
+                      "type": "list",
+                      "items": [
+                        "+2 bonus on three different saving throws",
+                        "+2 bonus on attacks and damage when using one particular weapon",
+                        "+1 bonus on all attack and damage rolls",
+                        "10 temporary hit points",
+                        "+10 feet to your speed"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "7th-level spell slot",
+                  "entries": [
+                    "The tattoo takes up four slots and grants one of the following abilities:",
+                    {
+                      "type": "list",
+                      "items": [
+                        "Advantage on saving throws against magical spells and effects",
+                        "Advantage on any three saving throws",
+                        "+2 bonus to any attribute",
+                        "+3 bonus to armor class",
+                        "15 temporary hit points"
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        "A Medium-sized humanoid has one slot on its neck, two on each arm, four on each leg, ten on its back and ten on its chest. A Small-sized humanoid has one slot on its neck, one on each arm, two on each leg, and five on its back and chest. When the spell expires, the tattoo fades away. A creature may have multiple {@i magic tattoos} but they must each be of different types. For instance, a creature could have two magic tattoos cast with a 3rd-level spell slot, with one granting a bonus to attack rolls and one granting a bonus on saving throws. Note that the presence of mundane tattoos does not get in the way of a {@i magic tattoos}, but body slots taken up by other forms of magical tattoos (such as one made with a {@spell Darklight's tattooed creature|nrctos} or {@spell Darklight's tattooed item|nrctos} spell (q.v.)) cannot be used by this spell."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "ec4441352d484e26a92a6048594077e0",
 			"miscTags": [
 				"THP"
 			]
-		},
-		{
-			"name": "Unnatural Lust",
-			"source": "NRCToS",
-			"page": 354,
-			"level": 2,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"One creature you choose that you can see within range must make a Wisdom saving throw. On a failure, it is {@condition charmed} by you and becomes incredibly enamored of another creature or object that you designate as you cast the spell. It will seek to possess the object at any cost, although it will not take actions that would violate its alignment. Once each minute, the creature may make another saving throw, ending the effect on a success. At the end of the spell, the creature knows it was {@condition charmed}, although not by whom."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"areaTags": [
-				"ST"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "d212865e7370bfc2ea1e730cd4b0ff77"
-		},
-		{
-			"name": "Undead Torch",
-			"source": "NRCToS",
-			"page": 354,
-			"level": 3,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a firefly"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You cause up to six corporeal undead to burst into sickly blue flames. The undead must be either willing or controlled by you. The flames do not harm the undead, but instead allow them to inflict an additional {@damage 2d6} fire damage with each of their physical attacks. These flames shed dim light in a 10-foot radius."
-			],
-			"damageInflict": [
-				"fire"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Death",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "38fb4912d5858ff78ef427f904673579"
-		},
-		{
-			"name": "Urlic's Unwholesome Meal",
-			"source": "NRCToS",
-			"page": 355,
-			"level": 3,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of gold dust"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Prayerbook",
-				"You cause bad food to appear and taste wonderful. If the food is rotten or poisoned, then any damage the taint would normally inflict only occurs {@dice 2d4} hours later. Magical attempts to discern poisoning or spoilage using spells of 3rd level or lower will reveal nothing. If a spell is cast on the food to purify it, that spellcaster must make a spellcasting ability check, with a DC equal to your spell save DC, to successfully purify the food. Regardless of the outcome, that caster will believe it has succeeded.",
-				"The spell may also be cast on purely illusory food, making it appear in all respects to be a complete, filling, and real meal. A creature who eats the food will feel as if it has actually eaten and won't be hungry again for the normal length of time. However, the eater has consumed no food. If the creature eats nothing but illusory food treated with this spell, it will begin to suffer the effects of {@book starvation|phb|8|food and water|0} (as per the {@i Player's Handbook}, {@book page 185|phb|8|food and water|0}). Thus, it is entirely possible to use this spell to make a creature think it is eating well while in reality it is starving to death."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "dfa60976b3b9e4fc45bdd94dc57d2ee0"
-		},
-		{
-			"name": "Cheat",
-			"source": "NRCToS",
-			"page": 113,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				},
-				{
-					"number": 1,
-					"unit": "reaction",
-					"condition": "taken when you are about to take your turn at a game"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pair of dice made from human bones"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You may subtly alter the hands of fate during games of chance. While using a {@filter gaming set|items|type=gaming set}, you may choose one player (who may be yourself) to make one roll at advantage or you may choose one player to make one roll at disadvantage. This spell can only be used with games that rely at least somewhat on chance; games that rely entirely on skill, such as dragonchess, cannot be affected by this spell."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Trickery",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "bf61a679c0adc4bc83743d766275ec58"
-		},
-		{
-			"name": "Chill",
-			"source": "NRCToS",
-			"page": 113,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One living creature you see within range must make a Constitution saving throw or be chilled and have disadvantage on all Dexterity-based rolls until the end of its next turn. A creature that is resistant or immune to cold damage is unaffected by this spell."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "4fcbea520ea5f4ff4ced4cbf7bb23664"
-		},
-		{
-			"name": "Body Temperature",
-			"source": "NRCToS",
-			"page": 101,
-			"level": 2,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a small flame, such as a lit candle"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One cold-blooded creature you touch gains warmth in its body, as if it was a living, warm-blooded creature. This has two main functions:",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Warmth",
-									"entries": [
-										"You provide warmth and energy to a cold-blooded creature. This will prevent a reptile from going into torpor. It can also be cast on an undead creature, giving it a near-living body temperature and some color to its skin rather than just the pallor of death, and will even cause its heart to beat, thus allowing the undead to better masquerade as living beings."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Chill",
-									"entries": [
-										"The second use of this spell causes one warm-blooded creature is made to appear to have the same body temperature as its surroundings, making it {@condition invisible} to creatures and spells that seek heat and unpalatable to creatures that feed on heat. This also mutes that creature's heartbeat, allowing it to appear dead (or undead), even on close inspection."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "1202ba0cbb9408052da29abced1b5e23"
-		},
-		{
-			"name": "Longevity",
-			"source": "NRCToS",
-			"page": 251,
-			"level": 8,
-			"school": "N",
-			"time": [
-				{
-					"number": 24,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "self"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "rare fruits worth at least 500 gp, which you burn during the course of the casting",
-					"cost": 50000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You stop aging for a number of years equal to {@dice 4d6} + twice your spellcasting ability modifier. The first casting of this spell causes no problems, but each subsequent time you cast this spell, you must make a DC 13 Constitution saving throw. If you fail, you instantly age to death. Otherwise, the spell works normally."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "ced6dbe17c653ebd7a53296b61e12dce"
-		},
-		{
-			"name": "Litany of Debasement",
-			"source": "NRCToS",
-			"page": 249,
-			"level": 2,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "bonus"
-				},
-				{
-					"number": 1,
-					"unit": "reaction",
-					"condition": "taken when you are attacked or about to attack a target"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You speak a quick prayer and a wave of holy energy washes over one target within range. One of the following affects your target until the end of its next turn, unless it succeeds at a Wisdom saving throw.",
-				{
-					"type": "list",
-					"items": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Entanglement",
-											"entries": [
-												"You create a chain of energy to lash upwards from the ground to impede your target, causing it to be {@condition restrained} and is {@condition paralyzed} until the end of its next turn."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Madness",
-											"entries": [
-												"Your prayer is filled with bizarre word salad and eldritch phrases, causing much confusion in your target. Your target cannot take actions or reactions and is {@condition paralyzed} until the end of its next turn."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Sloth",
-											"entries": [
-												"You speak about the sin of indolence and cause your target to being sluggish. It can use either an action or bonus action but not both and can't make more than one action during its turn."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Thunder",
-											"entries": [
-												"You shout your prayer, causing your target to be {@condition deafened} and {@condition stunned} and is {@condition paralyzed} until the end of its next turn."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Vengeance",
-											"entries": [
-												"You speak words of chastisement and your target feels pain more sharply. All creatures who attack the target until the end of the next round inflict an additional {@damage 1d4} force damage."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Weakness",
-											"entries": [
-												"You proclaim your target is weak and cause it to suffer {@dice 1d4} levels of {@condition exhaustion} until the end of its next turn."
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"conditionInflict": [
-				"deafened",
-				"exhaustion",
-				"paralyzed",
-				"restrained",
-				"stunned"
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "257d22b256e4c325b167748e23995f6b"
-		},
-		{
-			"name": "Litany of Grace",
-			"source": "NRCToS",
-			"page": 250,
-			"level": 2,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "bonus"
-				},
-				{
-					"number": 1,
-					"unit": "reaction",
-					"condition": "taken when you are attacked or about to attack a target"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You speak a quick prayer and a wave of holy energy washes over you or one ally within range. Until the end of your next turn, you receive one of the following affects:",
-				{
-					"type": "list",
-					"items": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Defense",
-											"entries": [
-												"With this prayer of protection, you gain +2 to your armor class and are immune to being {@condition charmed} or {@condition frightened}."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Eloquence",
-											"entries": [
-												"This prayer is so fascinating to listen to, one target within 10 feet of you is {@condition stunned} and is {@condition paralyzed} until the end of its next turn."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Escape",
-											"entries": [
-												"If you are {@condition grappled} or {@condition restrained}, you may use a bonus action to make another escape attempt, this time at advantage."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Righteousness",
-											"entries": [
-												"You imbue your weapon with holy right as you attack a foe. If you hit and the creature is evil, it takes +2 damage and is {@condition paralyzed} until the end of its next turn."
-											]
-										}
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"entries": [
-										{
-											"type": "entries",
-											"name": "Litany of Warding",
-											"entries": [
-												"You become more aware of your opponents. You gain +2 to your armor class against sneak attacks and can parry one attack. Roll a {@dice d8} and subtract that number from the damage caused by one melee attack made against you."
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"conditionInflict": [
-				"charmed",
-				"frightened",
-				"grappled",
-				"paralyzed",
-				"restrained",
-				"stunned"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Devotion",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "5b9011a9813b6348ef5ca6df90d318ed"
-		},
-		{
-			"name": "Kiss of Awakening",
-			"source": "NRCToS",
-			"page": 235,
-			"level": 2,
-			"school": "A",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One sleeping or {@condition unconscious} creature you kiss instantly wakes up. If you kiss a creature that is sleeping due to a spell (including the slumber variant of the imprisonment spell), this kiss will automatically wake up that creature if the spell is of 2nd level or lower. For a spell of 3rd level or higher, make an ability check using your spellcasting ability. The DC equals 10 + the spell's level. On a successful check, the effect ends and the creature wakes up. You may only try once per magically-{@condition unconscious} creature."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level or higher spell slot, you automatically wake a creature up who is under the effect of spell if the spell's level is equal to or less than the level of the spell slot you used."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Life",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "75bd3dd7fc506988c6d62ab7d344d551"
-		},
-		{
-			"name": "Kiss of Death",
-			"source": "NRCToS",
-			"page": 236,
-			"level": 9,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Once creature you kiss will die instantly, if it has 100 or fewer hit points. You must be able to kiss the target's skin (although you do not need to kiss its lips). The creature must be willing to be kissed, {@condition restrained}, or unaware. If the creature is in combat, you must make a melee spell attack roll to succeed."
-			],
-			"spellAttack": [
-				"M"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "e834050d3fededf8c52918784a39cc06"
-		},
-		{
-			"name": "Kiss of Intoxication",
-			"source": "NRCToS",
-			"page": 236,
-			"level": 1,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One creature you kiss becomes completely drunk, unless it succeeds on a Constitution saving throw. A drunk creature suffers from disadvantage on all Dexterity- and Intelligence-based attack rolls, saving throws, and ability checks, and its speed is reduced by 5 feet. In addition, it must make a concentration saving throw each time it attempts to cast a spell.",
-				"If the creature was already drunk when you cast the spell, on a successful saving throw, the creature is also {@condition poisoned} for the duration and its speed is reduced by half. On a failed saving throw, it falls {@condition unconscious} for the duration.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
-			],
-			"conditionInflict": [
-				"poisoned"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Archfey",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "9097bd752d0f7563a8b752ba2387918f"
-		},
-		{
-			"name": "Kiss of Slavery",
-			"source": "NRCToS",
-			"page": 236,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One creature you kiss becomes {@condition charmed} by you, unless it succeeds on a Wisdom saving throw. You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware.",
-				"If it fails the saving throw, it is {@condition charmed} by you until the spell ends or until you do anything harmful to it. The {@condition charmed} creature regards you as a trusted friend to be heeded and protected."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"If you cast this spell with a 5th-level spell slot, the duration increases to 12 hours. If you cast it with a 7th-level spell slot, the duration increases to 24 hours."
-					]
-				}
-			],
-			"conditionInflict": [
-				"charmed"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Oathbreaker",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "4c14d2a633eb2bfab2a0d3a92c00f0e1"
-		},
-		{
-			"name": "Kiss of Sleep",
-			"source": "NRCToS",
-			"page": 237,
-			"level": 5,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 8
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One creature you kiss falls {@condition unconscious}, unless it succeeds on a Wisdom saving throw. You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware.",
-				"Slapping the target hard will awaken it, as will any amount of damage taken, but normal noise or gentle shaking will not. Awakening is slow. For one minute after the creature wakes up, it cannot take reactions and can use either an action or bonus action on each of its turns, but not both.",
-				"This sleep does not count as either a short or long rest."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 6th-level spell slot, the duration becomes 24 hours. When you cast it with a 7th-level spell slot, the duration becomes 1 week. When you cast it with an 8th-level or higher spell slot, the duration becomes one year, and merely slapping the target will not awaken it; damage must be inflicted."
-					]
-				}
-			],
-			"conditionInflict": [
-				"unconscious"
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "176517ca580b93c9873a5528057fe31c"
-		},
-		{
-			"name": "Kiss of the Nereid",
-			"source": "NRCToS",
-			"page": 237,
-			"level": 7,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One creature you kiss must succeed on a Constitution saving throw. On a failure, the creature's lungs fill with seawater and it begins to suffocate, as per the {@book suffocation|phb|8|suffocating|0} rules in the {@i Player's Handbook} (page 183). After 10 minutes, the water vanishes from the target's lungs. This spell is countered by {@spell water breathing}, and does not affect creatures that can breathe water or that do not need to breathe.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "17bdd7dc7dec068073db85a147f5200d"
-		},
-		{
-			"name": "Kiss of the Toad",
-			"source": "NRCToS",
-			"page": 237,
-			"level": 2,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Oriental Adventures}",
-				"Your lips become poisonous, and one creature you kiss takes {@damage 4d8} poison damage and must make a Constitution saving throw, becoming {@condition poisoned} for 1 hour on a failure.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 3rd-level or higher spell slot, you inflict an additional {@scaledice 4d8|2-9|1d8} poison damage per slot level above 2nd."
-					]
-				}
-			],
-			"conditionInflict": [
-				"poisoned"
-			],
-			"damageInflict": [
-				"poison"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Oathbreaker",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "a6a6cd2c0cc7ffc2b2eac060d195550d"
-		},
-		{
-			"name": "Kiss of Torment",
-			"source": "NRCToS",
-			"page": 238,
-			"level": 4,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"Your kiss inflicts your target with madness and pain, and one creature you kiss takes {@damage 5d10} psychic damage and must succeed on a Constitution saving throw or become so wracked with pain that it is {@condition incapacitated} for the duration. It may make a new saving throw at the end of each of its turns, ending that effect on a success. However, each round that the creature remains {@condition incapacitated}, it takes an additional {@damage 1d10} psychic damage.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
-			],
-			"conditionInflict": [
-				"incapacitated"
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Fiend",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "5e3069c941f777ccf8e34991a704a296"
-		},
-		{
-			"name": "Kiss of Vampirism",
-			"source": "NRCToS",
-			"page": 238,
-			"level": 1,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Your kiss drains the life out of your target. You target takes {@damage 1d10} necrotic damage and you regain hit points equal to half the amount of necrotic damage dealt.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level or higher spell slot, your kiss causes an additional {@damage 1d10} necrotic damage for each slot level above 1st."
-					]
-				}
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"miscTags": [
-				"HL"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Warlock",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Undying",
-							"source": "SCAG"
-						}
-					}
-				]
-			},
-			"uniqueId": "68376d684edd554b2dbc7d233034d2b4"
-		},
-		{
-			"name": "Kiss of Weakness",
-			"source": "NRCToS",
-			"page": 238,
-			"level": 5,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Your kiss drains the vitality from the next target you kiss. Each round that you continue kissing your target, it must make a Constitution saving throw or have its Strength reduced by 2 points. When the spell ends, your target must make another Constitution saving throw or be {@condition stunned} for 10 minutes. Lost Strength points return after the creature takes a short or long rest.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
-			],
-			"conditionInflict": [
-				"stunned"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Vengeance",
-							"source": "PHB"
-						}
-					},
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Oathbreaker",
-							"source": "DMG"
-						}
-					}
-				]
-			},
-			"uniqueId": "49958385f2edd45616a98ac36783488f"
-		},
-		{
-			"name": "Kiss of Wounding",
-			"source": "NRCToS",
-			"page": 238,
-			"level": 0,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"Once creature you kiss must make a Constitution saving throw, taking {@damage 1d12} force damage on a failed saving throw or half as much damage on a successful one.",
-				"You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware.",
-				"You inflict additional damage with your kiss at 5th level ({@dice 2d12}), 11th level ({@dice 3d12}) and 17th level ({@dice 4d12})"
-			],
-			"damageInflict": [
-				"force"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "fcda1b2b8a1b537a7512ec70aa29f687"
-		},
-		{
-			"name": "Curse of Lycanthropy",
-			"source": "NRCToS",
-			"page": 132,
-			"level": 6,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a drop of blood from a true lycanthrope and a silver medallion worth 100 gp",
-					"cost": 10000
-				}
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You touch a humanoid and infect it with {@variantrule Player Characters as Lycanthropes|mm|lycanthropy}. The target may make a Constitution saving throw to avoid this spell. The exact species of lycanthrope depends on the nature and temperament of your target; you have no control over it.",
-				"If your target fails its saving throw, then it will transform into a lycanthrope on each of the three nights of the next full moon and on all subsequent full moons.",
-				"If your target does not kill any living creatures that have an Intelligence of 5 or greater during that time, then on the morning after the third day it may make a new saving throw. If it does kill an intelligent creature, it may attempt the saving throw at disadvantage.",
-				"This spell continues until the target succeeds at three saving throws. Those successes do not need to be consecutive. If the target instead fails at three saving throws, the curse is permanent.",
-				"Casting {@spell remove curse} on the target allows it to make its next saving throw at advantage but does not automatically restore the target. Other forms of lycanthropy cures work as well as they normally do."
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Druid",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "1bb5baa10df7c9b158325ef0de12bd00"
-		},
-		{
-			"name": "Curse of Undeath",
-			"source": "NRCToS",
-			"page": 132,
-			"level": 6,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 90
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a pinch of bone from an undead creature"
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You curse a creature so that, when it eventually dies, it will rise up again {@dice 1d4} hours later as an undead. As an undead, it will have a CR no higher than what the creature had when alive.",
-				"In addition, upon rising, it is permanently under your control (assuming you are still alive and able to assume control).",
-				"If your target dies and the {@spell gentle repose} spell is cast upon the corpse, the caster of that spell must make saving throw using its spellcasting ability in order to successfully prevent your curse from activating. A {@spell remove curse} spell can also end the curse."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "0217125a7c4efcd0967bd3c974c3d3e8"
-		},
-		{
-			"name": "Rising Colossus",
-			"source": "NRCToS",
-			"page": 302,
-			"level": 9,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 200
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a ball of clay and a bit of string, wire, or natural fiber"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"The head, torso, and arms of a truly enormous, vaguely humanoid-looking {@creature construct|nrctos} rises from the ground. It is easily 50 feet tall, completely hairless, lacks all facial features save a mouth, and is made of the same substance of the ground from which it rose.",
-				"The creature is under your command. Roll initiative for it, as it has its own turns. It obeys any verbal or mental commands that you issue to it (no action required by you) as long as you remain with 300 feet of it. If you don't issue any commands to it, it continues to follow your last command.",
-				{
-					"type": "dataCreature",
-					"dataCreature": {
-						"name": "Colossus",
-						"shortName": "colossus",
-						"source": "NRCToS",
-						"page": 303,
-						"size": "G",
-						"type": "construct",
-						"alignment": [
-							"U"
-						],
-						"ac": [
-							{
-								"ac": 18,
-								"from": [
-									"natural armor"
-								]
-							}
-						],
-						"hp": {
-							"formula": "{@dice 20d20 + 100}",
-							"average": 310
-						},
-						"speed": {
-							"walk": 0
-						},
-						"str": 28,
-						"dex": 8,
-						"con": 20,
-						"int": 1,
-						"wis": 5,
-						"cha": 1,
-						"senses": [
-							"truesight (blind beyond this radius) 120 ft."
-						],
-						"passive": 7,
-						"resist": [
-							{
-								"resist": [
-									"bludgeoning",
-									"piercing",
-									"slashing"
-								],
-								"note": "from nonmagical weapons"
-							}
-						],
-						"conditionImmune": [
-							"{@condition blinded}",
-							"{@condition charmed}",
-							"{@condition deafened}",
-							"{@condition exhaustion}",
-							"{@condition frightened}",
-							"{@condition petrified}",
-							"{@condition poisoned}",
-							"{@condition prone}",
-							"{@condition stunned}",
-							"{@condition unconscious}"
-						],
-						"cr": "18",
-						"trait": [
-							{
-								"name": "Immutable Form",
-								"entries": [
-									"The colossus is immune to any spell or effect that would alter its form."
-								]
-							},
-							{
-								"name": "Siege Monster",
-								"entries": [
-									"The colossus deals double damage to objects and structures."
-								]
-							},
-							{
-								"name": "Magic Resistance",
-								"entries": [
-									"The colossus has advantage on saving throws against spells and other magical effects."
-								]
-							}
-						],
-						"action": [
-							{
-								"name": "Slam",
-								"entries": [
-									"{@atk mw} {@hit 15} to hit, reach 20 ft., one target. {@h}48 ({@damage 6d12 + 9}) bludgeoning damage."
-								]
-							}
-						],
-						"traitTags": [
-							"Immutable Form",
-							"Magic Resistance",
-							"Siege Monster"
-						],
-						"senseTags": [
-							"U"
-						],
-						"damageTags": [
-							"B"
-						],
-						"miscTags": [
-							"MW",
-							"RCH"
-						]
-					}
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "217ab8aa31c5a7ee563b92fa380d3df3"
-		},
-		{
-			"name": "Naked Fury",
-			"source": "NRCToS",
-			"page": 269,
-			"level": 9,
-			"school": "N",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "radius",
-				"distance": {
-					"type": "miles",
-					"amount": 20
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a pound of salt, the ashes of a ghoul, and a 20,000 gp worth of gemstone dust",
-					"cost": 2000000
-				}
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "year",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"With an angry cry of pure wrath, you unleash your raw fury at the land around you.",
-				"You may use each of your actions to fire a bolt of noxious orange fire each round for up to 10 minutes at a target (for a total of 100 bolts) within range that you can see or simply at a piece of the landscape.",
-				"If you attack a creature, you must make a ranged spell attack to hit. On a hit, you inflict {@damage 4d8} fire damage and {@damage 4d8} poison damage. If you attack a structure or object, you inflict {@damage 4d8} fire damage and {@damage 4d8} bludgeoning damage. ",
-				"If you attack the land, the poisonous flames burst in a 10-foot-radius circle, setting all flammable objects not being worn or carried in that circle on fire. The fire will burn slowly and with a great deal of foul-smelling smoke for anywhere from one hour to one day, depending on how much flammable material there is in that area. The area becomes heavily obscured during this time.",
-				"This fire poisons the land. Plants that are destroyed by the fire will not regrow for at least one year. Any water that flows or stands in the area becomes toxic, as do any plants that manage to survive your onslaught. Any creature that drinks the poisoned water or eats any vegetation from the area must make a Constitution saving throw or become {@condition poisoned} for 24 hours. Likewise, any creature that sleeps in an affected area must make a Constitution saving throw or become {@condition poisoned} for 24 hours.",
-				"After one year, the toxic effects begin to fade and are completely gone after one week."
-			],
-			"damageInflict": [
-				"bludgeoning",
-				"fire",
-				"poison"
-			],
-			"conditionInflict": [
-				"poisoned"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "fed42b408ae6672da8b81ba7e551f627"
-		},
-		{
-			"name": "Prosthesis",
-			"source": "NRCToS",
-			"page": 293,
-			"level": 5,
-			"school": "N",
-			"time": [
-				{
-					"number": 10,
-					"unit": "minute"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a potion of healing and a pot of glue"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium} and The Great Net Spellbook",
-				"You may graft the limb of one corporeal creature (the donor), or an artificial prosthetic limb, onto the stump of another willing creature (the recipient). The limb must be of the same type of body part; you can't graft a leg to the stump of an arm. The donor does not need to be a living creature: you may use the limb of a celestial, construct, elemental fiend, or undead creature as well.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Donated Limb",
-									"entries": [
-										"If you use the limb from another creature, that creature can be no more than one size category larger or smaller than the target. If the creature had a higher or lower Strength or Dexterity than the recipient, then the recipient's attributes with that limb increases or decreases by 1 point for every 4 full points difference between the donor and recipient. For instance, if a human with a Strength of 11 and Dexterity of 13 were to get an arm from an ogre with a Strength of 19 and Dexterity of 8, the human would have an effective Strength of 13 and Dexterity of 12 with that arm. If the limb is a leg from a creature with a walking speed of 15 feet or more higher or lower than the recipient's, then the recipient's walking speed increases or decreases by 5 feet.",
-										"The appendage retains its original AC and keeps any physical melee weapon attacks. The damage remains the same but the Strength or Dexterity modifier may change. If the limb had an attack that caused the {@condition paralyzed} or {@condition poisoned} conditions, then it retains that ability. It does not retain any other special abilities (an arm taken from a red slaad, for instance, will not implant eggs). Likewise, the recipient does not gain any special abilities that the donor originally had.",
-										"However, if the recipient receives a limb taken from a living creature, there is a chance of rejection. If the recipient and donor are of the same species or a closely-related species (such as a human and half-elf), then the recipient must make a DC 11 Constitution saving throw. If the recipient and donor are of the same creature type (such as humanoid) but otherwise very different species (such as human and kobold), the saving throw DC becomes 13. If the recipient and donor are of different creature types (such as human and ogre or wolf), the saving throw DC becomes 15. If the recipient fails its saving throw, then the spell fails as well, the graft fails, and the recipient takes {@damage 3d10} necrotic damage."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "entries",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Artificial Limb",
-									"entries": [
-										"If you use a prosthetic limb (typically made out of wood or metal), there is no chance of rejection and the limb's Strength will be the same as the recipient's. If the limb was built to be fully articulated, then its Dexterity will be the same as the recipient's as well (a less well-designed limb will have a penalty to Dexterity\u2014and a {@i very} well-designed, and likely much more expensive, limb may grant as much as a +2 bonus). In addition, the recipient will retain its full sense of touch with the limb. Finally, a prosthetic limb can be built with attachments, hidden compartments, and the like. The limb's armor class depends on the material with which it was made."
-									]
-								}
-							]
-						}
-					]
-				}
-			],
-			"damageInflict": [
-				"necrotic"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b985f222f6eda4a0ea3e7fd97404489d"
-		},
-		{
-			"name": "Prismal's Pictograph",
-			"source": "NRCToS",
-			"page": 291,
-			"level": 7,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "an empty ink well, a feather pen, and a surface on which to write"
-			},
-			"duration": [
-				{
-					"type": "permanent"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You turn one creature or object in range that you can see into a full-color, two-dimensional image on the surface you have provided. The creature or object is reduced in size to anywhere from 2:1 scale to 12:1 scale; it must be able to fit on the surface in its reduced form for the spell to work. An unwilling creature may make a Charisma saving throw to avoid the effect.",
-				"You decide whether the creature is to remain animate (in which case, it counts as {@condition restrained}, although it still can move slowly about its canvas in a stilted manner), or if it to become a still picture. If you choose to allow it to remain animate, it can see and hear, but cannot speak, attack, or cast spells. If you choose for the creature to become a still picture, the creature is put in stasis. In both cases, the creature does not age, eat, drink, sleep, or breathe. Inanimate objects remain in the picture indefinitely.",
-				"A trapped creature may make a new saving throw each day at dawn. On a success, this effect ends and the creature is freed. A {@spell dispel magic}, {@spell remove curse}, or {@spell wish} spell can also end this effect."
-			],
-			"savingThrow": [
-				"charisma"
-			],
-			"miscTags": [
-				"SGT"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "28884cce276af30490b76b767a0971ed"
-		},
-		{
-			"name": "Instant Search",
-			"source": "NRCToS",
-			"page": 227,
-			"level": 1,
-			"school": "D",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "sphere",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Spell Compendium}",
-				"You can, in the space of a round, thoroughly search an area that would normally take many minutes or even hours to search properly. To do so, you must make a Wisdom ({@skill Perception}) skill check at advantage."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level or higher spell slot, the range of the spell increases by 30 feet per slot level above 1st."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Knowledge",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "d11e9f8bcfd80741f1e8aa904b9fdd92"
-		},
-		{
-			"name": "Intensify Sensation",
-			"source": "NRCToS",
-			"page": 227,
-			"level": 2,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You touch a creature and cause all physical and emotional sensations its experiences to become unbelievable powerful. A creature under the influence of this spell is {@condition incapacitated} for the duration. An unwilling target may make a Constitution saving throw to resist.",
-				"Spells designed to create an emotion or physical sensation (such as {@spell crushing despair|nrctos} (q.v.) or many of the effects of {@spell symbol}) have their duration doubled and the creature saves against them at disadvantage. This does not affect spells that merely inflict damage; the spell needs to create a sensation."
-			],
-			"conditionInflict": [
-				"incapacitated"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "7fa8749f6b5f9e4ef463366d94df6a46"
-		},
-		{
-			"name": "Interrogation",
-			"source": "NRCToS",
-			"page": 227,
-			"level": 1,
-			"school": "V",
-			"time": [
-				{
-					"number": 1,
-					"unit": "round"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You cast this spell on a creature you are questioning. If the target refuses to answer your question to your satisfaction, you may speak a word or touch the target and it suffers terrible pain and takes {@damage 1d10} psychic damage. The spell doesn't force the target to be truthful. If you ask the target a nonsensical question or if it fails to understand the question, it takes no damage and suffers no pain. You may ask one question per round.",
-				"If this damage would cause your target to have 0 hit points, it instead drops to 1 hit point and falls {@condition unconscious}."
-			],
-			"damageInflict": [
-				"psychic"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Paladin",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Vengeance",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "1abe98ba93c607c673235f906447cabf"
-		},
-		{
-			"name": "Intoxicate",
-			"source": "NRCToS",
-			"page": 227,
-			"level": 2,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 90
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a few drops of an alcoholic drink"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One creature you see within range must make a Constitution saving throw or become drunk. If the creature is currently sober or mildly tipsy, it becomes drunk. A drunk creature suffers from disadvantage on all Dexterity- and Intelligence-based attack rolls, saving throws, and ability checks, and its speed is reduced by 5 feet. In addition, it must make a concentration saving throw each time it attempts to cast a spell.",
-				"If the creature is currently drunk, it must make a second saving throw. On a success, the creature is also {@condition poisoned} for the duration and its speed is reduced by half. On a failure, the creature falls {@condition unconscious} for the duration."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 4th-level or higher spell slot, the duration becomes Concentration, up to 1 hour. When you cast it with a 6th-level or higher spell slot, the duration becomes 8 hours, without the need for concentration. When you cast it with an 8th-level or higher spell slot, the duration becomes 1 month."
-					]
-				}
-			],
-			"conditionInflict": [
-				"poisoned"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "359e70ced4b445402d94c72d1a6ac2c2"
-		},
-		{
-			"name": "Inaudibility",
-			"source": "NRCToS",
-			"page": 224,
-			"level": 1,
-			"school": "I",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"s": true,
-				"m": "a small wad of cotton"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 10
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"One creature you touch becomes silenced; all sounds made by that creature are completely muted. While this spell is in effect, the creature cannot speak or cast spells with verbal components. Objects that the target is carrying are also silenced, but anything thrown, dropped, or bumped into will still make noise. The target can still hear and this spell provides no protection against thunder damage or other effects that require hearing to work. If the target is unwilling, it may make a Wisdom saving throw to resist."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "702675e0544982aa602299a84e06a904"
-		},
-		{
-			"name": "Crushing Despair",
-			"source": "NRCToS",
-			"page": 131,
-			"level": 4,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "cone",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via {@dice d20}srd.org)",
-				"Each creature in a 30-foot cone must succeed on a Wisdom saving throw or lapse into despondent depression as they realize the hopelessness and folly of their beliefs.",
-				"An affected creature has disadvantage on all rolls. It may make a new saving throw at the start of each of its turns, but at disadvantage, ending the effect on a success. This spell counters and dispels {@spell good hope|nrctos}."
-			],
-			"savingThrow": [
-				"wisdom"
-			],
-			"areaTags": [
-				"N"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "5e7700ad66a6aed636b76d30a5154313"
-		},
-		{
-			"name": "Good Hope",
-			"source": "NRCToS",
-			"page": 203,
-			"level": 3,
-			"school": "E",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "round",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via {@dice d20}srd.org)",
-				"You fill up to 6 willing targets with cheer and powerful feelings of hope. Each creature gains advantage on all rolls until the end of its next turn. This spell counters and dispels {@spell crushing despair|nrctos}."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Paladin",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "Devotion",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "069cef1dc86f2b991cdac418235e6c96"
-		},
-		{
-			"name": "Weapon of the Earth",
-			"source": "NRCToS",
-			"page": 364,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a chink of iron ore"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Priest's Spell Compendium}",
-				"You pick up a chunk of rock or a handful of sand or soil and transform it into a melee weapon of your choice. It acts as a normal weapon but is immune to spells and effects that target metal."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Druid",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "3853efa73cb99b76fdd99f51711b6afd"
-		},
-		{
-			"name": "Weapon Return",
-			"source": "NRCToS",
-			"page": 364,
-			"level": 3,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You touch a throwing weapon; you may use this weapon or give it to someone else to use. When it is thrown, it will instantly return to the thrower's hand and can be used again the following round."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Ranger",
-						"source": "PHB"
-					},
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				],
-				"fromSubclass": [
-					{
-						"class": {
-							"name": "Cleric",
-							"source": "PHB"
-						},
-						"subclass": {
-							"name": "War",
-							"source": "PHB"
-						}
-					}
-				]
-			},
-			"uniqueId": "60a2d31b6a8345ec789e52d5d36cda0f"
-		},
-		{
-			"name": "Web Bolt",
-			"source": "NRCToS",
-			"page": 364,
-			"level": 1,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 30
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} Pathfinder (via d20pfsrd.com)",
-				"You hurl a ball of grayish light at a target or object within range. Make a ranged spell attack. On a hit, the light explodes into sticky webbing and the target is {@condition grappled} and {@condition restrained} (escape DC equal to your spell save DC). The target may attempt to escape at the beginning of each of its turns. After 1 minute or when you stop concentrating, the web dissolves on its own.",
-				"The webbing has AC 12 and 10 hit points. It is immune to bludgeoning, poison, and psychic damage but takes double damage from fire. If burned, the target that is encased in the webbing takes the same amount of fire damage."
-			],
-			"conditionInflict": [
-				"grappled",
-				"restrained"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "82789f55b146ef1a45c54f3c42ff745d"
-		},
-		{
-			"name": "Web of Shadows",
-			"source": "NRCToS",
-			"page": 364,
-			"level": 6,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 100
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a piece of spider web"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "hour",
-						"amount": 12
-					}
-				}
-			],
-			"entries": [
-				"{@b Converted from:} {@i Wizard's Spell Compendium}",
-				"You fill an area of 40 cubic feet with shadow-grey, semi-intangible strands of magical force that resembles a giant spider web. The webbing is almost {@condition invisible}; it requires a DC 15 {@skill Investigation} check to find them.",
-				"The webbing is an object with AC 15 and 30 hit points. It is immune to all nonmagical attacks but takes double damage from magical fire. Any creature who enters the web has its movement slowed to 10 feet. Each round a creature ends its turn in the webbing, the creature must make a Constitution saving throw. The creature takes {@damage 3d10} cold damage on a failed saving throw and has its Strength reduced by 1; the creature takes half as much damage on a successful check and does not lose Strength. Lost Strength returns after the creature takes a long rest."
-			],
-			"damageInflict": [
-				"cold"
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "adc62e1ecad47407d44f4dd9e7a08195"
-		},
-		{
-			"name": "Shut Up",
-			"source": "NRCToS",
-			"page": 322,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 60
-				}
-			},
-			"components": {
-				"v": true,
-				"m": "a bandage"
-			},
-			"duration": [
-				{
-					"type": "timed",
-					"duration": {
-						"type": "minute",
-						"amount": 1
-					},
-					"concentration": true
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You cause the mouth of one creature in range to disappear; the creature may make a Constitution saving throw to resist. While this spell is in effect, the creature cannot speak, eat, or drink."
-			],
-			"entriesHigherLevel": [
-				{
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 2nd-level spell slot, the duration becomes Concentration, up to 10 minutes. When you use a 3rd-level spell slot, the duration becomes Concentration, up to 1 hour. When you use a 4th-level or higher spell slot, the duration becomes 8 hours, with no need for concentration."
-					]
-				}
-			],
-			"savingThrow": [
-				"constitution"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "88005dde5495308ecf503b1e73296a05"
-		},
-		{
-			"name": "Shrapnel Shot",
-			"source": "NRCToS",
-			"page": 322,
-			"level": 1,
-			"school": "C",
-			"time": [
-				{
-					"number": 1,
-					"unit": "action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 120
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": "a small stone"
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You fire shards of stone shrapnel at one target within range. Make a ranged spell attack to hit. On a success, the target takes {@damage 2d10} piercing damage."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a spell slot of 2nd level or higher, you inflict an additional {@damage 1d10} piercing damage for each slot level above 1st."
-					]
-				}
-			],
-			"damageInflict": [
-				"piercing"
-			],
-			"spellAttack": [
-				"R"
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "b619658803f86314fa19bfe5667dedc1"
-		},
-		{
-			"name": "Snapshot",
-			"source": "NRCToS",
-			"page": 328,
-			"level": 1,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "bonus action"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "touch"
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true,
-				"m": {
-					"text": "a sheet of high-quality paper worth at least 5 sp",
-					"cost": 50
-				}
-			},
-			"duration": [
-				{
-					"type": "instant"
-				}
-			],
-			"meta": {
-				"ritual": true
-			},
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You cause whatever you see to appear on a sheet of paper you are holding. If you are currently using a spell such as detect magic which allows you to see auras of one type or another, this spell will record those auras as well.",
-				"The image appears to be drawn in a currently popular artistic style."
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Bard",
-						"source": "PHB"
-					},
-					{
-						"name": "Cleric",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "dfafe5fb9a770a9df05839ad0ec3eb68"
-		},
-		{
-			"name": "Stash",
-			"source": "NRCToS",
-			"page": 335,
-			"level": 8,
-			"school": "T",
-			"time": [
-				{
-					"number": 1,
-					"unit": "hour"
-				}
-			],
-			"range": {
-				"type": "point",
-				"distance": {
-					"type": "feet",
-					"amount": 1000
-				}
-			},
-			"components": {
-				"v": true,
-				"s": true
-			},
-			"duration": [
-				{
-					"type": "permanent",
-					"ends": [
-						"dispel"
-					]
-				}
-			],
-			"entries": [
-				"{@b Converted from:} The Great Net Spellbook",
-				"You can place one or more objects or willing creatures weighing 1 ton or less into a pocket demiplane. This demiplane is outside time, so anything in it is effectively in stasis. The objects will remain in the demiplane indefinitely until you recall them, which ends the spell. You may not add or remove anything from the stash without recalling the entire stash and ending the spell."
-			],
-			"entriesHigherLevel": [
-				{
-					"type": "entries",
-					"name": "At Higher Levels",
-					"entries": [
-						"When you cast this spell with a 9th-level spell slot, you may place up to 10 tons of objects or creatures in the demiplane."
-					]
-				}
-			],
-			"classes": {
-				"fromClassList": [
-					{
-						"name": "Sorcerer",
-						"source": "PHB"
-					},
-					{
-						"name": "Warlock",
-						"source": "PHB"
-					},
-					{
-						"name": "Wizard",
-						"source": "PHB"
-					}
-				]
-			},
-			"uniqueId": "ef59d396dc4e3957b49532c96167e5ae"
-		}
-	]
+    },
+    {
+      "name": "Unnatural Lust",
+      "source": "NRCToS",
+      "page": 354,
+      "level": 2,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "One creature you choose that you can see within range must make a Wisdom saving throw. On a failure, it is {@condition charmed} by you and becomes incredibly enamored of another creature or object that you designate as you cast the spell. It will seek to possess the object at any cost, although it will not take actions that would violate its alignment. Once each minute, the creature may make another saving throw, ending the effect on a success. At the end of the spell, the creature knows it was {@condition charmed}, although not by whom."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "areaTags": [
+        "ST"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "d212865e7370bfc2ea1e730cd4b0ff77"
+    },
+    {
+      "name": "Undead Torch",
+      "source": "NRCToS",
+      "page": 354,
+      "level": 3,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a firefly"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You cause up to six corporeal undead to burst into sickly blue flames. The undead must be either willing or controlled by you. The flames do not harm the undead, but instead allow them to inflict an additional {@damage 2d6} fire damage with each of their physical attacks. These flames shed dim light in a 10-foot radius."
+      ],
+      "damageInflict": [
+        "fire"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Death",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "38fb4912d5858ff78ef427f904673579"
+    },
+    {
+      "name": "Urlic's Unwholesome Meal",
+      "source": "NRCToS",
+      "page": 355,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of gold dust"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Prayerbook",
+        "You cause bad food to appear and taste wonderful. If the food is rotten or poisoned, then any damage the taint would normally inflict only occurs {@dice 2d4} hours later. Magical attempts to discern poisoning or spoilage using spells of 3rd level or lower will reveal nothing. If a spell is cast on the food to purify it, that spellcaster must make a spellcasting ability check, with a DC equal to your spell save DC, to successfully purify the food. Regardless of the outcome, that caster will believe it has succeeded.",
+        "The spell may also be cast on purely illusory food, making it appear in all respects to be a complete, filling, and real meal. A creature who eats the food will feel as if it has actually eaten and won't be hungry again for the normal length of time. However, the eater has consumed no food. If the creature eats nothing but illusory food treated with this spell, it will begin to suffer the effects of {@book starvation|phb|8|food and water|0} (as per the {@i Player's Handbook}, {@book page 185|phb|8|food and water|0}). Thus, it is entirely possible to use this spell to make a creature think it is eating well while in reality it is starving to death."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "dfa60976b3b9e4fc45bdd94dc57d2ee0"
+    },
+    {
+      "name": "Cheat",
+      "source": "NRCToS",
+      "page": 113,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        },
+        {
+          "number": 1,
+          "unit": "reaction",
+          "condition": "taken when you are about to take your turn at a game"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pair of dice made from human bones"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You may subtly alter the hands of fate during games of chance. While using a {@filter gaming set|items|type=gaming set}, you may choose one player (who may be yourself) to make one roll at advantage or you may choose one player to make one roll at disadvantage. This spell can only be used with games that rely at least somewhat on chance; games that rely entirely on skill, such as dragonchess, cannot be affected by this spell."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "bf61a679c0adc4bc83743d766275ec58"
+    },
+    {
+      "name": "Chill",
+      "source": "NRCToS",
+      "page": 113,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One living creature you see within range must make a Constitution saving throw or be chilled and have disadvantage on all Dexterity-based rolls until the end of its next turn. A creature that is resistant or immune to cold damage is unaffected by this spell."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "4fcbea520ea5f4ff4ced4cbf7bb23664"
+    },
+    {
+      "name": "Body Temperature",
+      "source": "NRCToS",
+      "page": 101,
+      "level": 2,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a small flame, such as a lit candle"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One cold-blooded creature you touch gains warmth in its body, as if it was a living, warm-blooded creature. This has two main functions:",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Warmth",
+                  "entries": [
+                    "You provide warmth and energy to a cold-blooded creature. This will prevent a reptile from going into torpor. It can also be cast on an undead creature, giving it a near-living body temperature and some color to its skin rather than just the pallor of death, and will even cause its heart to beat, thus allowing the undead to better masquerade as living beings."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Chill",
+                  "entries": [
+                    "The second use of this spell causes one warm-blooded creature is made to appear to have the same body temperature as its surroundings, making it {@condition invisible} to creatures and spells that seek heat and unpalatable to creatures that feed on heat. This also mutes that creature's heartbeat, allowing it to appear dead (or undead), even on close inspection."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "1202ba0cbb9408052da29abced1b5e23"
+    },
+    {
+      "name": "Longevity",
+      "source": "NRCToS",
+      "page": 251,
+      "level": 8,
+      "school": "N",
+      "time": [
+        {
+          "number": 24,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "rare fruits worth at least 500 gp, which you burn during the course of the casting",
+          "cost": 50000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You stop aging for a number of years equal to {@dice 4d6} + twice your spellcasting ability modifier. The first casting of this spell causes no problems, but each subsequent time you cast this spell, you must make a DC 13 Constitution saving throw. If you fail, you instantly age to death. Otherwise, the spell works normally."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "ced6dbe17c653ebd7a53296b61e12dce"
+    },
+    {
+      "name": "Litany of Debasement",
+      "source": "NRCToS",
+      "page": 249,
+      "level": 2,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "bonus"
+        },
+        {
+          "number": 1,
+          "unit": "reaction",
+          "condition": "taken when you are attacked or about to attack a target"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You speak a quick prayer and a wave of holy energy washes over one target within range. One of the following affects your target until the end of its next turn, unless it succeeds at a Wisdom saving throw.",
+        {
+          "type": "list",
+          "items": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Entanglement",
+                      "entries": [
+                        "You create a chain of energy to lash upwards from the ground to impede your target, causing it to be {@condition restrained} and is {@condition paralyzed} until the end of its next turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Madness",
+                      "entries": [
+                        "Your prayer is filled with bizarre word salad and eldritch phrases, causing much confusion in your target. Your target cannot take actions or reactions and is {@condition paralyzed} until the end of its next turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Sloth",
+                      "entries": [
+                        "You speak about the sin of indolence and cause your target to being sluggish. It can use either an action or bonus action but not both and can't make more than one action during its turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Thunder",
+                      "entries": [
+                        "You shout your prayer, causing your target to be {@condition deafened} and {@condition stunned} and is {@condition paralyzed} until the end of its next turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Vengeance",
+                      "entries": [
+                        "You speak words of chastisement and your target feels pain more sharply. All creatures who attack the target until the end of the next round inflict an additional {@damage 1d4} force damage."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Weakness",
+                      "entries": [
+                        "You proclaim your target is weak and cause it to suffer {@dice 1d4} levels of {@condition exhaustion} until the end of its next turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "deafened",
+        "exhaustion",
+        "paralyzed",
+        "restrained",
+        "stunned"
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "257d22b256e4c325b167748e23995f6b"
+    },
+    {
+      "name": "Litany of Grace",
+      "source": "NRCToS",
+      "page": 250,
+      "level": 2,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "bonus"
+        },
+        {
+          "number": 1,
+          "unit": "reaction",
+          "condition": "taken when you are attacked or about to attack a target"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You speak a quick prayer and a wave of holy energy washes over you or one ally within range. Until the end of your next turn, you receive one of the following affects:",
+        {
+          "type": "list",
+          "items": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Defense",
+                      "entries": [
+                        "With this prayer of protection, you gain +2 to your armor class and are immune to being {@condition charmed} or {@condition frightened}."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Eloquence",
+                      "entries": [
+                        "This prayer is so fascinating to listen to, one target within 10 feet of you is {@condition stunned} and is {@condition paralyzed} until the end of its next turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Escape",
+                      "entries": [
+                        "If you are {@condition grappled} or {@condition restrained}, you may use a bonus action to make another escape attempt, this time at advantage."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Righteousness",
+                      "entries": [
+                        "You imbue your weapon with holy right as you attack a foe. If you hit and the creature is evil, it takes +2 damage and is {@condition paralyzed} until the end of its next turn."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "entries": [
+                    {
+                      "type": "entries",
+                      "name": "Litany of Warding",
+                      "entries": [
+                        "You become more aware of your opponents. You gain +2 to your armor class against sneak attacks and can parry one attack. Roll a {@dice d8} and subtract that number from the damage caused by one melee attack made against you."
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "charmed",
+        "frightened",
+        "grappled",
+        "paralyzed",
+        "restrained",
+        "stunned"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Devotion",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "5b9011a9813b6348ef5ca6df90d318ed"
+    },
+    {
+      "name": "Kiss of Awakening",
+      "source": "NRCToS",
+      "page": 235,
+      "level": 2,
+      "school": "A",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One sleeping or {@condition unconscious} creature you kiss instantly wakes up. If you kiss a creature that is sleeping due to a spell (including the slumber variant of the imprisonment spell), this kiss will automatically wake up that creature if the spell is of 2nd level or lower. For a spell of 3rd level or higher, make an ability check using your spellcasting ability. The DC equals 10 + the spell's level. On a successful check, the effect ends and the creature wakes up. You may only try once per magically-{@condition unconscious} creature."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level or higher spell slot, you automatically wake a creature up who is under the effect of spell if the spell's level is equal to or less than the level of the spell slot you used."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Life",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "75bd3dd7fc506988c6d62ab7d344d551"
+    },
+    {
+      "name": "Kiss of Death",
+      "source": "NRCToS",
+      "page": 236,
+      "level": 9,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Once creature you kiss will die instantly, if it has 100 or fewer hit points. You must be able to kiss the target's skin (although you do not need to kiss its lips). The creature must be willing to be kissed, {@condition restrained}, or unaware. If the creature is in combat, you must make a melee spell attack roll to succeed."
+      ],
+      "spellAttack": [
+        "M"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "e834050d3fededf8c52918784a39cc06"
+    },
+    {
+      "name": "Kiss of Intoxication",
+      "source": "NRCToS",
+      "page": 236,
+      "level": 1,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One creature you kiss becomes completely drunk, unless it succeeds on a Constitution saving throw. A drunk creature suffers from disadvantage on all Dexterity- and Intelligence-based attack rolls, saving throws, and ability checks, and its speed is reduced by 5 feet. In addition, it must make a concentration saving throw each time it attempts to cast a spell.",
+        "If the creature was already drunk when you cast the spell, on a successful saving throw, the creature is also {@condition poisoned} for the duration and its speed is reduced by half. On a failed saving throw, it falls {@condition unconscious} for the duration.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
+      ],
+      "conditionInflict": [
+        "poisoned"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Archfey",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "9097bd752d0f7563a8b752ba2387918f"
+    },
+    {
+      "name": "Kiss of Slavery",
+      "source": "NRCToS",
+      "page": 236,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One creature you kiss becomes {@condition charmed} by you, unless it succeeds on a Wisdom saving throw. You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware.",
+        "If it fails the saving throw, it is {@condition charmed} by you until the spell ends or until you do anything harmful to it. The {@condition charmed} creature regards you as a trusted friend to be heeded and protected."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 5th-level spell slot, the duration increases to 12 hours. If you cast it with a 7th-level spell slot, the duration increases to 24 hours."
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "charmed"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Oathbreaker",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "4c14d2a633eb2bfab2a0d3a92c00f0e1"
+    },
+    {
+      "name": "Kiss of Sleep",
+      "source": "NRCToS",
+      "page": 237,
+      "level": 5,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One creature you kiss falls {@condition unconscious}, unless it succeeds on a Wisdom saving throw. You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware.",
+        "Slapping the target hard will awaken it, as will any amount of damage taken, but normal noise or gentle shaking will not. Awakening is slow. For one minute after the creature wakes up, it cannot take reactions and can use either an action or bonus action on each of its turns, but not both.",
+        "This sleep does not count as either a short or long rest."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 6th-level spell slot, the duration becomes 24 hours. When you cast it with a 7th-level spell slot, the duration becomes 1 week. When you cast it with an 8th-level or higher spell slot, the duration becomes one year, and merely slapping the target will not awaken it; damage must be inflicted."
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "unconscious"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "176517ca580b93c9873a5528057fe31c"
+    },
+    {
+      "name": "Kiss of the Nereid",
+      "source": "NRCToS",
+      "page": 237,
+      "level": 7,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One creature you kiss must succeed on a Constitution saving throw. On a failure, the creature's lungs fill with seawater and it begins to suffocate, as per the {@book suffocation|phb|8|suffocating|0} rules in the {@i Player's Handbook} (page 183). After 10 minutes, the water vanishes from the target's lungs. This spell is countered by {@spell water breathing}, and does not affect creatures that can breathe water or that do not need to breathe.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "17bdd7dc7dec068073db85a147f5200d"
+    },
+    {
+      "name": "Kiss of the Toad",
+      "source": "NRCToS",
+      "page": 237,
+      "level": 2,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Oriental Adventures}",
+        "Your lips become poisonous, and one creature you kiss takes {@damage 4d8} poison damage and must make a Constitution saving throw, becoming {@condition poisoned} for 1 hour on a failure.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 3rd-level or higher spell slot, you inflict an additional {@scaledice 4d8|2-9|1d8} poison damage per slot level above 2nd."
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "poisoned"
+      ],
+      "damageInflict": [
+        "poison"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Oathbreaker",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "a6a6cd2c0cc7ffc2b2eac060d195550d"
+    },
+    {
+      "name": "Kiss of Torment",
+      "source": "NRCToS",
+      "page": 238,
+      "level": 4,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "Your kiss inflicts your target with madness and pain, and one creature you kiss takes {@damage 5d10} psychic damage and must succeed on a Constitution saving throw or become so wracked with pain that it is {@condition incapacitated} for the duration. It may make a new saving throw at the end of each of its turns, ending that effect on a success. However, each round that the creature remains {@condition incapacitated}, it takes an additional {@damage 1d10} psychic damage.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
+      ],
+      "conditionInflict": [
+        "incapacitated"
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Fiend",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "5e3069c941f777ccf8e34991a704a296"
+    },
+    {
+      "name": "Kiss of Vampirism",
+      "source": "NRCToS",
+      "page": 238,
+      "level": 1,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Your kiss drains the life out of your target. You target takes {@damage 1d10} necrotic damage and you regain hit points equal to half the amount of necrotic damage dealt.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, your kiss causes an additional {@damage 1d10} necrotic damage for each slot level above 1st."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "miscTags": [
+        "HL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Undying",
+              "source": "SCAG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "68376d684edd554b2dbc7d233034d2b4"
+    },
+    {
+      "name": "Kiss of Weakness",
+      "source": "NRCToS",
+      "page": 238,
+      "level": 5,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Your kiss drains the vitality from the next target you kiss. Each round that you continue kissing your target, it must make a Constitution saving throw or have its Strength reduced by 2 points. When the spell ends, your target must make another Constitution saving throw or be {@condition stunned} for 10 minutes. Lost Strength points return after the creature takes a short or long rest.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware."
+      ],
+      "conditionInflict": [
+        "stunned"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Vengeance",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Oathbreaker",
+              "source": "DMG"
+            }
+          }
+        ]
+      },
+      "uniqueId": "49958385f2edd45616a98ac36783488f"
+    },
+    {
+      "name": "Kiss of Wounding",
+      "source": "NRCToS",
+      "page": 238,
+      "level": 0,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "Once creature you kiss must make a Constitution saving throw, taking {@damage 1d12} force damage on a failed saving throw or half as much damage on a successful one.",
+        "You must be able to kiss the target's skin (although you do not need to kiss its lips). If the creature is in combat, you must succeed at a melee spell attack to kiss it; if not in combat, the creature must be willing to be kissed, {@condition restrained}, or unaware.",
+        "You inflict additional damage with your kiss at 5th level ({@dice 2d12}), 11th level ({@dice 3d12}) and 17th level ({@dice 4d12})"
+      ],
+      "damageInflict": [
+        "force"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "fcda1b2b8a1b537a7512ec70aa29f687"
+    },
+    {
+      "name": "Curse of Lycanthropy",
+      "source": "NRCToS",
+      "page": 132,
+      "level": 6,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a drop of blood from a true lycanthrope and a silver medallion worth 100 gp",
+          "cost": 10000
+        }
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You touch a humanoid and infect it with {@variantrule Player Characters as Lycanthropes|mm|lycanthropy}. The target may make a Constitution saving throw to avoid this spell. The exact species of lycanthrope depends on the nature and temperament of your target; you have no control over it.",
+        "If your target fails its saving throw, then it will transform into a lycanthrope on each of the three nights of the next full moon and on all subsequent full moons.",
+        "If your target does not kill any living creatures that have an Intelligence of 5 or greater during that time, then on the morning after the third day it may make a new saving throw. If it does kill an intelligent creature, it may attempt the saving throw at disadvantage.",
+        "This spell continues until the target succeeds at three saving throws. Those successes do not need to be consecutive. If the target instead fails at three saving throws, the curse is permanent.",
+        "Casting {@spell remove curse} on the target allows it to make its next saving throw at advantage but does not automatically restore the target. Other forms of lycanthropy cures work as well as they normally do."
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "1bb5baa10df7c9b158325ef0de12bd00"
+    },
+    {
+      "name": "Curse of Undeath",
+      "source": "NRCToS",
+      "page": 132,
+      "level": 6,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 90
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a pinch of bone from an undead creature"
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You curse a creature so that, when it eventually dies, it will rise up again {@dice 1d4} hours later as an undead. As an undead, it will have a CR no higher than what the creature had when alive.",
+        "In addition, upon rising, it is permanently under your control (assuming you are still alive and able to assume control).",
+        "If your target dies and the {@spell gentle repose} spell is cast upon the corpse, the caster of that spell must make saving throw using its spellcasting ability in order to successfully prevent your curse from activating. A {@spell remove curse} spell can also end the curse."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "0217125a7c4efcd0967bd3c974c3d3e8"
+    },
+    {
+      "name": "Rising Colossus",
+      "source": "NRCToS",
+      "page": 302,
+      "level": 9,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 200
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a ball of clay and a bit of string, wire, or natural fiber"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "The head, torso, and arms of a truly enormous, vaguely humanoid-looking {@creature construct|nrctos} rises from the ground. It is easily 50 feet tall, completely hairless, lacks all facial features save a mouth, and is made of the same substance of the ground from which it rose.",
+        "The creature is under your command. Roll initiative for it, as it has its own turns. It obeys any verbal or mental commands that you issue to it (no action required by you) as long as you remain with 300 feet of it. If you don't issue any commands to it, it continues to follow your last command.",
+        {
+          "type": "dataCreature",
+          "dataCreature": {
+            "name": "Colossus",
+            "shortName": "colossus",
+            "source": "NRCToS",
+            "page": 303,
+            "size": "G",
+            "type": "construct",
+            "alignment": [
+              "U"
+            ],
+            "ac": [
+              {
+                "ac": 18,
+                "from": [
+                  "natural armor"
+                ]
+              }
+            ],
+            "hp": {
+              "formula": "{@dice 20d20 + 100}",
+              "average": 310
+            },
+            "speed": {
+              "walk": 0
+            },
+            "str": 28,
+            "dex": 8,
+            "con": 20,
+            "int": 1,
+            "wis": 5,
+            "cha": 1,
+            "senses": [
+              "truesight (blind beyond this radius) 120 ft."
+            ],
+            "passive": 7,
+            "resist": [
+              {
+                "resist": [
+                  "bludgeoning",
+                  "piercing",
+                  "slashing"
+                ],
+                "note": "from nonmagical weapons"
+              }
+            ],
+            "conditionImmune": [
+              "{@condition blinded}",
+              "{@condition charmed}",
+              "{@condition deafened}",
+              "{@condition exhaustion}",
+              "{@condition frightened}",
+              "{@condition petrified}",
+              "{@condition poisoned}",
+              "{@condition prone}",
+              "{@condition stunned}",
+              "{@condition unconscious}"
+            ],
+            "cr": "18",
+            "trait": [
+              {
+                "name": "Immutable Form",
+                "entries": [
+                  "The colossus is immune to any spell or effect that would alter its form."
+                ]
+              },
+              {
+                "name": "Siege Monster",
+                "entries": [
+                  "The colossus deals double damage to objects and structures."
+                ]
+              },
+              {
+                "name": "Magic Resistance",
+                "entries": [
+                  "The colossus has advantage on saving throws against spells and other magical effects."
+                ]
+              }
+            ],
+            "action": [
+              {
+                "name": "Slam",
+                "entries": [
+                  "{@atk mw} {@hit 15} to hit, reach 20 ft., one target. {@h}48 ({@damage 6d12 + 9}) bludgeoning damage."
+                ]
+              }
+            ],
+            "traitTags": [
+              "Immutable Form",
+              "Magic Resistance",
+              "Siege Monster"
+            ],
+            "senseTags": [
+              "U"
+            ],
+            "damageTags": [
+              "B"
+            ],
+            "miscTags": [
+              "MW",
+              "RCH"
+            ]
+          }
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "217ab8aa31c5a7ee563b92fa380d3df3"
+    },
+    {
+      "name": "Naked Fury",
+      "source": "NRCToS",
+      "page": 269,
+      "level": 9,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "radius",
+        "distance": {
+          "type": "miles",
+          "amount": 20
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a pound of salt, the ashes of a ghoul, and a 20,000 gp worth of gemstone dust",
+          "cost": 2000000
+        }
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "year",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "With an angry cry of pure wrath, you unleash your raw fury at the land around you.",
+        "You may use each of your actions to fire a bolt of noxious orange fire each round for up to 10 minutes at a target (for a total of 100 bolts) within range that you can see or simply at a piece of the landscape.",
+        "If you attack a creature, you must make a ranged spell attack to hit. On a hit, you inflict {@damage 4d8} fire damage and {@damage 4d8} poison damage. If you attack a structure or object, you inflict {@damage 4d8} fire damage and {@damage 4d8} bludgeoning damage. ",
+        "If you attack the land, the poisonous flames burst in a 10-foot-radius circle, setting all flammable objects not being worn or carried in that circle on fire. The fire will burn slowly and with a great deal of foul-smelling smoke for anywhere from one hour to one day, depending on how much flammable material there is in that area. The area becomes heavily obscured during this time.",
+        "This fire poisons the land. Plants that are destroyed by the fire will not regrow for at least one year. Any water that flows or stands in the area becomes toxic, as do any plants that manage to survive your onslaught. Any creature that drinks the poisoned water or eats any vegetation from the area must make a Constitution saving throw or become {@condition poisoned} for 24 hours. Likewise, any creature that sleeps in an affected area must make a Constitution saving throw or become {@condition poisoned} for 24 hours.",
+        "After one year, the toxic effects begin to fade and are completely gone after one week."
+      ],
+      "damageInflict": [
+        "bludgeoning",
+        "fire",
+        "poison"
+      ],
+      "conditionInflict": [
+        "poisoned"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "fed42b408ae6672da8b81ba7e551f627"
+    },
+    {
+      "name": "Prosthesis",
+      "source": "NRCToS",
+      "page": 293,
+      "level": 5,
+      "school": "N",
+      "time": [
+        {
+          "number": 10,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a potion of healing and a pot of glue"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium} and The Great Net Spellbook",
+        "You may graft the limb of one corporeal creature (the donor), or an artificial prosthetic limb, onto the stump of another willing creature (the recipient). The limb must be of the same type of body part; you can't graft a leg to the stump of an arm. The donor does not need to be a living creature: you may use the limb of a celestial, construct, elemental fiend, or undead creature as well.",
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Donated Limb",
+                  "entries": [
+                    "If you use the limb from another creature, that creature can be no more than one size category larger or smaller than the target. If the creature had a higher or lower Strength or Dexterity than the recipient, then the recipient's attributes with that limb increases or decreases by 1 point for every 4 full points difference between the donor and recipient. For instance, if a human with a Strength of 11 and Dexterity of 13 were to get an arm from an ogre with a Strength of 19 and Dexterity of 8, the human would have an effective Strength of 13 and Dexterity of 12 with that arm. If the limb is a leg from a creature with a walking speed of 15 feet or more higher or lower than the recipient's, then the recipient's walking speed increases or decreases by 5 feet.",
+                    "The appendage retains its original AC and keeps any physical melee weapon attacks. The damage remains the same but the Strength or Dexterity modifier may change. If the limb had an attack that caused the {@condition paralyzed} or {@condition poisoned} conditions, then it retains that ability. It does not retain any other special abilities (an arm taken from a red slaad, for instance, will not implant eggs). Likewise, the recipient does not gain any special abilities that the donor originally had.",
+                    "However, if the recipient receives a limb taken from a living creature, there is a chance of rejection. If the recipient and donor are of the same species or a closely-related species (such as a human and half-elf), then the recipient must make a DC 11 Constitution saving throw. If the recipient and donor are of the same creature type (such as humanoid) but otherwise very different species (such as human and kobold), the saving throw DC becomes 13. If the recipient and donor are of different creature types (such as human and ogre or wolf), the saving throw DC becomes 15. If the recipient fails its saving throw, then the spell fails as well, the graft fails, and the recipient takes {@damage 3d10} necrotic damage."
+                  ]
+                }
+              ]
+            }
+          ]
+        },
+        {
+          "type": "entries",
+          "entries": [
+            {
+              "type": "entries",
+              "entries": [
+                {
+                  "type": "entries",
+                  "name": "Artificial Limb",
+                  "entries": [
+                    "If you use a prosthetic limb (typically made out of wood or metal), there is no chance of rejection and the limb's Strength will be the same as the recipient's. If the limb was built to be fully articulated, then its Dexterity will be the same as the recipient's as well (a less well-designed limb will have a penalty to Dexterity\u2014and a {@i very} well-designed, and likely much more expensive, limb may grant as much as a +2 bonus). In addition, the recipient will retain its full sense of touch with the limb. Finally, a prosthetic limb can be built with attachments, hidden compartments, and the like. The limb's armor class depends on the material with which it was made."
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b985f222f6eda4a0ea3e7fd97404489d"
+    },
+    {
+      "name": "Prismal's Pictograph",
+      "source": "NRCToS",
+      "page": 291,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "an empty ink well, a feather pen, and a surface on which to write"
+      },
+      "duration": [
+        {
+          "type": "permanent"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You turn one creature or object in range that you can see into a full-color, two-dimensional image on the surface you have provided. The creature or object is reduced in size to anywhere from 2:1 scale to 12:1 scale; it must be able to fit on the surface in its reduced form for the spell to work. An unwilling creature may make a Charisma saving throw to avoid the effect.",
+        "You decide whether the creature is to remain animate (in which case, it counts as {@condition restrained}, although it still can move slowly about its canvas in a stilted manner), or if it to become a still picture. If you choose to allow it to remain animate, it can see and hear, but cannot speak, attack, or cast spells. If you choose for the creature to become a still picture, the creature is put in stasis. In both cases, the creature does not age, eat, drink, sleep, or breathe. Inanimate objects remain in the picture indefinitely.",
+        "A trapped creature may make a new saving throw each day at dawn. On a success, this effect ends and the creature is freed. A {@spell dispel magic}, {@spell remove curse}, or {@spell wish} spell can also end this effect."
+      ],
+      "savingThrow": [
+        "charisma"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "28884cce276af30490b76b767a0971ed"
+    },
+    {
+      "name": "Instant Search",
+      "source": "NRCToS",
+      "page": 227,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "sphere",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You can, in the space of a round, thoroughly search an area that would normally take many minutes or even hours to search properly. To do so, you must make a Wisdom ({@skill Perception}) skill check at advantage."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, the range of the spell increases by 30 feet per slot level above 1st."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Knowledge",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "d11e9f8bcfd80741f1e8aa904b9fdd92"
+    },
+    {
+      "name": "Intensify Sensation",
+      "source": "NRCToS",
+      "page": 227,
+      "level": 2,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You touch a creature and cause all physical and emotional sensations its experiences to become unbelievable powerful. A creature under the influence of this spell is {@condition incapacitated} for the duration. An unwilling target may make a Constitution saving throw to resist.",
+        "Spells designed to create an emotion or physical sensation (such as {@spell crushing despair|nrctos} (q.v.) or many of the effects of {@spell symbol}) have their duration doubled and the creature saves against them at disadvantage. This does not affect spells that merely inflict damage; the spell needs to create a sensation."
+      ],
+      "conditionInflict": [
+        "incapacitated"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "7fa8749f6b5f9e4ef463366d94df6a46"
+    },
+    {
+      "name": "Interrogation",
+      "source": "NRCToS",
+      "page": 227,
+      "level": 1,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You cast this spell on a creature you are questioning. If the target refuses to answer your question to your satisfaction, you may speak a word or touch the target and it suffers terrible pain and takes {@damage 1d10} psychic damage. The spell doesn't force the target to be truthful. If you ask the target a nonsensical question or if it fails to understand the question, it takes no damage and suffers no pain. You may ask one question per round.",
+        "If this damage would cause your target to have 0 hit points, it instead drops to 1 hit point and falls {@condition unconscious}."
+      ],
+      "damageInflict": [
+        "psychic"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Vengeance",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "1abe98ba93c607c673235f906447cabf"
+    },
+    {
+      "name": "Intoxicate",
+      "source": "NRCToS",
+      "page": 227,
+      "level": 2,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 90
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a few drops of an alcoholic drink"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One creature you see within range must make a Constitution saving throw or become drunk. If the creature is currently sober or mildly tipsy, it becomes drunk. A drunk creature suffers from disadvantage on all Dexterity- and Intelligence-based attack rolls, saving throws, and ability checks, and its speed is reduced by 5 feet. In addition, it must make a concentration saving throw each time it attempts to cast a spell.",
+        "If the creature is currently drunk, it must make a second saving throw. On a success, the creature is also {@condition poisoned} for the duration and its speed is reduced by half. On a failure, the creature falls {@condition unconscious} for the duration."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 4th-level or higher spell slot, the duration becomes Concentration, up to 1 hour. When you cast it with a 6th-level or higher spell slot, the duration becomes 8 hours, without the need for concentration. When you cast it with an 8th-level or higher spell slot, the duration becomes 1 month."
+          ]
+        }
+      ],
+      "conditionInflict": [
+        "poisoned"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "359e70ced4b445402d94c72d1a6ac2c2"
+    },
+    {
+      "name": "Inaudibility",
+      "source": "NRCToS",
+      "page": 224,
+      "level": 1,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "s": true,
+        "m": "a small wad of cotton"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 10
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "One creature you touch becomes silenced; all sounds made by that creature are completely muted. While this spell is in effect, the creature cannot speak or cast spells with verbal components. Objects that the target is carrying are also silenced, but anything thrown, dropped, or bumped into will still make noise. The target can still hear and this spell provides no protection against thunder damage or other effects that require hearing to work. If the target is unwilling, it may make a Wisdom saving throw to resist."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "702675e0544982aa602299a84e06a904"
+    },
+    {
+      "name": "Crushing Despair",
+      "source": "NRCToS",
+      "page": 131,
+      "level": 4,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "cone",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via {@dice d20}srd.org)",
+        "Each creature in a 30-foot cone must succeed on a Wisdom saving throw or lapse into despondent depression as they realize the hopelessness and folly of their beliefs.",
+        "An affected creature has disadvantage on all rolls. It may make a new saving throw at the start of each of its turns, but at disadvantage, ending the effect on a success. This spell counters and dispels {@spell good hope|nrctos}."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "areaTags": [
+        "N"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "5e7700ad66a6aed636b76d30a5154313"
+    },
+    {
+      "name": "Good Hope",
+      "source": "NRCToS",
+      "page": 203,
+      "level": 3,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "round",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via {@dice d20}srd.org)",
+        "You fill up to 6 willing targets with cheer and powerful feelings of hope. Each creature gains advantage on all rolls until the end of its next turn. This spell counters and dispels {@spell crushing despair|nrctos}."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Devotion",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "069cef1dc86f2b991cdac418235e6c96"
+    },
+    {
+      "name": "Weapon of the Earth",
+      "source": "NRCToS",
+      "page": 364,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a chink of iron ore"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You pick up a chunk of rock or a handful of sand or soil and transform it into a melee weapon of your choice. It acts as a normal weapon but is immune to spells and effects that target metal."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "3853efa73cb99b76fdd99f51711b6afd"
+    },
+    {
+      "name": "Weapon Return",
+      "source": "NRCToS",
+      "page": 364,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You touch a throwing weapon; you may use this weapon or give it to someone else to use. When it is thrown, it will instantly return to the thrower's hand and can be used again the following round."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "War",
+              "source": "PHB"
+            }
+          }
+        ]
+      },
+      "uniqueId": "60a2d31b6a8345ec789e52d5d36cda0f"
+    },
+    {
+      "name": "Web Bolt",
+      "source": "NRCToS",
+      "page": 364,
+      "level": 1,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You hurl a ball of grayish light at a target or object within range. Make a ranged spell attack. On a hit, the light explodes into sticky webbing and the target is {@condition grappled} and {@condition restrained} (escape DC equal to your spell save DC). The target may attempt to escape at the beginning of each of its turns. After 1 minute or when you stop concentrating, the web dissolves on its own.",
+        "The webbing has AC 12 and 10 hit points. It is immune to bludgeoning, poison, and psychic damage but takes double damage from fire. If burned, the target that is encased in the webbing takes the same amount of fire damage."
+      ],
+      "conditionInflict": [
+        "grappled",
+        "restrained"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "82789f55b146ef1a45c54f3c42ff745d"
+    },
+    {
+      "name": "Web of Shadows",
+      "source": "NRCToS",
+      "page": 364,
+      "level": 6,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 100
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of spider web"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 12
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You fill an area of 40 cubic feet with shadow-grey, semi-intangible strands of magical force that resembles a giant spider web. The webbing is almost {@condition invisible}; it requires a DC 15 {@skill Investigation} check to find them.",
+        "The webbing is an object with AC 15 and 30 hit points. It is immune to all nonmagical attacks but takes double damage from magical fire. Any creature who enters the web has its movement slowed to 10 feet. Each round a creature ends its turn in the webbing, the creature must make a Constitution saving throw. The creature takes {@damage 3d10} cold damage on a failed saving throw and has its Strength reduced by 1; the creature takes half as much damage on a successful check and does not lose Strength. Lost Strength returns after the creature takes a long rest."
+      ],
+      "damageInflict": [
+        "cold"
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "adc62e1ecad47407d44f4dd9e7a08195"
+    },
+    {
+      "name": "Shut Up",
+      "source": "NRCToS",
+      "page": 322,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "m": "a bandage"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause the mouth of one creature in range to disappear; the creature may make a Constitution saving throw to resist. While this spell is in effect, the creature cannot speak, eat, or drink."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level spell slot, the duration becomes Concentration, up to 10 minutes. When you use a 3rd-level spell slot, the duration becomes Concentration, up to 1 hour. When you use a 4th-level or higher spell slot, the duration becomes 8 hours, with no need for concentration."
+          ]
+        }
+      ],
+      "savingThrow": [
+        "constitution"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "88005dde5495308ecf503b1e73296a05"
+    },
+    {
+      "name": "Shrapnel Shot",
+      "source": "NRCToS",
+      "page": 322,
+      "level": 1,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 120
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a small stone"
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You fire shards of stone shrapnel at one target within range. Make a ranged spell attack to hit. On a success, the target takes {@damage 2d10} piercing damage."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a spell slot of 2nd level or higher, you inflict an additional {@scaledice 2d10|1-9|1d10} piercing damage for each slot level above 1st."
+          ]
+        }
+      ],
+      "damageInflict": [
+        "piercing"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "b619658803f86314fa19bfe5667dedc1"
+    },
+    {
+      "name": "Snapshot",
+      "source": "NRCToS",
+      "page": 328,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "bonus action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": {
+          "text": "a sheet of high-quality paper worth at least 5 sp",
+          "cost": 50
+        }
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause whatever you see to appear on a sheet of paper you are holding. If you are currently using a spell such as detect magic which allows you to see auras of one type or another, this spell will record those auras as well.",
+        "The image appears to be drawn in a currently popular artistic style."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "dfafe5fb9a770a9df05839ad0ec3eb68"
+    },
+    {
+      "name": "Stash",
+      "source": "NRCToS",
+      "page": 335,
+      "level": 8,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "hour"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 1000
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "permanent",
+          "ends": [
+            "dispel"
+          ]
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You can place one or more objects or willing creatures weighing 1 ton or less into a pocket demiplane. This demiplane is outside time, so anything in it is effectively in stasis. The objects will remain in the demiplane indefinitely until you recall them, which ends the spell. You may not add or remove anything from the stash without recalling the entire stash and ending the spell."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 9th-level spell slot, you may place up to 10 tons of objects or creatures in the demiplane."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "uniqueId": "ef59d396dc4e3957b49532c96167e5ae"
+    },
+    {
+      "name": "Sticks to Snakes",
+      "source": "NRCToS",
+      "page": 335,
+      "level": 4,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of snakeskin"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You transform {@dice 2d6} sticks or quarterstaves (or other wooden weapons) into serpents. Roll a die. On an even number, they turn into {@creature constrictor snake|mm|constrictor snakes}; on an odd number, they turn into {@creature poisonous snake|mm|poisonous snakes}.",
+        "Roll initiative for the snakes as a group, which has its own actions. They will obey any verbal commands that you issue to them (no action required by you). If you don't issue any commands to them, they defend themselves from hostile creatures but otherwise take no actions. At the end of the spell's duration, the snakes turn back into sticks.",
+        "The DM has the creature's statistics."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 7th-level or higher spell slot, the sticks turn into {@creature giant constrictor snake|mm|giant constrictor snakes} or {@creature giant poisonous snake|mm|giant poisonous snakes} instead."
+          ]
+        }
+      ],
+      "miscTags": [
+        "SCL",
+        "SMN"
+      ],
+      "areaTags": [
+        "MT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Stone Bridge",
+      "source": "NRCToS",
+      "page": 335,
+      "level": 4,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "round"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of knotted rope"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You cause a bridge of stone to grow out of the ground and end at a point you choose up to 100 feet away. If you so choose, the bridge may be angled up or down or have bends and curves. The resultant bridge is strong and sturdy, capable of holding up to 10 tons at a time. When the spell ends, the bridge will retreat back into the earth."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 5th-level or higher spell slot, the bridge may extend an additional 50 feet for each slot level above 4th."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Mountain"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Stone Spiders",
+      "source": "NRCToS",
+      "page": 335,
+      "level": 7,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Spell Compendium}",
+        "You transform three pebbles into tremendous stone spiders. These creatures have the same attributes as {@creature giant spider|mm|giant spiders}, save for the following: their type is construct, they have AC 17, resistance to bludgeoning, piercing, and slashing damage from nonmagical weapons, and their poison has a DC save equal to your spell save DC.",
+        "Roll initiative for the spiders as a group, which has its own turn. They obey any verbal commands that you issue to them (no action required by you). If you don't issue any commands to the spiders, they will continue to act as you had previously ordered it to."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "miscTags": [
+        "SMN"
+      ]
+    },
+    {
+      "name": "Lizard Limbs",
+      "source": "NRCToS",
+      "page": 250,
+      "level": 5,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You may shed up to two limbs (arms, legs, tail, wings) at will without suffering any damage or pain, although you do suffer all the effects of missing that limb ({@table Lingering Injuries|DMG|{@i Dungeon Master's Guide}, page 272}).",
+        "Shed limbs begin to grow again an hour after they were lost and will regenerate completely within 24 hours; if the lost limb is recovered, it can be reattached by holding it against the stump for 1 round."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Loathsome Veil",
+      "source": "NRCToS",
+      "page": 250,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a tangle of multicolored threads"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You create a curtain of ever-shifting, multicolored strands of light that twist and warp into strangely beautiful but also disturbingly alien patterns. You can make the wall up to 40 feet long and 20 feet high or a ringed wall up to 20 feet in diameter and 20 feet high. One side of the veil, chosen by you, is harmless. All creatures within 30 feet of the other side must make a Wisdom saving throw against poison. On a failed save, the creature is nauseated and spends its action retching and reeling. A creature may attempt a new saving throw at the end of each of its turns, ending the effect on a success."
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "areaTags": [
+        "Y",
+        "W"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Great Old One",
+              "source": "PHB"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Log to Lizard",
+      "source": "NRCToS",
+      "page": 251,
+      "level": 4,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 60
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a piece of reptilian skin"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You may transform a log or branch of at least 6 feet in length into a {@creature crocodile} ({@i Monster Manual}, page 320). Roll initiative for it, as it has its own actions. It will obey any verbal commands that you issue to it (no action required by you). If you don't issue any commands to it, it defends itself from hostile creatures but otherwise takes no actions. At the end of the spell's duration, it turns back into a log.",
+        "The DM has the creature's statistics."
+      ],
+      "entriesHigherLevel": [
+        {
+          "name": "At Higher Levels",
+          "entries": [
+            "If you cast this spell with a 6th-level or higher spell slot, it turns into a {@creature giant crocodile} (p. 324) instead."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          },
+          {
+            "name": "Druid",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Druid",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Land",
+              "source": "PHB",
+              "subSubclass": "Swamp"
+            }
+          }
+        ]
+      },
+      "miscTags": [
+        "SMN"
+      ],
+      "areaTags": [
+        "ST"
+      ]
+    },
+    {
+      "name": "Long Arm",
+      "source": "NRCToS",
+      "page": 251,
+      "level": 1,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} Pathfinder (via d20pfsrd.com)",
+        "You increase the length of one or both of your arms (and their reach) by 5 feet."
+      ],
+      "entriesHigherLevel": [
+        {
+          "type": "entries",
+          "name": "At Higher Levels",
+          "entries": [
+            "When you cast this spell with a 2nd-level or higher spell slot, you can increase your arms by an additional 5 feet for each slot level above 1st."
+          ]
+        }
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      },
+      "miscTags": [
+        "SCL"
+      ]
+    },
+    {
+      "name": "Lorloveim's Creeping Shadow",
+      "source": "NRCToS",
+      "page": 251,
+      "level": 3,
+      "school": "I",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a source of light and a small statuette of yourself made out of obsidian"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "conditionInflict": [
+        "blinded",
+        "deafened"
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "Your shadow elongates and stretches away from your body, moving under your mental command; when you cast this spell and as a bonus action on each subsequent turn, you can move your shadow up to 20 feet, to a maximum distance to 150 feet away from you.",
+        "You can use your action to shift your senses to your shadow; while doing so, you may speak through the shadow. While doing so, you are {@condition blinded} and {@condition deafened} as to your own surroundings.",
+        "Your shadow cannot be used to manipulate objects or attack, although you can cast spells through it, as long as those spells don’t require material components. Your shadow can be attacked with magical weapons and spells, although it has resistance to all forms of physical attack. It has your AC and any damage it takes is taken from your hit points.",
+        "You can also spend you action to move your shadow’s senses into the Shadowfell, although you still cannot affect other objects through it."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Lorth's Translocation",
+      "source": "NRCToS",
+      "page": 252,
+      "level": 9,
+      "school": "C",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You teleport yourself to one location that you can describe, even if you have never been there before, do not know what the location looks like, or don't even know for sure that the place exists. For instance, you can teleport yourself to \"10 feet in front of the royal thrones of Graygate\" or \"30 feet from the skeletal remains of an ancient red dragon.\"",
+        "If such a location exists, roll a {@dice d20}:",
+        {
+          "type": "table",
+          "colLabels": [
+            "{@dice d20}",
+            "Result"
+          ],
+          "colStyles": [
+            "col-1 text-center",
+            "col-11"
+          ],
+          "rows": [
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 1,
+                  "max": 3
+                }
+              },
+              "Mishap"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 4,
+                  "max": 6
+                }
+              },
+              "Similar area"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 7,
+                  "max": 11
+                }
+              },
+              "Off target"
+            ],
+            [
+              {
+                "type": "cell",
+                "roll": {
+                  "min": 12,
+                  "max": 20
+                }
+              },
+              "On target"
+            ]
+          ]
+        },
+        "If you have an object associated with the location (for instance, a bone, scale, or tooth of a red dragon, or an object that belonged to one of the rulers of Graygate), then you get +2 to this roll.",
+        "This spell does not guarantee safety. If \"30 feet to the north of the skeletal remains of an ancient red dragon\" would cause you to be teleported into thin air over a cliff face, then that is where you will be teleported.",
+        "If such a place does not exist, the spell fails."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Love Charm",
+      "source": "NRCToS",
+      "page": 252,
+      "level": 5,
+      "school": "E",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 30
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "something belonging to the spell's subject and target"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 12
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You attempt to beguile a target that you can see within range. That creature must make a Wisdom saving throw. If it fails, it is {@condition charmed} by you. The {@condition charmed} creature falls madly in love with you or with a target of your choice. It is not under your control, but will take your requests in the most favorable way and will attempt to protect you. If the target's saving throw is successful, the target is immune to this spell for 1 week.",
+        "The creature does not realize it was {@condition charmed} when the spell ends."
+      ],
+      "conditionInflict": [
+        "charmed"
+      ],
+      "savingThrow": [
+        "wisdom"
+      ],
+      "miscTags": [
+        "SGT"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Bard",
+            "source": "PHB"
+          },
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Trickery",
+              "source": "PHB"
+            }
+          },
+          {
+            "class": {
+              "name": "Warlock",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Archfey",
+              "source": "PHB"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Love's Pain",
+      "source": "NRCToS",
+      "page": 252,
+      "level": 3,
+      "school": "V",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "feet",
+          "amount": 100
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "instant"
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Book of Vile Darkness}",
+        "You fire a ray of green-black light at a target within range. Make a ranged spell attack. On a hit, then that creature suffers no harm. Instead, that creature's dearest friend or loved one takes {@damage 6d6} necrotic damage, no matter where that creature is (as long as it is on the same plane of existence as you). If the loved one is standing in an {@spell antimagic field}, it is immune. If the creature has no dear friends or loved ones, it takes the damage instead."
+      ],
+      "damageInflict": [
+        "necrotic"
+      ],
+      "spellAttack": [
+        "R"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Darsson's Cooling Breeze",
+      "source": "NRCToS",
+      "page": 144,
+      "level": 0,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 8
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "This produces a pleasant breeze that moves clockwise at approximately 4 miles per hour (roughly the speed of a ceiling fan). You may choose to place the effect on an object (including a willing target) or at a specific point in midair. This cantrip's primary function is its use as air conditioning."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Druid",
+            "source": "PHB"
+          },
+          {
+            "name": "Sorcerer",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ]
+      }
+    },
+    {
+      "name": "Darsson's Potion",
+      "source": "NRCToS",
+      "page": 144,
+      "level": 4,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "touch"
+        }
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a vial of pure water"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Wizard's Spell Compendium}",
+        "You cast this spell on a vial of water, and then immediately cast another spell on the vial. The second spell must be of {@filter 3rd level or lower and must have a range of Self or Touch|spells|level=0;1;2;3|range=self;touch}. Rather than take effect immediately, the second spell is absorbed into the water, creating a temporary \"potion.\" This potion lasts for 1 hour before going inert."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Cleric",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Arcana",
+              "source": "SCAG"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Deadly Feast",
+      "source": "NRCToS",
+      "page": 144,
+      "level": 5,
+      "school": "N",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "sphere",
+        "distance": {
+          "type": "feet",
+          "amount": 10
+        }
+      },
+      "components": {
+        "s": true,
+        "m": "a drop or pinch of poison"
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "hour",
+            "amount": 1
+          }
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} {@i Ravenloft: Legacy of Blood}",
+        "You poison all food and drink within range. Anyone who consumes it must make a saving throw or take {@damage 7d6} poison damage and be {@condition poisoned} for 1 hour. A creature takes half as much damage on a successful saving throw. This poison cannot be detected through use of the {@spell detect poison and disease} spell although it can be seen with {@spell detect magic}. After one hour, all traces of the poison vanish and surviving targets lose all but one level of {@condition exhaustion} and are no longer {@condition poisoned}, although they do not regain lost hit points."
+      ],
+      "damageInflict": [
+        "poison"
+      ],
+      "conditionInflict": [
+        "poisoned",
+        "exhaustion"
+      ],
+      "miscTags": [
+        "HL"
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Warlock",
+            "source": "PHB"
+          },
+          {
+            "name": "Wizard",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Oathbreaker",
+              "source": "DMG"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Deadly Strike",
+      "source": "NRCToS",
+      "page": 144,
+      "level": 3,
+      "school": "T",
+      "time": [
+        {
+          "number": 1,
+          "unit": "action"
+        }
+      ],
+      "range": {
+        "type": "point",
+        "distance": {
+          "type": "self"
+        }
+      },
+      "components": {
+        "s": true
+      },
+      "duration": [
+        {
+          "type": "timed",
+          "duration": {
+            "type": "minute",
+            "amount": 1
+          },
+          "concentration": true
+        }
+      ],
+      "entries": [
+        "{@b Converted from:} The Great Net Spellbook",
+        "You gain advantage with one specific weapon. In addition, on a successful hit, you roll twice as many damage dice as normal. You must be proficient with this weapon for the spell to work."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Paladin",
+            "source": "PHB"
+          },
+          {
+            "name": "Ranger",
+            "source": "PHB"
+          }
+        ],
+        "fromSubclass": [
+          {
+            "class": {
+              "name": "Paladin",
+              "source": "PHB"
+            },
+            "subclass": {
+              "name": "Crown",
+              "source": "SCAG"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "name": "Death Candle",
+      "source": "NRCToS",
+      "page": 144,
+      "level": 1,
+      "school": "D",
+      "time": [
+        {
+          "number": 1,
+          "unit": "minute"
+        }
+      ],
+      "range": {
+        "type": "special"
+      },
+      "components": {
+        "v": true,
+        "s": true,
+        "m": "a candle"
+      },
+      "duration": [
+        {
+          "type": "special"
+        }
+      ],
+      "meta": {
+        "ritual": true
+      },
+      "entries": [
+        "{@b Converted from:} {@i Priest's Spell Compendium}",
+        "You give a willing creature a candle; while casting this spell, that creature must light the candle.",
+        "From then on, the candle will burn continuously without using any fuel for as long as the creature that lit it is alive. If that creature is ever near death or contracts a fatal illness, the candle will gutter and dim, but it will only go out when that creature reaches 0 hit points. The candle cannot be extinguished except by magical means. If the creature reaches 0 hit points and is stabilized, or dies and brought back to life, it does not reignite the candle."
+      ],
+      "classes": {
+        "fromClassList": [
+          {
+            "name": "Cleric",
+            "source": "PHB"
+          }
+        ]
+      }
+    }
+  ]
 }


### PR DESCRIPTION
# Changelog
**Total spells converted:** 227/997
**Progress:** 22.77%

## Updates to Existing Content
- Shrapnel Shot: Fixes the @scaledice tag in the Higher Levels text

## Conversion Notes
- Sticks to Snakes: Fixed typo - Description, 2nd paragraph - "... which has its own actions" (removed extra "it")
- Stone Spider: Fixed typo - Description, 2nd paragraph - "... which has its own [turn]"
- Lizard Limbs: Linked to the "Lingering Injuries" table, so the information can be shown on hover
- Love's Pain: Description, first paragraph - Changed "If you do" to "On a hit" for clarity
- Death Candle: Fixed typo - added "a candle" to first paragraph