### PR TITLE
Update and rename Warlock; Witch.json to Walrock Homebrew; Witch.json

### DIFF
--- a/class/Walrock Homebrew; Witch.json
+++ b/class/Walrock Homebrew; Witch.json
@@ -19,7 +19,7 @@
 			"Jinx": "Jinx"
 		},
 		"dateAdded": 1595709333,
-		"dateLastModified": 1595709333
+		"dateLastModified": 1601181260
 	},
 	"class": [
 		{
@@ -3544,7 +3544,7 @@
 						],
 						[
 							"9th",
-							"{@spell dispel mislead|phb}, {@spell seeming|phb}"
+							"{@spell mislead|phb}, {@spell seeming|phb}"
 						]
 					]
 				}


### PR DESCRIPTION
Fixed "dispel mislead" being given as a subclass spell rather than "mislead". Corrected author name in the file name. Updated dateLastModified.