### PR TITLE
Update badooga; Fighter Subclasses.json

### DIFF
--- a/subclass/badooga; Fighter Subclasses.json
+++ b/subclass/badooga; Fighter Subclasses.json
@@ -12,11 +12,9 @@
 				"convertedBy": [
 					"badooga"
 				],
-				"version": "unknown"
+				"version": "2.0.1"
 			}
-		],
-		"dateAdded": 1612432934,
-		"dateLastModified": 1612867567
+		]
 	},
 	"subclass": [
 		{
@@ -231,8 +229,11 @@
 				"A banneret inspires greatness in others by committing brave deeds in battle. A lone banneret is a skilled warrior, but a banneret leading a band of allies can transform even the most poorly equipped militia into a ferocious war band.",
 				"A banneret prefers to lead through deeds, not words. As a banneret spearheads an attack, the banneret's actions can awaken reserves of courage and conviction in allies that they never suspected they had.",
 				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Champion and Purple Dragon Knight|Fighter||Banneret|B:Fs|3"
+					"name" : "Champion and Purple Dragon Knight",
+					"type": "inset",
+					"entries": [
+						"This subclass combines the Champion and Purple Dragon Knight martial archetypes into a single player option, replacing both of them at once."
+					]
 				},
 				{
 					"type": "refSubclassFeature",
@@ -245,25 +246,11 @@
 			]
 		},
 		{
-			"name": "Champion and Purple Dragon Knight",
-			"type": "inset",
-			"entries": [
-				"This subclass combines the Champion and Purple Dragon Knight martial archetypes into a single player option, replacing both of them at once."
-			],
-			"source": "B:Fs",
-			"className": "Fighter",
-			"classSource": "PHB",
-			"subclassShortName": "Banneret",
-			"subclassSource": "B:Fs",
-			"level": 3,
-			"header": 1
-		},
-		{
 			"type": "entries",
 			"name": "Improved Critical",
 			"entries": [
 				"{@i 3rd-level Banneret feature}",
-				"Your weapon attacks score a critical hit on a roll of 19 or 20 on the d20."
+				"Your weapon attack rolls score a critical hit on a roll of 19 or 20 on the d20."
 			],
 			"source": "B:Fs",
 			"className": "Fighter",
@@ -352,7 +339,7 @@
 			"name": "Superior Critical",
 			"entries": [
 				"{@i 15th-level Banneret feature}",
-				"Your weapon attacks score a critical hit on a roll of 19 or 20 on the d20."
+				"Your weapon attack rolls score a critical hit on a roll of 18-20 on the d20."
 			],
 			"source": "B:Fs",
 			"className": "Fighter",
@@ -754,8 +741,11 @@
 			"entries": [
 				"The Tactician is a master of both ranged and mounted combat. An excellent sniper and eagle-eyed scout, this fighter is a perilous foe who combines extraordinary marksmanship with the superior mobility of a mount.",
 				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Warlord Class|Fighter||Tactician|B:Fs|3"
+					"type": "inset",
+					"name": "Warlord Class",
+					"entries": [
+						"This subclass is an old attempt of mine to invoke the theme of a Warlord in 5e, and no longer receives any content updates or changes. Consider using \"Badooga's Warlord\" on 5eTools instead."
+					]
 				},
 				{
 					"type": "refSubclassFeature",
@@ -770,20 +760,6 @@
 					"subclassFeature": "Tactics|Fighter||Tactician|B:Fs|3"
 				}
 			]
-		},
-		{
-			"type": "inset",
-			"name": "Warlord Class",
-			"entries": [
-				"This subclass is an old attempt of mine to invoke the theme of a Warlord in 5e, and no longer receives any content updates or changes. Consider using \"Badooga's Warlord\" on 5eTools instead."
-			],
-			"source": "B:Fs",
-			"className": "Fighter",
-			"classSource": "PHB",
-			"subclassShortName": "Tactician",
-			"subclassSource": "B:Fs",
-			"level": 3,
-			"header": 1
 		},
 		{
 			"type": "entries",


### PR DESCRIPTION
This just has a few typo fixes.

Also, please don't add this stuff to the inset blocks again. They are supposed to be part of the flavor text, and are not meant to appear in the omnisearch bar as standalone subclass features.

![image](https://user-images.githubusercontent.com/33851191/118375029-0ee77c80-b58d-11eb-9b60-f95881c90e47.png)
