### PR TITLE
Fix author name for Critter Compendium

### DIFF
--- a/creature/Isabel Beis; Critter Compendium.json
+++ b/creature/Isabel Beis; Critter Compendium.json
@@ -6,7 +6,10 @@
 				"abbreviation": "CComp",
 				"full": "Critter Compendium",
 				"authors": [
-					"Tobias Beis"
+					"Isabel Beis"
+				],
+				"convertedBy": [
+					"Anonymous"
 				],
 				"version": "1.0",
 				"url": "https://www.dmsguild.com/product/210151/Critter-Compendium",


### PR DESCRIPTION
I saw in the history it was originally Kobold Press. Now this one is also wrong again. lmao

Also added a `convertedBy` array in case someone complains they can't find the converter when they want to file a typo.