### PR TITLE
Add long missing subclass description

### DIFF
--- a/subclass/Ophiuchus; Path of the Bloodrager.json
+++ b/subclass/Ophiuchus; Path of the Bloodrager.json
@@ -289,6 +289,7 @@
 			"subclassSource": "PotB",
 			"level": 3,
 			"entries": [
+				"The link between barbarians and magic has always been tenuous, the act of putting oneself onto an unfettered rage clashing with the strict discipline needed to cast even the simplest of magics. There is one rare exception to this rule: when the blood of a sorcerer is introduced to a barbaric society, this can manifest in the form of a warrior who can use their magical powers to fuel their rage and beyond. These gifted few are called the Bloodragers.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Spellcasting|Barbarian||Bloodrager|PotB|3"


### PR DESCRIPTION
The authors didn't finally agree on what to use, so the one thing they wrote gets added /shrug