### PR TITLE
Fix typos in MME and CCodex

### DIFF
--- a/creature/Dragonix; Monster Manual Expanded.json
+++ b/creature/Dragonix; Monster Manual Expanded.json
@@ -63571,11 +63571,6 @@
 						"The cambion is a 13th-level spellcaster. Its spellcasting ability is Intelligence (spell save {@dc 16}, {@hit 8} to hit with spell attacks). It has the following wizard spells prepared:"
 					],
 					"spells": {
-						"0": {
-							"spells": [
-								"{@spell antrips:}"
-							]
-						},
 						"1": {
 							"slots": 4,
 							"spells": [

--- a/creature/Dragonix; Monster Manual Expanded.json
+++ b/creature/Dragonix; Monster Manual Expanded.json
@@ -63571,6 +63571,14 @@
 						"The cambion is a 13th-level spellcaster. Its spellcasting ability is Intelligence (spell save {@dc 16}, {@hit 8} to hit with spell attacks). It has the following wizard spells prepared:"
 					],
 					"spells": {
+						"0": {
+							"spells": [
+								"{@spell infestation|XGE}",
+								"{@spell mage hand}",
+								"{@spell message}",
+								"{@spell poison spray}"
+							]
+						},
 						"1": {
 							"slots": 4,
 							"spells": [

--- a/creature/Kobold Press; Creature Codex.json
+++ b/creature/Kobold Press; Creature Codex.json
@@ -68087,7 +68087,7 @@
 						"2": {
 							"slots": 3,
 							"spells": [
-								"{@spell {@spell blindness/deafness}}",
+								"{@spell blindness/deafness}",
 								"{@spell silence}",
 								"{@spell spiritual weapon}"
 							]
@@ -70177,12 +70177,6 @@
 					"entries": [
 						"The whisperer has advantage on saving throws against spells and other magical effects."
 					]
-				},
-				{
-					"name": "Mind Blank, Weir",
-					"entries": [
-						"ind blank, weird"
-					]
 				}
 			],
 			"action": [
@@ -70287,8 +70281,8 @@
 					],
 					"daily": {
 						"3e": [
-							"{@spell {@spell confusion}",
-							"{@spell dimension door}}",
+							"{@spell confusion}",
+							"{@spell dimension door}",
 							"{@spell disintegrate}",
 							"{@spell dream}",
 							"{@spell modify memory}",
@@ -73692,7 +73686,7 @@
 							"slots": 3,
 							"spells": [
 								"{@spell black tentacles|PhB}",
-								"{@spell {@spell blight}"
+								"{@spell blight}"
 							]
 						},
 						"5": {


### PR DESCRIPTION
Monster Manual Expanded:
* Remove cantrip block with bad spell tag (statblock in PDF has an empty cantrips label)

Creature Codex:
* Fix spell entries with extra `{@spell` (and fix corresponding braces) in Whisperer in Darkness, Blood Mage (Midgard Version), and Vampire Priestess
* Remove trait from Whisperer in Darkness that appears to be a corruption of two spells