### PR TITLE
(Fixed typos/added tags) for KibblesTasty's Artificer Revised

### DIFF
--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -113,11 +113,11 @@
 				{
 					"title": "Spell Slots per Spell Level",
 					"colLabels": [
-						"1st",
-						"2nd",
-						"3rd",
-						"4th",
-						"5th"
+						"{@filter 1st|spells|level=1|class=artificer (kt:a)}",
+						"{@filter 2nd|spells|level=2|class=artificer (kt:a)}",
+						"{@filter 3rd|spells|level=3|class=artificer (kt:a)}",
+						"{@filter 4th|spells|level=4|class=artificer (kt:a)}",
+						"{@filter 5th|spells|level=5|class=artificer (kt:a)}"
 					],
 					"rows": [
 						[
@@ -264,7 +264,7 @@
 				},
 				{
 					"colLabels": [
-						"Upgrades"
+						"{@filter Upgrades|optionalfeatures|class=artificer (kt:a)}"
 					],
 					"rows": [
 						[
@@ -337,12 +337,12 @@
 				],
 				"weapons": [
 					"simple",
-					"hand crossbows",
-					"heavy crossbows"
+					"{@item hand crossbow}",
+					"{@item heavy crossbow}"
 				],
 				"tools": [
-					"thieves' tools",
-					"one other tool of your choice"
+					"{@item thieves' tools}",
+					"one other {@filter tool|items|type=tools} of your choice"
 				],
 				"skills": [
 					{
@@ -5858,14 +5858,14 @@
 					"type": "entries",
 					"name": "Spell Slots",
 					"entries": [
-						"The Artificer table shows how many spell slots you have to cast your {@filter artificer spells|spells|class=artificer (brew)} of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest."
+						"The Artificer table shows how many spell slots you have to cast your {@filter artificer spells|spells|class=artificer (kt:a)} of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest."
 					]
 				},
 				{
 					"type": "entries",
 					"name": "Spells Known of 1st Level and Higher",
 					"entries": [
-						"You know three 1st-level spells of your choice from the artificer spell list.",
+						"You know three 1st-level spells of your choice from the {@filter artificer spell list|spells|class=artificer (kt:a)}.",
 						"The Spells Known column of the Artificer table shows when you learn more artificer spells of your choice from this feature. Each of these spells must be of a level for which you have spell slots on the Artificer table.",
 						"Additionally, when you gain a level in this class, you can choose one of the artificer spells you know from this feature and replace it with another spell from the artificer spell list. The new spell must also be of a level for which you have spell slots on the Artificer table."
 					]
@@ -5895,7 +5895,7 @@
 					"type": "entries",
 					"name": "Spellcasting Focus",
 					"entries": [
-						"You can use an arcane focus as a spellcasting for your artificer spells. See chapter 5, \"Equipment\" in the Player's Handbook for various arcane focus options."
+						"You can use an {@item arcane focus} as a spellcasting for your artificer spells. See chapter 5, \"Equipment\" in the Player's Handbook for various arcane focus options."
 					]
 				},
 				{
@@ -5916,7 +5916,7 @@
 			"classSource": "ArtificerRevised",
 			"level": 3,
 			"entries": [
-				"Starting at 3rd level, choose an {@filter upgrade|optionalfeatures|Feature Type=AS:G;AS:O;AS:I;AS:P;AS:T;AS:W;AS:F} from the list at the end of your specialization, and gain the benefits listed in the description of the upgrade.",
+				"Starting at 3rd level, choose an {@filter Upgrade|optionalfeatures|Feature Type=AS:G;AS:O;AS:I;AS:P;AS:T;AS:W;AS:F} from the list at the end of your specialization, and gain the benefits listed in the description of the upgrade.",
 				"You select an additional Upgrade at 5th, 7th, 9th, 11th, 13th, 15th, 17th, and 19th level. You cannot select an Upgrade more than once, unless the Upgrade's description says otherwise. Whenever you level up, you can exchange one of your existing upgrades for another upgrade of the same level requirement as the replaced upgrade.",
 				"In any case that a specialization allows an Upgrade to be swapped out, Upgrades must always be selected as if the Artificer is the level they were when they got that Upgrade slot. For example, if you replace your Stormforged Weapon and reselect all of your upgrades as a 5th level Artificer, you could select one 3rd level upgrade and one 5th level upgrade, or two 3rd level upgrades, but you would not be able to select two 5th level upgrades.",
 				{


### PR DESCRIPTION
Added missing spell list tags to the class table, as well as a few other places.
Tagged stuff in the class starting items/proficiencies block.