### PR TITLE
MME1 and MME3 typos

### DIFF
--- a/creature/Dragonix; Monster Manual Expanded III.json
+++ b/creature/Dragonix; Monster Manual Expanded III.json
@@ -1,4 +1,4 @@
-{
+﻿{
 	"_meta": {
 		"sources": [
 			{
@@ -27,7 +27,7 @@
 			"monsterFluff"
 		],
 		"dateAdded": 1640053537,
-		"dateLastModified": 1648746565
+		"dateLastModified": 1649644269
 	},
 	"monsterFluff": [
 		{
@@ -11996,7 +11996,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Maurezhi%20Lord%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Maurezhi%20Lord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Maurezhi%20Lord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -12161,7 +12163,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20White%20Spectral%20Dragon%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spectral%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spectral%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -12490,10 +12494,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Illithidragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Illithidragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Illithidragon%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Illithidragon%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -12696,7 +12704,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Hellfire%20Wyrm%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Hellfire%20Wyrm%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -12840,7 +12850,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Gray%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Gray%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -12987,7 +12999,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Brown%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Young%20Brown%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -14198,7 +14212,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wraith%20Warlock%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wraith%20Warlock%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -14796,7 +14812,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wraith%20Archmage%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wraith%20Archmage%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -14900,7 +14918,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wortling%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wortling%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -15056,7 +15076,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wood%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wood%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -15194,10 +15216,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wolf-in-Sheep's-Clothing (Token 2).png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wolf-in-Sheep's-Clothing (Token 2).png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wolf-in-Sheep's-Clothing (Token 3).png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Wolf-in-Sheep's-Clothing (Token 3).png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -15426,7 +15452,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Winter%20Eladrin%20Elder%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Winter%20Eladrin%20Elder%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -15594,7 +15622,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warlock%20of%20the%20Undead%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warlock%20of%20the%20Undead%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -15790,7 +15820,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warlock%20of%20the%20Great%20Old%20One%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warlock%20of%20the%20Great%20Old%20One%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -16004,7 +16036,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warlock%20of%20the%20Fiend%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warlock%20of%20the%20Fiend%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -16190,7 +16224,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warden%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Warden%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -16541,7 +16577,7 @@
 				{
 					"name": "Summon Undead (1/Day)",
 					"entries": [
-						"The vampire conjures undead creatures no higher than CR 5 and whose combined average hit points don't exceed 150. These undead magically rise up from the ground or otherwise form in unoccupied spaces within 60 feet of the vampire and obey its commands until they are destroyed, until it dismisses them as an action, or 8 hours have passed."
+						"The vampire conjures {@filter undead creatures no higher than CR 5|bestiary|type=undead|challenge rating=[&0;&5]} and whose combined average hit points don't exceed 150. These undead magically rise up from the ground or otherwise form in unoccupied spaces within 60 feet of the vampire and obey its commands until they are destroyed, until it dismisses them as an action, or 8 hours have passed."
 					]
 				}
 			],
@@ -16608,7 +16644,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Vampire%20Spawn%20Priest%20of%20Death%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Vampire%20Spawn%20Priest%20of%20Death%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -16795,7 +16833,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Vampire%20Spawn%20Monk%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Vampire%20Spawn%20Monk%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -17200,7 +17240,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Vampire%20Spawn%20Commander%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Vampire%20Spawn%20Commander%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -17402,7 +17444,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ursinal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ursinal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -17559,7 +17603,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Urd%20Warlock%20of%20the%20Fiend%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Urd%20Warlock%20of%20the%20Fiend%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -17758,7 +17804,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Urd%20Batlord%20of%20Kuraulyek%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Urd%20Batlord%20of%20Kuraulyek%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -17969,7 +18017,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tyrant%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tyrant%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -18316,7 +18366,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Two-Headed%20Ancient%20Black%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Two-Headed%20Ancient%20Black%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -18718,7 +18770,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Trumpet%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Trumpet%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -19053,7 +19107,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tiktik%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tiktik%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -19253,7 +19309,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tikbalang%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tikbalang%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -19390,7 +19448,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tigbanua%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tigbanua%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -19554,7 +19614,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thug%20Gang%20Boss%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thug%20Gang%20Boss%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thug%20Gang%20Boss%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -19891,7 +19953,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Throne%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Throne%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -20083,7 +20147,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Threskisphinx%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Threskisphinx%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -20419,10 +20485,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Three-Headed%20Ancient%20Red%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Three-Headed%20Ancient%20Red%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Three-Headed%20Ancient%20Red%20Dragon%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Three-Headed%20Ancient%20Red%20Dragon%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -20747,10 +20817,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessaltrice%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessaltrice%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessaltrice%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessaltrice%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -20900,7 +20974,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessalmera%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessalmera%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -21054,7 +21130,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessalhydra%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessalhydra%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -21207,7 +21285,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessalgorgon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Thessalgorgon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -21348,7 +21428,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tendriculos%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Tendriculos%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -21679,7 +21761,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Templar%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Templar%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -21872,7 +21956,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Taurusphinx%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Taurusphinx%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -22070,7 +22156,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sword%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sword%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -22229,7 +22317,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Summer%20Eladrin%20Young%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Summer%20Eladrin%20Young%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -22456,7 +22546,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Summer%20Eladrin%20Elder%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Summer%20Eladrin%20Elder%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -22653,7 +22745,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Storm%20Giant%20King%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Storm%20Giant%20King%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -22832,7 +22926,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Stone%20Giant%20Warlock%20of%20Ogrémoch%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Stone%20Giant%20Warlock%20of%20Ogrémoch%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -22990,7 +23086,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Stone%20Giant%20Earthsinger%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Stone%20Giant%20Earthsinger%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -23166,7 +23264,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Stone%20Giant%20Champion%20of%20Ogrémoch%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Stone%20Giant%20Champion%20of%20Ogrémoch%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -23347,7 +23447,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spring%20Eladrin%20Young%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spring%20Eladrin%20Young%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -23580,7 +23682,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spring%20Eladrin%20Elder%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spring%20Eladrin%20Elder%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -23753,7 +23857,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spiderstone%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spiderstone%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -23893,7 +23999,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Smoke%20Paraelemental%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Smoke%20Paraelemental%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -24019,7 +24127,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Monstrous%20Shocker%20Lizard%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Monstrous%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Monstrous%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -24142,7 +24252,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Giant%20Shocker%20Lizard%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Giant%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Giant%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -24255,7 +24367,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Hatchling%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Hatchling%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -24362,10 +24476,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Hatchling%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shocker%20Lizard%20Hatchling%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -24563,7 +24681,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu,%20Greater%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -24800,7 +24920,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20Enlightened%20One%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -24994,7 +25116,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Shedu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -25254,7 +25378,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sarimanok%20Greater%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sarimanok%20Greater%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -25508,10 +25634,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sarimanok%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sarimanok%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sarimanok%20Greater%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sarimanok%20Greater%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -25696,7 +25826,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Shark%20of%20Sekolah%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Shark%20of%20Sekolah%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -25866,7 +25998,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Shaman%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Shaman%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -26047,7 +26181,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Duke%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Duke%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -26225,7 +26361,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sacred%20Fist%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sacred%20Fist%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -26415,7 +26553,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ravager%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ravager%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -26719,10 +26859,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/High%20Priest%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/High%20Priest%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Priest%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Priest%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -26911,7 +27055,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ranger%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ranger%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -27058,7 +27204,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Skirmisher%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Skirmisher%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -27212,7 +27360,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Mage%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Mage%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -27362,7 +27512,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Knight%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Knight%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -27515,7 +27667,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Druid%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Druid%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -27668,7 +27822,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Captain%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Captain%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -27807,25 +27963,39 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Captain%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Captain%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 3"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Druid%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Druid%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 4"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Knight%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Knight%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 5"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Mage%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Mage%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 6"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Skirmisher%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Pegataur%20Skirmisher%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 7"
 				}
 			]
 		},
@@ -28027,7 +28197,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Owl%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Owl%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -28211,7 +28383,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Warlord%20of%20Luthic%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Warlord%20of%20Luthic%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -28350,7 +28524,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Sergeant%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Sergeant%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -28538,7 +28714,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Hag%20of%20Luthic%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Hag%20of%20Luthic%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -28734,7 +28912,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Battle%20Priestess%20of%20Luthic%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orog%20Battle%20Priestess%20of%20Luthic%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -28892,7 +29072,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orcwort%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orcwort%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -29077,7 +29259,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orc%20Fist%20of%20Bahgtru%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orc%20Fist%20of%20Bahgtru%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -29251,7 +29435,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orc%20Boss%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orc%20Boss%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -29427,7 +29613,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orc%20Bloodrager%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Orc%20Bloodrager%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -29606,7 +29794,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Opinicus%20Greater%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Opinicus%20Greater%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -29777,10 +29967,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Opinicus%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Opinicus%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Opinicus%20Greater%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Opinicus%20Greater%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -29920,7 +30114,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ooze%20Paraelemental%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ooze%20Paraelemental%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -30781,7 +30977,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Obliviax%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Obliviax%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -30966,7 +31164,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nosferatu%20Master%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nosferatu%20Master%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -31131,7 +31331,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nosferatu%20Alpha%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nosferatu%20Alpha%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -31271,7 +31473,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Noran%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Noran%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -31461,7 +31665,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Necromancer%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Necromancer%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -31627,7 +31833,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nabassu%20Whelp%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nabassu%20Whelp%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -31810,7 +32018,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Musteval%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Musteval%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -31975,7 +32185,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Monk%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Monk%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -32142,7 +32354,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Mithral%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Mithral%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -32346,7 +32560,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Mavawhan%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Mavawhan%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -32681,7 +32897,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Manananggal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Manananggal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -32958,7 +33176,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Maligno%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Maligno%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -33103,10 +33323,14 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Sahuagin%20Malenti%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Malenti%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Malenti%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Malenti%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Malenti%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			],
 			"fluff": {
@@ -33270,7 +33494,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Magma%20Paraelemental%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Magma%20Paraelemental%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -33455,10 +33681,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archmage%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archmage%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Mage%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Mage%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -33643,7 +33873,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Luposphinx%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Luposphinx%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -33852,7 +34084,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Lupinal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Lupinal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -34062,7 +34296,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Leonal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Leonal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -34219,7 +34455,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Lantern%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Lantern%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -34566,7 +34804,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Lammasu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Lammasu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -34807,7 +35047,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Priest-King%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Priest-King%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -34982,7 +35224,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Mad%20One%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Mad%20One%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -35168,7 +35412,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Leviathan%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Leviathan%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -35325,7 +35571,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Lash%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Lash%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -35555,7 +35803,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Eye%20of%20Blipdoolpoolp%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kuo-toa%20Eye%20of%20Blipdoolpoolp%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -35727,10 +35977,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kubot%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kubot%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kubot%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kubot%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -36082,7 +36336,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Korred%20Elder%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Korred%20Elder%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -36444,7 +36700,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20War%20Leader%20of%20Kurtulmak%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20War%20Leader%20of%20Kurtulmak%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -36704,7 +36962,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Trapmaster%20of%20Gaknulak%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Trapmaster%20of%20Gaknulak%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -36896,7 +37156,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Dragonsinger%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Dragonsinger%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -37099,7 +37361,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Conqueror%20of%20Dakarnok%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kobold%20Conqueror%20of%20Dakarnok%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -37260,7 +37524,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Knight%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Knight%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -37423,7 +37689,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ki-rin%20Foal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ki-rin%20Foal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -37817,7 +38085,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kapre%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Kapre%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -38801,7 +39071,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Justice%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Justice%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -38969,7 +39241,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Iridescent%20Naga%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Iridescent%20Naga%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -39160,7 +39434,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Injustice%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Injustice%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -39449,7 +39725,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ice%20Paraelemental%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ice%20Paraelemental%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -39622,7 +39900,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ice%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ice%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -39754,7 +40034,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hybsil%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hybsil%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -39935,10 +40217,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hell%20Hound%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hell%20Hound%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hound%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hound%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -40154,7 +40440,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Wyrmlord%20of%20Tiamat%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Wyrmlord%20of%20Tiamat%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -40332,7 +40620,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Warlord%20of%20Nomog-Geaya%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Warlord%20of%20Nomog-Geaya%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -40479,7 +40769,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Warlock%20of%20the%20Legion%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Warlock%20of%20the%20Legion%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -40668,7 +40960,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20War%20Chanter%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20War%20Chanter%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -40883,7 +41177,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Iron%20Shadow%20Master%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Iron%20Shadow%20Master%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41072,7 +41368,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Iron%20Shadow%20Assassin%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Iron%20Shadow%20Assassin%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41238,7 +41536,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Elite%20Captain%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Elite%20Captain%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41440,7 +41740,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Annihilator%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hobgoblin%20Annihilator%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41585,7 +41887,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Warlord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Warlord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41727,7 +42031,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Warlock%20of%20Ogrémoch%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Warlock%20of%20Ogrémoch%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41841,7 +42147,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Skirmisher%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Skirmisher%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -41960,7 +42268,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Siege%20Hulk%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Siege%20Hulk%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -42098,7 +42408,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Gladiator%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Gladiator%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -42236,7 +42548,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Boss%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hill%20Giant%20Boss%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -42425,7 +42739,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/High%20Priest%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/High%20Priest%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -42683,7 +42999,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hierophant%20of%20Annihilation%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hierophant%20of%20Annihilation%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -43075,7 +43393,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hellblade%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hellblade%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -43274,7 +43594,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hell%20Hound%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hell%20Hound%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -43484,7 +43806,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Harbinger%20Archon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Harbinger%20Archon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -43628,7 +43952,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hangman%20Tree%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Hangman%20Tree%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -43803,7 +44129,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Halimaw%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Halimaw%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -44061,10 +44389,14 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ha-naga%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ha%20Naga%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ha%20Naga%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ha%20Naga%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ha%20Naga%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			],
 			"fluff": {
@@ -44227,7 +44559,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Green%20Duwende%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Green%20Duwende%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -44385,7 +44719,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gray%20Duwende%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gray%20Duwende%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -44637,10 +44973,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gorbel%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gorbel%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gorbel%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gorbel%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -45007,7 +45347,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Watcher%20of%20Maglubiyet%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Watcher%20of%20Maglubiyet%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -45184,7 +45526,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Instructor%20Of%20Khurgorbaeyag%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Instructor%20of%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Instructor%20of%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -45344,7 +45688,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Ganglord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Ganglord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -45518,7 +45864,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Battle%20Lord%20Of%20Maglubiyet%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Battlelord%20of%20Maglubiyet%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Battlelord%20of%20Maglubiyet%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -45683,7 +46031,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Artificer%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Artificer%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -45909,7 +46259,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Witherlock%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Witherlock%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -46179,7 +46531,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Warlock%20of%20Yeenoghu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Warlock%20of%20Yeenoghu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -46355,7 +46709,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20War%20Priest%20Of%20Yeenoghu%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Warpriest%20of%20Yeenoghu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Warpriest%20of%20Yeenoghu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -46553,7 +46909,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Priest%20of%20Refnara%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Priest%20of%20Refnara%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -46783,7 +47141,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Nimrod%20of%20Gorellik%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Nimrod%20of%20Gorellik%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -46923,7 +47283,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Cutthroat%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Cutthroat%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -47098,7 +47460,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gladiator%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gladiator%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -47569,7 +47933,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gatorfolk%20Claw%20of%20Sess'innek (Token 2).png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gatorfolk%20Claw%20of%20Sess'innek (Token 2).png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -47870,10 +48236,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gatorfolk%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gatorfolk%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gatorfolk%20Claw%20of%20Sess'innek (Token 2).png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gatorfolk%20Claw%20of%20Sess'innek (Token 2).png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -48048,7 +48418,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Wolflord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Wolflord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -48218,7 +48590,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Warlord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Warlord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -48370,7 +48744,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Warlock%20of%20Kostchtchie%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Warlock%20of%20Kostchtchie%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -48532,7 +48908,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Shaman%20of%20Auril%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Shaman%20of%20Auril%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -48807,7 +49185,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Mauler%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Mauler%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -48943,7 +49323,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Mammoth%20Rider%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Frost%20Giant%20Mammoth%20Rider%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -49100,7 +49482,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Warlock%20of%20Imix%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Warlock%20of%20Imix%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -49268,7 +49652,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20War%20Mage%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20War%20Mage%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -49408,7 +49794,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Juggernaut%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Juggernaut%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -49545,7 +49933,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Chain%20Brute%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Chain%20Brute%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -49753,7 +50143,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Blackguard%20of%20Surtur%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Blackguard%20of%20Surtur%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -49932,7 +50324,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Artillerist%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Fire%20Giant%20Artillerist%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -50265,7 +50659,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Favored%20Adult%20Dragon%20of%20Tiamat%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Favored%20Adult%20Dragon%20of%20Tiamat%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -50395,7 +50791,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eyewing%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eyewing%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -50618,7 +51016,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eye%20of%20Gulguthra%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eye%20of%20Gulguthra%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -50812,7 +51212,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Equinal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Equinal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -51000,7 +51402,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eldritch%20Naga%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eldritch%20Naga%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -51199,7 +51603,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eldritch%20Assassin%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Eldritch%20Assassin%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -51324,7 +51730,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20White%20Guard%20Drake%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20White%20Guard%20Drake%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -51442,7 +51850,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20Red%20Guard%20Drake%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20Red%20Guard%20Drake%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -51805,7 +52215,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20Black%20Guard%20Drake%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20Black%20Guard%20Drake%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -52346,10 +52758,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archdruid%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archdruid%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Druid%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Druid%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -53029,10 +53445,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dragonroot%20Tree%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dragonroot%20Tree%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dragonroot%20Tree%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dragonroot%20Tree%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -53209,7 +53629,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20War%20Mage%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20War%20Mage%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20War%20Mage%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -53375,7 +53797,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Shaman%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Shaman%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Shaman%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -53935,7 +54359,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Champion%20of%20Tiamat%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Champion%20of%20Tiamat%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -54089,7 +54515,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Berserker%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Berserker%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Berserker%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -54235,7 +54663,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Archer%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Archer%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20Archer%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -54386,7 +54816,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracotaur%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -54617,7 +55049,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracosphinx%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dracosphinx%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -54750,7 +55184,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Doom%20Blossom%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Doom%20Blossom%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -55023,7 +55459,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Diwata%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Diwata%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -55222,7 +55660,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Demonflesh%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Demonflesh%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -55463,10 +55903,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -55704,13 +56148,19 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Deepspawn%20Tyrant%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 3"
 				}
 			]
 		},
@@ -55906,7 +56356,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dark%20Naga%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dark%20Naga%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -56065,7 +56517,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dark%20Duwende%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Dark%20Duwende%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -56442,7 +56896,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Crocosphinx%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Crocosphinx%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -56584,7 +57040,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Corpse%20Flower%20Monstrous%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Corpse%20Flower%20Monstrous%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -56790,7 +57248,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Cloud%20Giant%20Divine%20Trickster%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Cloud%20Giant%20Divine%20Trickster%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -56997,7 +57457,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Clockwork%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Clockwork%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -57230,7 +57692,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Clockwork%20Beholder%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Clockwork%20Beholder%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -57389,7 +57853,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Champion%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Champion%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -57602,7 +58068,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Cervidal%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Cervidal%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -57792,7 +58260,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Canisphinx%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Canisphinx%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -58000,7 +58470,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Cambion%20Gladiator%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Cambion%20Gladiator%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -58167,7 +58639,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Buso%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Buso%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -58485,7 +58959,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bungisngis%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bungisngis%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -58660,7 +59136,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Warlock%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Warlock%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -58859,7 +59337,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Swarm%20Leader%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Swarm%20Leader%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -59002,7 +59482,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Skirmisher%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Skirmisher%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -59162,7 +59644,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Shaman%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Shaman%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -59483,7 +59967,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Maw%20of%20Ramenos%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Maw%20of%20Ramenos%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -59644,7 +60130,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Boss%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bullywug%20Boss%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -59794,7 +60282,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Witch%20Doctor%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Witch%20Doctor%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -59935,7 +60425,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Warlock%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Warlock%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -60061,7 +60553,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Hunter%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Hunter%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -60297,7 +60791,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Dread%20Eye%20of%20Grankhul%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Dread%20Eye%20of%20Grankhul%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -60490,7 +60986,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Dark%20Claw%20of%20Skiggaret%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Dark%20Claw%20of%20Skiggaret%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -60822,7 +61320,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Blood%20Ghost%20Berserker%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Blood%20Ghost%20Berserker%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -61041,7 +61541,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Beastlord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bugbear%20Beastlord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -61301,7 +61803,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bright%20Naga%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bright%20Naga%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -61467,7 +61971,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bladesinger%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bladesinger%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -61681,7 +62187,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Blackguard%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Blackguard%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -62053,7 +62561,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Barrow%20Hag%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Barrow%20Hag%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -62664,7 +63174,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bariaur%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bariaur%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -62853,7 +63365,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bard%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bard%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -63036,7 +63550,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Barbarian%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Barbarian%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -63205,7 +63721,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bandit%20Lord%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Bandit%20Lord%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -63406,7 +63924,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Avoral%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Avoral%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -63583,7 +64103,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Autumn%20Eladrin%20Young%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Autumn%20Eladrin%20Young%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -63820,7 +64342,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Autumn%20Eladrin%20Elder%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Autumn%20Eladrin%20Elder%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -64198,10 +64722,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Aurumvorax%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Aurumvorax%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Aurumvorax%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Aurumvorax%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -64363,7 +64891,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Assassin%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Assassin%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -64578,7 +65108,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archmage%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archmage%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -64789,7 +65321,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archdruid%20Legendary%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Archdruid%20Legendary%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -65047,7 +65581,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Anito%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Anito%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -65245,10 +65781,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Purple%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Purple%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Purple%20Dragon%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Purple%20Dragon%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -65439,10 +65979,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Gray%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Gray%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Gray%20Dragon%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Gray%20Dragon%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -65642,10 +66186,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Brown%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Brown%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Brown%20Dragon%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Ancient%20Brown%20Dragon%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -66077,10 +66625,14 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Illithidragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Illithidragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 1"
 				},
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Illithidragon%20%28Token%203%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Illithidragon%20%28Token%203%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border 2"
 				}
 			]
 		},
@@ -66353,7 +66905,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Hellfire%20Wyrm%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Hellfire%20Wyrm%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -66575,7 +67129,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Elder%20Blue%20Guard%20Drake%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spectral%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Spectral%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -66967,7 +67523,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Brown%20Dragon%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adult%20Brown%20Dragon%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -67129,7 +67687,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adamantine%20Golem%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Adamantine%20Golem%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -67311,7 +67871,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Peacemaker%20of%20Bargrivyek%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Goblin%20Peacemaker%20of%20Bargrivyek%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -67651,7 +68213,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Winter%20Eladrin%20Young%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Winter%20Eladrin%20Young%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		},
@@ -67835,7 +68399,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20War%20Leader%20of%20Yeenoghu%20%28Token%29.png",
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Warleader%20of%20Yeenoghu%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Gnoll%20Warleader%20of%20Yeenoghu%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			],
 			"fluff": {
@@ -68077,7 +68643,9 @@
 			},
 			"altArt": [
 				{
-					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nagahydra%20%28Token%202%29.png"
+					"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/MonsterManualExpanded3/creature/token/Nagahydra%20%28Token%202%29.png",
+					"source": "MonsterManualExpanded3",
+					"name": "Roll20-style border"
 				}
 			]
 		}
@@ -68372,7 +68940,7 @@
 					"items": [
 						"Unbearably hot, sulfuric smoke obscures the land within 6 miles of the dragon's lair. Creatures take 3 ({@damage 1d6}) poison damage and 3 ({@damage 1d6}) fire damage at the end of hour spent in the area.",
 						"Water sources within 1 mile of the lair are supernaturally warm and tainted by sulfur.",
-						"Rocky fissures within 1 mile of the dragon's lair form portals to the Nine Hells, allowing hell hounds and lesser devils (CR 5 or less) into the world to dwell nearby."
+						"Rocky fissures within 1 mile of the dragon's lair form portals to the Nine Hells, allowing {@creature hell hound|MM|hell hounds} and lesser devils ({@filter CR 5 or less|bestiary|tag=devil|challenge rating=[&0;&5]}) into the world to dwell nearby."
 					]
 				},
 				"If the dragon dies, the devils disappear immediately, and the other effects fade over the course of {@dice 1d10} days."

--- a/creature/Dragonix; Monster Manual Expanded.json
+++ b/creature/Dragonix; Monster Manual Expanded.json
@@ -18,7 +18,7 @@
 			}
 		],
 		"dateAdded": 1579291901,
-		"dateLastModified": 1649177632
+		"dateLastModified": 1649629420
 	},
 	"monster": [
 		{
@@ -16169,12 +16169,7 @@
 			"size": [
 				"M"
 			],
-			"type": {
-				"type": "humanoid",
-				"tags": [
-					"goblinoid"
-				]
-			},
+			"type": "undead",
 			"alignment": [
 				"C",
 				"E"

--- a/creature/Dragonix; Monster Manual Expanded.json
+++ b/creature/Dragonix; Monster Manual Expanded.json
@@ -18,7 +18,7 @@
 			}
 		],
 		"dateAdded": 1579291901,
-		"dateLastModified": 1649629420
+		"dateLastModified": 1649644260
 	},
 	"monster": [
 		{
@@ -42771,13 +42771,7 @@
 				{
 					"name": "Tangleweb",
 					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 20 ft., one creature. {@h}The creature must succeed on a {@dc 11} Strength saving throw or be {@condition restrained} by sticky web-like adhesive. As an"
-					]
-				},
-				{
-					"name": "escaping from the tangleweb on a success",
-					"entries": [
-						"The effect ends if the tangleweb is destroyed. The tangleweb has AC 10, 5 hit points, resistance to bludgeoning damage, and immunity to poison and psychic damage."
+						"{@atk rw} {@hit 4} to hit, range 20 ft., one creature. {@h}The creature must succeed on a {@dc 11} Strength saving throw or be {@condition restrained} by sticky web-like adhesive. As an action, the {@condition restrained} creature can make a {@dc 11} Strength check, escaping from the tangleweb on a success. The effect ends if the tangleweb is destroyed. The tangleweb has AC 10, 5 hit points, resistance to bludgeoning damage, and immunity to poison and psychic damage."
 					]
 				},
 				{


### PR DESCRIPTION
Small typos + add a `source` and `name` to all the MME3 `altArt`s so they actually work in Plutonium