### PR TITLE
SMIP: Create Priced Item _copies & Redirect Tags to Priced Items

### DIFF
--- a/book/Giddy; Sane Magic Item Prices Expanded.json
+++ b/book/Giddy; Sane Magic Item Prices Expanded.json
@@ -21,7 +21,7 @@
 			}
 		],
 		"dateAdded": 1608050554,
-		"dateLastModified": 1608050554,
+		"dateLastModified": 1630338859,
 		"dependencies": {
 			"item": [
 				"DMG",

--- a/book/Giddy; Sane Magic Item Prices Expanded.json
+++ b/book/Giddy; Sane Magic Item Prices Expanded.json
@@ -9808,57 +9808,5 @@
 				]
 			}
 		}
-	],
-	"itemEntry": [
-		{
-			"name": "Ring of Resistance",
-			"source": "SaneMagicItemPricesExpanded",
-			"entriesTemplate": [
-				"You have resistance to {{item.resist}} damage while wearing this ring. The ring is set with {{item.detail1}}."
-			]
-		},
-		{
-			"name": "Armor of Resistance",
-			"source": "SaneMagicItemPricesExpanded",
-			"entriesTemplate": [
-				"You have resistance to {{item.resist}} damage while you wear this armor."
-			]
-		},
-		{
-			"name": "Potion of Resistance",
-			"source": "SaneMagicItemPricesExpanded",
-			"entriesTemplate": [
-				"When you drink this potion, you gain resistance to {{item.resist}} damage for 1 hour."
-			]
-		},
-		{
-			"name": "Absorbing Tattoo",
-			"source": "SaneMagicItemPricesExpanded",
-			"entriesTemplate": [
-				"Produced by a special needle, this magic tattoo features designs that emphasize one color ({{item.detail1}}).",
-				{
-					"type": "entries",
-					"name": "Tattoo Attunement",
-					"entries": [
-						"To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin.",
-						"If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in your space."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Damage Resistance",
-					"entries": [
-						"While the tattoo is on your skin, you have resistance to {{item.resist}} damage."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Damage Absorption",
-					"entries": [
-						"When you take {{item.resist}} damage, you can use your reaction to gain immunity against that instance of the damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can't be used again until the next dawn."
-					]
-				}
-			]
-		}
 	]
 }

--- a/book/Giddy; Sane Magic Item Prices Expanded.json
+++ b/book/Giddy; Sane Magic Item Prices Expanded.json
@@ -33,7 +33,7 @@
 	"book": [
 		{
 			"name": "Sane Magic Item Prices: Expanded",
-			"id": "SMIP",
+			"id": "SMIP2",
 			"source": "SaneMagicItemPricesExpanded",
 			"author": "Saidoro, Voivode, TheGiddyLimit, revilowaldow",
 			"published": "2020-12-15",
@@ -58,7 +58,7 @@
 	],
 	"bookData": [
 		{
-			"id": "SMIP",
+			"id": "SMIP2",
 			"source": "SaneMagicItemPricesExpanded",
 			"data": [
 				{
@@ -83,11 +83,11 @@
 								{
 									"type": "list",
 									"items": [
-										"{@book Consumables|SMIP|0|Consumables} are items that are used some set amount of times (usually once) and then are gone.",
-										"{@book Combat Items|SMIP|0|Combat Items} are items that primarily make the user better at killing things. Some also have other killing-unrelated effects, but these are not the primary source of their utility.",
-										"{@book Non-combat Items|SMIP|0|Non-combat Items} are items that primarily make the user better at solving problems in a killing-unrelated manner. Some also make the user better at killing things, but this is not the primary source of their utility.",
-										"{@book Summoning Items|SMIP|0|Summoning Items} are items that summon creatures to kill things or solve problems for you.",
-										"{@book Gamechanging Items|SMIP|0|Gamechanging Items} are items that can have major effects on the way the players engage with the world or that can resculpt the campaign world in some major way all on their own. They are not necessarily overpowered, but the GM should take a look at them to make sure that the items they allow are compatible with the sort of game and world they want to create."
+										"{@book Consumables|SMIP2|0|Consumables} are items that are used some set amount of times (usually once) and then are gone.",
+										"{@book Combat Items|SMIP2|0|Combat Items} are items that primarily make the user better at killing things. Some also have other killing-unrelated effects, but these are not the primary source of their utility.",
+										"{@book Non-combat Items|SMIP2|0|Non-combat Items} are items that primarily make the user better at solving problems in a killing-unrelated manner. Some also make the user better at killing things, but this is not the primary source of their utility.",
+										"{@book Summoning Items|SMIP2|0|Summoning Items} are items that summon creatures to kill things or solve problems for you.",
+										"{@book Gamechanging Items|SMIP2|0|Gamechanging Items} are items that can have major effects on the way the players engage with the world or that can resculpt the campaign world in some major way all on their own. They are not necessarily overpowered, but the GM should take a look at them to make sure that the items they allow are compatible with the sort of game and world they want to create."
 									]
 								},
 								"Each is discussed further in their own section. By adjusting the prices of the various lists, the GM can make it easier or harder to get their hands on various types of problem solving abilities.",

--- a/book/Giddy; Sane Magic Item Prices Expanded.json
+++ b/book/Giddy; Sane Magic Item Prices Expanded.json
@@ -8,10 +8,12 @@
 				"authors": [
 					"Saidoro",
 					"Voivode",
-					"TheGiddyLimit"
+					"TheGiddyLimit",
+					"revilowaldow"
 				],
 				"convertedBy": [
-					"TheGiddyLimit"
+					"TheGiddyLimit",
+					"revilowaldow"
 				],
 				"version": "1.0",
 				"url": "http://www.giantitp.com/forums/showthread.php?424243",
@@ -19,15 +21,22 @@
 			}
 		],
 		"dateAdded": 1608050554,
-		"dateLastModified": 1608050554
+		"dateLastModified": 1608050554,
+		"dependencies": {
+			"item": [
+				"DMG",
+				"TCE",
+				"GGR"
+			]
+		}
 	},
 	"book": [
 		{
 			"name": "Sane Magic Item Prices: Expanded",
-			"id": "SMIP2",
+			"id": "SMIP",
 			"source": "SaneMagicItemPricesExpanded",
-			"author": "Saidoro, Voivode, TheGiddyLimit",
-			"published": "2020/12/15",
+			"author": "Saidoro, Voivode, TheGiddyLimit, revilowaldow",
+			"published": "2020-12-15",
 			"coverUrl": "https://i.ibb.co/0tpKVHh/smi-cover.png",
 			"contents": [
 				{
@@ -36,7 +45,7 @@
 						"Introduction",
 						"Consumables",
 						"Combat Items",
-						"Noncombat Items",
+						"Non-combat Items",
 						"Summoning Items",
 						"Gamechanging Items",
 						"Items that Won't be priced",
@@ -49,7 +58,7 @@
 	],
 	"bookData": [
 		{
-			"id": "SMIP2",
+			"id": "SMIP",
 			"source": "SaneMagicItemPricesExpanded",
 			"data": [
 				{
@@ -61,8 +70,8 @@
 							"type": "section",
 							"name": "Introduction",
 							"entries": [
-								"Have you ever wondered how much an item truly costs? Have you been wanting to find or craft an item but aren't sure how it fits in to the grand scheme of things? Did you ever look at sovereign glue and say to yourself, \"There is no way that glue is worth 500,000 gp when Sentinal shield is worth 500gp\". Well you are in luck because this guide is for you.",
-								"Brainstorming with the Giant In the Playground, /r/ DnDNext, and EnWorld forums, Saidoro has put together a set of tables that break down the costs, reasons for the costs, and DMG page to find the item."
+								"Have you ever wondered how much an item truly costs? Have you been wanting to find or craft an item but aren't sure how it fits in to the grand scheme of things? Did you ever look at sovereign glue and say to yourself, {@i \"There is no way that glue is worth 500,000 gp when Sentinel shield is worth 500gp\".} Well you are in luck because this guide is for you.",
+								"Brainstorming with the Giant In the Playground, /r/DnDNext, and EnWorld forums, Saidoro has put together a set of tables that break down the costs, reasons for the costs, and DMG page to find the item."
 							]
 						},
 						{
@@ -74,11 +83,11 @@
 								{
 									"type": "list",
 									"items": [
-										"Consumables are items that are used some set amount of times (usually once) and then are gone.",
-										"Combat Items are items that primarily make the user better at killing things. Some also have other killing-unrelated effects, but these are not the primary source of their utility.",
-										"Noncombat Items are items that primarily make the user better at solving problems in a killing-unrelated manner. Some also make the user better at killing things, but this is not the primary source of their utility.",
-										"Summoning Items are items that summon creatures to kill things or solve problems for you.",
-										"Gamechanging Items are items that can have major effects on the way the players engage with the world or that can resculpt the campaign world in some major way all on their own. They are not necessarily overpowered, but the GM should take a look at them to make sure that the items they allow are compatible with the sort of game and world they want to create."
+										"{@book Consumables|SMIP|0|Consumables} are items that are used some set amount of times (usually once) and then are gone.",
+										"{@book Combat Items|SMIP|0|Combat Items} are items that primarily make the user better at killing things. Some also have other killing-unrelated effects, but these are not the primary source of their utility.",
+										"{@book Non-combat Items|SMIP|0|Non-combat Items} are items that primarily make the user better at solving problems in a killing-unrelated manner. Some also make the user better at killing things, but this is not the primary source of their utility.",
+										"{@book Summoning Items|SMIP|0|Summoning Items} are items that summon creatures to kill things or solve problems for you.",
+										"{@book Gamechanging Items|SMIP|0|Gamechanging Items} are items that can have major effects on the way the players engage with the world or that can resculpt the campaign world in some major way all on their own. They are not necessarily overpowered, but the GM should take a look at them to make sure that the items they allow are compatible with the sort of game and world they want to create."
 									]
 								},
 								"Each is discussed further in their own section. By adjusting the prices of the various lists, the GM can make it easier or harder to get their hands on various types of problem solving abilities.",
@@ -106,218 +115,220 @@
 									],
 									"rows": [
 										[
-											"{@item Spell Scroll (Cantrip)|dmg|Spell Scroll, Cantrip}",
+											"{@item Spell Scroll (Cantrip)|SaneMagicItemPricesExpanded|Spell Scroll, Cantrip}",
 											"10",
-											"{@item Sovereign Glue}",
+											"{@item Sovereign Glue|SaneMagicItemPricesExpanded}",
 											"400"
 										],
 										[
-											"{@item +1 Ammunition} (each)",
+											"{@item +1 Ammunition|SaneMagicItemPricesExpanded} (each)",
 											"25",
-											"{@item Horn of Blasting}",
+											"{@item Horn of Blasting|SaneMagicItemPricesExpanded}",
 											"450"
 										],
 										[
-											"{@item Potion of Healing}",
+											"{@item Potion of Healing|SaneMagicItemPricesExpanded}",
 											"50",
-											"{@item Potion of Superior Healing}",
+											"{@item Potion of Superior Healing|SaneMagicItemPricesExpanded}",
 											"450"
 										],
 										[
-											"{@item Quaal's Feather Token, Anchor}",
+											"{@item Quaal's Feather Token, Anchor|SaneMagicItemPricesExpanded}",
 											"50",
-											"{@item Dust of Sneezing and Choking}",
+											"{@item Dust of Sneezing and Choking|SaneMagicItemPricesExpanded}",
 											"480"
 										],
 										[
-											"{@item Spell Scroll (1st Level)|dmg|Spell Scroll, Level 1}",
+											"{@item Spell Scroll (1st Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 1}",
 											"60",
-											"{@item Necklace of Fireballs} (Two beads)",
+											"{@item Necklace of Fireballs (Two Beads)|SaneMagicItemPricesExpanded}",
 											"480"
 										],
 										[
-											"{@item Philter of Love}",
+											"{@item Philter of Love|SaneMagicItemPricesExpanded}",
 											"90",
-											"{@item Oil of Slipperiness}",
+											"{@item Oil of Slipperiness|SaneMagicItemPricesExpanded}",
 											"480"
 										],
 										[
-											"{@item +2 Ammunition}  (each)",
+											"{@item +2 Ammunition|SaneMagicItemPricesExpanded} (each)",
 											"100",
-											"{@item Potion of Flying}",
+											"{@item Potion of Flying|SaneMagicItemPricesExpanded}",
 											"500"
 										],
 										[
-											"{@item Potion of Poison}",
+											"{@item Potion of Poison|SaneMagicItemPricesExpanded}",
 											"100",
-											"{@item Arrow of Slaying} (each)",
+											"{@item Arrow of Slaying (*)|SaneMagicItemPricesExpanded} (each)",
 											"600"
 										],
 										[
-											"{@item Dust of Dryness} (1 pellet)",
+											"{@item Dust of Dryness|SaneMagicItemPricesExpanded} (1 pellet)",
 											"120",
-											"{@item Spell Scroll (5th Level)|dmg|Spell Scroll, Level 5}",
+											"{@item Spell Scroll (5th Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 5}",
 											"640"
 										],
 										[
-											"{@item Elixir of Health}",
+											"{@item Elixir of Health|SaneMagicItemPricesExpanded}",
 											"120",
-											"{@item Bead of Force}",
+											"{@item Bead of Force|SaneMagicItemPricesExpanded}",
 											"960"
 										],
 										[
-											"{@item Keoghtom's Ointment} (Per dose)",
+											"{@item Keoghtom's Ointment|SaneMagicItemPricesExpanded} (Per dose)",
 											"120",
-											"{@item Elemental Gem}",
+											"{@item Elemental Gem|SaneMagicItemPricesExpanded}",
 											"960"
 										],
 										[
-											"{@item Spell Scroll (2nd Level)|dmg|Spell Scroll, Level 2}",
+											"{@item Spell Scroll (2nd Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 2}",
 											"120",
-											"{@item Necklace of Fireballs} (Three beads)",
+											"{@item Necklace of Fireballs (Three Beads)|SaneMagicItemPricesExpanded}",
 											"960"
 										],
 										[
-											"{@item Potion of Fire Breath}",
+											"{@item Potion of Fire Breath|SaneMagicItemPricesExpanded}",
 											"150",
-											"{@item Potion of Clairvoyance}",
+											"{@item Potion of Clairvoyance|SaneMagicItemPricesExpanded}",
 											"960"
 										],
 										[
-											"{@item Potion of Greater Healing}",
+											"{@item Potion of Greater Healing|SaneMagicItemPricesExpanded}",
 											"150",
-											"{@item Potion of Vitality}",
+											"{@item Potion of Vitality|SaneMagicItemPricesExpanded}",
 											"960"
 										],
 										[
-											"{@item Potion of Climbing}",
+											"{@item Potion of Climbing|SaneMagicItemPricesExpanded}",
 											"180",
-											"{@item Spell Scroll (6th Level)|dmg|Spell Scroll, Level 6}",
+											"{@item Spell Scroll (6th Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 6}",
 											"1280"
 										],
 										[
-											"{@item Potion of Heroism}",
+											"{@item Potion of Heroism|SaneMagicItemPricesExpanded}",
 											"180",
-											"{@item Potion of Supreme Healing}",
+											"{@item Potion of Supreme Healing|SaneMagicItemPricesExpanded}",
 											"1350"
 										],
 										[
-											"{@item Potion of Invisibility}",
+											"{@item Potion of Invisibility|SaneMagicItemPricesExpanded}",
 											"180",
-											"{@item Chime of Opening}",
+											"{@item Chime of Opening|SaneMagicItemPricesExpanded}",
 											"1500"
 										],
 										[
-											"{@item Potion of Mind Reading}",
+											"{@item Potion of Mind Reading|SaneMagicItemPricesExpanded}",
 											"180",
-											"{@item Necklace of Fireballs} (Four beads)",
+											"{@item Necklace of Fireballs (Four Beads)|SaneMagicItemPricesExpanded}",
 											"1600"
 										],
 										[
-											"{@item Potion of Water Breathing}",
+											"{@item Potion of Water Breathing|SaneMagicItemPricesExpanded}",
 											"180",
-											"{@item Oil of Etherealness}",
+											"{@item Oil of Etherealness|SaneMagicItemPricesExpanded}",
 											"1920"
 										],
 										[
-											"{@item Scroll of Protection}",
+											"{@item Scroll of Protection|SaneMagicItemPricesExpanded}",
 											"180",
-											"{@item Ioun Stone, Absorption}",
+											"{@item Ioun Stone, Absorption|SaneMagicItemPricesExpanded}",
 											"2400"
 										],
 										[
-											"{@item Nolzur's Marvelous Pigments}",
+											"{@item Nolzur's Marvelous Pigments|SaneMagicItemPricesExpanded}",
 											"200",
-											"{@item Spell Scroll (7th Level)|dmg|Spell Scroll, Level 7}",
+											"{@item Spell Scroll (7th Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 7}",
 											"2560"
 										],
 										[
-											"{@item Potion of Animal Friendship}",
+											"{@item Potion of Animal Friendship|SaneMagicItemPricesExpanded}",
 											"200",
-											"{@item Quaal's Feather Token, Bird}",
+											"{@item Quaal's Feather Token, Bird|SaneMagicItemPricesExpanded}",
 											"3000"
 										],
 										[
-											"{@item Spell Scroll (3rd Level)|dmg|Spell Scroll, Level 3}",
+											"{@item Spell Scroll (3rd Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 3}",
 											"200",
-											"{@item Quaal's Feather Token, Swan Boat}",
+											"{@item Quaal's Feather Token, Swan Boat|SaneMagicItemPricesExpanded}",
 											"3000"
 										],
 										[
-											"{@item Quaal's Feather Token, Fan}",
+											"{@item Quaal's Feather Token, Fan|SaneMagicItemPricesExpanded}",
 											"250",
-											"{@item Oil of Sharpness}",
+											"{@item Oil of Sharpness|SaneMagicItemPricesExpanded}",
 											"3200"
 										],
 										[
-											"{@item Quaal's Feather Token, Whip}",
+											"{@item Quaal's Feather Token, Whip|SaneMagicItemPricesExpanded}",
 											"250",
-											"{@item Necklace of Fireballs} (Five beads)",
+											"{@item Necklace of Fireballs (Five Beads)|SaneMagicItemPricesExpanded}",
 											"3840"
 										],
 										[
-											"{@item Potion of Diminution}",
+											"{@item Potion of Diminution|SaneMagicItemPricesExpanded}",
 											"270",
-											"{@item Potion of Invulnerability}",
+											"{@item Potion of Invulnerability|SaneMagicItemPricesExpanded}",
 											"3840"
 										],
 										[
-											"{@item Potion of Growth}",
+											"{@item Potion of Growth|SaneMagicItemPricesExpanded}",
 											"270",
-											"{@item Gem of Brightness}",
+											"{@item Gem of Brightness|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Dust of Disappearance}",
+											"{@item Dust of Disappearance|SaneMagicItemPricesExpanded}",
 											"300",
-											"{@item Spell Scroll (8th Level)|dmg|Spell Scroll, Level 8}",
+											"{@item Spell Scroll (8th Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 8}",
 											"5120"
 										],
 										[
-											"{@item Necklace of Fireballs} (One bead)",
+											"{@item Necklace of Fireballs (One Bead)|SaneMagicItemPricesExpanded}",
 											"300",
-											"{@item Deck of Illusions}",
+											"{@item Deck of Illusions|SaneMagicItemPricesExpanded}",
 											"6120"
 										],
 										[
-											"{@item Potion of Gaseous Form}",
+											"{@item Potion of Gaseous Form|SaneMagicItemPricesExpanded}",
 											"300",
-											"{@item Necklace of Fireballs} (Six beads)",
+											"{@item Necklace of Fireballs (Six Beads)|SaneMagicItemPricesExpanded}",
 											"7680"
 										],
 										[
-											"{@item Potion of Resistance}",
+											"{@item Potion of Resistance|SaneMagicItemPricesExpanded}",
 											"300",
-											"{@item Spell Scroll (9th Level)|dmg|Spell Scroll, Level 9}",
+											"{@item Spell Scroll (9th Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 9}",
 											"10240"
 										],
 										[
-											"{@item Universal Solvent}",
+											"{@item Universal Solvent|SaneMagicItemPricesExpanded}",
 											"300",
-											"{@item Ioun Stone, Greater Absorption}",
+											"{@item Ioun Stone, Greater Absorption|SaneMagicItemPricesExpanded}",
 											"31000"
 										],
 										[
-											"{@item Spell Scroll (4th Level)|dmg|Spell Scroll, Level 4}",
+											"{@item Spell Scroll (4th Level)|SaneMagicItemPricesExpanded|Spell Scroll, Level 4}",
 											"320",
-											"{@item Rod of Absorption}",
+											"{@item Rod of Absorption|SaneMagicItemPricesExpanded}",
 											"50000"
 										],
 										[
-											"{@item +3 Ammunition}  (each)",
+											"{@item +3 Ammunition|SaneMagicItemPricesExpanded} (each)",
 											"400",
-											"{@item Talisman of Ultimate Evil}",
+											"{@item Talisman of Ultimate Evil|SaneMagicItemPricesExpanded}",
 											"61440"
 										],
 										[
-											"{@item Potion of Speed}",
+											"{@item Potion of Speed|SaneMagicItemPricesExpanded}",
 											"400",
-											"{@item Talisman of Pure Good}",
+											"{@item Talisman of Pure Good|SaneMagicItemPricesExpanded}",
 											"71680"
 										],
 										[
-											"{@item Robe of Useful Items}",
-											"Items × 5"
+											"{@item Robe of Useful Items|SaneMagicItemPricesExpanded}",
+											"Items × 5",
+											"",
+											""
 										]
 									]
 								}
@@ -344,381 +355,381 @@
 									],
 									"rows": [
 										[
-											"{@item Vicious Weapon}",
+											"{@item Vicious Weapon|SaneMagicItemPricesExpanded}",
 											"350",
-											"{@item Brooch of Shielding}",
+											"{@item Brooch of Shielding|SaneMagicItemPricesExpanded}",
 											"7500"
 										],
 										[
-											"{@item Adamantine Armor}",
+											"{@item Adamantine Armor|SaneMagicItemPricesExpanded}",
 											"500",
-											"{@item Amulet of Health}",
+											"{@item Amulet of Health|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Mithral Armor}",
+											"{@item Mithral Armor|SaneMagicItemPricesExpanded}",
 											"800",
-											"{@item Dragon Slayer}",
+											"{@item Dragon Slayer|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item +1 Weapon}",
+											"{@item +1 Weapon|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Gauntlets of Ogre Power}",
+											"{@item Gauntlets of Ogre Power|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Sword of Life Stealing}",
+											"{@item Sword of Life Stealing|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Headband of Intellect}",
+											"{@item Headband of Intellect|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Ioun Stone, Protection}",
+											"{@item Ioun Stone, Protection|SaneMagicItemPricesExpanded}",
 											"1200",
-											"{@item Mace of Disruption}",
+											"{@item Mace of Disruption|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item +1 Wand of the War Mage}",
+											"{@item +1 Wand of the War Mage|SaneMagicItemPricesExpanded}",
 											"1200",
-											"{@item Mace of Terror}",
+											"{@item Mace of Terror|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Bracers of Archery}",
+											"{@item Bracers of Archery|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Nine Lives Stealer} (Fully Charged)",
+											"{@item Nine Lives Stealer|SaneMagicItemPricesExpanded} (Fully Charged)",
 											"8000"
 										],
 										[
-											"{@item Circlet of Blasting}",
+											"{@item Circlet of Blasting|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Wand of Magic Missiles}",
+											"{@item Wand of Magic Missiles|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Javelin of Lightning}",
+											"{@item Javelin of Lightning|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Wand of Web}",
+											"{@item Wand of Web|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Necklace of Prayer Beads|dmg|Prayer Bead} - Smiting",
+											"{@item Necklace of Prayer Beads - Smiting|SaneMagicItemPricesExpanded|Prayer Bead - Smiting}",
 											"1500",
-											"{@item Staff of Thunder and Lightning}",
+											"{@item Staff of Thunder and Lightning|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Wind Fan}",
+											"{@item Wind Fan|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Wand of Binding}",
+											"{@item Wand of Binding|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Sword of Sharpness}",
+											"{@item Sword of Sharpness|SaneMagicItemPricesExpanded}",
 											"1700",
-											"{@item Wand of Fear}",
+											"{@item Wand of Fear|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Staff of the Adder}",
+											"{@item Staff of the Adder|SaneMagicItemPricesExpanded}",
 											"1800",
-											"{@item Ioun Stone, Awareness}",
+											"{@item Ioun Stone, Awareness|SaneMagicItemPricesExpanded}",
 											"12000"
 										],
 										[
-											"{@item Dancing Sword}",
+											"{@item Dancing Sword|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item +1 Rod of the Pact Keeper}",
+											"{@item +1 Rod of the Pact Keeper|SaneMagicItemPricesExpanded}",
 											"12000"
 										],
 										[
-											"{@item Glamoured Studded Leather}",
+											"{@item Glamoured Studded Leather|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Staff of Charming}",
+											"{@item Staff of Charming|SaneMagicItemPricesExpanded}",
 											"12000"
 										],
 										[
-											"{@item Pipes of the Sewers}",
+											"{@item Pipes of the Sewers|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Sun Blade}",
+											"{@item Sun Blade|SaneMagicItemPricesExpanded}",
 											"12000"
 										],
 										[
-											"{@item Necklace of Prayer Beads|dmg|Prayer Bead} - Bless",
+											"{@item Necklace of Prayer Beads - Bless|SaneMagicItemPricesExpanded|Prayer Bead - Bless}",
 											"2000",
-											"{@item Staff of Healing}",
+											"{@item Staff of Healing|SaneMagicItemPricesExpanded}",
 											"13000"
 										],
 										[
-											"{@item Saddle of the Cavalier}",
+											"{@item Saddle of the Cavalier|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Ring of Shooting Stars}",
+											"{@item Ring of Shooting Stars|SaneMagicItemPricesExpanded}",
 											"14000"
 										],
 										[
-											"{@item Sword of Wounding}",
+											"{@item Sword of Wounding|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Ioun Stone, Mastery}",
+											"{@item Ioun Stone, Mastery|SaneMagicItemPricesExpanded}",
 											"15000"
 										],
 										[
-											"{@item Frost Brand}",
+											"{@item Frost Brand|SaneMagicItemPricesExpanded}",
 											"2200",
-											"{@item +3 Weapon}",
+											"{@item +3 Weapon|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Dagger of Venom}",
+											"{@item Dagger of Venom|SaneMagicItemPricesExpanded}",
 											"2500",
-											"{@item Hammer of Thunderbolts}",
+											"{@item Hammer of Thunderbolts|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Gloves of Missile Snaring}",
+											"{@item Gloves of Missile Snaring|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item +2 Rod of the Pact Keeper}",
+											"{@item +2 Rod of the Pact Keeper|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Ioun Stone, Agility}",
+											"{@item Ioun Stone, Agility|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Staff of Fire}",
+											"{@item Staff of Fire|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Ioun Stone, Fortitude}",
+											"{@item Ioun Stone, Fortitude|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Staff of Swarming Insects}",
+											"{@item Staff of Swarming Insects|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Ioun Stone, Insight}",
+											"{@item Ioun Stone, Insight|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Wand of Paralysis}",
+											"{@item Wand of Paralysis|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Ioun Stone, Intellect}",
+											"{@item Ioun Stone, Intellect|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Ring of Fire Elemental Command}",
+											"{@item Ring of Fire Elemental Command|SaneMagicItemPricesExpanded}",
 											"17000"
 										],
 										[
-											"{@item Ioun Stone, Leadership}",
+											"{@item Ioun Stone, Leadership|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Dwarven Thrower}",
+											"{@item Dwarven Thrower|SaneMagicItemPricesExpanded}",
 											"18000"
 										],
 										[
-											"{@item Ioun Stone, Strength}",
+											"{@item Ioun Stone, Strength|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item +3 Wand of the War Mage}",
+											"{@item +3 Wand of the War Mage|SaneMagicItemPricesExpanded}",
 											"19200"
 										],
 										[
-											"{@item Staff of Withering}",
+											"{@item Staff of Withering|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Efreeti Chain}",
+											"{@item Efreeti Chain|SaneMagicItemPricesExpanded}",
 											"20000"
 										],
 										[
-											"{@item Cloak of Protection}",
+											"{@item Cloak of Protection|SaneMagicItemPricesExpanded}",
 											"3500",
-											"{@item Ring of Free Action}",
+											"{@item Ring of Free Action|SaneMagicItemPricesExpanded}",
 											"20000"
 										],
 										[
-											"{@item Oathbow}",
+											"{@item Oathbow|SaneMagicItemPricesExpanded}",
 											"3500",
-											"{@item Sentinel Shield}",
+											"{@item Sentinel Shield|SaneMagicItemPricesExpanded}",
 											"20000"
 										],
 										[
-											"{@item Ring of Protection}",
+											"{@item Ring of Protection|SaneMagicItemPricesExpanded}",
 											"3500",
-											"{@item Staff of Striking}",
+											"{@item Staff of Striking|SaneMagicItemPricesExpanded}",
 											"21000"
 										],
 										[
-											"{@item +2 Weapon}",
+											"{@item +2 Weapon|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Ring of Spell Storing}",
+											"{@item Ring of Spell Storing|SaneMagicItemPricesExpanded}",
 											"24000"
 										],
 										[
-											"{@item Boots of Speed}",
+											"{@item Boots of Speed|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Vorpal Sword}",
+											"{@item Vorpal Sword|SaneMagicItemPricesExpanded}",
 											"24000"
 										],
 										[
-											"{@item Dragon Scale Mail}",
+											"{@item Dragon Scale Mail|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Ring of Water Elemental Command}",
+											"{@item Ring of Water Elemental Command|SaneMagicItemPricesExpanded}",
 											"25000"
 										],
 										[
-											"{@item Elven Chain}",
+											"{@item Elven Chain|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Rod of Alertness}",
+											"{@item Rod of Alertness|SaneMagicItemPricesExpanded}",
 											"25000"
 										],
 										[
-											"{@item Ioun Stone, Regeneration}",
+											"{@item Ioun Stone, Regeneration|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Staff of Frost}",
+											"{@item Staff of Frost|SaneMagicItemPricesExpanded}",
 											"26000"
 										],
 										[
-											"{@item Iron Bands of Bilarro}",
+											"{@item Iron Bands of Bilarro|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Instrument of the Bards, Fochlucan Bandore}",
+											"{@item Instrument of the Bards, Fochlucan Bandore|SaneMagicItemPricesExpanded}",
 											"26500"
 										],
 										[
-											"{@item Necklace of Prayer Beads|dmg|Prayer Bead} - Curing",
+											"{@item Necklace of Prayer Beads - Curing|SaneMagicItemPricesExpanded|Prayer Bead - Curing}",
 											"4000",
-											"{@item Instrument of the Bards, Mac-Fuirmidh Cittern}",
+											"{@item Instrument of the Bards, Mac-Fuirmidh Cittern|SaneMagicItemPricesExpanded}",
 											"27000"
 										],
 										[
-											"{@item Rope of Entanglement}",
+											"{@item Rope of Entanglement|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Rod of Lordly Might}",
+											"{@item Rod of Lordly Might|SaneMagicItemPricesExpanded}",
 											"28000"
 										],
 										[
-											"{@item Wand of Enemy Detection}",
+											"{@item Wand of Enemy Detection|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item +3 Rod of the Pact Keeper}",
+											"{@item +3 Rod of the Pact Keeper|SaneMagicItemPricesExpanded}",
 											"28000"
 										],
 										[
-											"{@item Stone of Good Luck}",
+											"{@item Stone of Good Luck|SaneMagicItemPricesExpanded}",
 											"4200",
-											"{@item Instrument of the Bards, Doss Lute}",
+											"{@item Instrument of the Bards, Doss Lute|SaneMagicItemPricesExpanded}",
 											"28500"
 										],
 										[
-											"{@item +2 Wand of the War Mage}",
+											"{@item +2 Wand of the War Mage|SaneMagicItemPricesExpanded}",
 											"4800",
-											"{@item Instrument of the Bards, Canaith Mandolin}",
+											"{@item Instrument of the Bards, Canaith Mandolin|SaneMagicItemPricesExpanded}",
 											"30000"
 										],
 										[
-											"{@item Flame Tongue}",
+											"{@item Flame Tongue|SaneMagicItemPricesExpanded}",
 											"5000",
-											"{@item Mantle of Spell Resistance}",
+											"{@item Mantle of Spell Resistance|SaneMagicItemPricesExpanded}",
 											"30000"
 										],
 										[
-											"{@item Periapt of Wound Closure}",
+											"{@item Periapt of Wound Closure|SaneMagicItemPricesExpanded}",
 											"5000",
-											"{@item Ring of Spell Turning}",
+											"{@item Ring of Spell Turning|SaneMagicItemPricesExpanded}",
 											"30000"
 										],
 										[
-											"{@item Ring of Evasion}",
+											"{@item Ring of Evasion|SaneMagicItemPricesExpanded}",
 											"5000",
-											"{@item Necklace of Prayer Beads|dmg|Prayer Bead} - Favor",
+											"{@item Necklace of Prayer Beads - Favor|SaneMagicItemPricesExpanded|Prayer Bead - Favor}",
 											"32000"
 										],
 										[
-											"{@item Ring of the Ram}",
+											"{@item Ring of the Ram|SaneMagicItemPricesExpanded}",
 											"5000",
-											"{@item Wand of Fireballs}",
+											"{@item Wand of Fireballs|SaneMagicItemPricesExpanded}",
 											"32000"
 										],
 										[
-											"{@item Tentacle Rod}",
+											"{@item Tentacle Rod|SaneMagicItemPricesExpanded}",
 											"5000",
-											"{@item Wand of Lightning Bolts}",
+											"{@item Wand of Lightning Bolts|SaneMagicItemPricesExpanded}",
 											"32000"
 										],
 										[
-											"{@item Animated Shield}",
+											"{@item Animated Shield|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Wand of Polymorph}",
+											"{@item Wand of Polymorph|SaneMagicItemPricesExpanded}",
 											"32000"
 										],
 										[
-											"{@item Armor of Resistance}",
+											"{@item Armor of Resistance|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Instrument of the Bards, Cli Lyre}",
+											"{@item Instrument of the Bards, Cli Lyre|SaneMagicItemPricesExpanded}",
 											"35000"
 										],
 										[
-											"{@item Arrow-Catching Shield}",
+											"{@item Arrow-Catching Shield|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Scarab of Protection}",
+											"{@item Scarab of Protection|SaneMagicItemPricesExpanded}",
 											"36000"
 										],
 										[
-											"{@item Belt of Dwarvenkind}",
+											"{@item Belt of Dwarvenkind|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Sword of Answering}",
+											"{@item Sword of Answering|SaneMagicItemPricesExpanded}",
 											"36000"
 										],
 										[
-											"{@item Bracers of Defense}",
+											"{@item Bracers of Defense|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Staff of the Woodlands}",
+											"{@item Staff of the Woodlands|SaneMagicItemPricesExpanded}",
 											"44000"
 										],
 										[
-											"{@item Ioun Stone, Reserve}",
+											"{@item Ioun Stone, Reserve|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Spellguard Shield}",
+											"{@item Spellguard Shield|SaneMagicItemPricesExpanded}",
 											"50000"
 										],
 										[
-											"{@item Pearl of Power}",
+											"{@item Pearl of Power|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Cloak of Displacement}",
+											"{@item Cloak of Displacement|SaneMagicItemPricesExpanded}",
 											"60000"
 										],
 										[
-											"{@item Pipes of Haunting}",
+											"{@item Pipes of Haunting|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Robe of Stars}",
+											"{@item Robe of Stars|SaneMagicItemPricesExpanded}",
 											"60000"
 										],
 										[
-											"{@item Ring of Resistance}",
+											"{@item Ring of Resistance|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Weapon of Warning}",
+											"{@item Weapon of Warning|SaneMagicItemPricesExpanded}",
 											"60000"
 										],
 										[
-											"{@item Robe of Scintillating Colors}",
+											"{@item Robe of Scintillating Colors|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Necklace of Prayer Beads|dmg|Prayer Bead} - Wind Walking",
+											"{@item Necklace of Prayer Beads - Wind Walking|SaneMagicItemPricesExpanded|Prayer Bead - Wind Walking}",
 											"96000"
 										],
 										[
-											"{@item Scimitar of Speed}",
+											"{@item Scimitar of Speed|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Instrument of the Bards, Anstruth Harp}",
+											"{@item Instrument of the Bards, Anstruth Harp|SaneMagicItemPricesExpanded}",
 											"109000"
 										],
 										[
-											"{@item Shield of Missile Attraction}",
+											"{@item Shield of Missile Attraction|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Instrument of the Bards, Ollamh Harp}",
+											"{@item Instrument of the Bards, Ollamh Harp|SaneMagicItemPricesExpanded}",
 											"125000"
 										],
 										[
-											"{@item Giant Slayer}",
+											"{@item Giant Slayer|SaneMagicItemPricesExpanded}",
 											"7000",
-											"{@item Necklace of Prayer Beads|dmg|Prayer Bead} - Summons",
+											"{@item Necklace of Prayer Beads - Summons|SaneMagicItemPricesExpanded|Prayer Bead - Summons}",
 											"128000"
 										],
 										[
-											"{@item Mace of Smiting}",
+											"{@item Mace of Smiting|SaneMagicItemPricesExpanded}",
 											"7000",
-											"{@item Holy Avenger}",
+											"{@item Holy Avenger|SaneMagicItemPricesExpanded}",
 											"165000"
 										]
 									]
@@ -727,9 +738,9 @@
 						},
 						{
 							"type": "entries",
-							"name": "Noncombat Items",
+							"name": "Non-combat Items",
 							"entries": [
-								"Noncombat items give some sort of problem-solving ability not directly related to combat. Some, like the Eversmoking Bottle and the Boots of Levitation are also useful in combat, but that isn't where the bulk of their utility comes from. Increase the price of these items if you'd rather have your players resort to combat more predictably instead of coming up with complicated schemes that avoid direct fighting.",
+								"Non-combat items give some sort of problem-solving ability not directly related to combat. Some, like the Eversmoking Bottle and the Boots of Levitation are also useful in combat, but that isn't where the bulk of their utility comes from. Increase the price of these items if you'd rather have your players resort to combat more predictably instead of coming up with complicated schemes that avoid direct fighting.",
 								{
 									"type": "table",
 									"colLabels": [
@@ -746,182 +757,184 @@
 									],
 									"rows": [
 										[
-											"{@item Helm of Comprehending Languages}",
+											"{@item Helm of Comprehending Languages|SaneMagicItemPricesExpanded}",
 											"500",
-											"{@item Boots of Striding and Springing}",
+											"{@item Boots of Striding and Springing|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Driftglobe}",
+											"{@item Driftglobe|SaneMagicItemPricesExpanded}",
 											"750",
-											"{@item Cloak of Arachnida}",
+											"{@item Cloak of Arachnida|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Trident of Fish Command}",
+											"{@item Trident of Fish Command|SaneMagicItemPricesExpanded}",
 											"800",
-											"{@item Cloak of Elvenkind}",
+											"{@item Cloak of Elvenkind|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Cap of Water Breathing}",
+											"{@item Cap of Water Breathing|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Gloves of Thievery}",
+											"{@item Gloves of Thievery|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Eversmoking Bottle}",
+											"{@item Eversmoking Bottle|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Hat of Disguise}",
+											"{@item Hat of Disguise|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Quiver of Ehlonna}",
+											"{@item Quiver of Ehlonna|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Horseshoes of Speed}",
+											"{@item Horseshoes of Speed|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Ioun Stone, Sustenance}",
+											"{@item Ioun Stone, Sustenance|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Immovable Rod}",
+											"{@item Immovable Rod|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Ring of Warmth}",
+											"{@item Ring of Warmth|SaneMagicItemPricesExpanded}",
 											"1000",
-											"{@item Lantern of Revealing}",
+											"{@item Lantern of Revealing|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Goggles of Night}",
+											"{@item Goggles of Night|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Periapt of Health}",
+											"{@item Periapt of Health|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Horseshoes of a Zephyr}",
+											"{@item Horseshoes of a Zephyr|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Periapt of Proof Against Poison}",
+											"{@item Periapt of Proof Against Poison|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Mariner's Armor}",
+											"{@item Mariner's Armor|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Slippers of Spider Climbing}",
+											"{@item Slippers of Spider Climbing|SaneMagicItemPricesExpanded}",
 											"5000"
 										],
 										[
-											"{@item Necklace of Adaptation}",
+											"{@item Necklace of Adaptation|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Cloak of the Bat}",
+											"{@item Cloak of the Bat|SaneMagicItemPricesExpanded}",
 											"6000"
 										],
 										[
-											"{@item Ring of Water Walking}",
+											"{@item Ring of Water Walking|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Cloak of the Manta Ray}",
+											"{@item Cloak of the Manta Ray|SaneMagicItemPricesExpanded}",
 											"6000"
 										],
 										[
-											"{@item Wand of Magic Detection}",
+											"{@item Wand of Magic Detection|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Ring of X-Ray Vision}",
+											"{@item Ring of X-Ray Vision|SaneMagicItemPricesExpanded}",
 											"6000"
 										],
 										[
-											"{@item Wand of Secrets}",
+											"{@item Wand of Secrets|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Cape of the Mountebank}",
+											"{@item Cape of the Mountebank|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Gloves of Swimming and Climbing}",
+											"{@item Gloves of Swimming and Climbing|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Portable Hole}",
+											"{@item Portable Hole|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Heward's Handy Haversack}",
+											"{@item Heward's Handy Haversack|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Apparatus of Kwalish}",
+											"{@item Apparatus of Kwalish|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Rope of Climbing}",
+											"{@item Rope of Climbing|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Boots of the Winterlands}",
+											"{@item Boots of the Winterlands|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Ring of Feather Falling}",
+											"{@item Ring of Feather Falling|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Folding Boat}",
+											"{@item Folding Boat|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Boots of Elvenkind}",
+											"{@item Boots of Elvenkind|SaneMagicItemPricesExpanded}",
 											"2500",
-											"{@item Ring of Invisibility}",
+											"{@item Ring of Invisibility|SaneMagicItemPricesExpanded}",
 											"10000"
 										],
 										[
-											"{@item Eyes of Minute Seeing}",
+											"{@item Eyes of Minute Seeing|SaneMagicItemPricesExpanded}",
 											"2500",
-											"{@item Helm of Telepathy}",
+											"{@item Helm of Telepathy|SaneMagicItemPricesExpanded}",
 											"12000"
 										],
 										[
-											"{@item Eyes of the Eagle}",
+											"{@item Eyes of the Eagle|SaneMagicItemPricesExpanded}",
 											"2500",
-											"{@item Cube of Force}",
+											"{@item Cube of Force|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Ring of Jumping}",
+											"{@item Ring of Jumping|SaneMagicItemPricesExpanded}",
 											"2500",
-											"{@item Ring of Mind Shielding}",
+											"{@item Ring of Mind Shielding|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Dimensional Shackles}",
+											"{@item Dimensional Shackles|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Rod of Rulership}",
+											"{@item Rod of Rulership|SaneMagicItemPricesExpanded}",
 											"16000"
 										],
 										[
-											"{@item Eyes of Charming}",
+											"{@item Eyes of Charming|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Mirror of Life Trapping}",
+											"{@item Mirror of Life Trapping|SaneMagicItemPricesExpanded}",
 											"18000"
 										],
 										[
-											"{@item Medallion of Thoughts}",
+											"{@item Medallion of Thoughts|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Amulet of Proof Against Detection and Location}",
+											"{@item Amulet of Proof Against Detection and Location|SaneMagicItemPricesExpanded}",
 											"20000"
 										],
 										[
-											"{@item Ring of Swimming}",
+											"{@item Ring of Swimming|SaneMagicItemPricesExpanded}",
 											"3000",
-											"{@item Robe of Eyes}",
+											"{@item Robe of Eyes|SaneMagicItemPricesExpanded}",
 											"30000"
 										],
 										[
-											"{@item Bag of Holding}",
+											"{@item Bag of Holding|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Gem of Seeing}",
+											"{@item Gem of Seeing|SaneMagicItemPricesExpanded}",
 											"32000"
 										],
 										[
-											"{@item Boots of Levitation}",
+											"{@item Boots of Levitation|SaneMagicItemPricesExpanded}",
 											"4000",
-											"{@item Plate Armor of Etherealness}",
+											"{@item Plate Armor of Etherealness|SaneMagicItemPricesExpanded}",
 											"48000"
 										],
 										[
-											"{@item Ring of Animal Influence}",
-											"4000"
+											"{@item Ring of Animal Influence|SaneMagicItemPricesExpanded}",
+											"4000",
+											"",
+											""
 										]
 									]
 								}
@@ -948,51 +961,51 @@
 									],
 									"rows": [
 										[
-											"{@item Figurine of Wondrous Power, Ivory Goats|dmg|Ivory Goat (Travail)}",
+											"{@item Figurine of Wondrous Power, Ivory Goats - Travail|SaneMagicItemPricesExpanded|Ivory Goat (Travail)}",
 											"400",
-											"{@item Bowl of Commanding Water Elementals}",
+											"{@item Bowl of Commanding Water Elementals|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Golden Lions|dmg|Golden Lion} (each)",
+											"{@item Figurine of Wondrous Power, Golden Lions - Each|SaneMagicItemPricesExpanded|Golden Lion} (each)",
 											"600",
-											"{@item Brazier of Commanding Fire Elementals}",
+											"{@item Brazier of Commanding Fire Elementals|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Ivory Goats|dmg|Ivory Goat (Traveling)}",
+											"{@item Figurine of Wondrous Power, Ivory Goats - Travelling|SaneMagicItemPricesExpanded|Ivory Goat (Travelling)}",
 											"1000",
-											"{@item Censer of Controlling Air Elementals}",
+											"{@item Censer of Controlling Air Elementals|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Staff of the Python}",
+											"{@item Staff of the Python|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item Stone of Controlling Earth Elementals}",
+											"{@item Stone of Controlling Earth Elementals|SaneMagicItemPricesExpanded}",
 											"8000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Onyx Dog|dmg|Onyx Dog}",
+											"{@item Figurine of Wondrous Power, Onyx Dog|SaneMagicItemPricesExpanded|Onyx Dog}",
 											"3000",
-											"{@item Horn of Valhalla, Brass}",
+											"{@item Horn of Valhalla, Brass|SaneMagicItemPricesExpanded}",
 											"8400"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Silver Raven|dmg|Silver Raven}",
+											"{@item Figurine of Wondrous Power, Silver Raven|SaneMagicItemPricesExpanded|Silver Raven}",
 											"5000",
-											"{@item Horn of Valhalla, Bronze}",
+											"{@item Horn of Valhalla, Bronze|SaneMagicItemPricesExpanded}",
 											"11200"
 										],
 										[
-											"{@item Horn of Valhalla, Silver}",
+											"{@item Horn of Valhalla, Silver|SaneMagicItemPricesExpanded}",
 											"5600",
-											"{@item Horn of Valhalla, Iron}",
+											"{@item Horn of Valhalla, Iron|SaneMagicItemPricesExpanded}",
 											"14000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Marble Elephant|dmg|Marble Elephant}",
+											"{@item Figurine of Wondrous Power, Marble Elephant|SaneMagicItemPricesExpanded|Marble Elephant}",
 											"6000",
-											"{@item Figurine of Wondrous Power, Ivory Goats|dmg|Ivory Goat (Terror)}",
+											"{@item Figurine of Wondrous Power, Ivory Goats - Terror|SaneMagicItemPricesExpanded|Ivory Goat (Terror)}",
 											"20000"
 										]
 									]
@@ -1020,111 +1033,111 @@
 									],
 									"rows": [
 										[
-											"{@item +1 Armor}",
+											"{@item +1 Armor|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item Talisman of the Sphere}",
+											"{@item Talisman of the Sphere|SaneMagicItemPricesExpanded}",
 											"20000"
 										],
 										[
-											"{@item +1 Shield}",
+											"{@item +1 Shield (*)|SaneMagicItemPricesExpanded}",
 											"1500",
-											"{@item +3 Armor}",
+											"{@item +3 Armor|SaneMagicItemPricesExpanded}",
 											"24000"
 										],
 										[
-											"{@item Sending Stones}",
+											"{@item Sending Stones|SaneMagicItemPricesExpanded}",
 											"2000",
-											"{@item +3 Shield}",
+											"{@item +3 Shield (*)|SaneMagicItemPricesExpanded}",
 											"24000"
 										],
 										[
-											"{@item Wings of Flying}",
+											"{@item Wings of Flying|SaneMagicItemPricesExpanded}",
 											"5000",
-											"{@item Defender}",
+											"{@item Defender|SaneMagicItemPricesExpanded}",
 											"24000"
 										],
 										[
-											"{@item Alchemy Jug}",
+											"{@item Alchemy Jug|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Ring of Earth Elemental Command}",
+											"{@item Ring of Earth Elemental Command|SaneMagicItemPricesExpanded}",
 											"31000"
 										],
 										[
-											"{@item +2 Armor}",
+											"{@item +2 Armor|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Robe of the Archmagi}",
+											"{@item Robe of the Archmagi|SaneMagicItemPricesExpanded}",
 											"34000"
 										],
 										[
-											"{@item +2 Shield}",
+											"{@item +2 Shield (*)|SaneMagicItemPricesExpanded}",
 											"6000",
-											"{@item Ring of Air Elemental Command}",
+											"{@item Ring of Air Elemental Command|SaneMagicItemPricesExpanded}",
 											"35000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Ebony Fly|dmg|Ebony Fly}",
+											"{@item Figurine of Wondrous Power, Ebony Fly|SaneMagicItemPricesExpanded|Ebony Fly}",
 											"6000",
-											"{@item Cubic Gate}",
+											"{@item Cubic Gate|SaneMagicItemPricesExpanded}",
 											"40000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Bronze Griffon|dmg|Bronze Griffon}",
+											"{@item Figurine of Wondrous Power, Bronze Griffon|SaneMagicItemPricesExpanded|Bronze Griffon}",
 											"8000",
-											"{@item Crystal Ball}",
+											"{@item Crystal Ball|SaneMagicItemPricesExpanded}",
 											"50000"
 										],
 										[
-											"{@item Broom of Flying}",
+											"{@item Broom of Flying|SaneMagicItemPricesExpanded}",
 											"8000",
-											"{@item Helm of Teleportation}",
+											"{@item Helm of Teleportation|SaneMagicItemPricesExpanded}",
 											"64000"
 										],
 										[
-											"{@item Figurine of Wondrous Power, Serpentine Owl|dmg|Serpentine Owl}",
+											"{@item Figurine of Wondrous Power, Serpentine Owl|SaneMagicItemPricesExpanded|Serpentine Owl}",
 											"8000",
-											"{@item Daern's Instant Fortress}",
+											"{@item Daern's Instant Fortress|SaneMagicItemPricesExpanded}",
 											"75000"
 										],
 										[
-											"{@item Winged Boots}",
+											"{@item Winged Boots|SaneMagicItemPricesExpanded}",
 											"8000",
-											"{@item Ring of Telekinesis}",
+											"{@item Ring of Telekinesis|SaneMagicItemPricesExpanded}",
 											"80000"
 										],
 										[
-											"{@item Dwarven Plate}",
+											"{@item Dwarven Plate|SaneMagicItemPricesExpanded}",
 											"9000",
-											"{@item Cloak of Invisibility}",
+											"{@item Cloak of Invisibility|SaneMagicItemPricesExpanded}",
 											"80000"
 										],
 										[
-											"{@item Potion of Longevity}",
+											"{@item Potion of Longevity|SaneMagicItemPricesExpanded}",
 											"9000",
-											"{@item Rod of Security}",
+											"{@item Rod of Security|SaneMagicItemPricesExpanded}",
 											"90000"
 										],
 										[
-											"{@item Carpet of Flying}",
+											"{@item Carpet of Flying|SaneMagicItemPricesExpanded}",
 											"12000",
-											"{@item Staff of Power}",
+											"{@item Staff of Power|SaneMagicItemPricesExpanded}",
 											"95500"
 										],
 										[
-											"{@item Ring of Regeneration}",
+											"{@item Ring of Regeneration|SaneMagicItemPricesExpanded}",
 											"12000",
-											"{@item Figurine of Wondrous Power, Obsidian Steed|dmg|Obsidian Steed}",
+											"{@item Figurine of Wondrous Power, Obsidian Steed|SaneMagicItemPricesExpanded|Obsidian Steed}",
 											"128000"
 										],
 										[
-											"{@item Sphere of Annihilation}",
+											"{@item Sphere of Annihilation|SaneMagicItemPricesExpanded}",
 											"15000",
-											"{@item Decanter of Endless Water}",
+											"{@item Decanter of Endless Water|SaneMagicItemPricesExpanded}",
 											"135000"
 										],
 										[
-											"{@item Armor of Invulnerability}",
+											"{@item Armor of Invulnerability|SaneMagicItemPricesExpanded}",
 											"18000",
-											"{@item Amulet of the Planes}",
+											"{@item Amulet of the Planes|SaneMagicItemPricesExpanded}",
 											"160000"
 										]
 									]
@@ -1184,80 +1197,82 @@
 									],
 									"rows": [
 										[
-											"{@item Moodmark Paint|GGR}",
+											"{@item Moodmark Paint|SaneMagicItemPricesExpanded}",
 											5,
-											"{@item Izzet Keyrune|GGR}",
+											"{@item Izzet Keyrune|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Pyroconverger|GGR}",
+											"{@item Pyroconverger|SaneMagicItemPricesExpanded}",
 											50,
-											"{@item Azorius Keyrune|GGR}",
+											"{@item Azorius Keyrune|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item Skyblinder Staff|GGR}",
+											"{@item Skyblinder Staff|SaneMagicItemPricesExpanded}",
 											100,
-											"{@item Mizzium Mortar|GGR}",
+											"{@item Mizzium Mortar|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item Mizzium Apparatus|GGR}",
+											"{@item Mizzium Apparatus|SaneMagicItemPricesExpanded}",
 											1300,
-											"{@item Boros Keyrune|GGR}",
+											"{@item Boros Keyrune|SaneMagicItemPricesExpanded}",
 											6000
 										],
 										[
-											"{@item Guild Signet|GGR}",
+											"{@item Guild Signet|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item Golgari Keyrune|GGR}",
+											"{@item Golgari Keyrune|SaneMagicItemPricesExpanded}",
 											6000
 										],
 										[
-											"{@item Mizzium Armor|GGR}",
+											"{@item Mizzium Armor|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item Sword of the Paruns|GGR}",
+											"{@item Sword of the Paruns|SaneMagicItemPricesExpanded}",
 											6000
 										],
 										[
-											"{@item Orzhov Keyrune|GGR}",
+											"{@item Orzhov Keyrune|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Dimir Keyrune|GGR}",
+											"{@item Dimir Keyrune|SaneMagicItemPricesExpanded}",
 											10000
 										],
 										[
-											"{@item Rakdos Keyrune|GGR}",
+											"{@item Rakdos Keyrune|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Pariah's Shield|GGR}",
+											"{@item Pariah's Shield|SaneMagicItemPricesExpanded}",
 											10000
 										],
 										[
-											"{@item Selesnya Keyrune|GGR}",
+											"{@item Selesnya Keyrune|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Peregrine Mask|GGR}",
+											"{@item Peregrine Mask|SaneMagicItemPricesExpanded}",
 											12000
 										],
 										[
-											"{@item Simic Keyrune|GGR}",
+											"{@item Simic Keyrune|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Illusionist's Bracers|GGR}",
+											"{@item Illusionist's Bracers|SaneMagicItemPricesExpanded}",
 											15000
 										],
 										[
-											"{@item Spies' Murmur|GGR}",
+											"{@item Spies' Murmur|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Rakdos Riteknife|GGR}",
+											"{@item Rakdos Riteknife|SaneMagicItemPricesExpanded}",
 											18000
 										],
 										[
-											"{@item Sunforger|GGR}",
+											"{@item Sunforger|SaneMagicItemPricesExpanded}",
 											3000,
-											"{@item Voyager Staff|GGR}",
+											"{@item Voyager Staff|SaneMagicItemPricesExpanded}",
 											90000
 										],
 										[
-											"{@item Gruul Keyrune|GGR}",
-											4000
+											"{@item Gruul Keyrune|SaneMagicItemPricesExpanded}",
+											4000,
+											"",
+											""
 										]
 									]
 								}
@@ -1285,175 +1300,175 @@
 									],
 									"rows": [
 										[
-											"{@item Spellwrought Tattoo (Cantrip)|TCE}",
+											"{@item Spellwrought Tattoo (Cantrip)|SaneMagicItemPricesExpanded}",
 											50,
-											"{@item Spellwrought Tattoo (5th Level)|TCE}",
+											"{@item Spellwrought Tattoo (5th Level)|SaneMagicItemPricesExpanded}",
 											3200
 										],
 										[
-											"{@item Prosthetic Limb|TCE}",
+											"{@item Prosthetic Limb|SaneMagicItemPricesExpanded}",
 											100,
-											"{@item Astral Shard|TCE}",
+											"{@item Astral Shard|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Spellwrought Tattoo (1st Level)|TCE}",
+											"{@item Spellwrought Tattoo (1st Level)|SaneMagicItemPricesExpanded}",
 											300,
-											"{@item Devotee's Censer|TCE}",
+											"{@item Devotee's Censer|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Eldritch Claw Tattoo|TCE}",
+											"{@item Eldritch Claw Tattoo|SaneMagicItemPricesExpanded}",
 											500,
-											"{@item Elemental Essence Shard|TCE}",
+											"{@item Elemental Essence Shard|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Illuminator's Tattoo|TCE}",
+											"{@item Illuminator's Tattoo|SaneMagicItemPricesExpanded}",
 											500,
-											"{@item Feywild Shard|TCE}",
+											"{@item Feywild Shard|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Masquerade Tattoo|TCE}",
+											"{@item Masquerade Tattoo|SaneMagicItemPricesExpanded}",
 											500,
-											"{@item Fulminating Treatise|TCE}",
+											"{@item Fulminating Treatise|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Spellwrought Tattoo (2nd Level)|TCE}",
+											"{@item Spellwrought Tattoo (2nd Level)|SaneMagicItemPricesExpanded}",
 											600,
-											"{@item Outer Essence Shard|TCE}",
+											"{@item Outer Essence Shard|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item Spellwrought Tattoo (3rd Level)|TCE}",
+											"{@item Spellwrought Tattoo (3rd Level)|SaneMagicItemPricesExpanded}",
 											1000,
-											"{@item Shadowfell Shard|TCE}",
+											"{@item Shadowfell Shard|SaneMagicItemPricesExpanded}",
 											4000
 										],
 										[
-											"{@item +1 All-Purpose Tool|TCE}",
+											"{@item +1 All-Purpose Tool|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item +2 All-Purpose Tool|TCE}",
+											"{@item +2 All-Purpose Tool|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item +1 Amulet of the Devout|TCE}",
+											"{@item +1 Amulet of the Devout|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item +2 Amulet of the Devout|TCE}",
+											"{@item +2 Amulet of the Devout|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item +1 Arcane Grimoire|TCE}",
+											"{@item +1 Arcane Grimoire|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item +2 Arcane Grimoire|TCE}",
+											"{@item +2 Arcane Grimoire|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item +1 Bloodwell Vial|TCE}",
+											"{@item +1 Bloodwell Vial|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item +2 Bloodwell Vial|TCE}",
+											"{@item +2 Bloodwell Vial|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item +1 Moon Sickle|TCE}",
+											"{@item +1 Moon Sickle|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item +2 Moon Sickle|TCE}",
+											"{@item +2 Moon Sickle|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item +1 Rhythm-Maker's Drum|TCE}",
+											"{@item +1 Rhythm-Maker's Drum|SaneMagicItemPricesExpanded}",
 											1500,
-											"{@item +2 Rhythm-Maker's Drum|TCE}",
+											"{@item +2 Rhythm-Maker's Drum|SaneMagicItemPricesExpanded}",
 											5000
 										],
 										[
-											"{@item Spellwrought Tattoo (4th Level)|TCE}",
+											"{@item Spellwrought Tattoo (4th Level)|SaneMagicItemPricesExpanded}",
 											1600,
-											"{@item Barrier Tattoo (Small)|TCE}",
+											"{@item Barrier Tattoo (Small)|SaneMagicItemPricesExpanded}",
 											6000
 										],
 										[
-											"{@item Alchemical Compendium|TCE}",
+											"{@item Alchemical Compendium|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Barrier Tattoo (Medium)|TCE}",
+											"{@item Barrier Tattoo (Medium)|SaneMagicItemPricesExpanded}",
 											12000
 										],
 										[
-											"{@item Astromancy Archive|TCE}",
+											"{@item Astromancy Archive|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item +3 All-Purpose Tool|TCE}",
+											"{@item +3 All-Purpose Tool|SaneMagicItemPricesExpanded}",
 											20000
 										],
 										[
-											"{@item Atlas of Endless Horizons|TCE}",
+											"{@item Atlas of Endless Horizons|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item +3 Amulet of the Devout|TCE}",
+											"{@item +3 Amulet of the Devout|SaneMagicItemPricesExpanded}",
 											20000
 										],
 										[
-											"{@item Bell Branch|TCE}",
+											"{@item Bell Branch|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item +3 Arcane Grimoire|TCE}",
+											"{@item +3 Arcane Grimoire|SaneMagicItemPricesExpanded}",
 											20000
 										],
 										[
-											"{@item Guardian Emblem|TCE}",
+											"{@item Guardian Emblem|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item +3 Bloodwell Vial|TCE}",
+											"{@item +3 Bloodwell Vial|SaneMagicItemPricesExpanded}",
 											20000
 										],
 										[
-											"{@item Heart Weaver's Primer|TCE}",
+											"{@item Heart Weaver's Primer|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item +3 Moon Sickle|TCE}",
+											"{@item +3 Moon Sickle|SaneMagicItemPricesExpanded}",
 											20000
 										],
 										[
-											"{@item Libram of Souls and Flesh|TCE}",
+											"{@item Libram of Souls and Flesh|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item +3 Rhythm-Maker's Drum|TCE}",
+											"{@item +3 Rhythm-Maker's Drum|SaneMagicItemPricesExpanded}",
 											20000
 										],
 										[
-											"{@item Lifewell Tattoo|TCE}",
+											"{@item Lifewell Tattoo|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Absorbing Tattoo|TCE}",
+											"{@item Absorbing Tattoo|SaneMagicItemPricesExpanded}",
 											24000
 										],
 										[
-											"{@item Shadowfell Brand Tattoo|TCE}",
+											"{@item Shadowfell Brand Tattoo|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Barrier Tattoo (Large)|TCE}",
+											"{@item Barrier Tattoo (Large)|SaneMagicItemPricesExpanded}",
 											24000
 										],
 										[
-											"{@item Nature's Mantle|TCE}",
+											"{@item Nature's Mantle|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Crystalline Chronicle|TCE}",
+											"{@item Crystalline Chronicle|SaneMagicItemPricesExpanded}",
 											25000
 										],
 										[
-											"{@item Planecaller's Codex|TCE}",
+											"{@item Planecaller's Codex|SaneMagicItemPricesExpanded}",
 											2000,
-											"{@item Demonomicon of Iggwilv|TCE}",
+											"{@item Demonomicon of Iggwilv|SaneMagicItemPricesExpanded}",
 											50000
 										],
 										[
-											"{@item Blood Fury Tattoo|TCE}",
+											"{@item Blood Fury Tattoo|SaneMagicItemPricesExpanded}",
 											3000,
-											"{@item Mighty Servant of Leuk-o|TCE}",
+											"{@item Mighty Servant of Leuk-o|SaneMagicItemPricesExpanded}",
 											80000
 										],
 										[
-											"{@item Coiling Grasp Tattoo|TCE}",
+											"{@item Coiling Grasp Tattoo|SaneMagicItemPricesExpanded}",
 											3000,
-											"{@item Cauldron of Rebirth|TCE}",
+											"{@item Cauldron of Rebirth|SaneMagicItemPricesExpanded}",
 											100000
 										],
 										[
-											"{@item Ghost Step Tattoo|TCE}",
+											"{@item Ghost Step Tattoo|SaneMagicItemPricesExpanded}",
 											3000,
 											"",
 											""
@@ -1462,6 +1477,8385 @@
 								}
 							]
 						}
+					]
+				}
+			]
+		}
+	],
+	"item": [
+		{
+			"name": "+1 All-Purpose Tool",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 All-Purpose Tool",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+1 Amulet of the Devout",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Amulet of the Devout",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+1 Arcane Grimoire",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Arcane Grimoire",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+1 Bloodwell Vial",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Bloodwell Vial",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+1 Moon Sickle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Moon Sickle",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+1 Rhythm-Maker's Drum",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Rhythm-Maker's Drum",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+1 Rod of the Pact Keeper",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Rod of the Pact Keeper",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "+1 Wand of the War Mage",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 120000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+1 Wand of the War Mage",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "+2 All-Purpose Tool",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 All-Purpose Tool",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+2 Amulet of the Devout",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Amulet of the Devout",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+2 Arcane Grimoire",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Arcane Grimoire",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+2 Bloodwell Vial",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Bloodwell Vial",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+2 Moon Sickle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Moon Sickle",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+2 Rhythm-Maker's Drum",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Rhythm-Maker's Drum",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+2 Rod of the Pact Keeper",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Rod of the Pact Keeper",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "+2 Wand of the War Mage",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 480000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+2 Wand of the War Mage",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "+3 All-Purpose Tool",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 All-Purpose Tool",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+3 Amulet of the Devout",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Amulet of the Devout",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+3 Arcane Grimoire",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Arcane Grimoire",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+3 Bloodwell Vial",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Bloodwell Vial",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+3 Moon Sickle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Moon Sickle",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+3 Rhythm-Maker's Drum",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Rhythm-Maker's Drum",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "+3 Rod of the Pact Keeper",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Rod of the Pact Keeper",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "+3 Wand of the War Mage",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1920000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "+3 Wand of the War Mage",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Acid Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Acid Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Alchemical Compendium",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Alchemical Compendium",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Alchemy Jug",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Alchemy Jug",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Amulet of Health",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Amulet of Health",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Amulet of Proof Against Detection and Location",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Amulet of Proof Against Detection and Location",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Amulet of the Planes",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 16000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Amulet of the Planes",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Animated Shield",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Animated Shield",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Apparatus of Kwalish",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Apparatus of Kwalish",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Armor of Invulnerability",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Armor of Invulnerability",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Arrow-Catching Shield",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Arrow-Catching Shield",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Astral Shard",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Astral Shard",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Astromancy Archive",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Astromancy Archive",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Atlas of Endless Horizons",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Atlas of Endless Horizons",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Azorius Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Azorius Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Azorius Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Azorius Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Bag of Holding",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Bag of Holding",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Barrier Tattoo (Large)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Barrier Tattoo (Large)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Barrier Tattoo (Medium)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Barrier Tattoo (Medium)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Barrier Tattoo (Small)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Barrier Tattoo (Small)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Bead of Force",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Bead of Force",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Bell Branch",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Bell Branch",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Belt of Dwarvenkind",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Belt of Dwarvenkind",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Black Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Black Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Blood Fury Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Blood Fury Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Blue Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Blue Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Boots of Elvenkind",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 250000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Boots of Elvenkind",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Boots of Levitation",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Boots of Levitation",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Boots of Speed",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Boots of Speed",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Boots of Striding and Springing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Boots of Striding and Springing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Boots of the Winterlands",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Boots of the Winterlands",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Boros Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Boros Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Boros Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Boros Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Bowl of Commanding Water Elementals",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Bowl of Commanding Water Elementals",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Bracers of Archery",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Bracers of Archery",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Bracers of Defense",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Bracers of Defense",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Brass Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Brass Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Brazier of Commanding Fire Elementals",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Brazier of Commanding Fire Elementals",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Bronze Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Bronze Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Brooch of Shielding",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 750000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Brooch of Shielding",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Broom of Flying",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Broom of Flying",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cap of Water Breathing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cap of Water Breathing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cape of the Mountebank",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cape of the Mountebank",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Carpet of Flying, 3 ft. × 5 ft.",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"name": "Carpet of Flying, 3 ft. × 5 ft.",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Carpet of Flying, 4 ft. × 6 ft.",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"name": "Carpet of Flying, 4 ft. × 6 ft.",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Carpet of Flying, 5 ft. × 7 ft.",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"name": "Carpet of Flying, 5 ft. × 7 ft.",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Carpet of Flying, 6 ft. × 9 ft.",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"name": "Carpet of Flying, 6 ft. × 9 ft.",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Cauldron of Rebirth",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 10000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cauldron of Rebirth",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Censer of Controlling Air Elementals",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Censer of Controlling Air Elementals",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Chime of Opening",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Chime of Opening",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Circlet of Blasting",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Circlet of Blasting",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of Arachnida",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of Arachnida",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of Displacement",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 6000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of Displacement",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of Elvenkind",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of Elvenkind",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of Invisibility",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 8000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of Invisibility",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of Protection",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 350000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of Protection",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of the Bat",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of the Bat",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cloak of the Manta Ray",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cloak of the Manta Ray",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Coiling Grasp Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Coiling Grasp Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Cold Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Cold Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Copper Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Copper Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Crystal Ball",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Crystal Ball",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Crystalline Chronicle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Crystalline Chronicle",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Cube of Force",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cube of Force",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Cubic Gate",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 4000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Cubic Gate",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Daern's Instant Fortress",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 7500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Daern's Instant Fortress",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Dagger of Venom",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 250000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dagger of Venom",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Decanter of Endless Water",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 13500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Decanter of Endless Water",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Deck of Illusions",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 612000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Deck of Illusions",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Demonomicon of Iggwilv",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Demonomicon of Iggwilv",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Devotee's Censer",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Devotee's Censer",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Dimensional Shackles",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dimensional Shackles",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Dimir Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Dimir Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Dimir Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dimir Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Driftglobe",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 75000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Driftglobe",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Dust of Disappearance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dust of Disappearance",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Dust of Dryness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dust of Dryness",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a single pellet"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Dust of Sneezing and Choking",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 48000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dust of Sneezing and Choking",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Dwarven Plate",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 900000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dwarven Plate",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Dwarven Thrower",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Dwarven Thrower",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Efreeti Chain",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Efreeti Chain",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Eldritch Claw Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 50000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Eldritch Claw Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Elemental Essence Shard",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Elemental Essence Shard",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Elemental Gem, Blue Sapphire",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"name": "Elemental Gem, Blue Sapphire",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Elemental Gem, Emerald",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"name": "Elemental Gem, Emerald",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Elemental Gem, Red Corundum",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"name": "Elemental Gem, Red Corundum",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Elemental Gem, Yellow Diamond",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"name": "Elemental Gem, Yellow Diamond",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Elixir of Health",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Elixir of Health",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Elven Chain",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Elven Chain",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Eversmoking Bottle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Eversmoking Bottle",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Eyes of Charming",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Eyes of Charming",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Eyes of Minute Seeing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 250000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Eyes of Minute Seeing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Eyes of the Eagle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 250000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Eyes of the Eagle",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Feywild Shard",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Feywild Shard",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Bronze Griffon",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Bronze Griffon",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Bronze Griffon Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Ebony Fly",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Ebony Fly",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Ebony Fly Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Golden Lions - Each",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 60000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Golden Lions",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Golden Lion Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Ivory Goats - Terror",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Ivory Goats",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for the Ivory Goat of Terror"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Ivory Goats - Travail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 40000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Ivory Goats",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for the Ivory Goat of Travail"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Ivory Goats - Travelling",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Ivory Goats",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for the Ivory Goat of Traveling"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Marble Elephant",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Marble Elephant",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Marble Elephant Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Obsidian Steed",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Obsidian Steed",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Obsidian Steed Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Onyx Dog",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Onyx Dog",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Onyx Dog Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Serpentine Owl",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Serpentine Owl",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Serpentine Owl Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Figurine of Wondrous Power, Silver Raven",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Figurine of Wondrous Power, Silver Raven",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"This item is priced specifically for a single Silver Raven Figurine"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Fire Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Fire Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Folding Boat",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Folding Boat",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Force Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Force Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Fulminating Treatise",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Fulminating Treatise",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Gauntlets of Ogre Power",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gauntlets of Ogre Power",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Gem of Brightness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gem of Brightness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Gem of Seeing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gem of Seeing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ghost Step Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ghost Step Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Glamoured Studded Leather",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Glamoured Studded Leather",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Gloves of Missile Snaring",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gloves of Missile Snaring",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Gloves of Swimming and Climbing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gloves of Swimming and Climbing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Gloves of Thievery",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gloves of Thievery",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Goggles of Night",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Goggles of Night",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Gold Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Gold Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Golgari Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Golgari Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Golgari Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Golgari Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Green Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Green Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Gruul Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Gruul Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Gruul Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Gruul Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Guardian Emblem",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Guardian Emblem",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Hammer of Thunderbolts",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Hammer of Thunderbolts",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Hat of Disguise",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Hat of Disguise",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Headband of Intellect",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Headband of Intellect",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Heart Weaver's Primer",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Heart Weaver's Primer",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Helm of Comprehending Languages",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 50000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Helm of Comprehending Languages",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Helm of Telepathy",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Helm of Telepathy",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Helm of Teleportation",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 6400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Helm of Teleportation",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Heward's Handy Haversack",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Heward's Handy Haversack",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horn of Blasting",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 45000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horn of Blasting",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horn of Valhalla, Brass",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 840000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horn of Valhalla, Brass",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horn of Valhalla, Bronze",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1120000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horn of Valhalla, Bronze",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horn of Valhalla, Iron",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horn of Valhalla, Iron",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horn of Valhalla, Silver",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 560000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horn of Valhalla, Silver",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horseshoes of Speed",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horseshoes of Speed",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Horseshoes of a Zephyr",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Horseshoes of a Zephyr",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Illuminator's Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 50000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Illuminator's Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Illusionist's Bracers",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Illusionist's Bracers",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Immovable Rod",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Immovable Rod",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Anstruth Harp",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 10900000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Anstruth Harp",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Canaith Mandolin",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Canaith Mandolin",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Cli Lyre",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Cli Lyre",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Doss Lute",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2850000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Doss Lute",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Fochlucan Bandore",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2650000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Fochlucan Bandore",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Mac-Fuirmidh Cittern",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2700000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Mac-Fuirmidh Cittern",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Instrument of the Bards, Ollamh Harp",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Instrument of the Bards, Ollamh Harp",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Absorption",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 240000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Absorption",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Agility",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Agility",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Awareness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Awareness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Fortitude",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Fortitude",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Greater Absorption",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Greater Absorption",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Insight",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Insight",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Intellect",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Intellect",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Leadership",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Leadership",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Mastery",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Mastery",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Protection",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 120000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Protection",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Regeneration",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Regeneration",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Reserve",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Reserve",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Strength",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Strength",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ioun Stone, Sustenance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ioun Stone, Sustenance",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Iron Bands of Bilarro",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Iron Bands of Bilarro",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Izzet Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Izzet Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Izzet Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Izzet Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Javelin of Lightning",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Javelin of Lightning",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Keoghtom's Ointment",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Keoghtom's Ointment",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is per dose of the ointment"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Lantern of Revealing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Lantern of Revealing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Libram of Souls and Flesh",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Libram of Souls and Flesh",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Lifewell Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Lifewell Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Lightning Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Lightning Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Mace of Disruption",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mace of Disruption",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Mace of Smiting",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 700000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mace of Smiting",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Mace of Terror",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mace of Terror",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Mantle of Spell Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mantle of Spell Resistance",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Masquerade Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 50000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Masquerade Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Medallion of Thoughts",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Medallion of Thoughts",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Mighty Servant of Leuk-o",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 8000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mighty Servant of Leuk-o",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Mirror of Life Trapping",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mirror of Life Trapping",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Mizzium Apparatus",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 130000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mizzium Apparatus",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Mizzium Mortar",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Mizzium Mortar",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Moodmark Paint",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Moodmark Paint",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Nature's Mantle",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Nature's Mantle",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Necklace of Adaptation",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Adaptation",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Necklace of Fireballs (Five Beads)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 384000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Fireballs",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a necklace with five beads"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Fireballs (Four Beads)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 160000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Fireballs",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a necklace with four beads"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Fireballs (One Bead)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Fireballs",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a necklace with one bead"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Fireballs (Six Beads)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 768000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Fireballs",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a necklace with six beads"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Fireballs (Three Beads)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Fireballs",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a necklace with three beads"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Fireballs (Two Beads)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 48000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Fireballs",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a necklace with two beads"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Prayer Beads - Bless",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Prayer Beads",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a Prayer Bead of Bless"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Prayer Beads - Curing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Prayer Beads",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a Prayer Bead of Curing"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Prayer Beads - Favor",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Prayer Beads",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a Prayer Bead of Favor"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Prayer Beads - Smiting",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Prayer Beads",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a Prayer Bead of Smiting"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Prayer Beads - Summons",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Prayer Beads",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a Prayer Bead of Summons"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necklace of Prayer Beads - Wind Walking",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 9600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Necklace of Prayer Beads",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The price is for a Prayer Bead of Wind Walking"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Necrotic Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Necrotic Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Nolzur's Marvelous Pigments",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 20000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Nolzur's Marvelous Pigments",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Oathbow",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 350000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Oathbow",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Oil of Etherealness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 192000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Oil of Etherealness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Oil of Sharpness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 320000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Oil of Sharpness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Oil of Slipperiness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 48000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Oil of Slipperiness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Orzhov Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Orzhov Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Orzhov Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Orzhov Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Outer Essence Shard",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Outer Essence Shard",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Pariah's Shield",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Pariah's Shield",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Pearl of Power",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Pearl of Power",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Peregrine Mask",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Peregrine Mask",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Periapt of Health",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Periapt of Health",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Periapt of Proof Against Poison",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Periapt of Proof Against Poison",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Periapt of Wound Closure",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Periapt of Wound Closure",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Philter of Love",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 9000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Philter of Love",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Pipes of Haunting",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Pipes of Haunting",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Pipes of the Sewers",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Pipes of the Sewers",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Planecaller's Codex",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Planecaller's Codex",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Plate Armor of Etherealness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 4800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Plate Armor of Etherealness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Poison Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Poison Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Portable Hole",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Portable Hole",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Acid Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Acid Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Animal Friendship",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 20000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Animal Friendship",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Clairvoyance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Clairvoyance",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Climbing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Climbing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Cold Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Cold Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Diminution",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 27000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Diminution",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Fire Breath",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 15000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Fire Breath",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Fire Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Fire Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Flying",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 50000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Flying",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Force Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Force Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Gaseous Form",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Gaseous Form",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Greater Healing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 15000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Greater Healing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Growth",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 27000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Growth",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Healing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Healing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Heroism",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Heroism",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Invisibility",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Invisibility",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Invulnerability",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 384000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Invulnerability",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Lightning Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Lightning Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Longevity",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 900000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Longevity",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Mind Reading",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Mind Reading",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Necrotic Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Necrotic Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Poison",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 10000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Poison",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Poison Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Poison Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Psychic Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Psychic Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Radiant Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Radiant Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Speed",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 40000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Speed",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Superior Healing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 45000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Superior Healing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Supreme Healing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 135000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Supreme Healing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Thunder Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"name": "Potion of Thunder Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Potion of Vitality",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 96000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Vitality",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Potion of Water Breathing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Potion of Water Breathing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Prosthetic Limb",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 10000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Prosthetic Limb",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Psychic Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Psychic Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Pyroconverger",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Pyroconverger",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Quaal's Feather Token, Anchor",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Quaal's Feather Token, Anchor",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Quaal's Feather Token, Bird",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Quaal's Feather Token, Bird",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Quaal's Feather Token, Fan",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 25000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Quaal's Feather Token, Fan",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Quaal's Feather Token, Swan Boat",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Quaal's Feather Token, Swan Boat",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Quaal's Feather Token, Whip",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 25000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Quaal's Feather Token, Whip",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Quiver of Ehlonna",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Quiver of Ehlonna",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Radiant Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Radiant Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Rakdos Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Rakdos Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Rakdos Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rakdos Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Rakdos Riteknife",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rakdos Riteknife",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Red Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Red Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Acid Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Acid Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Air Elemental Command",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Air Elemental Command",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Animal Influence",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Animal Influence",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Cold Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Cold Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Earth Elemental Command",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Earth Elemental Command",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Evasion",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Evasion",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Feather Falling",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Feather Falling",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Fire Elemental Command",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1700000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Fire Elemental Command",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Fire Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Fire Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Force Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Force Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Free Action",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Free Action",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Invisibility",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Invisibility",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Jumping",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 250000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Jumping",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Lightning Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Lightning Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Mind Shielding",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Mind Shielding",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Necrotic Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Necrotic Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Poison Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Poison Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Protection",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 350000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Protection",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Psychic Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Psychic Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Radiant Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Radiant Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Regeneration",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Regeneration",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Shooting Stars",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Shooting Stars",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Spell Storing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Spell Storing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Spell Turning",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Spell Turning",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Swimming",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Swimming",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Telekinesis",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 8000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Telekinesis",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Thunder Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"name": "Ring of Thunder Resistance",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Ring of Warmth",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Warmth",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Water Elemental Command",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Water Elemental Command",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of Water Walking",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of Water Walking",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of X-Ray Vision",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of X-Ray Vision",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Ring of the Ram",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Ring of the Ram",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Robe of Eyes",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Robe of Eyes",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Robe of Scintillating Colors",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Robe of Scintillating Colors",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Robe of Stars",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 6000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Robe of Stars",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Robe of Useful Items",
+			"source": "SaneMagicItemPricesExpanded",
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Robe of Useful Items",
+				"source": "DMG",
+				"_mod": {
+					"entries": [
+						{
+							"mode": "prependArr",
+							"items": {
+								"entries": [
+									{
+										"type": "inset",
+										"name": "Sane Magic Item Pricing Note",
+										"entries": [
+											"The Price of the Robe depends upon the number of items with which it was found.",
+											"The formula for the price is Items × 5 gp"
+										]
+									}
+								]
+							}
+						}
+					]
+				}
+			}
+		},
+		{
+			"name": "Robe of the Archmagi",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Robe of the Archmagi",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rod of Absorption",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rod of Absorption",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rod of Alertness",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rod of Alertness",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rod of Lordly Might",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rod of Lordly Might",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rod of Rulership",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rod of Rulership",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rod of Security",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 9000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rod of Security",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rope of Climbing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rope of Climbing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Rope of Entanglement",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Rope of Entanglement",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Saddle of the Cavalier",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Saddle of the Cavalier",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Scarab of Protection",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Scarab of Protection",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Scimitar of Speed",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Scimitar of Speed",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Scroll of Protection from Aberrations",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Aberrations",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Beasts",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Beasts",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Celestials",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Celestials",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Elementals",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Elementals",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Fey",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Fey",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Fiends",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Fiends",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Plants",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Plants",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Scroll of Protection from Undead",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 18000,
+			"_copy": {
+				"name": "Scroll of Protection from Undead",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Selesnya Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Selesnya Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Selesnya Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Selesnya Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Sending Stones",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sending Stones",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Sentinel Shield",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sentinel Shield",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Shadowfell Brand Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Shadowfell Brand Tattoo",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Shadowfell Shard",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Shadowfell Shard",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Shield of Missile Attraction",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Shield of Missile Attraction",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Silver Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "Silver Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Simic Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"name": "Simic Guild Signet",
+				"source": "GGR",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Simic Keyrune",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Simic Keyrune",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Skyblinder Staff",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 10000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Skyblinder Staff",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Slippers of Spider Climbing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Slippers of Spider Climbing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Sovereign Glue",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 40000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sovereign Glue",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (1st Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 6000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (1st Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (2nd Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 12000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (2nd Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (3rd Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 20000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (3rd Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (4th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 32000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (4th Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (5th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 64000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (5th Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (6th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 128000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (6th Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (7th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 256000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (7th Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (8th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 512000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (8th Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (9th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1024000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (9th Level)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spell Scroll (Cantrip)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spell Scroll (Cantrip)",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spellguard Shield",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellguard Shield",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spellwrought Tattoo (1st Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellwrought Tattoo (1st Level)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Spellwrought Tattoo (2nd Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 60000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellwrought Tattoo (2nd Level)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Spellwrought Tattoo (3rd Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellwrought Tattoo (3rd Level)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Spellwrought Tattoo (4th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 160000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellwrought Tattoo (4th Level)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Spellwrought Tattoo (5th Level)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 320000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellwrought Tattoo (5th Level)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Spellwrought Tattoo (Cantrip)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 5000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spellwrought Tattoo (Cantrip)",
+				"source": "TCE"
+			}
+		},
+		{
+			"name": "Sphere of Annihilation",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sphere of Annihilation",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Spies' Murmur",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Spies' Murmur",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Staff of Charming",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Charming",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Fire",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Fire",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Frost",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Frost",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Healing",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Healing",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Power",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 9550000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Power",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Striking",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2100000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Striking",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Swarming Insects",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Swarming Insects",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Thunder and Lightning",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Thunder and Lightning",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of Withering",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of Withering",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of the Adder",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 180000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of the Adder",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of the Python",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of the Python",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Staff of the Woodlands",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 4400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Staff of the Woodlands",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Stone of Controlling Earth Elementals",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Stone of Controlling Earth Elementals",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Stone of Good Luck",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 420000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Stone of Good Luck",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Sun Blade",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sun Blade",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Sunforger",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 300000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sunforger",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Sword of Answering (Answerer)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Answerer)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Back Talker)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Back Talker)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Concluder)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Concluder)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Last Quip)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Last Quip)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Rebutter)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Rebutter)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Replier)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Replier)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Retorter)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Retorter)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Scather)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Scather)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of Answering (Squelcher)",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3600000,
+			"_copy": {
+				"name": "Sword of Answering (Squelcher)",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Sword of the Paruns",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Sword of the Paruns",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Talisman of Pure Good",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 7168000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Talisman of Pure Good",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Talisman of Ultimate Evil",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 6144000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Talisman of Ultimate Evil",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Talisman of the Sphere",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Talisman of the Sphere",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Tentacle Rod",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Tentacle Rod",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Thunder Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 2400000,
+			"_copy": {
+				"name": "Thunder Absorbing Tattoo",
+				"source": "TCE",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Trident of Fish Command",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 80000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Trident of Fish Command",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Universal Solvent",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 30000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Universal Solvent",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Voyager Staff",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 9000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Voyager Staff",
+				"source": "GGR"
+			}
+		},
+		{
+			"name": "Wand of Binding",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Binding",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Enemy Detection",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Enemy Detection",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Fear",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1000000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Fear",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Fireballs",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Fireballs",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Lightning Bolts",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Lightning Bolts",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Magic Detection",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Magic Detection",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Magic Missiles",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Magic Missiles",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Paralysis",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 1600000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Paralysis",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Polymorph",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 3200000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Polymorph",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Secrets",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Secrets",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wand of Web",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wand of Web",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "White Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 400000,
+			"_copy": {
+				"name": "White Dragon Scale Mail",
+				"source": "DMG",
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				}
+			}
+		},
+		{
+			"name": "Wind Fan",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 150000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wind Fan",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Winged Boots",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 800000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Winged Boots",
+				"source": "DMG"
+			}
+		},
+		{
+			"name": "Wings of Flying",
+			"source": "SaneMagicItemPricesExpanded",
+			"value": 500000,
+			"_copy": {
+				"_preserve": {
+					"page": true,
+					"type": true,
+					"tier": true,
+					"lootTables": true
+				},
+				"name": "Wings of Flying",
+				"source": "DMG"
+			}
+		}
+	],
+	"itemGroup": [
+		{
+			"name": "Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 0,
+			"rarity": "very rare",
+			"reqAttune": true,
+			"wondrous": true,
+			"tattoo": true,
+			"value": 2400000,
+			"entries": [
+				"Produced by a special needle, this magic tattoo features designs that emphasize one color.",
+				{
+					"type": "entries",
+					"name": "Tattoo Attunement",
+					"entries": [
+						"To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin.",
+						"If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in your space."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Damage Resistance",
+					"entries": [
+						"While the tattoo is on your skin, you have resistance to a type of damage associated with that color, as shown on the table below. The DM chooses the color or determines it randomly.",
+						{
+							"type": "table",
+							"caption": "Absorbing Tattoo",
+							"colLabels": [
+								"d10",
+								"Color",
+								"Tattoo"
+							],
+							"colStyles": [
+								"col-2 text-center",
+								"col-2 text-center",
+								"col-8 text-center"
+							],
+							"rows": [
+								[
+									"1",
+									"Green",
+									"{@item Acid Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"2",
+									"Blue",
+									"{@item Cold Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"3",
+									"Red",
+									"{@item Fire Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"4",
+									"White",
+									"{@item Force Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"5",
+									"Yellow",
+									"{@item Lightning Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"6",
+									"Black",
+									"{@item Necrotic Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"7",
+									"Violet",
+									"{@item Poison Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"8",
+									"Silver",
+									"{@item Psychic Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"9",
+									"Gold",
+									"{@item Radiant Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								],
+								[
+									"10",
+									"Orange",
+									"{@item Thunder Absorbing Tattoo|SaneMagicItemPricesExpanded}"
+								]
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Damage Absorption",
+					"entries": [
+						"When you take damage of the chosen type, you can use your reaction to gain immunity against that instance of the damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can't be used again until the next dawn."
+					]
+				}
+			],
+			"items": [
+				"Acid Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Cold Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Fire Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Force Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Lightning Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Necrotic Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Poison Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Psychic Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Radiant Absorbing Tattoo|SaneMagicItemPricesExpanded",
+				"Thunder Absorbing Tattoo|SaneMagicItemPricesExpanded"
+			]
+		},
+		{
+			"name": "Armor of Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 8,
+			"value": 600000,
+			"type": "GV",
+			"tier": "major",
+			"rarity": "rare",
+			"reqAttune": true,
+			"entries": [
+				"You have resistance to one type of damage while you wear this armor. The DM chooses the type or determines it randomly from the options below.",
+				{
+					"type": "table",
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"colLabels": [
+						"d10",
+						"Damage Type"
+					],
+					"rows": [
+						[
+							"1",
+							"{@item armor of acid resistance|SaneMagicItemPricesExpanded|Acid}"
+						],
+						[
+							"2",
+							"{@item armor of cold resistance|SaneMagicItemPricesExpanded|Cold}"
+						],
+						[
+							"3",
+							"{@item armor of fire resistance|SaneMagicItemPricesExpanded|Fire}"
+						],
+						[
+							"4",
+							"{@item armor of force resistance|SaneMagicItemPricesExpanded|Force}"
+						],
+						[
+							"5",
+							"{@item armor of lightning resistance|SaneMagicItemPricesExpanded|Lightning}"
+						],
+						[
+							"6",
+							"{@item armor of necrotic resistance|SaneMagicItemPricesExpanded|Necrotic}"
+						],
+						[
+							"7",
+							"{@item armor of poison resistance|SaneMagicItemPricesExpanded|Poison}"
+						],
+						[
+							"8",
+							"{@item armor of psychic resistance|SaneMagicItemPricesExpanded|Psychic}"
+						],
+						[
+							"9",
+							"{@item armor of radiant resistance|SaneMagicItemPricesExpanded|Radiant}"
+						],
+						[
+							"10",
+							"{@item armor of thunder resistance|SaneMagicItemPricesExpanded|Thunder}"
+						]
+					]
+				}
+			],
+			"items": [
+				"Armor of Acid Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Cold Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Fire Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Force Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Lightning Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Necrotic Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Poison Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Psychic Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Radiant Resistance|SaneMagicItemPricesExpanded",
+				"Armor of Thunder Resistance|SaneMagicItemPricesExpanded"
+			]
+		},
+		{
+			"name": "Carpet of Flying",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 8,
+			"value": 1200000,
+			"tier": "major",
+			"rarity": "very rare",
+			"wondrous": true,
+			"items": [
+				"Carpet of Flying, 3 ft. × 5 ft.|SaneMagicItemPricesExpanded",
+				"Carpet of Flying, 4 ft. × 6 ft.|SaneMagicItemPricesExpanded",
+				"Carpet of Flying, 5 ft. × 7 ft.|SaneMagicItemPricesExpanded",
+				"Carpet of Flying, 6 ft. × 9 ft.|SaneMagicItemPricesExpanded"
+			],
+			"lootTables": [
+				"Magic Item Table H"
+			]
+		},
+		{
+			"name": "Dragon Scale Mail",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 8,
+			"value": 400000,
+			"type": "MA",
+			"tier": "major",
+			"rarity": "very rare",
+			"reqAttune": true,
+			"weight": 45,
+			"ac": 14,
+			"stealth": true,
+			"items": [
+				"Black Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Blue Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Brass Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Bronze Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Copper Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Gold Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Green Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Red Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"Silver Dragon Scale Mail|SaneMagicItemPricesExpanded",
+				"White Dragon Scale Mail|SaneMagicItemPricesExpanded"
+			],
+			"lootTables": [
+				"Magic Item Table H"
+			]
+		},
+		{
+			"name": "Elemental Gem",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 167,
+			"value": 96000,
+			"tier": "minor",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"items": [
+				"Elemental Gem, Blue Sapphire|SaneMagicItemPricesExpanded",
+				"Elemental Gem, Emerald|SaneMagicItemPricesExpanded",
+				"Elemental Gem, Red Corundum|SaneMagicItemPricesExpanded",
+				"Elemental Gem, Yellow Diamond|SaneMagicItemPricesExpanded"
+			],
+			"attachedSpells": [
+				"conjure elemental"
+			],
+			"lootTables": [
+				"Magic Item Table B"
+			]
+		},
+		{
+			"name": "Guild Signet",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 178,
+			"value": 150000,
+			"type": "RG",
+			"rarity": "uncommon",
+			"reqAttune": true,
+			"charges": 3,
+			"entries": [
+				"A guild signet is sometimes awarded to a guild member whose renown score in that guild is 5 or higher, as a reward for performing special services for the guild. Aside from its magical properties, the ring is also an indicator of the guild's recognition and favor."
+			],
+			"items": [
+				"Azorius Guild Signet|SaneMagicItemPricesExpanded",
+				"Boros Guild Signet|SaneMagicItemPricesExpanded",
+				"Dimir Guild Signet|SaneMagicItemPricesExpanded",
+				"Golgari Guild Signet|SaneMagicItemPricesExpanded",
+				"Gruul Guild Signet|SaneMagicItemPricesExpanded",
+				"Izzet Guild Signet|SaneMagicItemPricesExpanded",
+				"Orzhov Guild Signet|SaneMagicItemPricesExpanded",
+				"Rakdos Guild Signet|SaneMagicItemPricesExpanded",
+				"Selesnya Guild Signet|SaneMagicItemPricesExpanded",
+				"Simic Guild Signet|SaneMagicItemPricesExpanded"
+			]
+		},
+		{
+			"name": "Potion of Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 188,
+			"value": 30000,
+			"type": "P",
+			"tier": "minor",
+			"rarity": "uncommon",
+			"items": [
+				"Potion of Acid Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Cold Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Fire Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Force Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Lightning Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Necrotic Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Poison Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Psychic Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Radiant Resistance|SaneMagicItemPricesExpanded",
+				"Potion of Thunder Resistance|SaneMagicItemPricesExpanded"
+			],
+			"lootTables": [
+				"Magic Item Table B"
+			]
+		},
+		{
+			"name": "Ring of Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 192,
+			"value": 600000,
+			"type": "RG",
+			"tier": "major",
+			"rarity": "rare",
+			"entries": [
+				"You have resistance to one damage type while wearing this ring. The gem in the ring indicates the type, which the DM chooses or determines randomly.",
+				{
+					"type": "table",
+					"colStyles": [
+						"col-2 text-center",
+						"col-5",
+						"col-5"
+					],
+					"colLabels": [
+						"d10",
+						"Damage Type",
+						"Gem"
+					],
+					"rows": [
+						[
+							"1",
+							"{@item ring of acid resistance|SaneMagicItemPricesExpanded|Acid}",
+							"Pearl"
+						],
+						[
+							"2",
+							"{@item ring of cold resistance|SaneMagicItemPricesExpanded|Cold}",
+							"Tourmaline"
+						],
+						[
+							"3",
+							"{@item ring of fire resistance|SaneMagicItemPricesExpanded|Fire}",
+							"Garnet"
+						],
+						[
+							"4",
+							"{@item ring of force resistance|SaneMagicItemPricesExpanded|Force}",
+							"Sapphire"
+						],
+						[
+							"5",
+							"{@item ring of lightning resistance|SaneMagicItemPricesExpanded|Lightning}",
+							"Citrine"
+						],
+						[
+							"6",
+							"{@item ring of necrotic resistance|SaneMagicItemPricesExpanded|Necrotic}",
+							"Jet"
+						],
+						[
+							"7",
+							"{@item ring of poison resistance|SaneMagicItemPricesExpanded|Poison}",
+							"Amethyst"
+						],
+						[
+							"8",
+							"{@item ring of psychic resistance|SaneMagicItemPricesExpanded|Psychic}",
+							"Jade"
+						],
+						[
+							"9",
+							"{@item ring of radiant resistance|SaneMagicItemPricesExpanded|Radiant}",
+							"Topaz"
+						],
+						[
+							"10",
+							"{@item ring of thunder resistance|SaneMagicItemPricesExpanded|Thunder}",
+							"Spinel"
+						]
+					]
+				}
+			],
+			"items": [
+				"Ring of Acid Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Cold Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Fire Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Force Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Lightning Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Necrotic Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Poison Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Psychic Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Radiant Resistance|SaneMagicItemPricesExpanded",
+				"Ring of Thunder Resistance|SaneMagicItemPricesExpanded"
+			],
+			"lootTables": [
+				"Magic Item Table G"
+			]
+		},
+		{
+			"name": "Scroll of Protection",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 199,
+			"value": 18000,
+			"type": "SC",
+			"tier": "minor",
+			"rarity": "rare",
+			"items": [
+				"Scroll of Protection from Aberrations|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Beasts|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Celestials|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Elementals|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Fey|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Fiends|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Plants|SaneMagicItemPricesExpanded",
+				"Scroll of Protection from Undead|SaneMagicItemPricesExpanded"
+			],
+			"lootTables": [
+				"Magic Item Table C"
+			]
+		},
+		{
+			"name": "Sword of Answering",
+			"source": "SaneMagicItemPricesExpanded",
+			"page": 206,
+			"value": 3600000,
+			"baseItem": "longsword|phb",
+			"type": "M",
+			"tier": "major",
+			"rarity": "legendary",
+			"reqAttune": true,
+			"weight": 3,
+			"weaponCategory": "martial",
+			"property": [
+				"V"
+			],
+			"dmg1": "{@dice 1d8}",
+			"dmgType": "S",
+			"dmg2": "{@dice 1d10}",
+			"items": [
+				"Sword of Answering (Answerer)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Back Talker)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Concluder)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Last Quip)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Rebutter)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Replier)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Retorter)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Scather)|SaneMagicItemPricesExpanded",
+				"Sword of Answering (Squelcher)|SaneMagicItemPricesExpanded"
+			],
+			"lootTables": [
+				"Magic Item Table I"
+			]
+		}
+	],
+	"variant": [
+		{
+			"name": "+1 Ammunition",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "A"
+				},
+				{
+					"type": "AF"
+				}
+			],
+			"ammo": true,
+			"inherits": {
+				"namePrefix": "+1 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 2500",
+				"tier": "minor",
+				"rarity": "uncommon",
+				"bonusWeapon": "+1",
+				"entries": [
+					"You have a {=bonusWeapon} bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.",
+					{
+						"type": "inset",
+						"name": "Sane Magic Item Pricing Note",
+						"entries": [
+							"Price is per each individual piece of ammunition"
+						]
+					}
+				],
+				"lootTables": [
+					"Magic Item Table B"
+				]
+			}
+		},
+		{
+			"name": "+1 Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 150000",
+				"rarity": "rare",
+				"entries": [
+					"You have a {=bonusAc} bonus to AC while wearing this armor."
+				],
+				"namePrefix": "+1 ",
+				"tier": "major",
+				"bonusAc": "+1"
+			}
+		},
+		{
+			"name": "+1 Shield (*)",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "S"
+				}
+			],
+			"entries": [
+				"{@note * This generic variant has the same name and source as the item {@item +1 shield|SaneMagicItemPricesExpanded}}.",
+				"While holding this shield, you have a +1 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
+			],
+			"inherits": {
+				"namePrefix": "+1 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 150000",
+				"tier": "major",
+				"rarity": "uncommon",
+				"bonusAc": "+1",
+				"entries": [
+					"While holding this shield, you have a {=bonusAc} bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
+				]
+			}
+		},
+		{
+			"name": "+1 Weapon",
+			"type": "GV",
+			"requires": [
+				{
+					"weapon": true
+				}
+			],
+			"excludes": {
+				"net": true
+			},
+			"inherits": {
+				"namePrefix": "+1 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 100000",
+				"tier": "major",
+				"rarity": "uncommon",
+				"bonusWeapon": "+1",
+				"entries": [
+					"You have a {=bonusWeapon} bonus to attack and damage rolls made with this magic weapon."
+				],
+				"lootTables": [
+					"Magic Item Table F"
+				]
+			}
+		},
+		{
+			"name": "+2 Ammunition",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "A"
+				},
+				{
+					"type": "AF"
+				}
+			],
+			"ammo": true,
+			"inherits": {
+				"namePrefix": "+2 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 10000",
+				"tier": "minor",
+				"rarity": "rare",
+				"bonusWeapon": "+2",
+				"entries": [
+					"You have a {=bonusWeapon} bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.",
+					{
+						"type": "inset",
+						"name": "Sane Magic Item Pricing Note",
+						"entries": [
+							"Price is per each individual piece of ammunition"
+						]
+					}
+				],
+				"lootTables": [
+					"Magic Item Table C"
+				]
+			}
+		},
+		{
+			"name": "+2 Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "+2 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"tier": "major",
+				"rarity": "very rare",
+				"bonusAc": "+2",
+				"entries": [
+					"You have a {=bonusAc} bonus to AC while wearing this armor."
+				]
+			}
+		},
+		{
+			"name": "+2 Shield (*)",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "S"
+				}
+			],
+			"entries": [
+				"{@note * This generic variant has the same name and source as the item {@item +2 shield|SaneMagicItemPricesExpanded}}.",
+				"While holding this shield, you have a +2 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
+			],
+			"inherits": {
+				"namePrefix": "+2 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"tier": "major",
+				"rarity": "rare",
+				"bonusAc": "+2",
+				"entries": [
+					"While holding this shield, you have a {=bonusAc} bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
+				]
+			}
+		},
+		{
+			"name": "+2 Weapon",
+			"type": "GV",
+			"requires": [
+				{
+					"weapon": true
+				}
+			],
+			"excludes": {
+				"net": true
+			},
+			"inherits": {
+				"namePrefix": "+2 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 400000",
+				"tier": "major",
+				"rarity": "rare",
+				"bonusWeapon": "+2",
+				"entries": [
+					"You have a {=bonusWeapon} bonus to attack and damage rolls made with this magic weapon."
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "+3 Ammunition",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "A"
+				},
+				{
+					"type": "AF"
+				}
+			],
+			"ammo": true,
+			"inherits": {
+				"namePrefix": "+3 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 40000",
+				"tier": "minor",
+				"rarity": "very rare",
+				"bonusWeapon": "+3",
+				"entries": [
+					"You have a {=bonusWeapon} bonus to attack and damage rolls made with this piece of magic ammunition. Once it hits a target, the ammunition is no longer magical.",
+					{
+						"type": "inset",
+						"name": "Sane Magic Item Pricing Note",
+						"entries": [
+							"Price is per each individual piece of ammunition"
+						]
+					}
+				],
+				"lootTables": [
+					"Magic Item Table D"
+				]
+			}
+		},
+		{
+			"name": "+3 Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "+3 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 2400000",
+				"tier": "major",
+				"rarity": "legendary",
+				"bonusAc": "+3",
+				"entries": [
+					"You have a {=bonusAc} bonus to AC while wearing this armor."
+				]
+			}
+		},
+		{
+			"name": "+3 Shield (*)",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "S"
+				}
+			],
+			"entries": [
+				"{@note * This generic variant has the same name and source as the item {@item +3 shield|SaneMagicItemPricesExpanded}}.",
+				"While holding this shield, you have a +3 bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
+			],
+			"inherits": {
+				"namePrefix": "+3 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 2400000",
+				"tier": "major",
+				"rarity": "very rare",
+				"bonusAc": "+3",
+				"entries": [
+					"While holding this shield, you have a {=bonusAc} bonus to AC. This bonus is in addition to the shield's normal bonus to AC."
+				]
+			}
+		},
+		{
+			"name": "+3 Weapon",
+			"type": "GV",
+			"requires": [
+				{
+					"weapon": true
+				}
+			],
+			"excludes": {
+				"net": true
+			},
+			"inherits": {
+				"namePrefix": "+3 ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 1600000",
+				"tier": "major",
+				"rarity": "very rare",
+				"bonusWeapon": "+3",
+				"entries": [
+					"You have a {=bonusWeapon} bonus to attack and damage rolls made with this magic weapon."
+				],
+				"lootTables": [
+					"Magic Item Table H"
+				]
+			}
+		},
+		{
+			"name": "Adamantine Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "HA"
+				},
+				{
+					"type": "MA"
+				}
+			],
+			"excludes": {
+				"name": "Hide Armor"
+			},
+			"inherits": {
+				"namePrefix": "Adamantine ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 50000",
+				"tier": "major",
+				"rarity": "uncommon",
+				"entries": [
+					"This suit of armor is reinforced with adamantine, one of the hardest substances in existence. While you're wearing it, any critical hit against you becomes a normal hit."
+				]
+			}
+		},
+		{
+			"name": "Armor of Acid Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Acid Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "acid",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Cold Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Cold Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "cold",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Fire Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Fire Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "fire",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Force Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Force Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "force",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Lightning Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Lightning Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "lightning",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Necrotic Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Necrotic Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "necrotic",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Poison Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Poison Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "poison",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Psychic Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Psychic Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "psychic",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Radiant Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Radiant Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "radiant",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Armor of Thunder Resistance",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Thunder Resistance",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 600000",
+				"resist": "thunder",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true
+			}
+		},
+		{
+			"name": "Arrow of Slaying (*)",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "A"
+				},
+				{
+					"type": "AF"
+				}
+			],
+			"excludes": {
+				"page": 268
+			},
+			"ammo": true,
+			"entries": [
+				"{@note * This generic variant has the same name and source as the item {@item Arrow of Slaying|SaneMagicItemPricesExpanded}}.",
+				"An {@italic arrow of slaying} is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both {@italic arrows of dragon slaying} and {@italic arrows of blue dragon slaying}. If a creature belonging to the type, race, or group associated with an {@italic arrow of slaying} takes damage from the arrow, the creature must make a DC 17 Constitution saving throw, taking an extra {@dice 6d10} piercing damage on a failed save, or half as much extra damage on a successful one.",
+				"Once an {@italic arrow of slaying} deals its extra damage to a creature, it becomes a nonmagical arrow.",
+				"Other types of magic ammunition of this kind exist, such as bolts of slaying meant for a crossbow, though arrows are most common."
+			],
+			"inherits": {
+				"nameSuffix": " of Slaying",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 60000",
+				"tier": "minor",
+				"rarity": "very rare",
+				"entries": [
+					"{=baseName/at} {=baseName/l} of slaying is a magic weapon meant to slay a particular kind of creature. Some are more focused than others; for example, there are both {@i {=baseName/l}s of dragon slaying} and {@i {=baseName/l}s of blue dragon slaying}. If a creature belonging to the type, race, or group associated with {=baseName/a} {=baseName/l} of slaying takes damage from the {=baseName/l}, the creature must make a DC 17 Constitution saving throw, taking an extra {@dice 6d10} piercing damage on a failed save, or half as much extra damage on a successful one.",
+					"Once {=baseName/a} {=baseName/l} of slaying deals its extra damage to a creature, it becomes a nonmagical {=baseName/l}.",
+					{
+						"type": "inset",
+						"name": "Sane Magic Item Pricing Note",
+						"entries": [
+							"Price is per each individual piece of ammunition"
+						]
+					}
+				]
+			}
+		},
+		{
+			"name": "Dancing Sword",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Dancing ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 200000",
+				"tier": "major",
+				"rarity": "very rare",
+				"reqAttune": true,
+				"entries": [
+					"You can use a bonus action to toss this magic sword into the air and speak the command word. When you do so, the sword begins to hover, flies up to 30 feet, and attacks one creature of your choice within 5 feet of it. The sword uses your attack roll and ability score modifier to damage rolls.",
+					"While the sword hovers, you can use a bonus action to cause it to fly up to 30 feet to another spot within 30 feet of you. As part of the same bonus action, you can cause the sword to attack one creature within 5 feet of it.",
+					"After the hovering sword attacks for the fourth time, it flies up to 30 feet and tries to return to your hand. If you have no hand free, it falls to the ground at your feet. If the sword has no unobstructed path to you, it moves as close to you as it can and then falls to the ground. It also ceases to hover if you grasp it or move more than 30 feet away from it."
+				],
+				"lootTables": [
+					"Magic Item Table H"
+				]
+			}
+		},
+		{
+			"name": "Defender",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Defender ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 2400000",
+				"tier": "major",
+				"rarity": "legendary",
+				"reqAttune": true,
+				"bonusWeapon": "+3",
+				"bonusAc": "+1",
+				"entries": [
+					"You gain a +3 bonus to attack and damage rolls made with this magic weapon.",
+					"The first time you attack with the sword on each of your turns, you can transfer some or all of the sword's bonus to your Armor Class, instead of using the bonus on any attacks that turn. For example, you could reduce the bonus to your attack and damage rolls to +1 and gain a +2 bonus to AC. The adjusted bonuses remain in effect until the start of your next turn, although you must hold the sword to gain a bonus to AC from it."
+				],
+				"lootTables": [
+					"Magic Item Table I"
+				]
+			}
+		},
+		{
+			"name": "Dragon Slayer",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Dragon Slayer ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 800000",
+				"tier": "major",
+				"rarity": "rare",
+				"bonusWeapon": "+1",
+				"bonusAc": "+1",
+				"entries": [
+					"You gain a +1 bonus to attack and damage rolls made with this magic weapon.",
+					"When you hit a dragon with this weapon, the dragon takes an extra {@dice 3d6} damage of the weapon's type. For the purpose of this weapon, \"dragon\" refers to any creature with the dragon type, including dragon turtles and wyverns."
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "Flame Tongue",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Flame Tongue ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 500000",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true,
+				"entries": [
+					"You can use a bonus action to speak this magic sword's command word, causing flames to erupt from the blade. These flames shed bright light in a 40-foot radius and dim light for an additional 40 feet. While the sword is ablaze, it deals an extra {@dice 2d6} fire damage to any target it hits. The flames last until you use a bonus action to speak the command word again or until you drop or sheathe the sword."
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "Frost Brand",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Frost Brand ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 220000",
+				"tier": "major",
+				"rarity": "very rare",
+				"reqAttune": true,
+				"entries": [
+					"When you hit with an attack using this magic sword, the target takes an extra {@dice 1d6} cold damage. In addition, while you hold the sword, you have resistance to fire damage.",
+					"In freezing temperatures, the blade sheds bright light in a 10-foot radius and dim light for an additional 10 feet.",
+					"When you draw this weapon, you can extinguish all nonmagical flames within 30 feet of you. This property can be used no more than once per hour."
+				],
+				"lootTables": [
+					"Magic Item Table H"
+				]
+			}
+		},
+		{
+			"name": "Giant Slayer",
+			"type": "GV",
+			"requires": [
+				{
+					"axe": true
+				},
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Giant Slayer ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 8,
+				"valueExpression": "[[baseItem.value]] + 700000",
+				"tier": "major",
+				"rarity": "rare",
+				"bonusWeapon": "+1",
+				"bonusAc": "+1",
+				"entries": [
+					"You gain a +1 bonus to attack and damage rolls made with this magic weapon.",
+					"When you hit a giant with it, the giant takes an extra {@dice 2d6} damage of the weapon's type and must succeed on a DC 15 Strength saving throw or fall {@condition prone}. For the purpose of this weapon, \"giant\" refers to any creature with the giant type, including ettins and trolls."
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "Holy Avenger",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Holy Avenger ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 174,
+				"valueExpression": "[[baseItem.value]] + 16500000",
+				"tier": "major",
+				"rarity": "legendary",
+				"reqAttune": "by a paladin",
+				"bonusWeapon": "+3",
+				"bonusAc": "+3",
+				"entries": [
+					"You gain a +3 bonus to attack and damage rolls made with this magic weapon. When you hit a fiend or an undead with it, that creature takes an extra {@dice 2d10} radiant damage.",
+					"While you hold the drawn sword, it creates an aura in a 10-foot radius around you. You and all creatures friendly to you in the aura have advantage on saving throws against spells and other magical effects. If you have 17 or more levels in the paladin class, the radius of the aura increases to 30 feet."
+				],
+				"lootTables": [
+					"Magic Item Table I"
+				]
+			}
+		},
+		{
+			"name": "Mariner's Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"armor": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Mariner's ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 181,
+				"valueExpression": "[[baseItem.value]] + 150000",
+				"tier": "minor",
+				"rarity": "uncommon",
+				"entries": [
+					"While wearing this armor, you have a swimming speed equal to your walking speed. In addition, whenever you start your turn underwater with 0 hit points, the armor causes you to rise 60 feet toward the surface. The armor is decorated with fish and shell motifs."
+				],
+				"lootTables": [
+					"Magic Item Table B"
+				]
+			}
+		},
+		{
+			"name": "Mithral Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "HA"
+				},
+				{
+					"type": "MA"
+				}
+			],
+			"excludes": {
+				"name": "Hide Armor"
+			},
+			"inherits": {
+				"namePrefix": "Mithral ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 182,
+				"valueExpression": "[[baseItem.value]] + 80000",
+				"tier": "minor",
+				"rarity": "uncommon",
+				"strength": null,
+				"stealth": false,
+				"entries": [
+					"Mithral is a light, flexible metal. A mithral chain shirt or breastplate can be worn under normal clothes. If the armor normally imposes disadvantage on Dexterity ({@skill Stealth}) checks or has a Strength requirement, the mithral version of the armor doesn't."
+				],
+				"lootTables": [
+					"Magic Item Table B"
+				]
+			}
+		},
+		{
+			"name": "Mizzium Armor",
+			"type": "GV",
+			"requires": [
+				{
+					"type": "HA"
+				},
+				{
+					"type": "MA"
+				}
+			],
+			"excludes": {
+				"name": "Hide Armor"
+			},
+			"inherits": {
+				"namePrefix": "Mizzium ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 179,
+				"valueExpression": "[[baseItem.value]] + 150000",
+				"rarity": "rare",
+				"entries": [
+					"This suit of armor is reinforced with a magically enhanced metal alloy called mizzium, which is made in Izzet foundries. While you're wearing the armor, any critical hit against you becomes a normal hit. In addition, when you are subjected to a magical effect that allows you to make a Strength or Constitution saving throw to take only half damage, you instead take no damage if you succeed on the saving throw."
+				]
+			}
+		},
+		{
+			"name": "Nine Lives Stealer",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"namePrefix": "Nine Lives Stealer ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 183,
+				"valueExpression": "[[baseItem.value]] + 800000",
+				"tier": "major",
+				"rarity": "very rare",
+				"reqAttune": true,
+				"bonusWeapon": "+2",
+				"charges": "{@dice 1d8 + 1}",
+				"entries": [
+					"You gain a +2 bonus to attack and damage rolls made with this magic weapon.",
+					"The sword has {@dice 1d8 + 1} charges. If you score a critical hit against a creature that has fewer than 100 hit points, it must succeed on a DC 15 Constitution saving throw or be slain instantly as the sword tears its life force from its body (a construct or an undead is immune). The sword loses 1 charge if the creature is slain. When the sword has no charges remaining, it loses this property.",
+					{
+						"type": "inset",
+						"name": "Sane Magic Item Pricing Note",
+						"entries": [
+							"The price is for a fully charged item."
+						]
+					}
+				],
+				"lootTables": [
+					"Magic Item Table H"
+				]
+			}
+		},
+		{
+			"name": "Sword of Life Stealing",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Life Stealing",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 206,
+				"valueExpression": "[[baseItem.value]] + 100000",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true,
+				"entries": [
+					"When you attack a creature with this magic weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points.",
+					"{@i Note: According to the SRD, it is an extra {@dice 3d6} necrotic damage.}"
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "Sword of Sharpness",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true,
+					"dmgType": "S"
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Sharpness",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 206,
+				"valueExpression": "[[baseItem.value]] + 170000",
+				"tier": "major",
+				"rarity": "very rare",
+				"reqAttune": true,
+				"entries": [
+					"When you attack an object with this magic sword and hit, maximize your weapon damage dice against the target.",
+					"When you attack a creature with this weapon and roll a 20 on the attack roll, that target takes an extra 14 slashing damage. Then roll another {@dice d20}. If you roll a 20, you lop off one of the target's limbs, with the effect of such loss determined by the DM. If the creature has no limb to sever, you lop off a portion of its body instead.",
+					"{@i Note: According to the SRD, it is an extra {@dice 4d6} slashing damage, although {@link this is incorrect|https://twitter.com/JeremyECrawford/status/949111823990534144}}.",
+					"In addition, you can speak the sword's command to cause the blade to shed bright light in a 10-foot radius and dim light for an additional 10 feet. Speaking the command word again or sheathing the sword puts out the light."
+				],
+				"lootTables": [
+					"Magic Item Table H"
+				]
+			}
+		},
+		{
+			"name": "Sword of Wounding",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Wounding",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 207,
+				"valueExpression": "[[baseItem.value]] + 200000",
+				"tier": "major",
+				"rarity": "rare",
+				"reqAttune": true,
+				"entries": [
+					"Hit points lost to this weapon's damage can be regained only through a short or long rest, rather than by regeneration, magic, or any other means.",
+					"Once per turn, when you hit a creature with an attack using this magic weapon, you can wound the target. At the start of each of the wounded creature's turns, it takes {@dice 1d4} necrotic damage for each time you've wounded it, and it can then make a DC 15 Constitution saving throw, ending the effect of all such wounds on itself on a success. Alternatively, the wounded creature, or a creature within 5 feet of it, can use an action to make a DC 15 Wisdom ({@skill Medicine}) check, ending the effect of such wounds on it on a success."
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "Vicious Weapon",
+			"type": "GV",
+			"requires": [
+				{
+					"weapon": true
+				}
+			],
+			"excludes": {
+				"net": true
+			},
+			"entries": [
+				"When you roll a 20 with this magic weapon, the target takes an extra 7 damage of the weapon's type.",
+				"{@i Note: According to the SRD, it is an extra {@dice 2d6} damage.}"
+			],
+			"inherits": {
+				"namePrefix": "Vicious ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 209,
+				"valueExpression": "[[baseItem.value]] + 35000",
+				"tier": "major",
+				"rarity": "rare",
+				"entries": [
+					"When you roll a 20 with this magic weapon, the target takes an extra 7 {=dmgType} damage.",
+					"{@i Note: According to the SRD, it is an extra {@dice 2d6} {=dmgType} damage.}"
+				],
+				"lootTables": [
+					"Magic Item Table G"
+				]
+			}
+		},
+		{
+			"name": "Vorpal Sword",
+			"type": "GV",
+			"requires": [
+				{
+					"sword": true,
+					"dmgType": "S"
+				}
+			],
+			"inherits": {
+				"namePrefix": "Vorpal ",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 209,
+				"valueExpression": "[[baseItem.value]] + 2400000",
+				"tier": "major",
+				"rarity": "legendary",
+				"reqAttune": true,
+				"bonusWeapon": "+3",
+				"entries": [
+					"You gain a +3 bonus to attack and damage rolls made with this magic weapon. In addition, the weapon ignores resistance to slashing damage.",
+					"When you attack a creature that has at least one head with this weapon and roll a 20 on the attack roll, you cut off one of the creature's heads. The creature dies if it can't survive without the lost head. A creature is immune to this effect if it is immune to slashing damage, doesn't have or need a head, has legendary actions, or the DM decides that the creature is too big for its head to be cut off with this weapon. Such a creature instead takes an extra {@dice 6d8} slashing damage from the hit."
+				],
+				"lootTables": [
+					"Magic Item Table I"
+				]
+			}
+		},
+		{
+			"name": "Weapon of Warning",
+			"type": "GV",
+			"requires": [
+				{
+					"weapon": true
+				}
+			],
+			"inherits": {
+				"nameSuffix": " of Warning",
+				"source": "SaneMagicItemPricesExpanded",
+				"page": 213,
+				"valueExpression": "[[baseItem.value]] + 6000000",
+				"tier": "major",
+				"rarity": "uncommon",
+				"reqAttune": true,
+				"entries": [
+					"This magic weapon warns you of danger. While the weapon is on your person, you have advantage on initiative rolls. In addition, you and any of your companions within 30 feet of you can't be surprised, except when {@condition incapacitated} by something other than nonmagical sleep. The weapon magically awakens you and your companions within range if any of you are sleeping naturally when combat begins."
+				],
+				"lootTables": [
+					"Magic Item Table F"
+				]
+			}
+		}
+	],
+	"itemEntry": [
+		{
+			"name": "Ring of Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"entriesTemplate": [
+				"You have resistance to {{item.resist}} damage while wearing this ring. The ring is set with {{item.detail1}}."
+			]
+		},
+		{
+			"name": "Armor of Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"entriesTemplate": [
+				"You have resistance to {{item.resist}} damage while you wear this armor."
+			]
+		},
+		{
+			"name": "Potion of Resistance",
+			"source": "SaneMagicItemPricesExpanded",
+			"entriesTemplate": [
+				"When you drink this potion, you gain resistance to {{item.resist}} damage for 1 hour."
+			]
+		},
+		{
+			"name": "Absorbing Tattoo",
+			"source": "SaneMagicItemPricesExpanded",
+			"entriesTemplate": [
+				"Produced by a special needle, this magic tattoo features designs that emphasize one color ({{item.detail1}}).",
+				{
+					"type": "entries",
+					"name": "Tattoo Attunement",
+					"entries": [
+						"To attune to this item, you hold the needle to your skin where you want the tattoo to appear, pressing the needle there throughout the attunement process. When the attunement is complete, the needle turns into the ink that becomes the tattoo, which appears on the skin.",
+						"If your attunement to the tattoo ends, the tattoo vanishes, and the needle reappears in your space."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Damage Resistance",
+					"entries": [
+						"While the tattoo is on your skin, you have resistance to {{item.resist}} damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Damage Absorption",
+					"entries": [
+						"When you take {{item.resist}} damage, you can use your reaction to gain immunity against that instance of the damage, and you regain a number of hit points equal to half the damage you would have taken. Once this reaction is used, it can't be used again until the next dawn."
 					]
 				}
 			]


### PR DESCRIPTION
@TheGiddyLimit 

This is a fairly significant commit that extends the scope of the existing **Sane Magic Item Prices** `book`.
In addition to the book itself containing the tables, the file now also creates a priced item for every item in the list.
Any tags in the `book` itself that previously pointed to the original `item` now point to the priced `_copy`.

Wherever possible `_copy` has been used to create the priced item (_424 items_).
In the case of `Generic Variant`s (_41_) and `itemGroup`s (_10_) the `_copy` syntax didn't seem to work so the data has been duplicated with modifications.
In _4_ specific cases it was also necessary to duplicate the `itemEntry` blocks to get the `_copy`s to work.

A general rule has been applied that the `specific variant` costs are ` [[baseItem.value]] + SMIP cost`.
This avoid cases where e.g. a +1 Plate Armour costs the same as a non-magical Plate Armor (1500gp) if the base item cost is not included.

If you feel that this modification creeps the scope too greatly I'm open to having this file in the repo as "Sane Magic Item Prices Expanded (with items)" etc.

The list of items that presented challenges with `_copy` is below:
![BlockersSMIP](https://user-images.githubusercontent.com/52298102/131370019-2418565a-1878-4234-acee-290806ef3093.png)