### PR TITLE
Fixed incorrect reference for KibblesTasty;Psion

### DIFF
--- a/class/KibblesTasty; Psion.json
+++ b/class/KibblesTasty; Psion.json
@@ -2706,7 +2706,7 @@
 		},
 		{
 			"type": "entries",
-			"name": "Mental Emphasis",
+			"name": "Overwhelming Power",
 			"entries": [
 				"Additionally at 1st level, you gain the ability to cast {@spell thaumaturgy} with your psionic powers. When you cast it in this way, you have additional options:",
 				{


### PR DESCRIPTION
Incorrect reference name in the Unleashed subclass from a previous version name change