### PR TITLE
Update MCDM Production - The Illrigger Class.json

### DIFF
--- a/class/MCDM Production - The Illrigger Class.json
+++ b/class/MCDM Production - The Illrigger Class.json
@@ -865,7 +865,7 @@
 							"type": "entries",
 							"name": "Invoke Authority: Moloch's Blessing",
 							"entries": [
-								"As an action, you can become invisible and can, as part of this action, attempt to take the Hide action. The invisibility ends after 1 minute or if you make an attack or cast a spell."
+								"As a bonus action, you can place all your remaining seals on a creature."
 							]
 						}
 					]


### PR DESCRIPTION
Fixed Moloch's Blessing to show proper ability instead of Fade's description.