### PR TITLE
Charactermancer fixes

### DIFF
--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -341,7 +341,7 @@
 					"{@item heavy crossbow}"
 				],
 				"tools": [
-					"{@item thieves' tools}",
+					"{@item thieves' tools|PHB}",
 					"one other {@filter tool|items|type=tools} of your choice"
 				],
 				"skills": [

--- a/class/KibblesTasty; Artificer (Revised).json
+++ b/class/KibblesTasty; Artificer (Revised).json
@@ -560,6 +560,8 @@
 				"Vorpal Weapon|ArtificerRevised",
 				"Wall of Stone"
 			],
+			"casterProgression": "1/2",
+			"spellcastingAbility": "int",
 			"spellsKnownProgression": [
 				0,
 				3,
@@ -581,6 +583,42 @@
 				11,
 				12,
 				12
+			],
+			"optionalfeatureProgression": [
+				{
+					"name": "Upgrade",
+					"featureType": [
+						"AS:F",
+						"AS:G",
+						"AS:I",
+						"AS:O",
+						"AS:P",
+						"AS:T",
+						"AS:W"
+					],
+					"progression": [
+						0,
+						0,
+						1,
+						1,
+						2,
+						2,
+						3,
+						3,
+						4,
+						4,
+						5,
+						5,
+						6,
+						6,
+						7,
+						7,
+						8,
+						8,
+						9,
+						9
+					]
+				}
 			]
 		}
 	],


### PR DESCRIPTION
Updated Spells specifically adding a the spellcasting modifier, and the caster type to half caster so that spells generate in charactermancer.
Added upgrades as optional features that get assigned at their appropriate levels