### PR TITLE
Fix list definition in Pugilist Heart of the City feature

### DIFF
--- a/class/Benjamin Huffman; Pugilist.json
+++ b/class/Benjamin Huffman; Pugilist.json
@@ -2429,7 +2429,7 @@
 				"Starting at 11th level, when you take a long rest in a settlement, you can choose to become familiar with the settlement. When you use this feature again, you replace your previous familiar settlement with the current one. You gain the following benefits while in a familiar settlement:",
 				{
 					"type": "list",
-					"entries": [
+					"items": [
 						"You cannot be surprised and you add your proficiency bonus to your initiative.",
 						"You have darkvision to a range of 120 feet.",
 						"When you make an ability check using the Insight, Investigation, or Perception skills that adds your proficiency bonus, add twice your proficiency bonus instead."


### PR DESCRIPTION
Currently the Pugilist Heart of the City feature does not render correctly in 5e.tools for me: the list of benefits is missing. I've manually imported this modified JSON and it appears to fix the issue.