### PR TITLE
Fix XLEE healer crossbow variant from not linking to its specific variants

### DIFF
--- a/collection/DMsGuild; Xanathar's Lost Notes to Everything Else.json
+++ b/collection/DMsGuild; Xanathar's Lost Notes to Everything Else.json
@@ -13662,13 +13662,13 @@
 			"type": "GV",
 			"requires": [
 				{
-					"name": "heavy crossbow"
+					"name": "Heavy Crossbow"
 				},
 				{
-					"name": "light crossbow"
+					"name": "Light Crossbow"
 				},
 				{
-					"name": "hand crossbow"
+					"name": "Hand Crossbow"
 				}
 			],
 			"inherits": {


### PR DESCRIPTION
*TIL GV requirements are case sensitive