### PR TITLE
Fixed tag typos that were preventing plutonium form importing adventure

### DIFF
--- a/adventure/Kobold Press; Book of Lairs.json
+++ b/adventure/Kobold Press; Book of Lairs.json
@@ -2833,7 +2833,7 @@
 							"name": "8. Zahiil's Lair",
 							"entries": [
 								"Staircases representing the monument's ear frills lead to its hollow eyes. Each eyehole is 5 feet tall and opens into the dragon's head.",
-								"Using transmute rock, Zahiil the {@creture half-blue dragon mage|BookofLairs} created a rectangular room inside the dragon's head. In the back of the room is a stone pedestal that holds a shining orb of light\u2014the divine spark. Piled around this pedestal is a heap of gold and jewels: 300 cp, 216 sp, 527 gp, and ten tiny sapphires each worth 30 gp. Zahiil tried and failed to integrate the divine spark into his body, and is suffering from a permanent curse because of his failure: at the start of each of his turns, he must make a DC 16 Wisdom saving throw or waste his action that turn doing nothing. Zahiil is still able to move, use a bonus action, and take a reaction as normal on a turn when he loses his action.",
+								"Using transmute rock, Zahiil the {@creature half-blue dragon mage|BookofLairs} created a rectangular room inside the dragon's head. In the back of the room is a stone pedestal that holds a shining orb of light\u2014the divine spark. Piled around this pedestal is a heap of gold and jewels: 300 cp, 216 sp, 527 gp, and ten tiny sapphires each worth 30 gp. Zahiil tried and failed to integrate the divine spark into his body, and is suffering from a permanent curse because of his failure: at the start of each of his turns, he must make a DC 16 Wisdom saving throw or waste his action that turn doing nothing. Zahiil is still able to move, use a bonus action, and take a reaction as normal on a turn when he loses his action.",
 								"Use the {@creature mage|mm} statistics for Zahiil but add resistance to lightning damage and the breath weapon of a blue dragon wyrmling. These changes increase the mage's challenge rating to 7 and increase its XP value to 2,900.",
 								{
 									"type": "homebrew",
@@ -4246,7 +4246,7 @@
 									"type": "entries",
 									"name": "Treasure",
 									"entries": [
-										"An unlocked chest contains 7,600 cp, 2,100 gp, and 100 pp as well as {@item|oil of sharpness|dmg}."
+										"An unlocked chest contains 7,600 cp, 2,100 gp, and 100 pp as well as {@item oil of sharpness|dmg}."
 									]
 								},
 								{


### PR DESCRIPTION
Thease two typos were preventing plutonium from importing adventure.

I am new to thease things. Just vanted to make stuff work in my game so if I did something wrong please  let me know.