### PR TITLE
fix for paladin spell levels

### DIFF
--- a/collection/Mage Hand Press; Valda's Spire of Secrets.json
+++ b/collection/Mage Hand Press; Valda's Spire of Secrets.json
@@ -7435,19 +7435,19 @@
 							"feather fall",
 							"longstrider"
 						],
-						"7": [
+						"5": [
 							"find steed",
 							"misty step"
 						],
-						"15": [
+						"9": [
 							"fly",
 							"haste"
 						],
-						"18": [
+						"13": [
 							"dimension door",
 							"freedom of movement"
 						],
-						"20": [
+						"17": [
 							"passwall",
 							"teleportation circle"
 						]
@@ -7474,19 +7474,19 @@
 							"illusory script",
 							"protection from evil and good"
 						],
-						"7": [
+						"5": [
 							"magic weapon",
 							"zone of truth"
 						],
-						"15": [
+						"9": [
 							"dispel magic",
 							"speak with dead"
 						],
-						"18": [
+						"13": [
 							"banishment",
 							"Mordenkainen's private sanctum"
 						],
-						"20": [
+						"17": [
 							"dispel evil and good",
 							"legend lore"
 						]
@@ -7513,19 +7513,19 @@
 							"charm person",
 							"Tasha's hideous laughter"
 						],
-						"7": [
+						"5": [
 							"calm emotions",
 							"enhance ability"
 						],
-						"15": [
+						"9": [
 							"create food and water",
 							"hypnotic pattern"
 						],
-						"18": [
+						"13": [
 							"compulsion",
 							"freedom of movement"
 						],
-						"20": [
+						"17": [
 							"geas",
 							"Rary's telepathic bond"
 						]
@@ -7552,19 +7552,19 @@
 							"fog cloud",
 							"thunderwave"
 						],
-						"7": [
+						"5": [
 							"gust of wind",
 							"hold person"
 						],
-						"15": [
+						"9": [
 							"call lightning",
 							"wind wall"
 						],
-						"18": [
+						"13": [
 							"control water",
 							"ice storm"
 						],
-						"20": [
+						"17": [
 							"commune with nature",
 							"hold monster"
 						]
@@ -7591,19 +7591,19 @@
 							"burning hands",
 							"guiding bolt"
 						],
-						"7": [
+						"5": [
 							"darkvision",
 							"scorching ray"
 						],
-						"15": [
+						"9": [
 							"daylight",
 							"spirit guardians"
 						],
-						"18": [
+						"13": [
 							"fire shield",
 							"wall of fire"
 						],
-						"20": [
+						"17": [
 							"flame strike",
 							"hallow"
 						]
@@ -7630,19 +7630,19 @@
 							"create or destroy water",
 							"fog cloud"
 						],
-						"7": [
+						"5": [
 							"hold person",
 							"shatter"
 						],
-						"15": [
+						"9": [
 							"sleet storm",
 							"slow"
 						],
-						"18": [
+						"13": [
 							"fire shield",
 							"ice storm"
 						],
-						"20": [
+						"17": [
 							"cone of cold",
 							"hold monster"
 						]


### PR DESCRIPTION
Valda's paladins get their extra spells at the same levels as other oaths. Also fixed in latest PDF.