### PR TITLE
Sokan; Yastah Fixed Heavy property

### DIFF
--- a/collection/Sokan; Yastah.json
+++ b/collection/Sokan; Yastah.json
@@ -37670,6 +37670,19 @@
 			"source": "Yastah"
 		},
 		{
+			"abbreviation": "Heavy",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Heavy",
+					"entries": [
+						"The weapon is larger and more weighty than a standard weapon, lending it unique advantages and challenges. A Heavy weapon can be used to make only one attack per turn, unless it is being wielded by a character with a Strength score of 13 or more. For small creatures, there's no disadvantage but requirement is Strength score of 19 or more. A Heavy weapon uses a bonus action to draw or stow. Any attempt to disarm the wielder of a heavy weapon is made at disadvantage."
+					]
+				}
+			],
+			"source": "Yastah"
+		},
+		{
 			"abbreviation": "Limited",
 			"entries": [
 				{
@@ -42887,7 +42900,7 @@
 			"weight": 10,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"2H"
 			],
 			"dmg1": "2d6",
@@ -43992,7 +44005,7 @@
 			"value": 1000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Long",
 				"Tripping",
 				"2H"
@@ -44052,7 +44065,7 @@
 			"weapon": true,
 			"property": [
 				"Bypass",
-				"H"
+				"Heavy"
 			],
 			"entries": []
 		},
@@ -44065,7 +44078,7 @@
 			"value": 2000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"R",
 				"2H"
 			],
@@ -44083,7 +44096,7 @@
 			"value": 3000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"2H",
 				"Finisher"
 			],
@@ -44102,7 +44115,7 @@
 			"value": 500,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Long",
 				"R",
 				"2H",
@@ -44122,7 +44135,7 @@
 			"value": 2500,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"R",
 				"2H"
 			],
@@ -44158,7 +44171,7 @@
 			"value": 2000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Long",
 				"R",
 				"2H"
@@ -44341,7 +44354,7 @@
 			"value": 2000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"R",
 				"2H"
 			],
@@ -44359,7 +44372,7 @@
 			"value": 3000,
 			"weaponCategory": "martial",
 			"property": [
-				"H"
+				"Heavy"
 			],
 			"dmg1": "1d8",
 			"dmgType": "B",
@@ -44376,7 +44389,7 @@
 			"value": 1000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"2H"
 			],
 			"dmg1": "2d6",
@@ -44394,7 +44407,7 @@
 			"value": 3000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"V"
 			],
 			"dmg1": "1d8",
@@ -44429,7 +44442,7 @@
 			"value": 500,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Long",
 				"R",
 				"2H"
@@ -44448,7 +44461,7 @@
 			"value": 5000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Long",
 				"R",
 				"2H",
@@ -44468,7 +44481,7 @@
 			"value": 3500,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Long",
 				"R",
 				"2H",
@@ -44638,7 +44651,7 @@
 			"weaponCategory": "martial",
 			"property": [
 				"Bypass",
-				"H",
+				"Heavy",
 				"Ongoing",
 				"R",
 				"Tripping",
@@ -44685,7 +44698,7 @@
 			"value": 1000,
 			"weaponCategory": "martial",
 			"property": [
-				"H"
+				"Heavy"
 			],
 			"dmg1": "2d4",
 			"dmgType": "S",
@@ -44747,7 +44760,7 @@
 			"value": 6000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"Finisher",
 				"2H"
 			],
@@ -44844,7 +44857,7 @@
 			"weaponCategory": "martial",
 			"property": [
 				"Deadly",
-				"H"
+				"Heavy"
 			],
 			"dmg1": "2d4",
 			"dmgType": "P",
@@ -44879,7 +44892,7 @@
 			"weaponCategory": "martial",
 			"property": [
 				"Deadly",
-				"H",
+				"Heavy",
 				"Sharp",
 				"2H"
 			],
@@ -44924,7 +44937,7 @@
 			"value": 5000,
 			"weaponCategory": "martial",
 			"property": [
-				"H",
+				"Heavy",
 				"2H"
 			],
 			"dmg1": "2d6",
@@ -44998,7 +45011,7 @@
 			"weaponCategory": "martial",
 			"property": [
 				"Deadly",
-				"H"
+				"Heavy"
 			],
 			"dmg1": "1d8",
 			"dmgType": "Bludgeoning or Slashing",
@@ -45036,7 +45049,7 @@
 				"Critical",
 				"2H",
 				"Finisher",
-				"H"
+				"Heavy"
 			],
 			"dmg1": "1d12",
 			"dmgType": "S",
@@ -45290,7 +45303,7 @@
 			"weaponCategory": "martial",
 			"property": [
 				"Deadly",
-				"H",
+				"Heavy",
 				"V"
 			],
 			"dmg1": "2d4",
@@ -45570,7 +45583,7 @@
 			"weaponCategory": "martial",
 			"property": [
 				"A",
-				"H",
+				"Heavy",
 				"LD",
 				"2H"
 			],
@@ -45613,7 +45626,7 @@
 			"property": [
 				"A",
 				"2H",
-				"H",
+				"Heavy",
 				"Strongbow"
 			],
 			"range": "150/600",
@@ -45721,7 +45734,7 @@
 			"weaponCategory": "simple",
 			"property": [
 				"2H",
-				"H",
+				"Heavy",
 				"Nonlethal",
 				"Stable"
 			],
@@ -46517,7 +46530,7 @@
 			"value": 2500,
 			"weaponCategory": "Exotic",
 			"property": [
-				"H",
+				"Heavy",
 				"R",
 				"2H",
 				"Winged",

--- a/collection/Sokan; Yastah.json
+++ b/collection/Sokan; Yastah.json
@@ -1147,7 +1147,8 @@
 			"range": {
 				"type": "point",
 				"distance": {
-					"type": "self"
+					"type": "feet",
+					"amount": 60
 				}
 			},
 			"components": {

--- a/collection/Sokan; Yastah.json
+++ b/collection/Sokan; Yastah.json
@@ -10,11 +10,11 @@
 					"Sokan"
 				],
 				"convertedBy": [],
-				"version": "1.3.5.1"
+				"version": "1.3.8.1"
 			}
 		],
 		"dateAdded": 1612901649,
-		"dateLastModified": 1614973063
+		"dateLastModified": 1615221986
 	},
 	"spell": [
 		{

--- a/collection/Sokan; Yastah.json
+++ b/collection/Sokan; Yastah.json
@@ -14,7 +14,7 @@
 			}
 		],
 		"dateAdded": 1612901649,
-		"dateLastModified": 1614973062
+		"dateLastModified": 1614973063
 	},
 	"spell": [
 		{


### PR DESCRIPTION
Fixed custom heavy property for weapons.  Was using the standard 5e.tools one instead of the Yastah one.