### PR TITLE
Fix breaking typo in GH:PG

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Player's Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Player's Guide.json
@@ -22948,7 +22948,7 @@
 			"name": "Repeater Crossbow, Heavy",
 			"source": "GHPG",
 			"page": 131,
-			"type": "r",
+			"type": "R",
 			"rarity": "none",
 			"weight": 20,
 			"value": 100000,


### PR DESCRIPTION
Today we learned that item types are case-sensitive. I blame kierann.