### PR TITLE
Subtle Change: Titles of Resurrection Rules

### DIFF
--- a/collection/Matthew Mercer; TalDorei Campaign Guide.json
+++ b/collection/Matthew Mercer; TalDorei Campaign Guide.json
@@ -6491,7 +6491,7 @@
 			"page": 118
 		},
 		{
-			"name": "A Taxing Return",
+			"name": "Alternative Resurrection Rule: A Taxing Return",
 			"entries": [
 				"This rule calls to the old D&D rules where every time a character is restored to life, the process corrodes a fraction of their vitality, slowly consuming the body until it can no longer sustain life.",
 				"Each time a character is brought back to life via a spell or ritual, that character suffers a permanent loss of 1 point of their Constitution ability score. This loss cannot be restored outside of a carefully worded {@spell wish} spell. Use of the spell {@spell true resurrection} to restore a character does not impose this loss of Constitution. Characters that reach a Constitution ability score of 0 are permanently dead and cannot be resurrected."
@@ -6500,7 +6500,7 @@
 			"page": 118
 		},
 		{
-			"name": "Didn't Come Back Right",
+			"name": "Alternative Resurrection Rule: Didn't Come Back Right",
 			"entries": [
 				"Within this rule, the process of dying and being pulled back into your body is a harrowing experience. The magic itself pulls you from beyond the dark veil of death, taking its toll on your body and psyche each time, leaving you less and less the person you were.",
 				"When a character is brought back to life via magic, that character must make a Wisdom saving throw, DC (22 - level of the magic used to return the character to life). A failure on this check inflicts long term {@variantrule Madness} (see DMG, p260), except that the duration is measured in days rather than hours. A {@spell lesser restoration} or {@spell remove curse} will alleviate the madness itself, though it returns any time that character drops to 0 hit points or awakens from sleep, until its full duration has expired.",
@@ -6515,7 +6515,7 @@
 			"page": 118
 		},
 		{
-			"name": "The Fading Spirit",
+			"name": "Alternative Resurrection Rule: The Fading Spirit",
 			"entries": [
 				"This resurrection rule set is designed to add an element of party roleplaying and narrative to the resurrection attempt, as well as the creeping threat of permanent death to a character. Any of the following DC modifiers are easily adjusted to fit your campaign needs.",
 				{


### PR DESCRIPTION
Prefixes "Alternative Resurrection Rule: " to the Taxing Return, Didn't Come Back Right, and The Fading Spirit variant rule titles. This style matches the Downtime Activities, and more clearly and intuitively shows that these rules are more or less mutually exclusive.