### PR TITLE
AGMH 6/15 Update

### DIFF
--- a/collection/Amellwind; Amellwind's Guide to Monster Hunting.json
+++ b/collection/Amellwind; Amellwind's Guide to Monster Hunting.json
@@ -11,7 +11,7 @@
 				"convertedBy": [
 					"cellescent"
 				],
-				"version": "2022/04/29",
+				"version": "2022/06/15",
 				"url": "https://www.gmbinder.com/share/-LCk9FgQaqaXBVmLeCeT"
 			}
 		],
@@ -1383,7 +1383,7 @@
 			"source": "AGMH",
 			"group": "homebrew",
 			"author": "AGMH",
-			"published": "2021-05-22",
+			"published": "2022-06-15",
 			"contents": [
 				{
 					"name": "Welcome to Monster Hunter",
@@ -1435,6 +1435,7 @@
 						"Creating a Hunt",
 						"Going on a Hunt",
 						"Example Hunt",
+						"Traveling",
 						"Siege Weapons",
 						"Dragonships",
 						"Creating your own Loot Tables",
@@ -1462,6 +1463,7 @@
 					"headers": [
 						"Ancestral Steppes",
 						"The Dunes",
+						"Jungle",
 						"Ocean",
 						"Snowy Mountains",
 						"Verdant Hills",
@@ -2940,7 +2942,15 @@
 											"type": "entries",
 											"name": "The Artificer",
 											"entries": [
-												"The {@class artificer|TCE} is a special case when it comes to the rule set found within this book. As an artificer levels up, they gain the ability to attune to additional magical items. The balance of this system does not mesh well with this feature, so instead of an artificer gaining the ability to attune to additional magical items, they instead are given one additional material slot in both their armor and weapons at the 10th, 14th, and 18th level."
+												"The {@class artificer|TCE} is a special case when it comes to the rule set found within this book. As an artificer levels up, they gain the ability to attune to additional magical items. The balance of this system does not mesh well with this feature, so instead of an artificer gaining the ability to attune to additional magical items, they instead are given one additional material slot in both their armor and weapons at the 10th, 14th, and 18th level.",
+												{
+													"type": "entries",
+													"name": "Artificer Infusions",
+													"entries": [
+														"{@filter Artificer infusions|optionalfeatures|feature type=AI} are a special material that can be placed into a creature's armor,weapon, or trinket. These infusion materials are considered temporary and can be placed in slot(s) during a long rest. The slot can be empty or already contain a normal material. If it is placed in a slot with a normal material already in it, then the infusion material replaces it as the active material (but it does not destroy the normal material). The infusion material remains in the slot until it is removed during a long rest, the artificer no long knows the infusion, or the artificer is no longer apart of the hunting party.",
+														"If an infusion material requires attunement, then being attuned to the armor or weapon counts towards the attunement requirement for it with one condition. If the artifcer places an infusion material into another creature's armor or weapon and it requires attunement, then the infusion takes up two slots instead of one. When an artificer places an infusion material that requires attunement into its own armor or weapon, it takes only one slot."
+													]
+												}
 											]
 										},
 										{
@@ -3139,8 +3149,8 @@
 																],
 																[
 																	"2",
-																	"CR 4",
-																	"1d4"
+																	"--",
+																	"--"
 																],
 																[
 																	"3",
@@ -3440,11 +3450,11 @@
 								"Feats can be an important part of Dungeons and Dragons and should your Dungeon Master allow them, here are a few new additional feats you are able to choose from.",
 								"{@feat Armored Gunner|AGMH}",
 								"{@feat Bomb Specialist|AGMH}",
-								"{@feat Charge Blade Mastery|AGMH}",
 								"{@feat Frenzy Fever|AGMH}",
 								"{@feat Gunlance Mastery|AGMH}",
 								"{@feat Horn Maestro|AGMH}",
 								"{@feat Insect Glaive Mastery|AGMH}",
+								"{@feat Improved Hammer Charge|AGMH}",
 								"{@feat Kinsect Mastery|AGMH}",
 								"{@feat Master Craftsman|AGMH}",
 								"{@feat Master Mounter|AGMH}",
@@ -3490,17 +3500,9 @@
 									"name": "Artisan",
 									"entries": [
 										"{@i Primary Skill: {@item cook's utensils|PHB|Cooking Utensils}, Three highest Ability Scores}",
-										"The artisan can cook a meal for the party at the start of a hunt and during a short or long rest (if they choose to), granting all who eat it a boon to help them on their hunt/journey/day."
+										"The artisan can {@variantrule Artisan Cooking System|AGMH|cook a meal} for the party at the start of a hunt and during a short or long rest (if they choose to), granting all who eat it a boon to help them on their hunt/journey/day."
 									]
 								}
-							]
-						},
-						{
-							"type": "section",
-							"name": "Artisan Cooking System",
-							"page": 48,
-							"entries": [
-								"{@variantrule Artisan Cooking System|AGMH}"
 							]
 						},
 						{
@@ -3670,19 +3672,19 @@
 															"Rare",
 															"Hard Armor Sphere",
 															"10",
-															"1500 gp"
+															"1,500 gp"
 														],
 														[
 															"Very Rare",
 															"Heavy Armor Sphere",
 															"15",
-															"6000 gp"
+															"6,000 gp"
 														],
 														[
 															"Legendary",
 															"Royal Armor Sphere",
 															"20",
-															"24000 gp"
+															"24,000 gp"
 														]
 													],
 													"footnotes": [
@@ -3695,7 +3697,7 @@
 											"type": "entries",
 											"name": "Shields",
 											"entries": [
-												"Shields in the Monster Hunter universe can only be used with a weapon that already provides it. Any AC bonus it may provide is increased as the weapon's rarity changes, as shown in the weapons information in appendix A."
+												"{@item Shield|PHB}s in the Monster Hunter universe can only be used with a weapon that already provides it. Any AC bonus it may provide is increased as the weapon's rarity changes, as shown in the weapons information in appendix B."
 											]
 										}
 									]
@@ -3737,12 +3739,12 @@
 															"{@item Accel Axe|AGMH}",
 															"Martial Melee Weapon",
 															"{@item Battleaxe|PHB}, {@item Greataxe|PHB}",
-															"Shield"
+															"--"
 														],
 														[
 															"{@item Charge Blade|AGMH}",
 															"Martial Melee Weapon",
-															"{@item Greataxe|PHB}, {@item Shortsword|PHB}, {@item Longsword|PHB}, {@item Scimitar|PHB}",
+															"{@item Shield|PHB}, {@item Greataxe|PHB}, {@item Shortsword|PHB}, {@item Longsword|PHB}, {@item Scimitar|PHB}",
 															"Shield"
 														],
 														[
@@ -3806,6 +3808,12 @@
 															"--"
 														],
 														[
+															"{@item Splint Rapier|AGMH}",
+															"Martial Melee Weapon",
+															"{@item longsword|PHB}, {@item rapier|PHB}, {@item shortsword|PHB}",
+															"--"
+														],
+														[
 															"{@item Switch Axe|AGMH}",
 															"Martial Melee Weapon",
 															"{@item Greataxe|PHB}, {@item Greatsword|PHB}",
@@ -3814,13 +3822,19 @@
 														[
 															"{@item Sword and Shield|AGMH}",
 															"Martial or Simple Melee Weapon ",
-															"{@item Shortsword|PHB}, {@item Longsword|PHB}, {@item Scimitar|PHB}, {@item Light Hammer|PHB}, {@item Mace|PHB}",
+															"{@item Shield|PHB}; {@item Shortsword|PHB}, {@item Longsword|PHB}, {@item Scimitar|PHB}, {@item Light Hammer|PHB}, {@item Mace|PHB}",
 															"Shield"
 														],
 														[
 															"{@item Tonfas|AGMH}",
 															"Martial or Simple Melee Weapon",
 															"{@item Club|PHB}, {@item Flail|PHB}, {@item Handaxe|PHB}, {@item Light Hammer|PHB}, {@item Mace|PHB}, {@item Quarterstaff|PHB}, {@item Warhammer|PHB}",
+															"--"
+														],
+														[
+															"{@item Wyvern Boomerang|AGMH}",
+															"Martial or Simple Melee Weapon",
+															"{@item Greatsword|PHB}, {@filter Any weapon with the Thrown property|items|source=PHB|property=thrown}",
 															"--"
 														],
 														[
@@ -3831,7 +3845,7 @@
 														],
 														[
 															"{@item Dual Repeaters|AGMH}",
-															"Martial or Simple Ranged Weapon",
+															"Martial Ranged Weapon",
 															"Firearms, {@item Hand Crossbow|PHB}",
 															"--"
 														],
@@ -3898,6 +3912,7 @@
 															"type": "list",
 															"style": "list-decimal",
 															"items": [
+																"A weapon can have one material that causes an effect when you roll a 20, such as critical status effect on the Fancy Beak material. This material is exempt from rule 2.",
 																"A weapon can only have one extra damage, condition inflicting, or on-hit effect material. The extra damage material rule doesn't apply to materials that have a requirement to deal that extra damage, such as the partbreaker effect found on the Gravios Carapace material.",
 																"A weapon can only have one effect that uses runes.",
 																"A weapon can only have one bonus to spell DC and spell attack rolls.",
@@ -3920,7 +3935,7 @@
 														"Rarity",
 														"{@table minerals|AGMH|Resource*}",
 														"Amount Needed",
-														"Cost"
+														"Cost**"
 													],
 													"colStyles": [
 														"col-3 text-center",
@@ -3939,19 +3954,19 @@
 															"Rare",
 															"Machalite Ore",
 															"10",
-															"1500 gp"
+															"1,500 gp"
 														],
 														[
 															"Very Rare",
 															"Dragonite Ore",
 															"15",
-															"6000 gp"
+															"6,000 gp"
 														],
 														[
 															"Legendary",
 															"Carbalite Ore",
 															"20",
-															"24000 gp"
+															"24,000 gp"
 														]
 													],
 													"footnotes": [
@@ -3967,14 +3982,21 @@
 									"name": "Trinkets",
 									"entries": [
 										"Trinkets in Monster Hunter are not just for show. They have 1 material slot that you can place a weapon or armor magical effect into and still gain their benefit as if it was in a weapon or armor set. You can have up to two trinkets on you at a time, but you only gain the effect of one of the trinkets at a time. As an action, you can swap which trinket effect you are using.",
-										"Players can choose a {@item trinket|PHB} from the Player's Handbook (p.159) or perhaps a trophy from a creature they have hunted. If they do not find something they like on the list, the player can work with the GM to choose an appropriate trinket for their setting."
+										"Players can choose a {@item trinket|PHB} from the Player's Handbook (p.159) or perhaps a trophy from a creature they have hunted. If they do not find something they like on the list, the player can work with the GM to choose an appropriate trinket for their setting.",
+										{
+											"type": "entries",
+											"name": "Rules",
+											"entries": [
+												"If the material grants an effect such as extra damage on weapon attacks, or requires the armor to be worn, then it only works on armor or weapons you are attuned to."
+											]
+										}
 									]
 								},
 								{
 									"type": "entries",
-									"name": "Rules",
+									"name": "Cosmetic Material Slot",
 									"entries": [
-										"If the material grants an effect such as extra damage on weapon attacks, or requires the armor to be worn, then it only works on armor or weapons you are attuned to."
+										"There are many materials you may find while hunting monsters. These cosmetic materials have no mechanical benefit, but change your characters appearance in some way. You have one cosmetic slot in either your armor or weapon (your choice) that you can place a cosmetic material into or replace when you find a different that suits your character a bit more."
 									]
 								}
 							]
@@ -4017,7 +4039,7 @@
 											"Varies, see Appendix B",
 											"Varies",
 											"7 lb",
-											"heavy, two-handed, switch mode"
+											"heavy, two-handed, {@optfeature switch mode (cb)|AGMH|switch mode}"
 										],
 										[
 											"{@item Dual Blades|AGMH}",
@@ -4100,6 +4122,14 @@
 											"versatile (1d8)"
 										],
 										[
+											"{@item Splint Rapier|AGMH}",
+											"30 gp",
+											"Varies, see Appendix B.",
+											"--",
+											"4 lb",
+											"finesse, light"
+										],
+										[
 											"{@item Switch Axe|AGMH}",
 											"30 gp",
 											"Varies, see Appendix B.",
@@ -4122,6 +4152,14 @@
 											"--",
 											"6 lb",
 											"light, comes with a main & offhand weapon"
+										],
+										[
+											"{@item Wyvern Boomerang|AGMH}",
+											"40 gp",
+											"1d10 slashing",
+											"--",
+											"8 lb",
+											"heavy, two-handed, thrown (range 60/180)"
 										],
 										[
 											"{@item Bow|AGMH}",
@@ -4666,7 +4704,7 @@
 										],
 										[
 											"",
-											"{@item Large Barrel|AGMH}",
+											"Large Barrel",
 											"2 gp",
 											"2 lb."
 										],
@@ -4726,7 +4764,7 @@
 										],
 										[
 											"",
-											"{@item Small Barrel|AGMH}",
+											"Small Barrel",
 											"1 gp",
 											"1 lb."
 										],
@@ -5756,6 +5794,14 @@
 													"versatile (1d8)"
 												],
 												[
+													"{@item Splint Rapier|AGMH}",
+													"30 gp",
+													"Varies, see Appendix B.",
+													"--",
+													"4 lb",
+													"finesse, light"
+												],
+												[
 													"{@item Switch Axe|AGMH}",
 													"30 gp",
 													"Varies, see Appendix B.",
@@ -5778,6 +5824,14 @@
 													"--",
 													"6 lb",
 													"light, comes with a main & offhand weapon"
+												],
+												[
+													"{@item Wyvern Boomerang|AGMH}",
+													"40 gp",
+													"1d10 slashing",
+													"--",
+													"8 lb",
+													"heavy, two-handed, thrown (60/180)"
 												],
 												[
 													"{@item Bow|AGMH}",
@@ -5982,15 +6036,8 @@
 												],
 												[
 													"Bowgun Ammo",
-													"{@item Spread lvl 1 (20)|AGMH}",
+													"{@item Spread Ammo (20)|AGMH}",
 													"3 gp",
-													"1.5 lb.",
-													"40"
-												],
-												[
-													"Bowgun Ammo",
-													"{@item Spread lvl 2 (20)|AGMH}",
-													"5 gp",
 													"1.5 lb.",
 													"40"
 												],
@@ -6032,6 +6079,13 @@
 												[
 													"Bow",
 													"{@item Arrows (20)|PHB}",
+													"1 gp",
+													"1 lb.",
+													"--"
+												],
+												[
+													"Bow",
+													"{@item Normal Ammo (18)|AGMH}",
 													"1 gp",
 													"1 lb.",
 													"--"
@@ -6257,15 +6311,8 @@
 												],
 												[
 													"Bowgun Ammo",
-													"{@item Spread lvl 1 (20)|AGMH}",
+													"{@item Spread Ammo (20)|AGMH}",
 													"3 gp",
-													"1.5 lb.",
-													"40"
-												],
-												[
-													"Bowgun Ammo",
-													"{@item Spread lvl 2 (20)|AGMH}",
-													"5 gp",
 													"1.5 lb.",
 													"40"
 												],
@@ -6797,8 +6844,334 @@
 						},
 						{
 							"type": "section",
-							"name": "Siege Weapons",
+							"name": "Traveling",
 							"page": 83,
+							"entries": [
+								"In many Dungeons and Dragon campaigns your PCs are going to travel across the world. That is no different in a campaign that takes place in the Monster Hunter Universe.",
+								"In the rules below you will both the standard traveling pace rules from 5e Dungeons and Dragons as well as a new way for your PCs to travel across your world, using the same type of roles as when they go on a hunt (though with slightly different rules).",
+								{
+									"type": "entries",
+									"name": "Travel Pace",
+									"entries": [
+										"While traveling, a group of adventurers can move at a normal, fast, or slow pace, as shown on the Travel Pace table. The table states how far the party can move in a period of time and whether the pace has any effect. A fast pace makes characters less perceptive, while a slow pace makes it possible to sneak around and to search an area more carefully.",
+										{
+											"type": "table",
+											"caption": "Travel Pace Table",
+											"colLabels": [
+												"Pace",
+												"Distance per Minute",
+												"Distance per Hour",
+												"Distance per day",
+												"Effect"
+											],
+											"colStyles": [
+												"col-2 text-left",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-4 text-left"
+											],
+											"rows": [
+												[
+													"Fast",
+													"400 feet",
+													"4 miles",
+													"30 miles",
+													"-5 penalty to passive Wisdom ({@skill Perception}) scores"
+												],
+												[
+													"Normal",
+													"300 feet",
+													"3 miles",
+													"24 miles",
+													"-"
+												],
+												[
+													"Slow",
+													"200 feet",
+													"2 miles",
+													"18 miles",
+													"Able to use {@skill Stealth}"
+												]
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Forced March",
+											"entries": [
+												"The Travel Pace table assumes that characters travel for 8 hours in day. They can push on beyond that limit, at the risk of {@condition exhaustion}.",
+												"For each additional hour of travel beyond 8 hours, the characters cover the distance shown in the Hour column for their pace, and each character must make a Constitution saving throw at the end of the hour. The DC is 10 + 1 for each hour past 8 hours. On a failed saving throw, a character suffers one level of exhaustion."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Mounts and Vehicles",
+											"entries": [
+												"For short spans of time (up to an hour), many animals move much faster than humanoids. A mounted character can ride at a gallop for about an hour, covering twice the usual distance for a fast pace. If fresh mounts are available every 8 to 10 miles, characters can cover larger distances at this pace, but this is very rare except in densely populated areas.",
+												"Characters in wagons, carriages, or other land vehicles choose a pace as normal. Characters in a waterborne vessel are limited to the speed of the vessel, and they don't suffer penalties for a fast pace or gain benefits from a slow pace. Depending on the vessel and the size of the crew, ships might be able to travel for up to 24 hours per day.",
+												"{@i *Certain special mounts, such as a pegasus or griffon, or special vehicles, such as a carpet of flying, allow you to travel more swiftly.}"
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Difficult Terrain",
+											"entries": [
+												"The travel speeds given in the Travel Pace table assume relatively simple terrain: roads, open plains, or clear dungeon corridors. But adventurers often face dense forests, deep swamps, rubble-filled ruins, steep mountains, and ice-covered ground--all considered difficult terrain."
+											]
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Short and Long Rests During Travel",
+									"entries": [
+										"One of the biggest issue with traveling is that the party is able to get a long rest every single night, which makes it difficult for a DM to have to through 5-6 encounters in a single day vs 5-6 encounters over the course of the journey.",
+										"To fix this problem, we are going to \"extend\" out the encounter day, into an encounter week. During this week, the PCs are able to take two short rests. They can take a long rest at the end of each week and when they reach their destination.",
+										"With the additional rules you will read below, the party has the chance of 14 random encounters during a week of travel. On average the group should encounter between 3-6 encounters (and not all of these have to be combat encounters), but should they feel unable to continue their travels without a long rest, they can remain at their last camp site for the remainder of the week and take a long rest."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Random Encounters",
+									"entries": [
+										"As they travel, the PCs may encounter random creatures, places of interest, merchants, etc. A random encounter can happen during a days travel, or at night while the group is resting at camp. This leaves the potential for 2 random encounters each day.",
+										"To determine if a random encounter occurs, the DM will contest the trailblazer's and scout's checks with a random encounter check by rolling a d20 + modifiers based on the tables below. On a successful contest, roll a random encounter, or chose one you like.",
+										{
+											"type": "entries",
+											"name": "Modifier Tables",
+											"entries": [
+												"The following tables are used to determine the bonus to the DM adds to its contested role against the trailblazer and scouts checks.",
+												{
+													"type": "table",
+													"caption": "Environment",
+													"colLabels": [
+														"Modifier Bonus",
+														"Type of Environment"
+													],
+													"colStyles": [
+														"col-1 text-center",
+														"col-11 text-left"
+													],
+													"rows": [
+														[
+															"+0",
+															"An inn or home at a well-established settlement"
+														],
+														[
+															"+1",
+															"Peaceful countryside or safe roads"
+														],
+														[
+															"+2",
+															"Tamed wilderness, or the streets of an urban city"
+														],
+														[
+															"+3",
+															"Untamed wilderness of hazardous or unknown terrain"
+														],
+														[
+															"+4",
+															"Deadly wilderness or caves infested by dangerous monsters"
+														],
+														[
+															"+5",
+															"Alien planes of unspeakable horror"
+														]
+													]
+												},
+												{
+													"type": "table",
+													"caption": "Season",
+													"colLabels": [
+														"Modifier Bonus",
+														"Season"
+													],
+													"colStyles": [
+														"col-1 text-center",
+														"col-11 text-left"
+													],
+													"rows": [
+														[
+															"+0",
+															"Spring"
+														],
+														[
+															"+0",
+															"Summer"
+														],
+														[
+															"+0",
+															"Autumn"
+														],
+														[
+															"+1",
+															"Winter"
+														]
+													]
+												},
+												{
+													"type": "table",
+													"caption": "Travel Pace",
+													"colLabels": [
+														"Modifier Bonus",
+														"Pace"
+													],
+													"colStyles": [
+														"col-1 text-center",
+														"col-11 text-left"
+													],
+													"rows": [
+														[
+															"-2",
+															"Stealth"
+														],
+														[
+															"+0",
+															"Normal"
+														],
+														[
+															"+3",
+															"Fast"
+														]
+													]
+												},
+												{
+													"type": "table",
+													"caption": "Weather",
+													"colLabels": [
+														"Modifier Bonus",
+														"Weather",
+														"Cold Climate",
+														"Temperate Climate",
+														"Desert"
+													],
+													"colStyles": [
+														"col-1 text-center",
+														"col-2 text-center",
+														"col-3 text-left",
+														"col-3 text-left",
+														"col-3 text-left"
+													],
+													"rows": [
+														[
+															"+0",
+															"Normal",
+															"Cold, calm",
+															"Normal for season",
+															"Calm"
+														],
+														[
+															"+1",
+															"Abnormal",
+															"Heat wave or cold snap",
+															"Heat wave or cold snap",
+															"-"
+														],
+														[
+															"+2",
+															"Inclement",
+															"Precipitation (snow)",
+															"Precipitation (normal for season)",
+															"Windy"
+														],
+														[
+															"+3",
+															"Storm",
+															"Snowstorm",
+															"Thunderstorm, snowstorm",
+															"Duststorm"
+														],
+														[
+															"+4",
+															"Powerful storm",
+															"Blizzard",
+															"Windstorm, blizzard, hurricane, tornado",
+															"Sandstorm"
+														],
+														[
+															"+5",
+															"Strange Phenomena",
+															"",
+															"",
+															""
+														]
+													]
+												},
+												{
+													"type": "table",
+													"caption": "Time of Day When the Journey Starts",
+													"colLabels": [
+														"Modifier Bonus",
+														"Time of Day"
+													],
+													"colStyles": [
+														"col-1 text-center",
+														"col-11 text-left"
+													],
+													"rows": [
+														[
+															"+0",
+															"Morning"
+														],
+														[
+															"+1",
+															"Afternoon"
+														],
+														[
+															"+2",
+															"Evening"
+														],
+														[
+															"+3",
+															"Night"
+														]
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Roles for the Journey",
+									"entries": [
+										"Traveling across the world uses the same roles as PCs choose from when going on a hunt, but with slightly different uses.",
+										{
+											"type": "entries",
+											"name": "Trailblazer",
+											"entries": [
+												"The trailblazer is the PC that decides the pace the group is going to travel at (slow, normal, fast). Once they decide the pace for the day, they make a Wisdom ({@skill Survival}) check. This is then contested by the DM's random encounter check. If the DM succeeds, they roll on a random encounter table."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Scout",
+											"entries": [
+												"The scouts role while traveling is not to forge ahead of the group, but instead they are tasked with finding a safe and secluded location to make camp at the end of the traveling day. When finding a camp, the scout will make a Wisdom ({@skill Perception}) check and a Dexterity ({@skill Stealth}) check. The DM can then contest the average of the two checks, the lowest check, or highest check (The choice you make should be the standard for the entire campaign). If the DM succeeds, they roll on a random encounter table."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Spotter",
+											"entries": [
+												"The spotter is still the eyes and ears of the party during travel. Their passive {@skill Perception} is used to determine if a random encounter is able to stealthily sneak up on the party or not. Additionally, once a week the spotter is able to roll on the {@table minerals|AGMH|mineral} or {@table bonepiles|AGMH|bone} resource table. Skill checks are not required to gather in this way. They may also gather from a lower level location stat block for the area. EX: A level 9 PC can choose to gather from the Level 1-5 location stat block or the 6-10 location stat block."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Artisan",
+											"entries": [
+												"A meal cooked by the artisan during travel can last up to one week, but they are able to cook a new meal when camp is setup at the end of the traveling day. Additionally, each day the artisan can roll on an edible resource table ({@table fish|AGMH}, {@table insects|AGMH}, {@table mushrooms|AGMH}, {@table plants|AGMH}) appropriate for the location they are traveling through, to gather a resource. Skill checks are not required to gather in this way. They may also gather from a lower level location stat block for the area. EX: A level 9 PC can choose to gather from the Level 1-5 location stat block or the 6-10 location stat block."
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"type": "section",
+							"name": "Siege Weapons",
+							"page": 85,
 							"entries": [
 								"Siege weapons in the Monster Hunter Universe are designed to assail the massive creatures that pose a threat to civilization. They see much use in campaigns that feature attacks on cities and other defensive settlements. As the DM, these weapons are an option to provide your players when they might be challenging a creature outside of their normal ability to kill.",
 								{
@@ -11950,6 +12323,740 @@
 						},
 						{
 							"type": "section",
+							"name": "Jungle",
+							"page": 132,
+							"entries": [
+								{
+									"type": "entries",
+									"name": "Biome",
+									"entries": [
+										"Coastal, Forest, Hills"
+									]
+								},
+								{
+									"type": "table",
+									"colLabels": [
+										"Navigation DC",
+										"Encounter DC",
+										"Investigation DC",
+										"Total Resources"
+									],
+									"colStyles": [
+										"col-1 text-center",
+										"col-1 text-center",
+										"col-1 text-center",
+										"col-1 text-center"
+									],
+									"rows": [
+										[
+											14,
+											18,
+											12,
+											8
+										]
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Common Weather",
+									"entries": [
+										"hot & humid temperature, light to strong wind, heavy rain depending on the season"
+									]
+								},
+								{
+									"type": "entries",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "{@i Howler Congas}",
+											"entries": [
+												"When entering the Jungle for the first time on a hunt, roll a d20. On a 20, the {@creature conga|MHMM}s of the jungle are in a mood. They are constantly making noise, granting advantage on Dexterity ({@skill Stealth}) check to stay hidden, to all creatures in the jugnle, but creature's that normally would be sleeping during the time of day the hunters are there are grumpy and aggressive to anything in their path."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "{@i Inhabited}",
+											"entries": [
+												"When entering the Jungle for the first time on a hunt, roll a d20. On a 20, On a 20, the jungle is inhabited by a tribe of {@creature shakalaka|MHMM} who have a 50% chance to be enemies or allies of the hunting party. If they are enemies, random shakalaka will appear in areas to interfere with the hunters. If they are allies, they will provide opportunities to make the hunter's lives easier in the jungle."
+											]
+										},
+										{
+											"type": "entries",
+											"name": "{@i Weather}",
+											"entries": [
+												"At the start of the hunt, roll on the table below to determine what type of weather is occurring in the verdant hills. Reroll each day or as you see fit.",
+												{
+													"type": "table",
+													"colLabels": [
+														"d20",
+														"Weather"
+													],
+													"colStyles": [
+														"col-1 text-center",
+														"col-4 text-center"
+													],
+													"rows": [
+														[
+															"1",
+															"Heavy Rain, Flooding."
+														],
+														[
+															"2-5",
+															"Extreme Heat during the day, Extreme Cold during the nights."
+														],
+														[
+															"6-1",
+															"Heavy Rain, no wind."
+														],
+														[
+															"16-19",
+															"Warm with no Wind."
+														],
+														[
+															"20",
+															"Comfortable with clear skies"
+														]
+													]
+												},
+												{
+													"type": "entries",
+													"name": "Heavy Rains with Flooding",
+													"entries": [
+														"Flooding causes the following effects:",
+														"{@b Poor vision.} The rain, lightly obscures the area with a 50% chance to heavily obscure each area they enter, after the first.",
+														"{@b Rising Water.} Every hour, the water rises 1 inch above ground level. Walking in 4 or more inches of water is difficult terrain."
+													]
+												}
+											]
+										}
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Resources",
+									"entries": [
+										"Make a resource check against the resources DC. On a success, roll on the table for the players' level range."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Encounters",
+									"entries": [
+										"For every hour that passes, make an Encounter roll. If the roll equals or exceeds the Encounter DC, roll 1d10 and consult the table for the players' level range."
+									]
+								},
+								{
+									"type": "inset",
+									"name": "Low Rank (Player Level 1-4)",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Common Small Monsters",
+											"entries": [
+												"{@creature Aptonoth|MHMM}, {@creature Bullfango|MHMM}, {@creature Conga|MHMM}, {@creature Hornetaur|MHMM}, {@creature Kelbi|MHMM}, {@creature Mosswine|MHMM}, {@creature Velociprey|MHMM}, {@creature Vespoid|MHMM}"
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Common Large Monsters",
+											"entries": [
+												"{@creature Bulldrome|MHMM}, {@creature Congalala|MHMM}, {@creature Gypceros|MHMM}, {@creature Hypnocatrice|MHMM}, {@creature Seltas|MHMM}, {@creature Velocidrome|MHMM}, {@creature Yian Kut-Ku|MHMM}, {@creature Blue Yian Kut-Ku|MHMM}"
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Resources",
+											"colLabels": [
+												"d6",
+												"{@table Bonepiles|AGMH} ({@dc 14})",
+												"{@table Fish|AGMH} ({@dc 10})",
+												"{@table Insects|AGMH} ({@dc 10})",
+												"{@table Minerals|AGMH} ({@dc 14})",
+												"{@table Mushrooms|AGMH} ({@dc 10})",
+												"{@table Plants|AGMH} ({@dc 12})"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"Bone",
+													"Pin Tuna",
+													"Insect Husk",
+													"Stone",
+													"Nitroshroom",
+													"Herb"
+												],
+												[
+													"2",
+													"Lg Bone Husk",
+													"Whetfish",
+													"firefly",
+													"Stone",
+													"Blue Mushroom",
+													"Paintberry"
+												],
+												[
+													"3",
+													"Sm Bone Husk",
+													"Bomb Arrowana",
+													"Carpenterbug",
+													"Earth Crystal",
+													"Nitroshroom",
+													"Fire Herb"
+												],
+												[
+													"4",
+													"Bird Wyvern bone",
+													"Burst Arrowana",
+													"Snakebee Larva",
+													"Earth Crystal",
+													"Nitroshroom",
+													"Ivy"
+												],
+												[
+													"5",
+													"Sm Bone Husk",
+													"Pin Tuna",
+													"Spiderweb",
+													"Earth Crystal",
+													"Nitroshroom",
+													"Needleberry"
+												],
+												[
+													"6",
+													"Jumbo Bone",
+													"Small Goldenfish",
+													"Bitterbug",
+													"Hard Armor Sphere",
+													"Blue Mushroom",
+													"Dragonseed"
+												]
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Encounters",
+											"colLabels": [
+												"d10",
+												"Encounters"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-12 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"2d8 {@creature nitrotoad|MHMM}s"
+												],
+												[
+													"2",
+													"1d6 {@creature slagtoth|MHMM} protecting an injured {@creature gajalaka|MHMM}"
+												],
+												[
+													"3",
+													"All goes quiet as the branches above the group move and shake as if something is moving through them. Normal sounds continue a few minutes later."
+												],
+												[
+													"4",
+													"3d4 {@creature wingdrake|MHMM}s"
+												],
+												[
+													"5",
+													"1 {@creature great maccao|MHMM}"
+												],
+												[
+													"6",
+													"A group of {@creature jagras|MHMM} pups gnaw on the body of unidentified creature. They scatter into the jungle as the party nears."
+												],
+												[
+													"7",
+													"1d4 {@creature conga|MHMM}"
+												],
+												[
+													"8",
+													"1d4 {@creature young seregios|MHMM}"
+												],
+												[
+													"9",
+													"1 {@creature pukei-pukei|MHMM}"
+												],
+												[
+													"10",
+													"1 {@creature great jagras|MHMM} plus 2 {@creature jagras|MHMM}"
+												]
+											]
+										}
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"name": "Player level 5-10",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Common Small Monsters",
+											"entries": [
+												"{@creature Aptonoth|MHMM}, {@creature Bullfango|MHMM}, {@creature Conga|MHMM}, {@creature Hornetaur|MHMM}, {@creature Kelbi|MHMM}, {@creature Mosswine|MHMM}, {@creature Velociprey|MHMM}, {@creature Vespoid|MHMM}"
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Common Large Monsters",
+											"entries": [
+												"{@creature Astalos|MHMM}, {@creature Bulldrome|MHMM}, {@creature Congalala|MHMM}, {@creature Gypceros|MHMM}, {@creature Hypnocatrice|MHMM}, {@creature Nargacuga|MHMM}, {@creature Plesioth|MHMM}, Green Plesioth, {@creature Rathian|MHMM}, {@creature Seltas|MHMM}, {@creature Seltas Queen|MHMM}, {@creature Velocidrome|MHMM}, {@creature Zinogre|MHMM}, {@creature Yian Garuga|MHMM}, {@creature Yian Kut-Ku|MHMM}, {@creature Blue Yian Kut-Ku|MHMM}"
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Resources",
+											"colLabels": [
+												"d6",
+												"{@table Bonepiles|AGMH} ({@dc 16})",
+												"{@table Fish|AGMH} ({@dc 12})",
+												"{@table Insects|AGMH} ({@dc 12})",
+												"{@table Minerals|AGMH} ({@dc 16})",
+												"{@table Mushrooms|AGMH} ({@dc 12})",
+												"{@table Plants|AGMH} ({@dc 14})"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"Lg Bone Husk",
+													"Sleepyfish",
+													"Honey",
+													"Earth Crystal",
+													"Nitroshroom",
+													"Nullberry"
+												],
+												[
+													"2",
+													"Sm Bone Husk",
+													"Bomb Arrowana",
+													"Bitterbug",
+													"Earth Crystal",
+													"Nitroshroom",
+													"Needleberry"
+												],
+												[
+													"3",
+													"Brute Bone",
+													"Popfish",
+													"Thunderbug",
+													"Machalite Ore",
+													"Blue Mushroom",
+													"Antidote Herb"
+												],
+												[
+													"4",
+													"Med Monster Bone",
+													"Burst Arrowana",
+													"Bitterbug",
+													"Machalite Ore",
+													"Blue Mushroom",
+													"Hot Pepper"
+												],
+												[
+													"5",
+													"Med Monsterbone",
+													"Wanchovy",
+													"Godbug",
+													"Machalite Ore",
+													"Exciteshroom",
+													"Tropical Berry"
+												],
+												[
+													"6",
+													"Monster Toughbone",
+													"Glutton Tuna",
+													"Flashbug",
+													"Heavy Armor Sphere",
+													"Exciteshroom",
+													"Adamant Seed"
+												]
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Encounters",
+											"colLabels": [
+												"d10",
+												"Encounters"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-12 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"1d8 {@creature hornetaur|MHMM} plus 1d8 {@creature vespoid|MHMM}"
+												],
+												[
+													"2",
+													"1d2 {@creature bulldrome|MHMM}"
+												],
+												[
+													"3",
+													"A small hunting party of aggressive {@creature shakalaka|MHMM} chase a kelbi, cross path with the party."
+												],
+												[
+													"4",
+													"1d8 + 1 {@creature young kecha wacha|MHMM}"
+												],
+												[
+													"5",
+													"1d4 {@creature seltas|MHMM}"
+												],
+												[
+													"6",
+													"1d4+3 {@creature tobi-kitachi|MHMM}"
+												],
+												[
+													"7",
+													"A large {@creature awakened tree} asks for assistance ridding it of a {@creature vespoid|MHMM} infestation and offers rare mushrooms as a reward."
+												],
+												[
+													"8",
+													"1 {@creature royal ludroth|MHMM}"
+												],
+												[
+													"9",
+													"A {@creature nargacuga|MHMM} watches as her cubs attempt to kill a lone {@creature shakalaka|MHMM}."
+												],
+												[
+													"10",
+													"1 {@creature glavenus|MHMM}"
+												]
+											]
+										}
+									]
+								},
+								{
+									"type": "inset",
+									"name": "Player level 11-16",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Common Small Monsters",
+											"entries": [
+												"{@creature Aptonoth|MHMM}, {@creature Bullfango|MHMM}, {@creature Conga|MHMM}, {@creature Hornetaur|MHMM}, {@creature Kelbi|MHMM}, {@creature Mosswine|MHMM}, {@creature Velociprey|MHMM}, {@creature Vespoid|MHMM}"
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Common Large Monsters",
+											"entries": [
+												"{@creature Astalos|MHMM}, {@creature Bulldrome|MHMM}, {@creature Congalala|MHMM}, {@creature Daimyo Hermitaur|MHMM}, {@creature Duramboros|MHMM}, {@creature Gypceros|MHMM}, {@creature Hypnocatrice|MHMM}, {@creature Glavenus|MHMM}, {@creature Kushala Daora|MHMM}, {@creature Lagiacrus|MHMM}, {@creature Mizutsune|MHMM}, {@creature Nargacuga|MHMM}, {@creature Plesioth|MHMM}, {@creature Rathian|MHMM}, {@creature Seltas|MHMM}, {@creature Seltas Queen|MHMM}, {@creature Valstrax|MHMM}, {@creature Velocidrome|MHMM}, {@creature Zinogre|MHMM}, {@creature Yian Garuga|MHMM}, {@creature Yian Kut-Ku|MHMM}, {@creature Blue Yian Kut-Ku|MHMM}"
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Resources",
+											"colLabels": [
+												"d6",
+												"{@table Bonepiles|AGMH} ({@dc 18})",
+												"{@table Fish|AGMH} ({@dc 15})",
+												"{@table Insects|AGMH} ({@dc 15})",
+												"{@table Minerals|AGMH} ({@dc 19})",
+												"{@table Mushrooms|AGMH} ({@dc 15})",
+												"{@table Plants|AGMH} ({@dc 17})"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"Sm BoneHusk x3",
+													"Popfish",
+													"Insect Husk",
+													"Heavy Armor Sphere",
+													"Blue Mushroom",
+													"Ivy x2"
+												],
+												[
+													"2",
+													"Med Monster Bone",
+													"Wanchovy",
+													"Flashbug x2",
+													"Dragonite Ore",
+													"Blue Mushroom x2",
+													"Sap Plant x2"
+												],
+												[
+													"3",
+													"Lg Monster Bone",
+													"Small Goldenfish",
+													"Large Toxic Kumori",
+													"Dragonite Ore",
+													"Nitroshroom",
+													"Adamant Seed"
+												],
+												[
+													"4",
+													"Lg Monster Bone",
+													"Glutton Tuna",
+													"Godbug x2",
+													"Dragonite Ore",
+													"Nitroshroom x3",
+													"Tropical Berry"
+												],
+												[
+													"5",
+													"Lg Monster Bone",
+													"Ancient Fish",
+													"Godbug x3.",
+													"Carbalite Ore",
+													"Exciteshroom x2",
+													"Hot Pepper x2"
+												],
+												[
+													"6",
+													"Elder Dragon Bone",
+													"Ancient Fish",
+													"Bitterbug x3",
+													"Carbalite Ore",
+													"Exciteshroom x3",
+													"Dosbiscus"
+												]
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Encounters",
+											"colLabels": [
+												"d10",
+												"Encounters"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-12 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"1 {@creature congalala|MHMM}"
+												],
+												[
+													"2",
+													"1 {@creature najarala|MHMM}"
+												],
+												[
+													"3",
+													"1d4 {@creature young nargacuga|MHMM} or 1d4 {@creature blue yian kut-ku|MHMM}"
+												],
+												[
+													"4",
+													"1 {@creature rathian|MHMM}"
+												],
+												[
+													"5",
+													"1 {@creature seltas queen|MHMM}"
+												],
+												[
+													"6",
+													"2d6 {@creature juvenile zinogre|MHMM} are rampaging through a lynian village."
+												],
+												[
+													"7",
+													"1d3 {@creature adolescent rajang|MHMM}"
+												],
+												[
+													"8",
+													"A veggie elder sleeping while holding a fishing pole."
+												],
+												[
+													"9",
+													"1 {@creature scarred yian garuga|MHMM}"
+												],
+												[
+													"10",
+													"1 {@creature savage deviljho|MHMM}"
+												]
+											]
+										}
+									]
+								},
+								{
+									"type": "insetReadaloud",
+									"name": "Player level 17-20",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Common Small Monsters",
+											"entries": [
+												"{@creature Aptonoth|MHMM}, {@creature Bullfango|MHMM}, {@creature Conga|MHMM}, {@creature Hornetaur|MHMM}, {@creature Kelbi|MHMM}, {@creature Mosswine|MHMM}, {@creature Velociprey|MHMM}, {@creature Vespoid|MHMM}"
+											]
+										},
+										{
+											"type": "entries",
+											"name": "Common Large Monsters",
+											"entries": [
+												"{@creature Astalos|MHMM}, {@creature Bulldrome|MHMM}, {@creature Chameleos|MHMM}, {@creature Congalala|MHMM}, {@creature Daimyo Hermitaur|MHMM}, {@creature Deviljho|MHMM}, {@creature Duramboros|MHMM}, {@creature Gypceros|MHMM}, {@creature Hypnocatrice|MHMM}, {@creature Glavenus|MHMM}, {@creature Kushala Daora|MHMM}, {@creature Lagiacrus|MHMM}, {@creature Mizutsune|MHMM}, {@creature Nargacuga|MHMM}, {@creature Silverwind Nargacuga|MHMM}, {@creature Plesioth|MHMM}, Green Plesioth, {@creature Furious Rajang|MHMM}, {@creature Rathian|MHMM}, {@creature Seltas|MHMM}, {@creature Seltas Queen|MHMM}, {@creature Valstrax|MHMM}, {@creature Velocidrome|MHMM}, {@creature Zinogre|MHMM}, {@creature Yian Garuga|MHMM}, {@creature Yian Kut-Ku|MHMM}, {@creature Blue Yian Kut-Ku|MHMM}"
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Resources",
+											"colLabels": [
+												"d6",
+												"{@table Bonepiles|AGMH} ({@dc 21})",
+												"{@table Fish|AGMH} ({@dc 18})",
+												"{@table Insects|AGMH} ({@dc 18})",
+												"{@table Minerals|AGMH} ({@dc 23})",
+												"{@table Mushrooms|AGMH} ({@dc 18})",
+												"{@table Plants|AGMH} ({@dc 20})"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center",
+												"col-2 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"Lg Bone Husk x5",
+													"Glutton Tuna",
+													"Spiderweb x3",
+													"Dragonite Ore",
+													"Blue Mushroom",
+													"Ivy x4"
+												],
+												[
+													"2",
+													"Monster Toughbone",
+													"Small Goldenfish",
+													"Large Toxic Kumori",
+													"Lifecrystals x2",
+													"Exciteshroom",
+													"Nulberry x2"
+												],
+												[
+													"3",
+													"Lg Monster Bone",
+													"Speartuna",
+													"Honey x4",
+													"Royal Armor Sphere",
+													"Blue Mushroom x3",
+													"Adamant Seed"
+												],
+												[
+													"4",
+													"Lg Monster Bone",
+													"Ancient Fish",
+													"Emperor Locust",
+													"Carbalite Ore",
+													"Nitroshroom x4",
+													"Hot Pepper x2"
+												],
+												[
+													"5",
+													"Lg Monster Bone",
+													"Ancient Fish",
+													"Honey x5",
+													"Carbalite Ore",
+													"Exciteshroom x3",
+													"Might Seed"
+												],
+												[
+													"6",
+													"Elder Dragon Bone",
+													"Gastronome Tuna",
+													"King Scarab",
+													"Carbalite Ore",
+													"Dragon Toadstool",
+													"Dosbiscus"
+												]
+											]
+										},
+										{
+											"type": "table",
+											"caption": "Encounters",
+											"colLabels": [
+												"d10",
+												"Encounters"
+											],
+											"colStyles": [
+												"col-1 text-center",
+												"col-12 text-center"
+											],
+											"rows": [
+												[
+													"1",
+													"1 {@creature nargacuga|MHMM}"
+												],
+												[
+													"2",
+													"1 {@creature glavenus|MHMM}"
+												],
+												[
+													"3",
+													"A {@creature rajang|MHMM} fightning a {@creature scarred yian garuga|MHMM} to the death."
+												],
+												[
+													"4",
+													"2d6 {@creature aknosom|MHMM}"
+												],
+												[
+													"5",
+													"1d3 {@creature seltas queen|MHMM}s"
+												],
+												[
+													"6",
+													"1 {@creature brachydios|MHMM}"
+												],
+												[
+													"7",
+													"The party comes across 1d10 {@creature giant vigorwasp|MHMM}s The wasps carry the frenzy virus which spread with their deathburst."
+												],
+												[
+													"8",
+													"1d6 {@creature viper tobi-kadachi|MHMM}"
+												],
+												[
+													"9",
+													"1 {@creature raging brachydios|MHMM}"
+												],
+												[
+													"10",
+													"1 {@creature lao-shan lung|MHMM}"
+												]
+											]
+										}
+									]
+								}
+							]
+						},
+						{
+							"type": "section",
 							"name": "Ocean",
 							"page": 128,
 							"entries": [
@@ -15450,9 +16557,504 @@
 								"{@creature Guild Knight Captain|AGMH}",
 								"{@creature Guild Knight Commander|AGMH}"
 							]
+						},
+						{
+							"type": "entries",
+							"name": "Monstie Sidekick Class",
+							"entries": [
+								"{@variantrule Monstie Sidekicks|AGMH}"
+							]
 						}
 					]
 				}
+			]
+		}
+	],
+	"class": [
+		{
+			"name": "Monstie Sidekick",
+			"source": "AGMH",
+			"page": 169,
+			"isSidekick": true,
+			"classFeatures": [
+				"Sidekick Class|Monstie Sidekick|AGMH|1",
+				"Monstie Proficiencies|Monstie Sidekick|AGMH|1",
+				"Monstie Signature Attack|Monstie Sidekick|AGMH|1",
+				"Monstie Trait|Monstie Sidekick|AGMH|2",
+				"Creature|Monstie Sidekick|AGMH|3",
+				"Ability score improvement|Monstie Sidekick|AGMH|4",
+				"Monstie Proficiencies Improvement|Monstie Sidekick|AGMH|4",
+				"Extra Attack or Damage|Monstie Sidekick|AGMH|6",
+				"Size Increase|Monstie Sidekick|AGMH|6",
+				"Saving Throws|Monstie Sidekick|AGMH|7",
+				"Ability score improvement|Monstie Sidekick|AGMH|8",
+				"Monstie Proficiencies Improvement|Monstie Sidekick|AGMH|8",
+				"Monstie Trait Improvement|Monstie Sidekick|AGMH|10",
+				"Creature Improvement|Monstie Sidekick|AGMH|11",
+				"Ability score improvement|Monstie Sidekick|AGMH|12",
+				"Monstie Proficiencies Improvement|Monstie Sidekick|AGMH|12",
+				"Ability score improvement|Monstie Sidekick|AGMH|14",
+				"Monstie Proficiencies Improvement|Monstie Sidekick|AGMH|14",
+				"Extra Attack or Damage|Monstie Sidekick|AGMH|15",
+				"Size Increase|Monstie Sidekick|AGMH|15",
+				"Ability score improvement|Monstie Sidekick|AGMH|16",
+				"Monstie Proficiencies Improvement|Monstie Sidekick|AGMH|16",
+				"Creature Improvement|Monstie Sidekick|AGMH|18",
+				"Ability score improvement|Monstie Sidekick|AGMH|19",
+				"Monstie Proficiencies Improvement|Monstie Sidekick|AGMH|19",
+				"Monstie Trait Improvement|Monstie Sidekick|AGMH|20"
+			],
+			"fluff": [
+				{
+					"name": "Monstie Sidekick",
+					"type": "section",
+					"entries": [
+						{
+							"type": "inset",
+							"entries": [
+								"{@b Note to Players}. This is still in the testing phase. It reads well on paper, but not every monstie created will be balanced. When using a monstie, expect that you may have to make adjustments as you play with your DM.",
+								"{@b Note to DM}. When allowing your players to use monsties, you will count them as another PC when determining your encounter difficulty."
+							]
+						},
+						"A monstie is a monster that you can form bonds with. This is typically accomplished through a kinship stone or perhaps by rescuing it from near death. However, it happens you now have a friend for life.",
+						{
+							"type": "entries",
+							"name": "Monstie Rules",
+							"entries": [
+								"There are over 240 monsters in the Monster Hunter Monster Manual and each one is someone's favorite. But not all monsters are created equal and many of them would be entirely too strong as monsties. Due to this the following rules are put in place to help balance out the monstie sidekick class.",
+								{
+									"type": "list",
+									"name": "Rules",
+									"items": [
+										"Elder Dragons and Paragon monsters cannot be monsties (They have too many unique traits and attacks to try and balance).",
+										"A monstie is based off the original stat block of a creature, not a tempered version (subspecies, deviants, etc are still ok to use).",
+										"Monsties all use the same basic creature template when initially created.",
+										"\"PB\" stands for proficiency bonus when looking through this sidekick class."
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Choose your Original Monster",
+							"entries": [
+								"Look through the Monster Hunter Monster Manual for a monster following the above rules to be the original monster that your Monstie will be based on. Your original monster will be referenced often as your monstie levels up and learns new traits and actions."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Create Your Monstie",
+							"entries": [
+								"Using the template to the right and the information below, put together your level 1 monstie before it gains its initial level 1 features.",
+								{
+									"type": "entries",
+									"name": "Ability Scores",
+									"entries": [
+										"The monsties ability score array is 15, 14, 13, 12, 10, and 8. The ability scores are placed in the stat block the same way as the original monster. If strength is the original's strongest ability score, then you would make the monsties strength a 15 as it is the strongest ability score in the array. If Strength is the 3rd strongest ability score, then you would place the 13 in the Strength for the monstie.",
+										"For example: A {@creature rajang|MHMM} monstie would have Str 15, Dex 12, Con 14, Int 10, Wis 13, Cha 8"
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Saving Throws",
+									"entries": [
+										"Some of your monstie's features require the target to make a saving throw to resist its effects. The saving throw DC is calculated as follows:",
+										{
+											"type": "abilityDc",
+											"name": "Monstie",
+											"attributes": [
+												"appropriate Ability Score modifier for the save"
+											]
+										},
+										"When a creature succeeds on a saving throw against a condition from the monstie, they are immune to that effect for 24 hours.",
+										"{@b Most Common Ability Scores for Saves}",
+										"STR: Being knocked prone, charge trait",
+										"CON: Breath attacks, disease, poisons, roars",
+										"CHA: Frightful Presence"
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Senses",
+									"entries": [
+										"The Monstie gains the same senses as the main stat block ({@sense darkvision}, {@sense blindsight}, {@sense truesight}, {@sense tremorsense}) but it has a maximum range of 30 feet. If the original monster's sense is lower than 30 feet, your monsties sense is equal to that. As the monstie's size increases at 6th, the range of its senses increases to 60 feet, or the original monster’s maximum sense range (whichever is lower). This range is increased to 120 feet at 15th level, or the original monsters maximum sense range (whichever is lower)."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Speed",
+									"entries": [
+										"A monstie has the same types of movement as the original monster it is based on, but it is not as fast initially. Their base walking speed is 25 feet. Any other type of movement (flying, burrowing, climbing, etc) is 15 feet. Each time the monstie levels up it gains an extra 5 feet of each type of movement up to its original stat blocks movement for each type."
+									]
+								}
+							]
+						}
+					],
+					"source": "AGMH"
+				}
+			]
+		}
+	],
+	"classFeature": [
+		{
+			"name": "Sidekick Class",
+			"source": "AGMH",
+			"page": 169,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 1,
+			"type": "inset",
+			"entries": [
+				"{@note Note: this class is intended for NPC {@variantrule monstie sidekicks|AGMH|monsties}.}"
+			]
+		},
+		{
+			"name": "Monstie Proficiencies",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 1,
+			"entries": [
+				"{@i 1st-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Monstie Signature Attack",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 1,
+			"entries": [
+				"{@i 1st-level Monstie Sidekick feature}",
+				"At 1st level the monstie knows the original monsters recharge action. If it does not have a recharge action, the monstie can know an attack that can only be used a number of times a day or one that recharges on a short or long rest.",
+				"If the monstie learns a recharge 5-6 action, it can be used a number of times equal to its proficiency bonus, regaining all expended uses when it finishes a long rest. If it learns a recharge 6 action, it can use it a number of times equal to half its proficiency bonus.",
+				"The damage of these attacks is reduced. While using the same damage die as the original, the number of dice the attack deals is equal to your proficiency bonus (add one extra die if the ability only targets one creature). If the action has multiple damage types, the # of dice are split evenly between them.",
+				"The range of these actions are also different. If the type of range the attack has is not listed below, it is up to you and your DM to adjust it. The range of this attack cannot go beyond the maximum range of the original monster.",
+				{
+					"type": "list",
+					"items": [
+						"{@b Cone.} A cone has a 15-foot range at 1st level. Its range increases to 30 feet at 6th-level, 45 feet at 11th-level, and 60 feet at 16th-level.",
+						"{@b Line.} A line is 30-foot long and 5-feet wide at 1st level. Its length increases to 45 feet at 6th-level, and 60 feet at 11th-level. At 16th-level its length increases to 90 feet and its width increases to 10 feet.",
+						"{@b Targeted Creature or Point.} An action that targets a point within range has its reduced by 75% of the original monsters range at 1st level. Its range increases to 50% at 6th-level, 75% at 11th-level, and 100% at 16th-level."
+					]
+				}
+			]
+		},
+		{
+			"name": "Monstie Trait",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 2,
+			"entries": [
+				"{@i 2nd-level Monstie Sidekick feature}",
+				"Beginning at 2nd level your monstie natural instincts are heightened. Choose one nondamage dealing trait, except legendary resistance or magic resistance, the original monster has. Your monstie gains that trait. Your monstie gains another trait from the original monster at 10th and 20th level.",
+				"If the trait your monstie learns provides bonuses to a skill(s) or AC, the bonus is equal to the monstie's PB.",
+				"If the original monster only has traits that deal damage or your monstie knows all the original monster's traits, then your monstie increase one ability score of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Creature",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Monstie Sidekick feature}",
+				"At 3rd level you can pick one trait or action (that isn't multiattack, or doesn't have a recharge or a use limit) from the original monster. Your monstie gains that trait or action. If the action is a melee or ranged attack, it follows the same rules as the monstie's original attack, except it can do more than just deal damage.",
+				"If it is an action that deals damage, it deals the damage the original monster deals or the same damage as the monstie's signature attack (whichever is lower).",
+				"If it is a trait it is adjusted in the following ways:",
+				{
+					"type": "list",
+					"items": [
+						"Aura damage is reduced by 1 die size.",
+						"Any bonus to AC or a skill(s) is equal to the monsties PB."
+					]
+				},
+				"You can choose one additional trait or action the monstie learns from the original monster at 11th level and 18th level."
+			]
+		},
+		{
+			"name": "Monstie Proficiencies Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 4,
+			"entries": [
+				"{@i 4th-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Ability score improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 4,
+			"entries": [
+				"{@i 4th-level Monstie Sidekick feature}",
+				"At 4th level and again at 8th, 12th, 14th, 16th, and 19th level, the monstie increases one ability score of your choice by 2, or the sidekick increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Extra Attack or Damage",
+			"source": "AGMH",
+			"page": 171,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 6,
+			"entries": [
+				"{@i 6th-level Monstie Sidekick feature}",
+				"The monstie can attack twice, instead of once, whenever it takes the Attack action on its turn. The number of attacks increases to three when the sidekick reaches 15th level.",
+				"If the original monster, the monstie is based on, doesn't have a multiattack or the extra attack would increase the number of attacks it has beyond the original monster's multiattack; then the monstie does not gain an extra attack. Instead, the monstie's melee and ranged attacks deal one extra die of damage."
+			]
+		},
+		{
+			"name": "Size Increase",
+			"source": "AGMH",
+			"page": 171,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 6,
+			"entries": [
+				"{@i 6th-level Monstie Sidekick feature}",
+				"At 6th level, the monstie's size increases by one to Medium. At 15th level, its size increases to Large, its maximum hit points increase by 15, and increases by 1 again whenever it gains a level."
+			]
+		},
+		{
+			"name": "Saving Throws",
+			"source": "AGMH",
+			"page": 171,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 7,
+			"entries": [
+				"{@i 7th-level Monstie Sidekick feature}",
+				"At 7th level your monstie gains proficiency in the same saving throws that the original monster has. If the original monster doesn't have any saving throw, then your monstie can gain one condition immunity the original monster has, or it increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Monstie Proficiencies Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 8,
+			"entries": [
+				"{@i 8th-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Ability score improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 8,
+			"entries": [
+				"{@i 8th-level Monstie Sidekick feature}",
+				"At 4th level and again at 8th, 12th, 14th, 16th, and 19th level, the monstie increases one ability score of your choice by 2, or the sidekick increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Monstie Trait Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 10,
+			"entries": [
+				"{@i 10th-level Monstie Sidekick feature}",
+				"Beginning at 2nd level your monstie natural instincts are heightened. Choose one nondamage dealing trait, except legendary resistance or magic resistance, the original monster has. Your monstie gains that trait. Your monstie gains another trait from the original monster at 10th and 20th level.",
+				"If the trait your monstie learns provides bonuses to a skill(s) or AC, the bonus is equal to the monstie's PB.",
+				"If the original monster only has traits that deal damage or your monstie knows all the original monster's traits, then your monstie increase one ability score of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Creature Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 11,
+			"entries": [
+				"{@i 11th-level Monstie Sidekick feature}",
+				"At 3rd level you can pick one trait or action (that isn't multiattack, or doesn't have a recharge or a use limit) from the original monster. Your monstie gains that trait or action. If the action is a melee or ranged attack, it follows the same rules as the monstie's original attack, except it can do more than just deal damage.",
+				"If it is an action that deals damage, it deals the damage the original monster deals or the same damage as the monstie's signature attack (whichever is lower).",
+				"If it is a trait it is adjusted in the following ways:",
+				{
+					"type": "list",
+					"items": [
+						"Aura damage is reduced by 1 die size.",
+						"Any bonus to AC or a skill(s) is equal to the monsties PB."
+					]
+				},
+				"You can choose one additional trait or action the monstie learns from the original monster at 11th level and 18th level."
+			]
+		},
+		{
+			"name": "Monstie Proficiencies Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 12,
+			"entries": [
+				"{@i 12th-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Ability score improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 12,
+			"entries": [
+				"{@i 12th-level Monstie Sidekick feature}",
+				"At 4th level and again at 8th, 12th, 14th, 16th, and 19th level, the monstie increases one ability score of your choice by 2, or the sidekick increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Monstie Proficiencies Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 14,
+			"entries": [
+				"{@i 14th-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Ability score improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 14,
+			"entries": [
+				"{@i 14th-level Monstie Sidekick feature}",
+				"At 4th level and again at 8th, 12th, 14th, 16th, and 19th level, the monstie increases one ability score of your choice by 2, or the sidekick increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Extra Attack or Damage",
+			"source": "AGMH",
+			"page": 171,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 15,
+			"entries": [
+				"{@i 15th-level Monstie Sidekick feature}",
+				"The monstie can attack twice, instead of once, whenever it takes the Attack action on its turn. The number of attacks increases to three when the sidekick reaches 15th level.",
+				"If the original monster, the monstie is based on, doesn't have a multiattack or the extra attack would increase the number of attacks it has beyond the original monster's multiattack; then the monstie does not gain an extra attack. Instead, the monstie's melee and ranged attacks deal one extra die of damage."
+			]
+		},
+		{
+			"name": "Size Increase",
+			"source": "AGMH",
+			"page": 171,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 15,
+			"entries": [
+				"{@i 15th-level Monstie Sidekick feature}",
+				"At 6th level, the monstie's size increases by one to Medium. At 15th level, its size increases to Large, its maximum hit points increase by 15, and increases by 1 again whenever it gains a level."
+			]
+		},
+		{
+			"name": "Monstie Proficiencies Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 16,
+			"entries": [
+				"{@i 16th-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Ability score improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 16,
+			"entries": [
+				"{@i 16th-level Monstie Sidekick feature}",
+				"At 4th level and again at 8th, 12th, 14th, 16th, and 19th level, the monstie increases one ability score of your choice by 2, or the sidekick increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Creature Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 18,
+			"entries": [
+				"{@i 18th-level Monstie Sidekick feature}",
+				"At 3rd level you can pick one trait or action (that isn't multiattack, or doesn't have a recharge or a use limit) from the original monster. Your monstie gains that trait or action. If the action is a melee or ranged attack, it follows the same rules as the monstie's original attack, except it can do more than just deal damage.",
+				"If it is an action that deals damage, it deals the damage the original monster deals or the same damage as the monstie's signature attack (whichever is lower).",
+				"If it is a trait it is adjusted in the following ways:",
+				{
+					"type": "list",
+					"items": [
+						"Aura damage is reduced by 1 die size.",
+						"Any bonus to AC or a skill(s) is equal to the monsties PB."
+					]
+				},
+				"You can choose one additional trait or action the monstie learns from the original monster at 11th level and 18th level."
+			]
+		},
+		{
+			"name": "Monstie Proficiencies Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 19,
+			"entries": [
+				"{@i 19th-level Monstie Sidekick feature}",
+				"At 1st level, choose up to 2 skills the base stat block has, the monstie now has those skills. If the original monster has more than two skills your monstie gains another skill at 4th, 8th, 12th, 14th, 16th, and 19th level (or until the monstie knows all the skills the original monster does)."
+			]
+		},
+		{
+			"name": "Ability score improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 19,
+			"entries": [
+				"{@i 19th-level Monstie Sidekick feature}",
+				"At 4th level and again at 8th, 12th, 14th, 16th, and 19th level, the monstie increases one ability score of your choice by 2, or the sidekick increases two ability scores of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Monstie Trait Improvement",
+			"source": "AGMH",
+			"page": 170,
+			"className": "Monstie Sidekick",
+			"classSource": "AGMH",
+			"level": 20,
+			"entries": [
+				"{@i 20th-level Monstie Sidekick feature}",
+				"Beginning at 2nd level your monstie natural instincts are heightened. Choose one nondamage dealing trait, except legendary resistance or magic resistance, the original monster has. Your monstie gains that trait. Your monstie gains another trait from the original monster at 10th and 20th level.",
+				"If the trait your monstie learns provides bonuses to a skill(s) or AC, the bonus is equal to the monstie's PB.",
+				"If the original monster only has traits that deal damage or your monstie knows all the original monster's traits, then your monstie increase one ability score of your choice by 1. The monstie can't increase an ability score above 20 using this feature."
 			]
 		}
 	],
@@ -15502,25 +17104,6 @@
 			]
 		},
 		{
-			"name": "Charge Blade Mastery",
-			"source": "AGMH",
-			"page": 46,
-			"ability": [
-				{
-					"str": 1
-				}
-			],
-			"entries": [
-				"You master fighting with a {@item charge blade|AGMH}, gaining the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"You have learned how to amplify your elemental discharge. As an action you can expend any number of phial charges and release a shockwave of acid, cold, fire, or lightning damage (your choice) in a 15-foot cone in front of you. Each creature in that area must succeed on a Dexterity saving throw equal to 8 + your proficiency modifier + your Strength modifier taking an amount of damage equal to your charge blades elemental discharge damage, times the number of phials you have expended on a failed save, or half as much damage on a successful one. Once you use this ability, you cannot use it again until you finish a short or long rest."
-					]
-				}
-			]
-		},
-		{
 			"name": "Frenzy Fever",
 			"source": "AGMH",
 			"page": 46,
@@ -15552,7 +17135,7 @@
 			"source": "AGMH",
 			"page": 46,
 			"entries": [
-				"You have unlocked the secrets of the {@item gunlance|AGMH}. While you are attuned to a gunlance, its wyvernfire now recharges on a short or long rest. Additionally, it uses a new type of shell. Choose one of the following shells below that you now use in place of your original shells:",
+				"You have unlocked the secrets of the {@item gunlance|AGMH}. While you are attuned to a gunlance, its {@optfeature wyvernfire|AGMH} now recharges on a short or long rest. Additionally, it uses a new type of shell. Choose one of the following shells below that you now use in place of your original {@optfeature shells|AGMH}:",
 				{
 					"type": "list",
 					"items": [
@@ -15560,7 +17143,7 @@
 							"type": "entries",
 							"name": "Long Range Shells",
 							"entries": [
-								"Your shell's attack range is now 80/320 feet."
+								"Your shell's attack range is now 150/600 feet."
 							]
 						},
 						{
@@ -15584,7 +17167,7 @@
 		{
 			"name": "Horn Maestro",
 			"source": "AGMH",
-			"page": 47,
+			"page": 46,
 			"entries": [
 				"Thanks to extensive practice with the {@item hunting horn|AGMH}, you gain the following benefits:",
 				{
@@ -15618,14 +17201,24 @@
 			]
 		},
 		{
+			"name": "Improved Hammer Charge",
+			"source": "AGMH",
+			"page": 47,
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"When you are wielding a {@item Hammer|AGMH}, you can use its hammer {@optfeature charge (H)|AGMH} property when you move 15 feet instead of 20.",
+						"If you jump when performing a hammer charge, you perform a spinning hammer charge that allows you to pass through a hostile creatures space without provoking opportunity attacks.",
+						"You can add the extra damage from the hammer charge to 1 additional attack on this turn for every 5 feet you jump during the charge, so long as the attacks target a creature you passed through during the spinning hammer charge."
+					]
+				}
+			]
+		},
+		{
 			"name": "Kinsect Mastery",
 			"source": "AGMH",
 			"page": 47,
-			"ability": [
-				{
-					"str": 1
-				}
-			],
 			"entries": [
 				"You can use an action to have your {@item insect glaive|AGMH|kinsect} act as if it was summoned by the {@spell find familiar} spell, with the following differences:",
 				{
@@ -15722,9 +17315,9 @@
 				{
 					"type": "list",
 					"items": [
-						"When your switchaxe has no active phial, you can use a bonus action to coat your weapon with any phial.",
-						"When you have an active phial, you can use a bonus action to replace the active phial with a power or elemental phial.",
-						"You can use a free action on your turn to switch weapon modes. This replaces your free action to draw or stow a weapon."
+						"When you use a phial and critically hit with this weapon, you regain a number of expended {@optfeature phials|AGMH} equal to half the cost of the one you used (rounded up).",
+						"Your phials save DC is increased by 1.",
+						"You can use a free action on your turn to {@optfeature switch mode (sa)|AGMH|switch weapon modes}. This replaces your free action to draw or stow a weapon."
 					]
 				}
 			]
@@ -19277,7 +20870,7 @@
 			"type": "G",
 			"rarity": "none",
 			"weight": 2,
-			"value": 3000,
+			"value": 30000,
 			"entries": [
 				"{@i (Replaces one of the hunter's trinkets)} This horn has 3 charges. While holding it, you can use an action to expend a charge to give one creature that is within 60 feet of you advantage on saving throws against poisons for 1 hour. It confers no benefit to undead or constructs. The horn regains 1d4-1 expended charges daily at dawn. If you expend the last charge, roll a d20. On a 1, the horn is destroyed."
 			]
@@ -19436,7 +21029,7 @@
 			"weight": 0.5,
 			"value": 10000,
 			"entries": [
-				"As an action, you can throw this bomb up to 40 feet, releasing a horrid stench on impact. Make a ranged attack against a creature or object, treating the dung bomb as an improvised weapon. On a hit, the creature has disadvantage on Wisdom ({@skill Perception}) checks that rely on sight and smell for 1 hour."
+				"As an action, you can throw this bomb up to 40 feet, releasing a horrid stench on impact. Make a ranged attack against a creature or object, treating the dung bomb as an improvised weapon. On a hit, the creature has disadvantage on Wisdom ({@skill Perception}) checks that rely on sight and smell for 1 hour and disadvantage on Constitution saving throws to maintain concentration for 1 minute. If the target is a creature with an Intelligence score of 8 or lower, it must succeed on a {@dc 15} Constitution saving throw or immediately use its reaction to move up to its speed away from you."
 			]
 		},
 		{
@@ -19460,7 +21053,7 @@
 			"weight": 0.25,
 			"value": 100,
 			"entries": [
-				"When you succeed on a fishing skill check while using this lure, roll a 1d4. On a 1-2, you catch a burst arrowana; on a 3-4, you catch a bomb arrowana. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
+				"When you succeed on a {@table fish|AGMH|fishing} skill check while using this lure, roll a 1d4. On a 1-2, you catch a burst arrowana; on a 3-4, you catch a bomb arrowana. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
 			]
 		},
 		{
@@ -19472,7 +21065,7 @@
 			"weight": 0.25,
 			"value": 100,
 			"entries": [
-				"When you succeed on a fishing skill check while using this lure, you catch a popfish instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
+				"When you succeed on a {@table fish|AGMH|fishing} skill check while using this lure, you catch a popfish instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
 			]
 		},
 		{
@@ -19484,7 +21077,7 @@
 			"weight": 0.25,
 			"value": 100,
 			"entries": [
-				"When you succeed on a fishing skill check while using this lure, you catch a sushifish instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
+				"When you succeed on a {@table fish|AGMH|fishing} skill check while using this lure, you catch a sushifish instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
 			]
 		},
 		{
@@ -19496,7 +21089,7 @@
 			"weight": 0.25,
 			"value": 100,
 			"entries": [
-				"When you succeed on a fishing skill check while using this lure, you catch a pin tuna instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
+				"When you succeed on a {@table fish|AGMH|fishing} skill check while using this lure, you catch a pin tuna instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
 			]
 		},
 		{
@@ -19508,7 +21101,7 @@
 			"weight": 0.25,
 			"value": 100,
 			"entries": [
-				"When you succeed on a fishing skill check while using this lure, you catch a whetfish instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
+				"When you succeed on a {@table fish|AGMH|fishing} skill check while using this lure, you catch a whetfish instead of rolling on the fish resource table. If you roll a 1 on your fishing skill check, the line snaps and the lure is lost."
 			]
 		},
 		{
@@ -19690,7 +21283,7 @@
 			"weight": 0.5,
 			"value": 2000,
 			"entries": [
-				"When you throw this item at a creature, make a ranged weapon attack. On a hit, the creature is marked for 1 hour. While marked you have advantage on Wisdom ({@skill Perception}) and Wisdom ({@condition Survival}) checks to find it."
+				"When you throw this item at a creature, make a ranged weapon attack. On a hit, the creature is marked for 1 hour. While marked you have advantage on Wisdom ({@skill Perception}) and Wisdom ({@skill Survival}) checks to find it."
 			]
 		},
 		{
@@ -20250,8 +21843,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RW",
-				"HPR"
+				"RW"
 			],
 			"group": [
 				"Flying Wyvern"
@@ -20721,8 +22313,7 @@
 			"miscTags": [
 				"AOE",
 				"MW",
-				"RCH",
-				"HPR"
+				"RCH"
 			],
 			"conditionInflict": [
 				"grappled",
@@ -29372,6 +30963,346 @@
 	],
 	"variantrule": [
 		{
+			"name": "Monstie Sidekicks",
+			"source": "AGMH",
+			"page": 169,
+			"type": "section",
+			"entries": [
+				{
+					"type": "inset",
+					"entries": [
+						"{@b Note to Players}. This is still in the testing phase. It reads well on paper, but not every monstie created will be balanced. When using a monstie, expect that you may have to make adjustments as you play with your DM.",
+						"{@b Note to DM}. When allowing your players to use monsties, you will count them as another PC when determining your encounter difficulty."
+					]
+				},
+				"A monstie is a monster that you can form bonds with. This is typically accomplished through a kinship stone or perhaps by rescuing it from near death. However, it happens you now have a {@class monstie sidekick|AGMH|friend for life}.",
+				{
+					"type": "entries",
+					"name": "Monstie Rules",
+					"entries": [
+						"There are over 240 monsters in the Monster Hunter Monster Manual and each one is someone's favorite. But not all monsters are created equal and many of them would be entirely too strong as monsties. Due to this the following rules are put in place to help balance out the monstie sidekick class.",
+						{
+							"type": "list",
+							"name": "Rules",
+							"items": [
+								"Elder Dragons and Paragon monsters cannot be monsties (They have too many unique traits and attacks to try and balance).",
+								"A monstie is based off the original stat block of a creature, not a tempered version (subspecies, deviants, etc are still ok to use).",
+								"Monsties all use the same basic creature template when initially created.",
+								"\"PB\" stands for proficiency bonus when looking through this sidekick class."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Choose your Original Monster",
+					"entries": [
+						"Look through the Monster Hunter Monster Manual for a monster following the above rules to be the original monster that your Monstie will be based on. Your original monster will be referenced often as your monstie levels up and learns new traits and actions."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Create Your Monstie",
+					"entries": [
+						"Using the template to the right and the information below, put together your level 1 monstie before it gains its initial level 1 features.",
+						{
+							"type": "entries",
+							"name": "Ability Scores",
+							"entries": [
+								"The monsties ability score array is 15, 14, 13, 12, 10, and 8. The ability scores are placed in the stat block the same way as the original monster. If strength is the original's strongest ability score, then you would make the monsties strength a 15 as it is the strongest ability score in the array. If Strength is the 3rd strongest ability score, then you would place the 13 in the Strength for the monstie.",
+								"For example: A {@creature rajang|MHMM} monstie would have Str 15, Dex 12, Con 14, Int 10, Wis 13, Cha 8"
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Saving Throws",
+							"entries": [
+								"Some of your monstie's features require the target to make a saving throw to resist its effects. The saving throw DC is calculated as follows:",
+								{
+									"type": "abilityDc",
+									"name": "Monstie",
+									"attributes": [
+										"appropriate Ability Score modifier for the save"
+									]
+								},
+								"When a creature succeeds on a saving throw against a condition from the monstie, they are immune to that effect for 24 hours.",
+								"{@b Most Common Ability Scores for Saves}",
+								"STR: Being knocked prone, charge trait",
+								"CON: Breath attacks, disease, poisons, roars",
+								"CHA: Frightful Presence"
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Senses",
+							"entries": [
+								"The Monstie gains the same senses as the main stat block ({@sense darkvision}, {@sense blindsight}, {@sense truesight}, {@sense tremorsense}) but it has a maximum range of 30 feet. If the original monster's sense is lower than 30 feet, your monsties sense is equal to that. As the monstie's size increases at 6th, the range of its senses increases to 60 feet, or the original monster’s maximum sense range (whichever is lower). This range is increased to 120 feet at 15th level, or the original monsters maximum sense range (whichever is lower)."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Speed",
+							"entries": [
+								"A monstie has the same types of movement as the original monster it is based on, but it is not as fast initially. Their base walking speed is 25 feet. Any other type of movement (flying, burrowing, climbing, etc) is 15 feet. Each time the monstie levels up it gains an extra 5 feet of each type of movement up to its original stat blocks movement for each type."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Monstie Template",
+					"entries": [
+						{
+							"type": "dataCreature",
+							"style": "inset",
+							"dataCreature": {
+								"name": "Monstie Template",
+								"source": "AGMH",
+								"page": 169,
+								"size": [
+									"S"
+								],
+								"type": {
+									"type": "original monster's type"
+								},
+								"alignment": [
+									"U"
+								],
+								"ac": [
+									{
+										"special": "10 + Dex + PB (natural armor)"
+									}
+								],
+								"hp": {
+									"special": "10 + Con (an extra 1d8 + Con per level)"
+								},
+								"speed": {
+									"walk": {
+										"number": 25,
+										"condition": "(+5 feet for each level until it reaches its original monsters speed); Burrow, Climb, Fly, Swim 15 ft. (if the original stat block has it, +5 feet for each level until it reaches its original monsters speed)"
+									}
+								},
+								"str": 0,
+								"dex": 0,
+								"con": 0,
+								"int": 0,
+								"wis": 0,
+								"cha": 0,
+								"passive": 0,
+								"senses": [
+									"determined by original monster"
+								],
+								"languages": [
+									"Same as original monster; understands common, but can't speak it"
+								],
+								"action": [
+									{
+										"name": "One attack the original monster knows that only deals damage",
+										"entries": [
+											"The {@i +to Hit} is equal to: the appropriate Ability Score Modifier plus PB. Its damage is equal to 1d#, where # is equal to the original monster's attack's damage die. The attack's reach is 5 feet if it is a melee attack. If it is a ranged attack, its range is equal to the original monster's attack range."
+										]
+									}
+								]
+							}
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Monstie Sidekick Class",
+					"entries": [
+						"{@class Monstie Sidekick|AGMH}"
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Example level 1 Rajang",
+					"entries": [
+						{
+							"type": "dataCreature",
+							"style": "inset",
+							"dataCreature": {
+								"name": "Rajang Monstie Lvl 1",
+								"source": "AGMH",
+								"page": 171,
+								"size": [
+									"S"
+								],
+								"type": {
+									"type": "beast",
+									"tags": [
+										"fanged"
+									]
+								},
+								"alignment": [
+									"U"
+								],
+								"ac": [
+									{
+										"special": "13 (natural armor)"
+									}
+								],
+								"hp": {
+									"special": "10"
+								},
+								"speed": {
+									"walk": 30
+								},
+								"str": 15,
+								"dex": 12,
+								"con": 14,
+								"int": 10,
+								"wis": 13,
+								"cha": 8,
+								"skill": {
+									"athletics": "+4",
+									"perception": "+3"
+								},
+								"passive": 13,
+								"languages": [
+									"understands common, but can't speak it"
+								],
+								"action": [
+									{
+										"name": "Fist",
+										"entries": [
+											"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) bludgeoning damage."
+										]
+									},
+									{
+										"name": "Lighting Breath (2 Uses)",
+										"entries": [
+											"The rajang exhales lightning in a 30-foot line that is 5 feet wide. Each creature in that line must make a {@dc 12} Dexterity saving throw, taking 9 ({@damage 2d8}) lightning damage on a failed save, or half as much damage on a successful one."
+										]
+									}
+								]
+							}
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Example level 20 Nargacuga",
+					"entries": [
+						{
+							"type": "dataCreature",
+							"style": "inset",
+							"dataCreature": {
+								"name": "Nargacuga lvl 20",
+								"size": [
+									"L"
+								],
+								"type": {
+									"type": "wyvern",
+									"tags": [
+										"flying"
+									]
+								},
+								"group": [
+									"Flying Wyverns"
+								],
+								"environment": [
+									"arctic",
+									"coastal",
+									"desert",
+									"forest",
+									"grassland",
+									"hill",
+									"mountain",
+									"swamp",
+									"underdark",
+									"urban"
+								],
+								"source": "AGMH",
+								"page": 171,
+								"alignment": [
+									"U"
+								],
+								"ac": [
+									{
+										"ac": 21,
+										"from": [
+											"natural armor"
+										]
+									}
+								],
+								"hp": {
+									"special": "169"
+								},
+								"speed": {
+									"walk": 30
+								},
+								"str": 20,
+								"dex": 20,
+								"con": 18,
+								"int": 10,
+								"wis": 12,
+								"cha": 8,
+								"skill": {
+									"perception": "+7",
+									"stealth": "+11"
+								},
+								"passive": 17,
+								"languages": [
+									"understands common, but can't speak it"
+								],
+								"senses": [
+									"darkvision 60 ft."
+								],
+								"trait": [
+									{
+										"name": "Shadow Stealth",
+										"entries": [
+											"While in dim light or Darkness, the Nargacuga can take the {@action Hide} action as a Bonus Action. Its stealth bonus is also improved to +17."
+										]
+									}
+								],
+								"action": [
+									{
+										"name": "Extra Attack",
+										"entries": [
+											"The nargacuga makes three attacks."
+										]
+									},
+									{
+										"name": "Bite",
+										"entries": [
+											"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}9 ({@damage 1d8 + 5}) piercing damage."
+										]
+									},
+									{
+										"name": "Bladed Wings",
+										"entries": [
+											"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d6 + 5}) slashing damage."
+										]
+									},
+									{
+										"name": "Tail Swipe",
+										"entries": [
+											"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}11 ({@damage 1d12 + 5}) bludgeoning damage."
+										]
+									},
+									{
+										"name": "Tail Spikes",
+										"entries": [
+											"{@atk rw} {@hit 11} to hit, reach 30/120 ft., one target. {@h}10 ({@damage 1d10 + 5}) piercing damage."
+										]
+									},
+									{
+										"name": "Feral Pounce (6 uses).",
+										"entries": [
+											"The nargacuga leaps towards a creature, jumping 10 feet as part of its movement, and attacks the creature with its bladed wing. The target must make a {@dc 19} Dexterity saving throw, taking 37 ({@damage 7d10}) piercing damage and be knocked {@condition prone} on a failed save, or half as much damage and is not knocked prone on a successful one. Additionally, if the target is prone or knocked prone, the nargacuga can make one bite attack against it as a bonus action."
+										]
+									}
+								],
+								"tokenUrl": "https://i.imgur.com/mWs0N7h.png"
+							}
+						}
+					]
+				}
+			]
+		},
+		{
 			"name": "Artisan Cooking System",
 			"entries": [
 				{
@@ -29469,7 +31400,7 @@
 						[
 							"Fruity Jam",
 							"10",
-							"You have advantage on Dexterity ({@skill Sleight of Hand}) checks to catch insects."
+							"You have advantage on Dexterity ({@skill Sleight of Hand}) checks to catch {@table insects|AGMH}."
 						],
 						[
 							"Furahiya Cola",
@@ -29504,7 +31435,7 @@
 						[
 							"Snake Salmon",
 							"10",
-							"You have advantage on Wisdom ({@skill Athletics}) checks to catch fish."
+							"You have advantage on Wisdom ({@skill Athletics}) checks to catch {@table fish|AGMH}."
 						],
 						[
 							"Snowy Rice",
@@ -29643,7 +31574,7 @@
 						[
 							"Western Parsley",
 							"13",
-							"You have advantage on Strength ({@skill Athletic}) checks to mine ore."
+							"You have advantage on Strength ({@skill Athletics}) checks to mine ore."
 						],
 						[
 							"Wild Mushrooms",
@@ -29883,84 +31814,84 @@
 									"type": "entries",
 									"name": "Felyne Swimmer",
 									"entries": [
-										"Your swim speed is increased by 15 feet. "
+										"Your swim speed is increased by 15 feet."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Fur Coating",
 									"entries": [
-										"You take half as much damage from environmental hazards and blight effects. "
+										"You take half as much damage from environmental hazards and blight effects."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Gatherer (Lo)",
 									"entries": [
-										"Increase the number of resources you can gain on a hunt by 2. "
+										"Increase the number of resources you can gain on a hunt by 2."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Backer",
 									"entries": [
-										"Prevents being knocked {@condition prone} when transporting items. "
+										"Prevents being knocked {@condition prone} when transporting items."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Provoker",
 									"entries": [
-										"When a creature within 5 feet of you is hit by a melee weapon attack, you can use your reaction to redirect the damage to you. "
+										"When a creature within 5 feet of you is hit by a melee weapon attack, you can use your reaction to redirect the damage to you."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Researcher",
 									"entries": [
-										"You are able to immediately identify any materials effects as soon as you touch them. Additionally, you can add both your Wisdom and Intelligence ability modifiers to any one History or Nature check. "
+										"You are able to immediately identify any materials effects as soon as you touch them. Additionally, you can add both your Wisdom and Intelligence ability modifiers to any one {@skill History} or {@skill Nature} check."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Escape Artist",
 									"entries": [
-										"You have advantage on Strength ({@skill Athletics}) and Dexterity ({@skill Acrobatics}) checks when attempting to escape from a creature or object that has you {@condition grappled} or {@condition restrained}. "
+										"You have advantage on Strength ({@skill Athletics}) and Dexterity ({@skill Acrobatics}) checks when attempting to escape from a creature or object that has you {@condition grappled} or {@condition restrained}."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Insurance",
 									"entries": [
-										"The first time you or an ally drops to 0 hit points on the hunt, they instead drop to 1 hit point. "
+										"The first time you or an ally drops to 0 hit points on the hunt, they instead drop to 1 hit point."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Crafter",
 									"entries": [
-										"You have a +2 bonus to crafting checks. "
+										"You have a +2 bonus to crafting checks."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Medic",
 									"entries": [
-										"Health recovery items add 1 extra die. "
+										"Health recovery items add 1 extra die."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Fisher",
 									"entries": [
-										"You have advantage on skill checks when fishing. "
+										"You have advantage on skill checks when fishing."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Sprinter",
 									"entries": [
-										"When you take the dash action, you can move an extra 10 feet. "
+										"When you take the dash action, you can move an extra 10 feet."
 									]
 								},
 								{
@@ -29974,21 +31905,21 @@
 									"type": "entries",
 									"name": "Felyne Cliffhanger",
 									"entries": [
-										"You have a climbing speed of 20 feet. "
+										"You have a climbing speed of 20 feet."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Lander",
 									"entries": [
-										"You always land on your feet when falling from a height greater than 10 feet. This does not prevent the damage you would still take. "
+										"You always land on your feet when falling from a height greater than 10 feet. This does not prevent the damage you would still take."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Parting Gift",
 									"entries": [
-										"The first time an ally drops to 0 hit points during a hunt, they can choose up to 6 creatures in a 30-foot radius of them. Those creatures are healed for 2d6 hit points. "
+										"The first time an ally drops to 0 hit points during a hunt, they can choose up to 6 creatures in a 30-foot radius of them. Those creatures are healed for 2d6 hit points."
 									]
 								},
 								{
@@ -30009,35 +31940,35 @@
 									"type": "entries",
 									"name": "Felyne Foodie",
 									"entries": [
-										"The food bonus lasts for 48 hours, you cannot become inebriated during this time, and you can cast the {@spell thaumaturgy} spell at will. "
+										"The food bonus lasts for 48 hours, you cannot become inebriated during this time, and you can cast the {@spell thaumaturgy} spell at will."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Courage",
 									"entries": [
-										"If you are {@condition frightened}, you can choose to repeat your saving throw at the start of your turn instead of the end. "
+										"If you are {@condition frightened}, you can choose to repeat your saving throw at the start of your turn instead of the end."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Rider",
 									"entries": [
-										"You have advantage on checks to stay mounted on monsters. "
+										"You have advantage on checks to stay mounted on monsters."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Cleats",
 									"entries": [
-										"Your movement is unaffected by the first 15 feet of difficult terrain (magical or otherwise) you move through on your turn. "
+										"Your movement is unaffected by the first 15 feet of difficult terrain (magical or otherwise) you move through on your turn."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Felyne Bomb Expert",
 									"entries": [
-										"{@filter Barrel bombs and thrown bombs|items|source=AGMH|type=EXP} gain a +1 bonus to their range attack roll or save DC. "
+										"{@filter Barrel bombs and thrown bombs|items|source=AGMH|type=Explosive} gain a +1 bonus to their range attack roll or save DC."
 									]
 								},
 								{
@@ -30053,7 +31984,7 @@
 				}
 			],
 			"source": "AGMH",
-			"page": 48
+			"page": 51
 		},
 		{
 			"name": "Downtime Activity: Solo Hunt",
@@ -31262,6 +33193,14 @@
 								],
 								[
 									"PHIALS",
+									"{@item Dragon Phial|AGMH}",
+									"{@table mushrooms|AGMH|Dragon Toadstool}",
+									"Empty Phial",
+									"12",
+									"5"
+								],
+								[
+									"PHIALS",
 									"{@item Element Phial|AGMH}",
 									"{@table insects|AGMH|Bitterbug}",
 									"Empty Phial",
@@ -31539,7 +33478,7 @@
 								],
 								[
 									"Bowgun Ammo",
-									"{@item Spread Lvl 1 (20)|AGMH|Spread Lvl 1}",
+									"{@item Spread Ammo (20)|AGMH|Spread Lvl 1}",
 									"{@table plants|AGMH|Huskberry}",
 									"{@table plants|AGMH|Scatternut}",
 									"12",
@@ -31547,7 +33486,7 @@
 								],
 								[
 									"Bowgun Ammo",
-									"{@item Spread Lvl 2 (20)|AGMH|Spread Lvl 2}",
+									"{@item Spread Ammo (20)|AGMH|Spread Lvl 2}",
 									"{@table plants|AGMH|Huskberry}",
 									"Bird Wyvern Fang",
 									"15",

--- a/collection/Amellwind; Monster Hunter Monster Manual.json
+++ b/collection/Amellwind; Monster Hunter Monster Manual.json
@@ -6,7 +6,7 @@
 				"abbreviation": "MHMM",
 				"full": "Monster Hunter Monster Manual",
 				"authors": [
-					"/u/Amellwind"
+					"Amellwind"
 				],
 				"convertedBy": [
 					"LordDusk",
@@ -15,7 +15,7 @@
 					"Desorda",
 					"cellescent"
 				],
-				"version": "2021/05/22",
+				"version": "2021/09/10",
 				"url": "https://www.gmbinder.com/share/-L0j3FWNhBx15I-lR7qC",
 				"targetSchema": "1.0.0"
 			}
@@ -104,7 +104,7 @@
 				{
 					"type": "section",
 					"name": "Introduction",
-					"page": "ii",
+					"page": 0,
 					"entries": [
 						{
 							"type": "entries",
@@ -134,6 +134,17 @@
 							"entries": [
 								"Carving your kills is one of 2 ways to obtain materials while on a hunt. When you attempt to carve a creature, make a Dexterity ({@skill Survival}) check against the creatures Carve DC. On a success, roll a d20 and compare the results to the creatures loot table (Monster Hunter Loot Table PDF). On a failed save, treat the roll as if they rolled a 1 on the loot table.",
 								{
+									"type": "table",
+									"colStyles": [
+										"col-6 text-center"
+									],
+									"rows": [
+										[
+											"{@b Carve DC} = 10 + 1/2 of the creatures CR rounded down"
+										]
+									]
+								},
+								{
 									"type": "inset",
 									"name": "Variant Carve Rule: Rewarding the natural 20",
 									"entries": [
@@ -156,7 +167,7 @@
 				{
 					"type": "section",
 					"name": "Conditions, Poisons, and Diseases",
-					"page": "iii",
+					"page": 0,
 					"entries": [
 						"Within this Monster Manual you will find new conditions, poisons, and diseases. These have been consolidated here.",
 						{
@@ -237,7 +248,8 @@
 								"{@creature Acidic Glavenus|MHMM}",
 								"{@creature Radobaan|MHMM}",
 								"{@creature Uragaan|MHMM}",
-								"{@creature Juvenile Uragaan|MHMM}"
+								"{@creature Juvenile Uragaan|MHMM}",
+								"{@creature Pumpkin Uragaan|MHMM}"
 							]
 						}
 					]
@@ -245,7 +257,7 @@
 				{
 					"type": "section",
 					"name": "Carapaceons",
-					"page": 49,
+					"page": 51,
 					"entries": [
 						"Carapaceons are crustacean-like monsters that have hard shells and exoskeletons or crab-like bodies, When they're weakened by physical damage, they show internal bleeding by the frothing of the purple bubbles from their mouths. Carapaceons are known to hide underground and attack their prey once within range. Most of these crustaceans resemble crabs, lobsters or scorpions.",
 						{
@@ -263,7 +275,7 @@
 				{
 					"type": "section",
 					"name": "Elder Dragons",
-					"page": 57,
+					"page": 59,
 					"entries": [
 						"A very broad term, the only thing in common amongst all elder dragons is their power which seems to border the mystical as opposed to the wyverns which are all limited to natural laws. It is said that an elder dragon is powerful enough to single handedly bring about the destruction of an ecosystem. In ancient times, they would be mistaken for gods. Many elder dragons feature four legs and wings that are separate limbs, unlike wyverns with two legs and winged forelimbs.",
 						"Although all are called dragons, the genus isn't limited to four-legged, winged creatures. Spanning to beasts such as Kirin and Yama Tsukami as well as the more traditional Fatalis. Aside from these are the 'second generation' breeds that all feature a similar build, the Teostra and Kushala Daora are members of this type with all featuring some form of barrier or aura to protect them.",
@@ -309,6 +321,7 @@
 								"{@creature Vaal Hazak|MHMM}",
 								"{@creature Blackveil Vaal Hazak|MHMM}",
 								"{@creature Valstrax|MHMM}",
+								"{@creature Crimson Glow Valstrax|MHMM}",
 								"{@creature Velkhana|MHMM}",
 								"{@creature Tempered Velkhana|MHMM}",
 								"{@creature Archtempered Velkhana|MHMM}",
@@ -322,7 +335,7 @@
 				{
 					"type": "section",
 					"name": "Fanged Beasts",
-					"page": 158,
+					"page": 162,
 					"entries": [
 						"Once known as Pelagus, Fanged Beasts are mammalian creatures with no wings. They are often much faster than other larger threats, but not all of them are aggressive. Many of these beasts will ignore adventurers unless they make themselves known or startle the beast. While other Fanged Beasts attack on site, using the environment and speed to their advantage.",
 						"Fanged Beasts exhibit a wide variety of dietary habits; some are strictly herbivorous or carnivorous, while others subsist on insects. Most of them have unique attributes for survival, such as powerful forelimbs or large tusks, and are well evolved for the environment they live in. Others form packs, with the strongest of them as the Alpha.",
@@ -332,10 +345,12 @@
 								"{@creature Arzuros|MHMM}",
 								"{@creature Young Arzuros|MHMM}",
 								"{@creature Arzuros Cub|MHMM}",
+								"{@creature Blood Soaked Arzuros|MHMM}",
 								"{@creature Bishaten|MHMM}",
 								"{@creature Blango|MHMM}",
 								"{@creature Blangonga|MHMM}",
 								"{@creature Bullfango|MHMM}",
+								"{@creature Bullfango Shoat|MHMM}",
 								"{@creature Bulldrome|MHMM}",
 								"{@creature Conga|MHMM}",
 								"{@creature Congalala|MHMM}",
@@ -360,7 +375,7 @@
 				{
 					"type": "section",
 					"name": "Fanged Wyverns",
-					"page": 184,
+					"page": 189,
 					"entries": [
 						"Fanged Wyverns are known for being Fanged Beast-like Wyvern monsters that have highly developed limbs. Typically ignored by towns and cities due to their preferred territories being far away from civilization. Up until recently scholars only classified the Zinogre as the only known species of these wyverns. New species have been discovered in far off regions, although they are more reptilian in nature when compared to their kin.",
 						{
@@ -393,7 +408,7 @@
 				{
 					"type": "section",
 					"name": "Flying Wyverns",
-					"page": 204,
+					"page": 210,
 					"entries": [
 						"Flying Wyverns are typically large, bipedal monsters capable of flight, having developed wings. Some, due to their sheer size and weight are able to hover in the air for a brief time. that have two wings. These Wyverns are known as \"True Wyverns\". However, there are some Wyverns that are quadrupedal, operating their wingarms as forearms instead like Tigrex and Nargacuga. These monsters have been dubbed by academics as \"Pseudo Wyverns\" (Pseudo meaning \"False\" or \"Mimic\"), due to these species only displaying partial Wyvern traits. Some are flightless despite their classification as Flying Wyverns, like the Akantor and Ukanlos. These wyverns show their Wyvern ancestry by the small forewings on their two front limbs. Flying wyverns have evolved over time and live in nearly every known area, encompassing many elements and types.",
 						{
@@ -410,6 +425,7 @@
 								"{@creature Diablos|MHMM}",
 								"{@creature Giggi|MHMM}",
 								"{@creature Gigginox|MHMM}",
+								"{@creature Chaotic Gigginox|MHMM}",
 								"{@creature Gravios|MHMM}",
 								"{@creature Khezu|MHMM}",
 								"{@creature Legiana|MHMM}",
@@ -436,7 +452,7 @@
 				{
 					"type": "section",
 					"name": "Leviathans",
-					"page": 252,
+					"page": 259,
 					"entries": [
 						"The Leviathan monster species are identified by their similar appearance to crocodiles. They are also known to survive in underwater conditions, while others throughout magma in volcanoes. Fighting one almost always involves underwater combat; a leviathan is always guaranteed at some point to retreat to the depths of the oceans or lakes. They are almost always more adept at fighting underwater, while most adventurers are hindered by the liquids. Fighting one requires at least a modest proficiency in underwater fighting, and, barring any skill in that, a measure of luck to coax the Leviathan on land.",
 						{
@@ -464,7 +480,7 @@
 				{
 					"type": "section",
 					"name": "Neopterons",
-					"page": 273,
+					"page": 280,
 					"entries": [
 						"Neopterons are insectoid monsters known for their rigid carapaces. These monsters can range in size from tiny to enormous, and some species can fly, while others cannot. Neopterons are situated in large groups rather than individually. Most carry poisonous stingers that can paralyze prey, and their bodies are made up of acidic substances. Their weak outer-shell structures means that they are easily damaged, making it difficult to obtain adequate materials from their remains. Their materials are often used to make very sharp weapons.",
 						{
@@ -489,7 +505,7 @@
 				{
 					"type": "section",
 					"name": "Piscine Wyverns",
-					"page": 286,
+					"page": 294,
 					"entries": [
 						"The term 'Piscine' is applied to creatures that are known to swim or glide in preference to walking on solid ground. The body structure of a Piscine usually resembles that of a fish, with lesser evolved legs in comparison to most other monster species. Piscines include the sand-dwelling creatures, which can be found throughout the desert. Monsters found commonly in the waters and one which dwells in magma, and can be found in the volcanic areas. Piscines are also known as Wyverns, due to their similar structure and ability of flight. All Piscines have two Limbs that enable them to walk on land, and a selection of Fins to help them swim through their chosen habitat. Many of their \"wings\" have evolved into fins.",
 						{
@@ -510,7 +526,7 @@
 				{
 					"type": "section",
 					"name": "Snake Wyverns",
-					"page": 296,
+					"page": 303,
 					"entries": [
 						"Snake Wyverns are a class of monsters known for their serpentine features, such as long, coiling bodies and forked tongues. They can range dramatically in both size and overall body structure, with some members being large, serpentine land-dwellers, while others are smaller and more reminiscent of Flying Wyverns.",
 						{
@@ -526,13 +542,14 @@
 				{
 					"type": "section",
 					"name": "Temnocerans",
-					"page": 299,
+					"page": 306,
 					"entries": [
 						"Temnoceran, are a class of monster characterized by its arachnoid characteristics, such as the ability to produce silk, though they have six limbs similar to Neopterons or Carapaceons.",
 						{
 							"type": "list",
 							"items": [
 								"{@creature Nerscylla|MHMM}",
+								"{@creature Fey Nerscylla|MHMM}",
 								"{@creature Rachnoid|MHMM}",
 								"{@creature Rakna-Kadaki|MHMM}"
 							]
@@ -542,7 +559,7 @@
 				{
 					"type": "section",
 					"name": "Theropods",
-					"page": 304,
+					"page": 313,
 					"entries": [
 						"Theropods are reminiscent of Brute Wyverns; flightless, bipedal creatures with long tails and powerful legs. Unlike Brute Wyverns however, these monsters are generally quite small. Furthermore, Theropods almost always live under a social hierarchy, with young individuals, females and beta males led by a strong, dominant alpha male, which can command and control his subjects during combat.",
 						{
@@ -562,6 +579,7 @@
 								"{@creature Jaggia|MHMM}",
 								"{@creature Great Jaggi|MHMM}",
 								"{@creature Kulu-Ya-Ku|MHMM}",
+								"{@creature Tempered Kulu-Ya-Ku|MHMM}",
 								"{@creature Maccao|MHMM}",
 								"{@creature Great Maccao|MHMM}",
 								"{@creature Tzitzi-Ya-Ku|MHMM}",
@@ -576,7 +594,7 @@
 				{
 					"type": "section",
 					"name": "Unknown",
-					"page": 323,
+					"page": 337,
 					"entries": [
 						"Unknown, are a class of monsters that has been identified by scholars, but not yet given a proper classification.",
 						{
@@ -599,7 +617,7 @@
 				{
 					"type": "section",
 					"name": "Herbivores",
-					"page": 334,
+					"page": 344,
 					"entries": [
 						"Herbivores are minor creatures that eat vegetation. While there are herbivorous creatures in other classes, such as Diablos and Duramboros, monsters in the Herbivore class are usually docile, reside at the bottom of the food chain, and therefore pose little threat to an adventurer.",
 						{
@@ -628,7 +646,7 @@
 				{
 					"type": "section",
 					"name": "Lynians",
-					"page": 345,
+					"page": 355,
 					"entries": [
 						"Lynians are sapient monsters, and are typically short of stature. There are currently two distinct groups of Lynian: the cat-like Melynx, Felyne, and Grimalkyne, and the humanoid Shakalaka and Gajalaka. Lynians are intelligent, have complex societies, and speak their own languages. Whereas the Shakalaka and Gajalaka are more primitive and tribal, the feline species tend to lead peaceful lives and often coexist with human society.",
 						{
@@ -656,7 +674,7 @@
 				{
 					"type": "section",
 					"name": "Endemic Life",
-					"page": 352,
+					"page": 362,
 					"entries": [
 						"Endemic Life are creatures found in Monster Hunter Universe across many locations that can be captured by a hunter's Net or fishing pole. They are not hostile, but will be scared away easily, making their study and capture difficult.",
 						"Some Endemic Life creatures also present Environmental Hazards or useful effects - see Environment and Hazards for more information. Endemic creatures are classified into 5 types, following the ingame Monster Field Guide.",
@@ -686,6 +704,20 @@
 	],
 	"condition": [
 		{
+			"name": "Dragonblight",
+			"source": "MHMM",
+			"page": 0,
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"While afflicted with dragonblight, the target can't deal cold, fire, lightning, necrotic, or thunder damage with its spells and attacks, and it can't impose any of the following conditions on other creatures: {@condition blinded}, {@condition charmed}, {@condition paralyzed}, {@condition poisoned}, and {@condition petrified}.",
+						"Dragonblight can be cured early with the {@spell lesser restoration} spell or similar magic."
+					]
+				}
+			]
+		},
+		{
 			"name": "Slick",
 			"source": "MHMM",
 			"page": 0,
@@ -697,7 +729,7 @@
 						"A creature who is slick has disavantage on Dexterity saving throws.",
 						"A creature may only move up to half its speed while under this effect.",
 						"A creature has disavantage when attempting to {@action grapple} a creature, but advantage when attempting to escape a {@condition grappled|PHB|grapple} when using {@skill Acrobatics}.",
-						"A creature can use its action on itself or another adjacent creature to wipe off the liquid, removing the effect."
+						"{@i A creature can use its action on itself or another adjacent creature to wipe off the liquid, removing the effect}."
 					]
 				}
 			]
@@ -714,43 +746,9 @@
 						"A creature who is tarred is {@condition restrained}, immune to being disarmed, and cannot use an object or weapon not already in hand.",
 						"A tarred Object cannot be moved or used.",
 						"An area that is tarred is considered difficult terrain.",
-						"The condition ends if a creature, object, or area that has this condition takes fire damage. When the condition ends in this way the creature, object, or area ignite. Until a creature takes an action to douse the fire , the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns.",
+						"The condition ends if a creature, object, or area that has this condition takes fire damage. When the condition ends in this way the creature, object, or area ignite. Until a creature takes an action to douse the fire , the target takes 6 ({@damage 1d10}) fire damage at the start of each of its turns.",
 						"When an area ignites, any object or creature in that area also ignite.",
 						"An area that ignites in this way burns for 1 minute."
-					]
-				}
-			]
-		},
-		{
-			"name": "Dragonblight",
-			"source": "MHMM",
-			"page": 0,
-			"entries": [
-				{
-					"type": "list",
-					"items": [
-						"While afflicted with dragonblight, the target can't deal cold, fire, lightning, necrotic, or thunder damage with its spells and attacks, and it can't impose any of the following conditions on other creatures: {@condition blinded}, {@condition charmed}, {@condition paralyzed}, {@condition poisoned}, and {@condition petrified}.",
-						"Dragonblight can be cured early with the {@spell lesser restoration} spell or similar magic."
-					]
-				}
-			]
-		},
-		{
-			"name": "Waterblight",
-			"source": "MHMM",
-			"page": 0,
-			"entries": [
-				{
-					"type": "homebrew",
-					"entries": [
-						"Waterblight is considered a type of poison, not just a condition."
-					]
-				},
-				"A creature effected by waterblight has their stamina drained.",
-				{
-					"type": "list",
-					"items": [
-						"On the creatures turn, it can use either an Action or a Bonus Action, not both."
 					]
 				}
 			]
@@ -768,17 +766,38 @@
 					]
 				}
 			]
-		}
-	],
-	"disease": [
+		},
 		{
-			"name": "Iceblight",
+			"name": "Waterblight",
+			"source": "MHMM",
 			"page": 0,
 			"entries": [
 				{
 					"type": "homebrew",
 					"entries": [
-						"Iceblight is considered a type of disease, not just a condition."
+						"Waterblight is considered a type of poison for the purposes of features that grant advantage on saves against or immunity to poisons."
+					]
+				},
+				"A creature effected by waterblight has their stamina drained.",
+				{
+					"type": "list",
+					"items": [
+						"On the creatures turn, it can use either an Action or a Bonus Action, not both."
+					]
+				}
+			]
+		}
+	],
+	"disease": [
+		{
+			"name": "Iceblight",
+			"source": "MHMM",
+			"page": 0,
+			"entries": [
+				{
+					"type": "homebrew",
+					"entries": [
+						"Iceblight is considered a type of disease for the purposes of features that grant advantage on saves against or immunity to diseases."
 					]
 				},
 				"A creature who is afflicted with iceblight is chilled to the bone.",
@@ -790,13 +809,12 @@
 						"It can't make more than one attack on its turn."
 					]
 				}
-			],
-			"source": "MHMM"
+			]
 		},
 		{
 			"name": "Frenzy Virus",
-			"page": 0,
 			"source": "MHMM",
+			"page": 336,
 			"entries": [
 				"The Frenzy Virus is an infectious disease caused by the attacks and breath weapons of {@creature Gore Magala|MHMM} and {@creature Shagaru Magala|MHMM}, affecting both sentient races and monsters alike.",
 				{
@@ -1055,6 +1073,7 @@
 				}
 			],
 			"regionalEffects": [
+				"Fatalis makes its lair in the courtyard of the ruins of Castle Schrade that was built during ancient times, a shadow of its former glory. The area features blood red skies that have dark hues, and swirls of purple clouds.",
 				"The region containing Fatalis's lair is warped by the dragon's magic, which creates one or more of the following effects:",
 				{
 					"type": "list",
@@ -1194,21 +1213,28 @@
 					]
 				},
 				{
-					"name": "Tail Spin",
+					"name": "Tail Spin {@recharge 5}",
 					"entries": [
-						"The glavenus uses one of the following tail spin attacks depending on which form its tail is in. Both share the same recharge."
-					]
-				},
-				{
-					"name": "Acid Tail Spin  {@recharge 5}",
-					"entries": [
-						"The glavenus launches itself forward 50 feet, without provoking opportunity attacks, using its tail to slash at all foes in or within a 15-foot radius of its path. Each creature in that area must then make a {@dc 21} Dexterity saving throw, taking 24 ({@dice 7d6}) slashing and 24 ({@dice 7d6}) acid damage on a failed save, and half as much on a successful one."
-					]
-				},
-				{
-					"name": "Sharpened Tail Spin  {@recharge 5}",
-					"entries": [
-						"The glavenus launches itself forward 50 feet, using its tail to slash at all foes in 15-foot radius around it. Each creature in that area must then make a {@dc 21} Dexterity saving throw, taking 63 ({@damage 18d6}) slashing damage on a failed save, and half as much on a successful one."
+						"The glavenus uses one of the following tail spin attacks depending on which form its tail is in. Both share the same recharge.",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Acid Tail Spin",
+									"entries": [
+										"The glavenus launches itself forward 50 feet, without provoking opportunity attacks, using its tail to slash at all foes in or within a 15-foot radius of its path. Each creature in that area must then make a {@dc 21} Dexterity saving throw, taking 24 ({@dice 7d6}) slashing and 24 ({@dice 7d6}) acid damage on a failed save, and half as much on a successful one."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Sharpened Tail Spin",
+									"entries": [
+										"The glavenus launches itself forward 50 feet, using its tail to slash at all foes in 15-foot radius around it. Each creature in that area must then make a {@dc 21} Dexterity saving throw, taking 63 ({@damage 18d6}) slashing damage on a failed save, and half as much on a successful one."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -1228,7 +1254,9 @@
 			"fluff": {
 				"entries": [
 					"Acidic glavenus' body is a variety of emerald and blue shades, with dark grey spikes and horns. Its tail is usually covered in yellow crystals, which, when scraped off reveal a dull blue, katana-like blade. Its eyes are dark red.",
-					"Acidic glavenus has greater control over its tail attacks than the standard Glavenus due to its lighter tail, and subsequently uses more precise tail slashes and jabs in addition to wider slashes. When covered in the acidic crystals, its tail is heavier and thus acidic glavenus behaves more like the ordinary species. The acid on its tail is highly corrosive and can reduce the effects of magical armor and weapons, or destroy nonmagical ones.",
+					"Acidic Glavenus' most notable adaption that sets it apart from the main species is its tail. The tail is lighter and more resembles a Long Sword, and because of this, it is able to attack quicker and use more gracile moves reminiscent of its weapon counterpart. When the tail dulls it will grow an acidic compound that covers the entirety of its tail. This acid will lower the toughness of whatever it is fighting, and can be thrown off at opponents during some of its attacks.",
+					"While the common {@creature Glavenus|MHMM} inhabits forests, deserts, and volcanos, Acidic Glavenus inhabits the more extreme Rotten Vale and the Rotten region of the Guiding Lands. It is able to grow sulphurous crystals on its tail that create acidic mist when shattered, perhaps because of its habitat choice.",
+					"Due to living in the hostile Rotten Vale, Acidic Glavenus are very aggressive towards whatever they may come across. Oddly enough, there are no records of an Acidic Glavenus scavenging despite its habitat, only of it hunting other inhabitants of the Rotten Vale.",
 					{
 						"type": "inset",
 						"name": "Acidic Glavenus",
@@ -1389,7 +1417,7 @@
 										"type": "entries",
 										"name": "Acidic Glavenus Spineshell",
 										"entries": [
-											"Your weapon deals an extra 1d10 acid damage."
+											"Your weapon deals an extra {@damage 1d10} acid damage."
 										]
 									},
 									{
@@ -1911,7 +1939,7 @@
 											[
 												"18",
 												"-",
-												"Monsterbone+",
+												"Monster Bone+",
 												"(O)"
 											],
 											[
@@ -2013,7 +2041,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Monsterbone+",
+												"name": "Monster Bone+",
 												"entries": [
 													"Rare armor upgrade material."
 												]
@@ -2523,7 +2551,7 @@
 			],
 			"conditionInflict": [
 				"prone",
-				"restrained"
+				"Restrained"
 			]
 		},
 		{
@@ -3096,11 +3124,6 @@
 				"grappled",
 				"prone",
 				"blinded"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"AOE"
 			]
 		},
 		{
@@ -3402,9 +3425,6 @@
 			],
 			"conditionInflict": [
 				"prone"
-			],
-			"miscTags": [
-				"MW"
 			]
 		},
 		{
@@ -3462,6 +3482,10 @@
 			"skill": {
 				"perception": "+14"
 			},
+			"senses": [
+				"blindsight 60 ft.",
+				"darkvision 120 ft."
+			],
 			"conditionImmune": [
 				"charmed",
 				"frightened"
@@ -3484,7 +3508,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The alatreon makes three attacks; two claw attacks one bite or tail attack."
+						"The alatreon makes three attacks: two with its claw and one with its bite or tail."
 					]
 				},
 				{
@@ -3541,7 +3565,7 @@
 									"type": "entries",
 									"name": "Cold Breath",
 									"entries": [
-										"The alatreon exhales an icy blast in a 90-foot cone. Each creature in that area must make a {@dc 22} Constitution saving throw, taking 72 (l{@dice 6d8}) cold damage on a failed save, or half as much damage on a successful one."
+										"The alatreon exhales an icy blast in a 90-foot cone. Each creature in that area must make a {@dc 22} Constitution saving throw, taking 72 ({@dice 16d8}) cold damage on a failed save, or half as much damage on a successful one."
 									]
 								}
 							]
@@ -3588,8 +3612,8 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Known as the Blazing Black Dragon, Alatreon possesses control over the Fire, Thunder, and Ice elements, and is said to be elementally unstable. In its scales are each of the three elements which it constantly produces, even when it is dead. However, it is unknown how its scales are able to harness the elements.On top of Alatreon's head are two large horns, these horns seem to play some part in Alatreon's control over the three elements, however, it is unknown to scholars if they actually do.",
-							"From Alatreon living isolated from all other monsters, it is hard to say where it fits in the ecological niche. Due to Alatreon living in the Sacred Land, it has changed the area into an inhospitable environment. No living things, including plants, can live in the area due to the constant weather changes that occur in the Sacred Land. Alatreon are monsters capable of destroying the world. Some locals even believe that the Alatreon is a god or demon which is transformed into an Elder Dragon. Many of Alatreon's abilities seem to be unnatural, much like the Fatalis, but not much else is really known about the Elder Dragon.",
+							"Known as the Blazing Black Dragon, Alatreon possesses control over the Fire, Thunder, and Ice elements, and is said to be elementally unstable. In its scales are each of the three elements which it constantly produces, even when it is dead. However, it is unknown how its scales are able to harness the elements. On top of Alatreon's head are two large horns, these horns seem to play some part in Alatreon's control over the three elements, however, it is unknown to scholars if they actually do.",
+							"From Alatreon living isolated from all other monsters, it is hard to say where it fits in the ecological niche. Due to Alatreon living in the Sacred Land, it has changed the area into an inhospitable environment. No living things, including plants, can live in the area due to the constant weather changes that occur in the Sacred Land. Alatreon are monsters capable of destroying the world. Some locals even believe that the Alatreon is a god or demon which is transformed into an Elder Dragon. Many of Alatreon's abilities seem to be unnatural, much like the {@creature Fatalis|MHMM}, but not much else is really known about the Elder Dragon.",
 							{
 								"type": "inset",
 								"name": "Alatreon",
@@ -3798,11 +3822,6 @@
 			"conditionInflict": [
 				"grappled",
 				"prone"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"AOE"
 			]
 		},
 		{
@@ -4245,11 +4264,6 @@
 				"grappled",
 				"restrained",
 				"stunned"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"AOE"
 			]
 		},
 		{
@@ -4433,9 +4447,6 @@
 			"tokenUrl": "https://i.imgur.com/4UTdwHn.png",
 			"damageTags": [
 				"A"
-			],
-			"miscTags": [
-				"RW"
 			]
 		},
 		{
@@ -4539,7 +4550,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The amatsu makes two tail attacks and one bite attack. It can replace any of these attacks with a water beam attack."
+						"The amatsu makes one tail attack and one bite attack. It can replace any of these attacks with a water beam attack."
 					]
 				},
 				{
@@ -4557,13 +4568,13 @@
 				{
 					"name": "Water Beam",
 					"entries": [
-						"{@atk rw} {@hit 6} to hit, reach 150/600 ft., one target. {@h}23 ({@damage 5d8}) cold damage."
+						"{@atk rw} {@hit 6} to hit, range 150/600 ft., one target. {@h}23 ({@damage 5d8}) cold damage."
 					]
 				},
 				{
 					"name": "Wind Vortex {@recharge 5}",
 					"entries": [
-						"The amatsu conjures an swirling vortex of high winds within 100 feet of it. Each creature within that area must make a {@dc 20} Strength saving throw or are pulled 30 feet towards the amatsu. A creature that is pulled within 30 feet of the amatsu or is already within that range must make a {@dc 20} Strength saving throw or be thrown 140 feet straight up into the air on a failed save, or half as high on successful one. If a thrown target strikes a solid surface upon landing, the target takes 3 ({@damage 1d6}) bludgeoning damage for every 10 feet it was thrown."
+						"The amatsu conjures an swirling vortex of high winds within 100 feet of it. Each creature within that area must make a {@dc 20} Strength saving throw or are pulled 30 feet towards the amatsu. A creature that is pulled within 30 feet of the amatsu or is already within that range must make a {@dc 20} Strength saving throw or be thrown 130 feet straight up into the air on a failed save, or half as high on successful one. If a thrown target strikes a solid surface upon landing, the target takes 3 ({@damage 1d6}) bludgeoning damage for every 10 feet it was thrown."
 					]
 				},
 				{
@@ -4595,7 +4606,7 @@
 				{
 					"name": "Whirlwind (Costs 3 Actions)",
 					"entries": [
-						"The amatsu chooses 3 unoccupied 5-foot cube within 5 feet of it. An elemental force that resembles a dust devil appears in the cubes and they move in a straight line 60 feet away from the amatsu before dispersing. Each creature in one of the lines must make a {@dc 20} Strength saving throw, taking 18 ({@damage 4d8}) force damage on a failed save or half as much on a successful one"
+						"The amatsu chooses 3 unoccupied 5-foot cube within 5 feet of it. An elemental force that resembles a dust devil appears in the cubes and they move in a straight line 60 feet away from the amatsu before dispersing. Each creature in one of the lines must make a {@dc 20} Strength saving throw, taking 18 ({@damage 4d8}) force damage on a failed save or half as much on a successful one."
 					]
 				}
 			],
@@ -4773,7 +4784,7 @@
 												"type": "entries",
 												"name": "Storm Vesicle",
 												"entries": [
-													"{@i Partbreaker+2.} You deal an extra 1d8 weapon damage when you critically hit with this weapon."
+													"{@i Partbreaker+2.} You deal an extra {@damage 1d8} weapon damage when you critically hit with this weapon."
 												]
 											},
 											{
@@ -4794,7 +4805,7 @@
 												"type": "entries",
 												"name": "Amatsu Stormtail",
 												"entries": [
-													"Your weapon deals an extra 1d8 radiant damage."
+													"Your weapon deals an extra {@damage 1d8} radiant damage."
 												]
 											},
 											{
@@ -4849,12 +4860,6 @@
 			],
 			"conditionInflict": [
 				"prone"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"RW",
-				"AOE"
 			]
 		},
 		{
@@ -5283,12 +5288,11 @@
 			"passive": 14,
 			"cr": "7",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Keen Smell",
 					"entries": [
-						"The anjanath has advantage on Wisdom (Perception) checks that rely on smell."
+						"The anjanath has advantage on Wisdom ({@skill Perception}) checks that rely on smell."
 					]
 				}
 			],
@@ -5296,7 +5300,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The anjanath makes two attacks. one with its bite and one with its tail. It can't make both attacks against the same target."
+						"The anjanath makes two attacks: one with its bite and one with its tail. It can't make both attacks against the same target."
 					]
 				},
 				{
@@ -5526,12 +5530,7 @@
 			],
 			"conditionInflict": [
 				"restrained",
-				"grappled"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"AOE"
+				"Grappled"
 			]
 		},
 		{
@@ -5713,9 +5712,6 @@
 			],
 			"conditionInflict": [
 				"prone"
-			],
-			"miscTags": [
-				"MW"
 			]
 		},
 		{
@@ -5825,7 +5821,7 @@
 											],
 											[
 												"16-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -5844,7 +5840,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -5861,9 +5857,6 @@
 			"damageTags": [
 				"B",
 				"S"
-			],
-			"miscTags": [
-				"MW"
 			]
 		},
 		{
@@ -5974,7 +5967,7 @@
 											],
 											[
 												"16-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -5993,7 +5986,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -6010,9 +6003,6 @@
 			"damageTags": [
 				"B",
 				"S"
-			],
-			"miscTags": [
-				"MW"
 			]
 		},
 		{
@@ -6314,7 +6304,7 @@
 										"type": "entries",
 										"name": "AT.Miralis Fireclaw",
 										"entries": [
-											"Your weapon deals an extra 1d10 fire damage."
+											"Your weapon deals an extra 2d6 fire damage."
 										]
 									},
 									{
@@ -6567,7 +6557,7 @@
 				{
 					"name": "Water Globule",
 					"entries": [
-						"{@atk rw} {@hit 11} to hit, range 30/120 ft., one target. {@h}17 ({@damage 5d6}) cold damage and the target must succeed on a {@dc 21} Constitution saving throw, or become affected with {@disease waterblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. On a hit or miss, the 5 foot area below the target is flooded."
+						"{@atk rw} {@hit 9} to hit, range 30/120 ft., one target. {@h}17 ({@damage 5d6}) cold damage and the target must succeed on a {@dc 21} Constitution saving throw, or become affected with {@disease waterblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. On a hit or miss, the 5 foot area below the target is flooded."
 					]
 				},
 				{
@@ -6830,10 +6820,7 @@
 						]
 					}
 				]
-			},
-			"conditionInflict": [
-				"prone"
-			]
+			}
 		},
 		{
 			"name": "Archtempered Velkhana",
@@ -6982,21 +6969,28 @@
 				{
 					"name": "Breath Weapons",
 					"entries": [
-						"The velkhana uses one of the following breath weapons. Both share the same recharge."
-					]
-				},
-				{
-					"name": "Cold Breath {@recharge 5}",
-					"entries": [
-						"The velkhana exhales an icy blast in a 90-foot line that is 5 feet wide. That area is covered in rime for 1 minute and each creature in that line must make a {@dc 25} Dexterity saving throw, taking 88 ({@damage 16d10}) cold damage on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Hoarfrost Breath {@recharge 5}",
-					"entries": [
-						"The velkhana exhales an icy blast of hoarfrost in a 60-foot cone. The area is covered in rime for 1 minute and each creature in that area must make a {@dc 25} Constitution saving throw, taking 35 ({@damage 10d6}) cold damage on a failed save, or half as much damage on a successful one.",
-						"Additionally, five 1 foot thick, 10-foot-square walls of ice form within the area and last for 10 minutes. If the wall is formed on a creature's space, the creature is pushed to one side of the wall and must make a {@dc 22} Dexterity saving throw, taking 35 ({@damage 10d6}) cold damage on a failed save, or half as much on a successful one.",
-						"Each 10-foot section of the wall has 15 AC and 50 hit points, and is vulnerable to fire damage. If damaged to 0 hit points, it leaves a hole filled with freezing air. The first time a creature moves through the air on a turn, it makes a {@dc 25} Constitution save, taking 17 ({@damage 5d6}) cold damage on a failed save or half as much on a successful one."
+						"The velkhana uses one of the following breath weapons.",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Cold Breath {@recharge 5}",
+									"entries": [
+										"The velkhana exhales an icy blast in a 90-foot line that is 5 feet wide. That area is covered in rime for 1 minute and each creature in that line must make a {@dc 25} Dexterity saving throw, taking 88 ({@damage 16d10}) cold damage on a failed save, or half as much damage on a successful one."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Hoarfrost Breath {@recharge 5}",
+									"entries": [
+										"The velkhana exhales an icy blast of hoarfrost in a 60-foot cone. The area is covered in rime for 1 minute and each creature in that area must make a {@dc 25} Constitution saving throw, taking 35 ({@damage 10d6}) cold damage on a failed save, or half as much damage on a successful one.",
+										"Additionally, five 1 foot thick, 10-foot-square walls of ice form within the area and last for 10 minutes. If the wall is formed on a creature's space, the creature is pushed to one side of the wall and must make a {@dc 22} Dexterity saving throw, taking 35 ({@damage 10d6}) cold damage on a failed save, or half as much on a successful one.",
+										"Each 10-foot section of the wall has 15 AC and 50 hit points, and is vulnerable to fire damage. If damaged to 0 hit points, it leaves a hole filled with freezing air. The first time a creature moves through the air on a turn, it makes a {@dc 25} Constitution save, taking 17 ({@damage 5d6}) cold damage on a failed save or half as much on a successful one."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -7031,7 +7025,7 @@
 			],
 			"fluff": {
 				"entries": [
-					"Velkhana is a traditional dragon with the slim, upright body structure of elder Dragons like {@creature kushala daora|MHMM}. Its scales and shell are a unique crystalline blue. Its head has a tiara-like crown of small horns. It summons ice to cover its wings, limbs, and tail. Its thin, lance-like tail is highly flexible and can jab at enemies.",
+					"{@creature Velkhana|MHMM} is a traditional dragon with the slim, upright body structure of elder Dragons like {@creature kushala daora|MHMM}. Its scales and shell are a unique crystalline blue. Its head has a tiara-like crown of small horns. It summons ice to cover its wings, limbs, and tail. Its thin, lance-like tail is highly flexible and can jab at enemies.",
 					"Velkhana freely controls ice and cold wind, and can cover wide areas in ice in an instant. It breathes beams of supercooled fluid that can instantly freeze monsters. When covered in its ice armor, ice crystals form nearby, and when struck by Velkhana's ice breath they form large spires that soon explode. Small ice platforms sometimes form, which can be jumped off of. Occasionally, spikes of ice rain from clouds close to the ground when it is enraged.",
 					{
 						"type": "inset",
@@ -7153,7 +7147,7 @@
 										"type": "entries",
 										"name": "AT.Velkhana Crystal",
 										"entries": [
-											"You have immunity to cold damage and resistance to radiant damage while you wear this armor."
+											"You are immune to cold damage and resistance to radiant damage while you wear this armor."
 										]
 									}
 								]
@@ -7174,7 +7168,7 @@
 										"type": "entries",
 										"name": "AT.Velkhana Cortex",
 										"entries": [
-											"While attuned to this weapon you can use an action to cast the wall of ice (save {@dc 19}) spell from it. Once you use this property, new walls deal no damage and are only 3 feet tall until you finish along rest."
+											"While attuned to this weapon you can use an action to cast the {@spell wall of ice} (save {@dc 19}) spell from it. Once you use this property, new walls deal no damage and are only 3 feet tall until you finish along rest."
 										]
 									},
 									{
@@ -7203,7 +7197,7 @@
 										"type": "entries",
 										"name": "AT.Velkhana Crystal",
 										"entries": [
-											"{@i Coalescence+2.} Whenever you succeed on a saving throw to end a condition, you gain a +3 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra 1d8 cold, fire, or lightning damage (your choice) until the end of your next turn."
+											"{@i Coalescence+2.} Whenever you succeed on a saving throw to end a condition, you gain a +3 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra {@damage 1d8} cold, fire, or lightning damage (your choice) until the end of your next turn."
 										]
 									}
 								]
@@ -7235,8 +7229,8 @@
 						"type": "insetReadaloud",
 						"name": "AT.Velkhana Divinity",
 						"entries": [
-							"{@b Set bonus (2):} When you critically hit with a weapon or spell that deals cold damage, you deal an extra 1d10 cold damage.",
-							"{@b Set bonus (4):} An aura of frost builds when your weapon is sheathed for at least 1 minute. When you draw this weapon, it deals an extra 1d10 cold damage for the next 4 rounds."
+							"{@b Set bonus (2):} When you critically hit with a weapon or spell that deals cold damage, you deal an extra {@damage 1d10} cold damage.",
+							"{@b Set bonus (4):} An aura of frost builds when your weapon is sheathed for at least 1 minute. When you draw this weapon, it deals an extra {@damage 1d10} cold damage for the next 4 rounds."
 						]
 					}
 				]
@@ -7284,7 +7278,8 @@
 				"formula": "12d10 + 24"
 			},
 			"speed": {
-				"walk": 35
+				"walk": 35,
+				"climb": 30
 			},
 			"str": 18,
 			"dex": 12,
@@ -7295,12 +7290,17 @@
 			"passive": 9,
 			"cr": "4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Aggressive",
 					"entries": [
 						"As a bonus action, the arzuros can move up to its speed toward a hostile creature that it can see."
+					]
+				},
+				{
+					"name": "Keen Smell",
+					"entries": [
+						"The arzuros has advantage on Wisdom ({@skill Perception}) checks that rely on smell."
 					]
 				}
 			],
@@ -7308,7 +7308,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The arzuros makes three melee attacks. one bite attack, one claw attack, and one body slam attack."
+						"The arzuros makes three melee attacks: one with its bite, one with its claw, and one with its body slam."
 					]
 				},
 				{
@@ -7331,7 +7331,8 @@
 				}
 			],
 			"traitTags": [
-				"Aggressive"
+				"Aggressive",
+				"Keen Senses"
 			],
 			"actionTags": [
 				"Multiattack"
@@ -7500,9 +7501,6 @@
 				"P",
 				"S",
 				"B"
-			],
-			"miscTags": [
-				"MW"
 			]
 		},
 		{
@@ -8008,11 +8006,6 @@
 			],
 			"conditionInflict": [
 				"paralyzed"
-			],
-			"miscTags": [
-				"MW",
-				"RCH",
-				"AOE"
 			]
 		},
 		{
@@ -8062,7 +8055,6 @@
 			"passive": 8,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Stomp",
@@ -8275,7 +8267,6 @@
 			"passive": 10,
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "False Appearance",
@@ -8861,7 +8852,6 @@
 			"passive": 9,
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Pack Tactics",
@@ -8951,7 +8941,7 @@
 											],
 											[
 												"17-18",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -9003,7 +8993,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -9032,7 +9022,7 @@
 				"MW"
 			],
 			"conditionInflict": [
-				"incapacitated"
+				"Incapacitated"
 			]
 		},
 		{
@@ -9277,8 +9267,8 @@
 												"type": "list",
 												"name": "1 banbaro material",
 												"items": [
-													"Blue Mushroom, {@i Restores 1d4 hit points.}",
-													"Toadstool, {@i You regain 1 hit point at the start of each of your turns for 1 minute.}"
+													"Blue Mushroom, {@i Restores a 2d4 hit points.}",
+													"Toadstool, {@i You regain 2 hit points at the start of each of your turns for 1 minute.}"
 												]
 											},
 											{
@@ -9286,7 +9276,7 @@
 												"name": "2 banbaro material",
 												"items": [
 													"Nitroshroom, {@i Your Strength score increases by +2 for 1 minute.}",
-													"Parashroom, {@i Your AC becomes 13 + your Dexterity modifier for the next 8 hours.}"
+													"Parashroom, {@i Your AC becomes 14 + your Dexterity modifier for the next 8 hours.}"
 												]
 											},
 											{
@@ -9294,7 +9284,7 @@
 												"name": "3 banbaro material",
 												"items": [
 													"Chaos Mushroom, {@i You are {@condition poisoned} for 1 hour, and gain 5 temporary hit points per character level for the next 10 minutes.}",
-													"Bindshroom, {@i Your speed increases by 10 feet for 1 hour.}",
+													"Bindshroom, {@i Your speed increases by 15 feet for 1 hour.}",
 													"Exciteshroom, {@i Provides one of the other mushroom effects, roll a d6 to see which one:}",
 													{
 														"type": "list",
@@ -9771,29 +9761,28 @@
 			"wis": 6,
 			"cha": 4,
 			"skill": {
-				"perception": "+2"
+				"perception": "+0"
 			},
 			"passive": 10,
 			"cr": "4",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The barroth makes two attacks. one headbutt and one stomp."
+						"The barroth makes two attacks: one headbutt and one stomp."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}11 ({@damage 2d6 + 4}) bludgeoning damage."
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}10 ({@damage 2d6 + 3}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "HeadButt",
 					"entries": [
-						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) bludgeoning damage."
+						"{@atk mw} {@hit 5} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d8 + 3}) bludgeoning damage."
 					]
 				},
 				{
@@ -9805,7 +9794,7 @@
 				{
 					"name": "Shake",
 					"entries": [
-						"While the barroth is covered in mud it may use its action shake chunks of mud free from its body landing in a 10-foot radius around him. Each creature in that area must make a {@dc 14} Dexterity saving throw or become {@condition restrained} by the mud. As an action, the {@condition restrained} target can make a {@dc 13} Strength check, bursting the mud on a success. The mud can also be attacked and destroyed (AC 10; hp 5)"
+						"While the barroth is covered in mud it may use its action to shake chunks of mud free from its body landing in a 10-foot radius around it. Each creature in that area must make a {@dc 14} Dexterity saving throw or become {@condition restrained} by the mud. As an action, the {@condition restrained} target can make a {@dc 13} Strength check, bursting the mud on a success. The mud can also be attacked and destroyed (AC 10; hp 5)"
 					]
 				}
 			],
@@ -9819,7 +9808,7 @@
 						"entries": [
 							"Barroth is a large, bipedal monster characteristic of the Brute Wyvern class. It is noted for the large crown structure atop its skull, which houses its nostrils. Its body is covered in rigid plates of armored hide that help protect it from the harsh desert environment. Barroth possesses a pair of small red eyes and a mouthful of long, peg-shaped teeth.",
 							"Barroth is capable of using its heavy head as a plow to smash through the environment, as well as cause damage to any living thing caught in its way. Because its nostrils are located on top of its head, Barroth can completely submerge itself in the cool mud during the scorching desert days.",
-							"It will occasionally roll in dirt and mud, possibly to cool off from the hot desert sun. Although docile by default, Barroth becomes extremely territorial when disturbed. It will release an initial warning roar. If that fails, it will continuously attack until the threat is exterminated. An insectivore, it is known to attack Altaroth nests in order to feast on the occupants inside.",
+							"It will occasionally roll in dirt and mud, possibly to cool off from the hot desert sun. Although docile by default, Barroth becomes extremely territorial when disturbed. It will release an initial warning roar. If that fails, it will continuously attack until the threat is exterminated. An insectivore, it is known to attack {@creature Altaroth|MHMM} nests in order to feast on the occupants inside.",
 							"Barroth is uniquely adapted to a desert lifestyle, and as such can almost exclusively be found in such regions, although it has been known to wander into the woods occasionally.",
 							{
 								"type": "inset",
@@ -10050,7 +10039,6 @@
 			"passive": 10,
 			"cr": "6",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Trampling Charge",
@@ -10366,7 +10354,6 @@
 			"passive": 11,
 			"cr": "17",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Explosive Scales",
@@ -10739,12 +10726,6 @@
 					]
 				},
 				{
-					"name": "Erupting Flames",
-					"entries": [
-						"When the behemoth makes a claw attack, flames erupt from the ground at the targets location. The target must make a {@dc 22} Dexterity saving throw, taking 27 ({@damage 5d10}) fire damage on a failed save."
-					]
-				},
-				{
 					"name": "Legendary Resistance (3/Day)",
 					"entries": [
 						"If the behemoth fails a saving throw, it can choose to succeed instead."
@@ -10773,7 +10754,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The behemoth makes three attacks, one with its horn and one with its tail and one with its claw."
+						"The behemoth makes three attacks: one with its horn, one with its tail, and one with its claw."
 					]
 				},
 				{
@@ -10785,7 +10766,7 @@
 				{
 					"name": "Claw",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 15 ft., one target. {@h}15 ({@damage 2d6 + 8}) slashing damage."
+						"{@atk mw} {@hit 16} to hit, reach 15 ft., one target. {@h}15 ({@damage 2d6 + 8}) slashing damage. On a hit or miss, flames erupt from the ground and the target must make a {@dc 22} Dexterity saving throw, taking 27 ({@damage 5d10}) fire damage on a failed save."
 					]
 				},
 				{
@@ -10816,9 +10797,9 @@
 				{
 					"name": "Ecliptic Meteor (1/day)",
 					"entries": [
-						"The behemoth summons an enormous magic circle in the sky. From it a massive 30-foot wide meteor begins to fall from the sky. At the beginning of the behemoth's next turn, even if it dies, the meteor hits the ground in the location the behemoth summoned it from. Each creature, besides the behemoth, within a 300-foot sphere of the meteor's impact point must make a {@dc 22} Dexterity saving throw. On a failed save, the creature takes 58 ({@damage 9d12}) fire damage and 65 ({@damage 10d12}) thunder damage and they are pushed 25 feet away from the meteor location. On a successful save the creature takes half damage and is not pushed back. ",
-						"A creature that has full cover from the meteor, takes no damage and it is not knocked back. ",
-						"All comets, tree, rocks, and smaller cover is destroyed with 300 feet of the meteor's impact."
+						"The behemoth summons an enormous magic circle in the sky. From it a massive 30-foot wide meteor begins to fall from the sky. At the beginning of the behemoth's next turn, even if it dies, the meteor hits the ground in the location the behemoth summoned it from. Each creature, besides the behemoth, within a 300-foot sphere of the meteor's impact point must make a {@dc 22} Dexterity saving throw. On a failed save, the creature takes 58 ({@damage 9d12}) fire damage and 65 ({@damage 10d12}) thunder damage and they are pushed 25 feet away from the meteor location. On a successful save the creature takes half damage and is not pushed back.",
+						"A creature that has full cover from the meteor, takes no damage and it is not knocked back.",
+						"All comets, tree, rocks, and smaller cover are destroyed with 300 feet of the meteor's impact."
 					]
 				}
 			],
@@ -10965,7 +10946,7 @@
 										"type": "entries",
 										"name": "Behemoth Tail",
 										"entries": [
-											"You have immunity to lightning damage and you cannot be {@condition paralyzed} while you wear this armor."
+											"You are immune to lightning damage and you cannot be {@condition paralyzed} while you wear this armor."
 										]
 									},
 									{
@@ -10979,7 +10960,7 @@
 										"type": "entries",
 										"name": "Aetheryte Shard",
 										"entries": [
-											"As a bonus action, you can utter a vow of enmity against a creature you can see within 10 feet of you. You gain advantage on attack rolls against the creature and disadvantage on attack rolls against other creatures for 1 minute, until it drops to 0 hit points, or falls {@condition unconscious}."
+											"As a bonus action, you can utter a vow of enmity against a creature you can see within 10 feet of you. You gain advantage on attack rolls against the creature and disadvantage on attack rolls against other creatures for 1 minute, until it drops to 0 hit points, or falls {@condition unconscious}. Once used, you can't use this property again until you finish a long rest."
 										]
 									}
 								]
@@ -11021,7 +11002,7 @@
 										"type": "entries",
 										"name": "Behemoth Great Horn",
 										"entries": [
-											"{@i (Insect Glaive) Dragon Soul.} Your kinsect takes on the characteristics of a dragon and your kinsect attacks deal an extra 1d12 bludgeoning damage."
+											"{@i (Insect Glaive) Dragon Soul.} Your kinsect takes on the characteristics of a dragon and your kinsect attacks deal an extra {@damage 1d12} bludgeoning damage."
 										]
 									},
 									{
@@ -11454,9 +11435,6 @@
 				"acrobatics": "+5",
 				"perception": "+5"
 			},
-			"immune": [
-				"necrotic"
-			],
 			"trait": [
 				{
 					"name": "Belly Pouch",
@@ -11886,7 +11864,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vaal hazak regains 30 hit points at the start of its turn if it has at least 1 hit point. If the vaal hazak takes radiant damage or damage from holy water, this trait doesn't function at the start of the vaal hazak's next turn."
+						"The vaal hazak regains 30 hit points at the start of its turn if it has at least 1 hit point. If the vaal hazak takes radiant damage or damage from {@item holy water (flask)|PHB|holy water}, this trait doesn't function at the start of the vaal hazak's next turn."
 					]
 				}
 			],
@@ -11930,7 +11908,7 @@
 					"name": "Effluvium Burst {@recharge}",
 					"entries": [
 						"The vaal hazak lets out an ear shattering roar causing effluvium spores to erupt from its body in a 300-foot radius around that remains until the start of the vaal hazak's next turn. Each creature that starts its turn in that area, or enters it for the first time must make a {@dc 21} Constitution saving throw or become cursed for 1 minute. A creature that succeeds on its saving throw, is immune to this effect for 24 hours.",
-						"While cursed in this way, the target must make a {@dc 21} Wisdom saving throw at the start of each of its turns. If it fails, it wastes its action that turn doing nothing.",
+						"While cursed in this way, the target must make a {@dc 21} Wisdom saving throw at the start of each of its turns. On a failed save, it is {@condition incapacitated} until the start of its next turn.",
 						"When the efflivium disperses at the start of the vaal hazak's next turn, all destroyed spore pods regrow on the vaal hazak and ten spore clouds remain in the area that are at least 20 feet apart from each other."
 					]
 				}
@@ -11938,8 +11916,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"AOE",
-				"HPR"
+				"AOE"
 			],
 			"actionTags": [
 				"Multiattack"
@@ -12251,7 +12228,6 @@
 			"passive": 13,
 			"cr": "1/2",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
@@ -12443,6 +12419,12 @@
 				"athletics": "+8",
 				"perception": "+3"
 			},
+			"senses": [
+				"tremorsense 60 ft."
+			],
+			"senseTags": [
+				"T"
+			],
 			"resist": [
 				"cold"
 			],
@@ -12461,7 +12443,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The blangonga makes three fist attacks. It can use Ice Boulder in place of any melee attack."
+						"The blangonga makes three fist attacks. It can use its ice boulder in place of any melee attack."
 					]
 				},
 				{
@@ -12473,7 +12455,7 @@
 				{
 					"name": "Ice Boulder",
 					"entries": [
-						"{@atk rw} {@hit 7} to hit, reach 30/120 ft., one target. {@h}4 ({@damage 1d8}) bludgeoning damage plus 4 ({@damage 1d8}) cold damage."
+						"{@atk rw} {@hit 8} to hit, reach 30/120 ft., one target. {@h}4 ({@damage 1d8}) bludgeoning damage plus 4 ({@damage 1d8}) cold damage."
 					]
 				},
 				{
@@ -12692,6 +12674,315 @@
 			]
 		},
 		{
+			"name": "Blood Soaked Arzuros",
+			"size": [
+				"L"
+			],
+			"type": {
+				"type": "beast",
+				"tags": [
+					"fanged"
+				]
+			},
+			"group": [
+				"Fanged Beasts"
+			],
+			"environment": [
+				"arctic",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 14,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 150,
+				"formula": "20d10 + 40"
+			},
+			"speed": {
+				"walk": 35
+			},
+			"str": 18,
+			"dex": 12,
+			"con": 14,
+			"int": 8,
+			"wis": 8,
+			"cha": 8,
+			"save": {
+				"str": "+6",
+				"wis": "+3"
+			},
+			"skill": {
+				"athletics": "+6",
+				"perception": "+3"
+			},
+			"passive": 13,
+			"cr": "11",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Aggressive",
+					"entries": [
+						"As a bonus action, the arzuros can move up to its speed toward a hostile creature that it can see."
+					]
+				},
+				{
+					"name": "Blood Armor",
+					"entries": [
+						"Whenever the arzuros deals damage to a creature that isn't an undead or a construct, it gains a +2 bonus to its AC until the end of its next turn."
+					]
+				},
+				{
+					"name": "Blood Frenzy",
+					"entries": [
+						"The arzuros has advantage on melee attack rolls against any creature that doesn't have all its hit points."
+					]
+				},
+				{
+					"name": "Keen Smell",
+					"entries": [
+						"The arzuros has advantage on Wisdom ({@skill Perception}) checks that rely on smell."
+					]
+				},
+				{
+					"name": "Seeing Red",
+					"entries": [
+						"The arzuros has resistance to bludgeoning, piercing, and slashing damage when it can see a creature that doesn't have all its hit points, isn't an undead or a construct, and is still conscious."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The arzuros makes three melee attacks: one with its bite, one with its claw, and one with its body slam."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}13 ({@damage 2d8 + 4}) piercing damage."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}11 ({@damage 2d6 + 4}) slashing damage."
+					]
+				},
+				{
+					"name": "Body Slam",
+					"entries": [
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}15 ({@damage 2d10 + 4}) bludgeoning damage."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Move",
+					"entries": [
+						"The arzuros moves up to its speed without provoking opportunity attacks."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"The arzuros makes one claw attack."
+					]
+				},
+				{
+					"name": "Roar (Costs 2 Actions)",
+					"entries": [
+						"The arzuros roars at the top of its lungs. Each creature that is within 10 feet of the arzuros must succeed on a {@dc 14} Constitution saving throw or be pushed 5 feet away from the azuros and knocked {@condition prone}. If the saving throw fails by 5 or more, the target is also {@condition incapacitated} until the end of its next turn."
+					]
+				}
+			],
+			"traitTags": [
+				"Aggressive",
+				"Keen Senses"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"{@creature Arzuros|MHMM} is noted for its turquoise colored fur and ursine body structure. It has a ridge of erect hair aligned with its nose. Its back is made of a tough hide, somewhat characteristic of a carapace. Hair runs from its cheeks, connecting to its back, where it forms a trim along the sides of the back. The claws of an Arzuros have elongated, red nails. Each claw has a tough brace encasing and protecting the wrist and forearm. Arzuros has large, bulky legs connected to much smaller feet and a short, wide tail.",
+							"Arzuros is armed with two vicious claws which it uses for most of its attacks. It can use its large body and surprising agility for charge attacks and pinning down prey.",
+							"Arzuros are omnivorous creatures that enjoy feasting on fish and honey. When eating honey, Arzuros pays little to no attention to its surroundings. When threatened by other large monsters, Arzuros will try to use its size and claws to frighten the monster, or will use its agility to escape. Arzuros often hangs its tongue out of its mouth.",
+							{
+								"type": "inset",
+								"name": "Blood Soaked Arzuros",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"11",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-6",
+												"1-5",
+												"Blood Honey x2",
+												"(O)"
+											],
+											[
+												"7-14",
+												"6-7",
+												"Bloodsoaked Pelt",
+												"(A,W)"
+											],
+											[
+												"15-17",
+												"8-13",
+												"Bloodsoaked Shell",
+												"(A)"
+											],
+											[
+												"18",
+												"14-17",
+												"Azure Jumbo Bone",
+												"(W,O)"
+											],
+											[
+												"19-20",
+												"18-20",
+												"Bloodsoaked Allbrace",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Pelt",
+												"entries": [
+													"{@i Honey Hunter+.} When you use an {@item herbalism kit|PHB|herbalist kit} to gather {@table plants|AGMH}, you gather 1 {@table insects|AGMH|honey} with it. The honey has a 50% chance to be blood honey."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Shell",
+												"entries": [
+													"While wearing this armor, you have advantage on Wisdom ({@skill Perception}) checks that rely on smell."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Allbrace",
+												"entries": [
+													"While you are wearing this armor, you can use your action to gain resistance to bludgeoning damage for 1 minute. Once you use this property, you cannot use it again until you finish a long rest."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Pelt",
+												"entries": [
+													"While you are attuned to this weapon, you can use this weapon as your spellcasting focus."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Jumbo Bone",
+												"entries": [
+													"Your bludgeoning weapon deals an extra {@damage 1d6} bludgeoning damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Allbrace",
+												"entries": [
+													"You are proficient in unarmed strikes while you are attuned to this weapon. Additionally, your unarmed strikes deal slashing damage instead of bludgeoning damage and you can use a d8 in place of the normal weapon damage dice with unarmed strikes."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Honey",
+												"entries": [
+													"You can add this to a potion, increasing the amount it heals by {@damage 2d4} and curing one disease afflicting the drinker. ({@item alchemist's supplies|PHB|Alchemy} {@dc 12}) You cannot add more than one blood honey to a potion."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Bloodsoaked Jumbo Bone",
+												"entries": [
+													"Very rare armor or weapon upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/s2ubUGU.png",
+			"damageTags": [
+				"P",
+				"S",
+				"B"
+			]
+		},
+		{
 			"name": "Blue Yian Kut-ku",
 			"size": [
 				"L"
@@ -12777,7 +13068,7 @@
 				{
 					"name": "Sensitive Ears",
 					"entries": [
-						"If the blue yian kut-ku takes thunder damage or a thunder spell is used within 60 feet of it, it is {@condition stunned} until the start of its next turn."
+						"If the blue yian kut-ku takes thunder damage or a thunder spell is used within 60 feet of it, it must succeed on a {@dc 15} Constitution saving throw or become {@condition stunned} until the start of its next turn."
 					]
 				}
 			],
@@ -12831,7 +13122,8 @@
 			],
 			"fluff": {
 				"entries": [
-					"Typically smaller than their normal pink counterparts, the blue yian kut-ku is stronger and more aggressive. They are covered in an indigo carapace, and blue streaks can be found on its beak and ears.",
+					"Although they are usually smaller than their pink counterparts, the blue yian kut-ku are stronger and more aggressive. They are covered in an indigo carapace, and blue streaks can be found on its beak and ears. Although the Blue Yian Kut-Ku are stronger than the normal variation, they are still pretty low in the food chain. Though still weak, Blue Yian Kut-Ku are known to occasionally scare away {@creature Yian Kut-Ku|MHMM}. When not being preyed upon by large predators, Blue Yian Kut-Ku feed on insects, honey, and nuts.",
+					"Blue Yian Kut-Ku are very cautious and wary creatures that are easily startled by sudden loud noises. When undisturbed, these monsters spend their day foraging for food, but if confronted they will flare out their ears and spread their wings while making loud shrieks.",
 					{
 						"type": "inset",
 						"name": "Blue Yian Kut-ku",
@@ -12895,7 +13187,7 @@
 									[
 										"--",
 										"11-14",
-										"Monsterbone+",
+										"Monster Bone+",
 										"(O)"
 									],
 									[
@@ -13032,7 +13324,7 @@
 								"items": [
 									{
 										"type": "entries",
-										"name": "Monsterbone+",
+										"name": "Monster Bone+",
 										"entries": [
 											"Rare armor upgrade material."
 										]
@@ -13101,7 +13393,6 @@
 			"passive": 11,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Flyby",
@@ -13240,8 +13531,7 @@
 				"P"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			]
 		},
 		{
@@ -13743,12 +14033,11 @@
 			"passive": 9,
 			"cr": "17",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The brachydios makes three attacks, one with its horn and two with its fist."
+						"The brachydios makes three attacks: one with its horn and two with its fist."
 					]
 				},
 				{
@@ -13945,7 +14234,7 @@
 												"type": "entries",
 												"name": "Brach Gem",
 												"entries": [
-													"You have immunity to fire damage while you wear this armor."
+													"You are immune to fire damage while you wear this armor."
 												]
 											}
 										]
@@ -14352,7 +14641,7 @@
 										"type": "entries",
 										"name": "Brute Tigrex Shard",
 										"entries": [
-											"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+											"{@i Weakness Exploit.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a long rest."
 										]
 									},
 									{
@@ -14620,7 +14909,7 @@
 										"type": "entries",
 										"name": "Bulldrome Tusk",
 										"entries": [
-											"Your slashing weapon deals an extra 1 slashing damage."
+											"Your slashing weapon deals an extra 2 slashing damage."
 										]
 									},
 									{
@@ -14721,7 +15010,6 @@
 			"passive": 9,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Charge",
@@ -14779,7 +15067,6 @@
 										"type": "table",
 										"colLabels": [
 											"Carve Chance",
-											"Capture Chance",
 											"Material",
 											"Slots"
 										],
@@ -14801,7 +15088,7 @@
 											],
 											[
 												"14-18",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -14853,7 +15140,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -14875,6 +15162,191 @@
 			],
 			"conditionInflict": [
 				"prone"
+			]
+		},
+		{
+			"name": "Bullfango Shoat",
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "beast",
+				"tags": [
+					"fanged"
+				]
+			},
+			"group": [
+				"Fanged Beasts"
+			],
+			"environment": [
+				"arctic",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"swamp",
+				"underdark",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 9,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 7,
+				"formula": "2d6"
+			},
+			"speed": {
+				"walk": 20
+			},
+			"str": 8,
+			"dex": 8,
+			"con": 10,
+			"int": 1,
+			"wis": 9,
+			"cha": 10,
+			"passive": 9,
+			"cr": "0",
+			"page": 0,
+			"action": [
+				{
+					"name": "Headbutt",
+					"entries": [
+						"{@atk mw} {@hit 1} to hit, reach 5 ft., one target. {@h}1 ({@damage 1d4 - 1}) bludgeoning damage."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Although veteran adventurers can generally take a {@creature bullfango|MHMM} out easily, they can be dangerous for beginners and may even pose a threat to more experienced adventurers when several attack at once. {@creature Bulldrome|MHMM}s on the other hand have larger tusks than Bullfango, and a layer of white fur, as opposed to Bullfango's black fur. Bulldromes are more agile when running and proficient at finding and locking onto their victims. These Fanged Beasts are sometimes found in packs and will charge at all intruders once noticed. They are very territorial, and can be a considerable nuisance.",
+							{
+								"type": "inset",
+								"name": "Bullfango Shoat",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"0",
+												"Carves",
+												"1"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-8",
+												"Raw Meat",
+												"(O)"
+											],
+											[
+												"9-13",
+												"Shoat Pelt",
+												"(A)"
+											],
+											[
+												"14-18",
+												"Shoat Head",
+												"(O)"
+											],
+											[
+												"19-20",
+												"Sm Monster Bone",
+												"(W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Shoat Pelt",
+												"entries": [
+													"You have a +1 bonus to {@skill Persuasion} checks while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Shoat Head",
+												"entries": [
+													"{@i Forager.} When you harvest {@table mushrooms|AGMH}, you instead gather two."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Raw Meat",
+												"entries": [
+													"Provides 2 days rations when cooked."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Sm Monster Bone",
+												"entries": [
+													"Uncommon weapon upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/y2x5EIi.png",
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MW"
 			]
 		},
 		{
@@ -15011,7 +15483,7 @@
 				{
 					"name": "Hydropump {@recharge 5}",
 					"entries": [
-						"The ceadeus releases a high pressure stream of water in an 120-foot line that is 10 feet wide. Each creature in that line must make a {@dc 17} Dexterity saving throw, taking 72 ({@damage 9d10}) cold damage on a failed save, or half as much damage and not on a successful one."
+						"The ceadeus releases a high pressure stream of water in an 120-foot line that is 10 feet wide. Each creature in that line must make a {@dc 17} Dexterity saving throw, taking 72 ({@damage 16d8}) cold damage on a failed save, or half as much damage and not on a successful one."
 					]
 				}
 			],
@@ -15019,7 +15491,7 @@
 				{
 					"name": "Detect",
 					"entries": [
-						"The ceadeus makes a Wisdom (Perception) check."
+						"The ceadeus makes a Wisdom ({@skill Perception}) check."
 					]
 				},
 				{
@@ -15054,8 +15526,9 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Ceadeus are giant sea dwelling Elder Dragons that have only been recently discovered. Older Ceadeus individuals are called Goldbeard Ceadeus. It is said that Ceadeus and Jhen Mohran share the same common ancestor.",
-							"Ceadeus is up to 5837.2cm in length. Ceadeus has a special relationship with an algae, which is the reason why it has its beard. It farms for the algae with its beard and uses the glow from the luminous bacteria as a form of photosynthesis. With this algae, Ceadeus can spend longer times under the depths without having to come up for air. When it needs air, it will swim up with a burst of speed and jump out of the water for a breath. It is estimated a Ceadeus can hold its breath for about several months. Ceadeus has powerful fins and a tail fin designed for swimming in the sea with both power and grace. The horns of a Ceadeus never stop growing, and at times, the Elder Dragon will grind them against the sea floor, with enough force to produce earthquakes and tsunamis. It is believed that this behavior resulted in the destruction of an island on at least one occasion. Throughout their years, Ceadeus are able to use an organ called the Luminous Organ. This organ is used to help farm the algae it uses to breath. The luminous bacteria on its body reacts to the organ by reflecting the light.",
+							"Ceadeus are giant sea dwelling Elder Dragons that have only been recently discovered. Older Ceadeus individuals are called Goldbeard Ceadeus. It is said that Ceadeus and {@creature Jhen Mohran|MHMM} share the same common ancestor. Ceadeus is up to 5837.2cm in length. Ceadeus has a special relationship with an algae, which is the reason why it has its beard. It farms for the algae with its beard and uses the glow from the luminous bacteria as a form of photosynthesis.",
+							"With this algae, Ceadeus can spend longer times under the depths without having to come up for air. When it needs air, it will swim up with a burst of speed and jump out of the water for a breath. It is estimated a Ceadeus can hold its breath for about several months. Ceadeus has powerful fins and a tail fin designed for swimming in the sea with both power and grace. The horns of a Ceadeus never stop growing, and at times, the Elder Dragon will grind them against the sea floor, with enough force to produce earthquakes and tsunamis.", 
+							"It is believed that this behavior resulted in the destruction of an island on at least one occasion. Throughout their years, Ceadeus are able to use an organ called the Luminous Organ. This organ is used to help farm the algae it uses to breath. The luminous bacteria on its body reacts to the organ by reflecting the light.",
 							"The Ceadeus is known to be a rather peaceful creature until provoked. It won't take notice of adventurers until it is greatly damaged by them. If Ceadeus is provoked, it'll try to kill its enemy with its immense strength.",
 							{
 								"type": "inset",
@@ -15187,14 +15660,14 @@
 												"type": "entries",
 												"name": "Ceadeus Scale",
 												"entries": [
-													"{@i Partbreaker +4.} You deal an extra 1d12 damage when you critically hit with this weapon."
+													"{@i Partbreaker +4.} You deal an extra {@damage 1d12} damage when you critically hit with this weapon."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Ceadeus Hide",
 												"entries": [
-													"Your weapon deals an extra 1d10 cold damage."
+													"Your weapon deals an extra {@damage 1d10} cold damage."
 												]
 											},
 											{
@@ -15297,6 +15770,12 @@
 			],
 			"trait": [
 				{
+					"name": "Amphibious",
+					"entries": [
+						"The ceanataur can breathe air and water."
+					]
+				},
+				{
 					"name": "Scuttle",
 					"entries": [
 						"As a bonus action, the ceanataur can moves up to its half speed in a straight line."
@@ -15307,19 +15786,22 @@
 				{
 					"name": "Claws",
 					"entries": [
-						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a {@dc 10} Constitution saving throw or lose 2 ({@dice 1d4}) hit points at the start of each of its turns due to an bloody wound. Each time the ceanataur hits the wounded target with this attack, the damage dealt by the wound increases by 2 ({@dice 1d4}). Any creature can take an action to stanch the wound with a successful {@dc 10} Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}6 ({@damage 1d8 + 2}) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a {@dc 10} Constitution saving throw or lose 2 ({@dice 1d4}) hit points at the start of each of its turns due to an bloody wound. Each time the ceanataur hits the wounded target with this attack, the damage dealt by the wound increases by 2 ({@dice 1d4}). Any creature can take an action to stanch the wound with a successful {@dc 10} Wisdom ({@skill Medicine}) check. The wound also closes if the target receives magical healing."
 					]
 				},
 				{
 					"name": "Poison Spit",
 					"entries": [
-						"{@atk rw} {@hit 4} to hit, reach 30/120 ft., one target. {@h}5 ({@damage 2d4}) poison damage. On a hit, the target must make a {@dc 10} Constitution saving throw or become {@condition poisoned}. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"{@atk rw} {@hit 4} to hit, reach 30/120 ft., one target. {@h}5 ({@damage 2d4}) poison damage. On a hit, the target must make a {@dc 10} Constitution saving throw or become {@condition poisoned} until cured. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
 			"senseTags": [
 				"D",
 				"T"
+			],
+			"traitTags": [
+				"Amphibious"
 			],
 			"fluff": {
 				"entries": [
@@ -15371,7 +15853,7 @@
 											],
 											[
 												"10-14",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -15416,7 +15898,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -15435,8 +15917,7 @@
 				"I"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			],
 			"conditionInflict": [
 				"poisoned"
@@ -15491,7 +15972,6 @@
 			"passive": 11,
 			"cr": "7",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Sensitive Ears",
@@ -15696,8 +16176,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"RW"
+				"RCH"
 			]
 		},
 		{
@@ -15749,7 +16228,6 @@
 			"passive": 11,
 			"cr": "2",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Sensitive Ears",
@@ -15912,8 +16390,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"RW"
+				"RCH"
 			]
 		},
 		{
@@ -15994,7 +16471,7 @@
 				{
 					"name": "Elder Sight",
 					"entries": [
-						"Magical Darkness doesn't impede the chameleos's darkvision."
+						"Magical Darkness doesn't impede the chameleos's {@sense darkvision}."
 					]
 				},
 				{
@@ -16006,7 +16483,7 @@
 				{
 					"name": "Chameleon Skin",
 					"entries": [
-						"The chameleos has advantage on Dexterity (Stealth) checks made to hide."
+						"The chameleos has advantage on Dexterity ({@skill Stealth}) checks made to hide."
 					]
 				},
 				{
@@ -16020,7 +16497,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The chameleos makes three attacks. two with its horn and one with its tongue lash attack. It can replace any of these attacks with a poison spit attack."
+						"The chameleos makes three attacks: two with its horn and one with its tongue lash attack. It can replace any of these attacks with a poison spit attack."
 					]
 				},
 				{
@@ -16297,7 +16774,7 @@
 						"type": "entries",
 						"name": "A Chameleos's Lair",
 						"entries": [
-							"The Forest-Dwelling Chameleos very rarely share their territory with other dragons. With its ability to become invisible at will, it steals the treasures from anything that attempts to invade and take over. A chameleos lair is sometimes confused with the a green dragon's lair due to both of them having a perpetual fog hanging in the air, the chameleos carrying a sweeter whiff of its poison mist. Tiny mushrooms, known has toadstool, litter the ground releasing poisonous spores at the slightest touch. Growing bigger as you deeper into the forest.",
+							"The Forest-Dwelling Chameleos very rarely share their territory with other dragons. With its ability to become invisible at will, it steals the treasures from anything that attempts to invade and take over. A chameleos lair is sometimes confused with a green dragon's lair due to both of them having a perpetual fog hanging in the air, the chameleos carrying a sweeter whiff of its poison mist. Tiny mushrooms, known has toadstool, litter the ground releasing poisonous spores at the slightest touch. Growing bigger as you deeper into the forest.",
 							"At the center of the forest, the chameleos chooses a grove typically covered in mushrooms. The tree lining the grove are sparse, allowing the chameleos to move freely in and out. A hole has been dug out in the middle and has been filled with the treasures the chameleos has gathered from lost folk, adventurers, and anything else it has stolen in its travels."
 						]
 					}
@@ -16316,8 +16793,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"AOE",
-				"RW"
+				"AOE"
 			],
 			"traitTags": [
 				"Legendary Resistances"
@@ -16376,7 +16852,6 @@
 			"passive": 13,
 			"cr": "1/2",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
@@ -16393,7 +16868,7 @@
 				{
 					"name": "Fart",
 					"entries": [
-						"The Conga release a noxious odor from its behind at a target within 5 feet of it. The target must make a {@dc 13} Constitution saving throw or have disadvantage on all Concentration checks for 1 minute."
+						"The conga release a noxious odor from its behind at a target within 5 feet of it. The target must make a {@dc 13} Constitution saving throw or have disadvantage on Constitution saving throws to maintain concentration for 1 minute."
 					]
 				}
 			],
@@ -16576,7 +17051,7 @@
 				{
 					"name": "Mushroom Eater",
 					"entries": [
-						"All congalala love to eat mushrooms, so much so that they always carry one around their tail. Roll {@dice 1d6}, the number determines the element of the mushroom the congalala has with it. 1=fire; 2=poison; 3=lightning; 4=cold; 5=acid; 6=necrotic."
+						"All congalala love to eat mushrooms, so much so that they always carry one around their tail. Roll {@dice 1d6}, the number determines the element of the mushroom the congalala has with it. On a 1, fire; On a 2, poison; On a 3, lightning; On a 4, cold; On a 5, acid; On a 6, necrotic."
 					]
 				}
 			],
@@ -16764,7 +17239,7 @@
 												"type": "entries",
 												"name": "Brute Bone",
 												"entries": [
-													"Your weapon deals an extra 1d4 bludgeoning damage."
+													"Your weapon deals an extra {@damage 1d4} bludgeoning damage."
 												]
 											},
 											{
@@ -16917,13 +17392,13 @@
 					]
 				},
 				{
-					"name": "Arc Water Jet (Costs 2 Actions)",
+					"name": "Water Jet - Arc (Costs 2 Actions)",
 					"entries": [
 						"The pukei-pukei discharges a beam of high pressurized water from its mouth or tail in a 30-foot cone. Each creature in that area must make a {@dc 15} Dexterity saving throw, taking 21 ({@damage 6d6}) cold damage on a failed save, or half as much damage on a successful one. "
 					]
 				},
 				{
-					"name": "Line Water Jet (Costs 2 Actions)",
+					"name": "Water Jet - Line (Costs 2 Actions)",
 					"entries": [
 						"The pukei-pukei discharges a beam of high pressurized water from its mouth or tail in a 60-foot line that is 10 feet wide. Each creature in a line must make a {@dc 15} Dexterity saving throw, taking 21 ({@damage 6d6}) cold damage on a failed save, or half as much damage on a successful one."
 					]
@@ -16931,7 +17406,7 @@
 			],
 			"fluff": {
 				"entries": [
-					"Coral Pukei-Pukei retains most of its characteristics from Pukei-Pukei. ",
+					"Coral Pukei-Pukei retains most of its characteristics from {@creature Pukei-Pukei|MHMM}.",
 					"However, Coral Pukei-Pukei sports bright orange coloring on its face, feet, and front wing claws. These turn red when it becomes enraged. The rest of its body has a pinkish-red tint to it while its underbelly and tail tip are violet. ",
 					"While the Pukei-Pukei utilizes poison, the Coral Pukei-Pukei uses water as its main element of attack. Coral Pukei-Pukei is able to store high concentrations of water in its tail by drinking the sponge-like plants that lie in the Coral Highlands. By doing this, it is then able to shoot out jets of high pressurized water beams at hunters. It is also capable of doing this from its mouth by eating various plants. In addition to this, it can also throw out globs of water balls at hunters from its mouth. Unlike Pukei-Pukei, Coral Pukei-Pukei is more aggressive with its attacks. It is also shown to be able to use its tail far more effectively than Pukei-Pukei when attacking hunters. ",
 					{
@@ -17128,6 +17603,406 @@
 			]
 		},
 		{
+			"name": "Crimson Glow Valstrax",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Elder Dragons"
+			],
+			"environment": [
+				"arctic",
+				"coastal",
+				"desert",
+				"forest",
+				"mountain",
+				"swamp"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 20,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 264,
+				"formula": "23d12 + 115"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 180
+			},
+			"str": 22,
+			"dex": 16,
+			"con": 21,
+			"int": 16,
+			"wis": 10,
+			"cha": 10,
+			"save": {
+				"dex": "+10",
+				"con": "+12",
+				"cha": "+7"
+			},
+			"skill": {
+				"acrobatics": "+10",
+				"perception": "+14"
+			},
+			"passive": 20,
+			"immune": [
+				"necrotic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Draconic"
+			],
+			"cr": "22",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Blight Resistance",
+					"entries": [
+						"The valstrax has advantage on saving throws against blight effects such as fireblight, {@condition waterblight|MHMM}, or the {@spell blight} spell."
+					]
+				},
+				{
+					"name": "Dive Attack",
+					"entries": [
+						"If the valstrax is flying and dives at least 120 feet straight toward a target and then hits it with a melee weapon attack, the attack deals an extra 36 ({@damage 8d8}) necrotic damage to the target."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the valstrax fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "The Red Comet",
+					"entries": [
+						"The valstrax doesn't provoke opportunity attacks when it takes the {@action Dash} action."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The valstrax makes two bite attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}15 ({@damage 2d8 + 6}) piercing damage."
+					]
+				},
+				{
+					"name": "Wing",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 15 ft., one target. {@h}24 ({@damage 4d8 + 6}) piercing damage. If the target is a creature, it must succeed on a {@dc 20} Constitution saving throw or be afflicted with {@condition dragonblight|MHMM} for 1 minute. A creature can repeat its saving throw at the end of its turn, ending the dragonblight on a success."
+					]
+				},
+				{
+					"name": "Crimson Salvo",
+					"entries": [
+						"The valstrax fires six draconic energy balls at a target within 60 feet of it. That target must make a {@dc 20} Dexterity saving throw, taking 27 ({@damage 6d8}) necrotic and be afflicted with {@condition dragonblight|MHMM} for 1 minute on a failed save or half as much damage and isn't afflicted with dragonblight on a successful one. If the creature was on the ground, the energy remains in a 15-foot squared area centered on a point where the target was standing when the attack was made. At the start of the valstrax next turn each creature in that area takes 9 ({@damage 2d8}) necrotic damage. A creature can make a {@dc 20} Constitution saving throw at the end of its turn, ending the dragonblight on a success."
+					]
+				},
+				{
+					"name": "Crimson Beam {@recharge 5}",
+					"entries": [
+						"The valstrax ppositions its wings in front of it to release accumulated draconic energy in a 120-foot line that is 10-feet wide. Each creature in that line must make a {@dc 20} Dexterity saving throw, taking 70 ({@damage 20d6}) necrotic damage and be afflicted with {@condition dragonblight|MHMM} for 1 minute on a failed save or half as much damage and isn't afflicted with dragonblight on a successful one. A creature can make a {@dc 20} Constitution saving throw at the end of its turn, ending the dragonblight on a success."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Detect",
+					"entries": [
+						"The valstrax makes a Wisdom ({@skill Perception}) Check."
+					]
+				},
+				{
+					"name": "Attack",
+					"entries": [
+						"The valstrax makes a wing attack."
+					]
+				},
+				{
+					"name": "Rocket Dash (Costs 2 Actions)",
+					"entries": [
+						"The valstrax moves up to half its fly speed in a straight line, during this move it can move through other creatures without provoking attacks of opportunity. Any creatures the valstrax moves through must succeed on a {@dc 20} Dexterity saving throw or take 24 ({@damage 4d8 + 6}) slashing damage plus 9 ({@damage 2d8}) necrotic damage and are knocked {@condition prone} on a failed save. On a successful save, the target takes half damage and is not knocked prone."
+					]
+				},
+				{
+					"name": "Ground Zero Burst (Costs 2 Actions)",
+					"entries": [
+						"The valstrax releases draconic energy in a 15-foot radius around it. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 31 ({@damage 7d8}) necrotic damage and be afflicted with {@condition dragonblight|MHMM} for 1 minute on a failed save or half as much damage and isn't afflicted with dragonblight on a successful one. A creature can make a {@dc 20} Constitution saving throw at the end of its turn, ending the dragonblight on a success."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"fluff": {
+				"entries": [
+					"Due to the rampant dragon energy, Crimson Glow Valstrax has permanent glowing red marks connecting from the chest to the wings, showing up on the sides and wing-arms. The wings have a different design than a normal {@creature Valstrax|MHMM}'s wings, looking more like exhaust vents, and are covered in glowing red color similar to a normal enraged Valstrax. When inhaling air, the wings will glow a bright red and start spewing out dragon energy. When angered significantly, the energy starts to burst out in the form of large energy spikes on its head, and the whole torso glows red in color, with large amounts of dragon flame coming out of the chest and sides.",
+					{
+						"type": "inset",
+						"name": "Crimson Glow Valstrax",
+						"entries": [
+							{
+								"type": "table",
+								"colStyles": [
+									"col-1 bold",
+									"col-1",
+									"col-2 bold text-right",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"Challenge Rating",
+										"22",
+										"Carves/Capture",
+										"4"
+									]
+								]
+							},
+							{
+								"type": "table",
+								"colLabels": [
+									"Carve Chance",
+									"Material",
+									"Slots"
+								],
+								"colStyles": [
+									"col-1 text-center",
+									"col-2 text-center",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"1-2",
+										"Elder Dragon Blood",
+										"(O)"
+									],
+									[
+										"3-4",
+										"Elder Dragon Bone",
+										"(O)"
+									],
+									[
+										"5-7",
+										"Gleaming Shell",
+										"(A,W)"
+									],
+									[
+										"8-9",
+										"Shimmering Scale",
+										"(A,W)"
+									],
+									[
+										"10-12",
+										"CG.Valstrax Claw",
+										"(A,W)"
+									],
+									[
+										"13-15",
+										"Rouge Spikewing",
+										"(A,W)"
+									],
+									[
+										"16-17",
+										"Crimson Liquid",
+										"(A,W)"
+									],
+									[
+										"18-19",
+										"Valstrax Spineshell",
+										"(A,W)"
+									],
+									[
+										"20",
+										"Red Serpent Orb",
+										"(A,W)"
+									]
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "ARMOR MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Gleaming Shell",
+										"entries": [
+											"{@i Resuscitate.} You have advantage on Dexterity saving throws if you are suffering from a condition."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Shimmering Scale",
+										"entries": [
+											"{@i Survivor+.} When an ally, that you can see, is reduced to 0 hit points you can use your reaction to gain +2 AC, +2 damage, and +2 to attack rolls for 1 minute. Once used, this property can't be used again until the next dawn."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "CG.Valstrax Claw",
+										"entries": [
+											"While wearing this armor, difficult terrain doesn't cost you extra movement. In addition, magic can neither reduce your speed nor cause you to be {@condition paralyzed} or {@condition restrained}."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Rouge Spikewing",
+										"entries": [
+											"While wearing this armor you can use an action to speak its command word. This causes a pair of metallic dragon wings to appear on your back for 1 hour or until you repeat the command word as an action. The wings give you a flying speed of 90 feet. When they disappear, you can't use them again for 1d12 hours."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Crimson Liquid",
+										"entries": [
+											"{@i Blightproof.} While wearing this armor you are immune to blight spells, spell like abilities, and conditions."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Valstrax Spineshell",
+										"entries": [
+											"{@i Dragonheart.} When you fall below half of your maximum hit points you gain the {@condition dragonblight|MHMM} condition for 1 minute. While affected by dragonblight, you have resistance to cold, fire, lightning, and necrotic damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Ruby Dragon Mindstone",
+										"entries": [
+											"{@i Defense Boost (Necrotic).} While wearing this armor, you gain a +1 bonus to your AC, and you are immune to necrotic damage."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "WEAPON MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Gleaming Shell",
+										"entries": [
+											"{@i (spellcaster only)} This weapon has 7 runes. While holding it, you can use an action to expend 1 or more of its runes to cast the {@spell scorching ray} spell from it using your spell attack bonus, and it deals necrotic damage instead of fire. For 1 rune, you cast the 2nd-level version of the spell. You can increase the spell slot level by one for each additional rune you expend."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Shimmering Scale",
+										"entries": [
+											"{@i Resentment.} Until the end of your turn, you gain a +1 bonus to attack and damage rolls against any creature that has damaged you since the end of your last turn."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "CG.Valstrax Claw",
+										"entries": [
+											"{@i Elderseal.} A creature hit by this weapon cannot use an action that has a recharge until the start of your next turn. The creature can still roll to recharge its ability at the end of its turn."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Rouge Spikewing",
+										"entries": [
+											"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Crimson Liquid",
+										"entries": [
+											"Your weapon deals an extra {@damage 1d10} necrotic damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Valstrax Spineshell",
+										"entries": [
+											"{@i (Ranged weapon only) Rapid Reload.} You can reload as a free action while you are attuned to this weapon. Additionally, when you make a ranged weapon attack roll and roll a 20 for the attack roll, you can make one additional attack as a free action."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Red Serpent Orb",
+										"entries": [
+											"{@i (Spellcaster only)} While attuned to this weapon, you can cast the {@spell disintegrate} spell from it, using your spell save DC. Once you use this property, you can't use it again until you finish a long rest."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "OTHER MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Elder Dragon Blood",
+										"entries": [
+											"Any rarity weapon upgrade material."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Elder Dragon Bone",
+										"entries": [
+											"Any rarity armor upgrade material."
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/cbqGNPQ.png",
+			"damageTags": [
+				"P",
+				"F",
+				"S"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"RW",
+				"AOE"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
 			"name": "Crimson Qurupeco",
 			"size": [
 				"L"
@@ -17175,7 +18050,7 @@
 			"cha": 16,
 			"save": {
 				"cha": "+6",
-				"con": "+5"
+				"con": "+4"
 			},
 			"skill": {
 				"performance": "+6"
@@ -17186,7 +18061,6 @@
 			"passive": 12,
 			"cr": "6",
 			"page": 20,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Sensitive Ears",
@@ -17441,9 +18315,6 @@
 			],
 			"spellcastingTags": [
 				"I"
-			],
-			"damageTagsSpell": [
-				"Y"
 			]
 		},
 		{
@@ -17477,7 +18348,7 @@
 			],
 			"hp": {
 				"average": 553,
-				"formula": "36d20 + 360"
+				"formula": "27d20 + 270"
 			},
 			"speed": {
 				"walk": 20,
@@ -17532,7 +18403,7 @@
 				"Draconic"
 			],
 			"cr": "27",
-			"page": 169,
+			"page": 0,
 			"senses": [
 				"blindsight 120 ft."
 			],
@@ -17572,19 +18443,19 @@
 				{
 					"name": "Body Slam",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 5 ft., one target. {@h}34 ({@damage 4d12 + 8}) bludgeoning damage."
+						"{@atk mw} {@hit 17} to hit, reach 5 ft., one target. {@h}34 ({@damage 4d12 + 8}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Horn",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 30 ft., one target. {@h}30 ({@damage 4d10 + 8}) piercing damage."
+						"{@atk mw} {@hit 17} to hit, reach 30 ft., one target. {@h}30 ({@damage 4d10 + 8}) piercing damage."
 					]
 				},
 				{
 					"name": "Rock Toss",
 					"entries": [
-						"{@atk rw} {@hit 8} to hit, reach 80/320 ft., one target. {@h}24 ({@damage 7d6}) bludgeoning damage."
+						"{@atk rw} {@hit 9} to hit, reach 80/320 ft., one target. {@h}24 ({@damage 7d6}) bludgeoning damage."
 					]
 				},
 				{
@@ -17616,7 +18487,7 @@
 			],
 			"fluff": {
 				"entries": [
-					"Jhen Mohran is a giant Elder Dragon that swims within the sand. itfeeds very much like a baleen whale. It swallows large amounts of sand to filter in any type of nutrients found within the sands.",
+					"{@creature Jhen Mohran|MHMM} is a giant Elder Dragon that swims within the sand. itfeeds very much like a baleen whale. It swallows large amounts of sand to filter in any type of nutrients found within the sands.",
 					"Jhen Mohran's main adaptation is its huge size. Jhen Mohran is up to 11161.9 cm, twenty percent of this length is its tusks. Its body is streamlined and equipped with immensely powerful limbs, which allows it to travel through the sand at great speeds. It uses the front limbs and tusks to push aside sand. Though Jhen Mohran feeds on the nutrients found within the sand, it will expel the unnecessary materials outside of its body with the help of multiple blowholes. The expelled sand alone can cause a change in flow to the quicksand in the Great Desert. Occasionally, seasonal winds can catch the expelled sands and blow the sands in the direction of settlements, causing massive sandstorms. Jhen Mohran has powerful lungs that helps it hold its breath for long periods of time. Some older Jhen Mohran can even use their lungs to fire a destructive beam of sand at foes. If sand wasn't covering Jhen Mohran than it would be a beautiful blue color. By spending long periods in the sand, the ore has formed from be polished by the sands.",
 					"Jhen Mohran is a relatively calm creature, but has been known to retaliate against Desert/Dragon Ships if attacked as they see them as potential rivals. It takes little notice of hunters climbing on its back, and will only occasionally try to fling them off.",
 					{
@@ -17928,6 +18799,12 @@
 			],
 			"trait": [
 				{
+					"name": "Amphibious",
+					"entries": [
+						"The hermitaur can breathe air and water."
+					]
+				},
+				{
 					"name": "Scuttle",
 					"entries": [
 						"As a bonus action, the daimyo hermitaur can moves up to its speed in a straight line."
@@ -17938,7 +18815,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The daimyo hermitaur makes two claw attacks."
+						"The hermitaur makes two claw attacks."
 					]
 				},
 				{
@@ -17956,7 +18833,7 @@
 				{
 					"name": "Crush {@recharge 5}",
 					"entries": [
-						"If the daimyo hermitaur jumps at least 15 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a {@dc 18} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 22 ({@damage 4d8 + 4}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the daimyo hermitaur's space into an unoccupied space of the creature's choice. If no unoccupied space is with in range, the creature instead falls {@condition prone} in the daimyo hermitaur's space."
+						"If the hermitaur jumps at least 15 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a {@dc 18} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 22 ({@damage 4d8 + 4}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the hermitaur's space into an unoccupied space of the creature's choice. If no unoccupied space is with in range, the creature instead falls {@condition prone} in the hermitaur's space."
 					]
 				}
 			],
@@ -17964,7 +18841,7 @@
 				{
 					"name": "Retreat",
 					"entries": [
-						"After being hit by an attack, the daimyo hermitaur can take the dodge action until the start of its next turn by retreating into its shell and using its shield-like claws to protect its head."
+						"After being hit by an attack, the daimyo hermitaur can take the {@action dodge} action until the start of its next turn by retreating into its shell and using its shield-like claws to protect its head."
 					]
 				}
 			],
@@ -17975,13 +18852,16 @@
 				"D",
 				"T"
 			],
+			"traitTags": [
+				"Amphibious"
+			],
 			"fluff": {
 				"entries": [
 					{
 						"type": "entries",
 						"entries": [
 							"Daimyo Hermitaur has a large, crab-like body. It is covered in a red and white carapace and wears the skull of a {@creature Monoblos|MHMM} as a protective shell. They have huge, thick claws capable of holding prey as well as shielding the giant crab from most any attacks. Daimyo Hermitaur's shell is also very tough, able to deflect the blows of most weapons. The one chink in the creature's armor is its soft hindquarters, where many of the creature's major organs are stored. To fix this problem, Daimyo Hermitaur will wear the skulls of dead wyverns on their backs. Acquiring the right size shell is a chore though, and occasionally Daimyo Hermitaur can be spotted with shells too large, or small for their bodies. Almost all of Daimyo Hermitaur's shells come from members of the larger species like Monoblos. Daimyo Hermitaur also possess surprisingly strong legs, able to move the creature with great speed if necessary. The legs assist the creature in digging holes and they are able to launch themselves many feet into the air, causing them to land vigorously on top of hunters who don't react fast enough.",
-							"Some unusual rare Daimyo Hermitaur have a dark redish color on their claws, darker legs and more shiny eyes. Along with this their shells are unusually covered in moss or algae. They also have the ability to spit long streams of water. They use new attack techniques as their claws are much stronger than average, they use their claws in a shielded position much like a human boxing while walking at a target, these claws are reported to be so strong in this position that ranged projectiles fired from guns ricochet, along with this new smarter advancing technique they perform a very aggressive non stop side to side claw snapping attack behavior that out-speeds most attackers.",
+							"Some unusual rare Daimyo Hermitaur have a dark reddish color on their claws, darker legs and more shiny eyes. Along with this their shells are unusually covered in moss or algae. They also have the ability to spit long streams of water. They use new attack techniques as their claws are much stronger than average, they use their claws in a shielded position much like a human boxing while walking at a target, these claws are reported to be so strong in this position that ranged projectiles fired from guns ricochet, along with this new smarter advancing technique they perform a very aggressive non stop side to side claw snapping attack behavior that out-speeds most attackers.",
 							"Despite their size, Daimyo Hermitaur are fairly calm, when undisturbed. However, Daimyo Hermitaur will turn aggressive if they feel threatened or attacked. Most of time, they can be seen foraging for food as they roam around their environment.",
 							{
 								"type": "inset",
@@ -18034,7 +18914,7 @@
 											[
 												"13-15",
 												"7-10",
-												"Monsterbone+",
+												"Monster Bone+",
 												"(O)"
 											],
 											[
@@ -18101,7 +18981,7 @@
 												"type": "entries",
 												"name": "Decayed Crimson Horn",
 												"entries": [
-													"{@i Crisis.} While suffering from an abnormal status effect, such as poisoned, burning, slowed, blinded, etc, all attacks and spells deal an extra 1d10 spell or weapon damage."
+													"{@i Crisis.} While suffering from an abnormal status effect, such as poisoned, burning, slowed, blinded, etc, all attacks and spells deal an extra {@damage 1d10} spell or weapon damage."
 												]
 											}
 										]
@@ -18120,7 +19000,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Monsterbone+",
+												"name": "Monster Bone+",
 												"entries": [
 													"Rare weapon upgrade material."
 												]
@@ -18146,8 +19026,7 @@
 				"B"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			],
 			"conditionInflict": [
 				"poisoned",
@@ -18798,8 +19677,7 @@
 				"B"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			]
 		},
 		{
@@ -18919,7 +19797,8 @@
 				{
 					"name": "Swallow",
 					"entries": [
-						"The deviljho makes one bite attack against a Large or smaller creature that is {@condition prone}. If the attack hits, the target takes the bite's damage, the target is swallowed, and no longer {@condition prone}. While swallowed, the creature is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the deviljho, and it takes 56 ({@damage 16d6}) acid damage at the start of each of the deviljho's turns. If the deviljho takes  40 damage or more on a single turn from a creature inside it, the deviljho must succeed on a {@dc 20} Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall {@condition prone} in a space within 10 feet of the deviljho. If the deviljho dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 15 feet of movement, exiting {@condition prone}."
+						"The deviljho makes one bite attack against a Large or smaller creature that is {@condition prone}. If the attack hits, the target takes the bite's damage, the target is swallowed, and no longer {@condition prone}. While swallowed, the creature is {@condition blinded} and {@condition restrained}, it has total cover against attacks and other effects outside the deviljho, and it takes 56 ({@damage 16d6}) acid damage at the start of each of the deviljho's turns.",
+						"If the deviljho takes  40 damage or more on a single turn from a creature inside it, the deviljho must succeed on a {@dc 20} Constitution saving throw at the end of that turn or regurgitate all swallowed creatures, which fall {@condition prone} in a space within 10 feet of the deviljho. If the deviljho dies, a swallowed creature is no longer {@condition restrained} by it and can escape from the corpse by using 15 feet of movement, exiting {@condition prone}."
 					]
 				}
 			],
@@ -19104,7 +19983,7 @@
 												"type": "entries",
 												"name": "Deviljho Talon",
 												"entries": [
-													"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+													"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
 												]
 											},
 											{
@@ -20049,7 +20928,7 @@
 											[
 												"1-3",
 												"1-3",
-												"Monsterbone+",
+												"Monster Bone+",
 												"(O)"
 											],
 											[
@@ -20174,7 +21053,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Monsterbone+",
+												"name": "Monster Bone+",
 												"entries": [
 													"Rare weapon upgrade material."
 												]
@@ -20324,14 +21203,13 @@
 					"resist": [
 						"piercing"
 					],
-					"note": "from nonmagical weapons",
+					"note": "from nonmagical attacks",
 					"cond": true
 				}
 			],
 			"passive": 10,
 			"cr": "9",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "High Jump",
@@ -20350,7 +21228,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The duramboros makes two attacks. one with its Horn attack and one Tail attack. It can't make both attacks against the same target."
+						"The duramboros makes two attacks: one with its horn and one with its tail. It can't make both attacks against the same target."
 					]
 				},
 				{
@@ -20541,8 +21419,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"AOE"
+				"RCH"
 			]
 		},
 		{
@@ -20557,7 +21434,7 @@
 				]
 			},
 			"group": [
-				"Fanged Wyvern"
+				"Fanged Wyverns"
 			],
 			"environment": [
 				"arctic",
@@ -21027,7 +21904,7 @@
 											],
 											[
 												"11-16",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -21072,7 +21949,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -21143,22 +22020,22 @@
 			"wis": 17,
 			"cha": 20,
 			"save": {
-				"dex": "+7",
-				"con": "+15",
-				"wis": "+10",
-				"cha": "+12"
+				"dex": "+8",
+				"con": "+16",
+				"wis": "+11",
+				"cha": "+13"
 			},
 			"skill": {
 				"insight": "+10",
 				"intimidation": "+12",
-				"perception": "+10"
+				"perception": "+11"
 			},
-			"passive": 20,
+			"passive": 21,
 			"languages": [
 				"Common",
 				"Draconic"
 			],
-			"cr": "22",
+			"cr": "28",
 			"page": 0,
 			"senses": [
 				"blindsight 60 ft.",
@@ -21191,7 +22068,7 @@
 										{
 											"name": "Black Fire {@recharge 5}",
 											"entries": [
-												"The fatalis exhales a black flame in a 90-foot cone. Each creature in that area must make a {@dc 23} Dexterity saving throw, taking 55 ({@damage 10d10}) necrotic damage plus 28 ({@dice 8d6}) fire damage on a failed save, or half as much damage on a successful one."
+												"The fatalis exhales a black flame in a 90-foot cone. Each creature in that area must make a {@dc 24} Dexterity saving throw, taking 55 ({@damage 10d10}) necrotic damage plus 28 ({@dice 8d6}) fire damage on a failed save, or half as much damage on a successful one."
 											]
 										},
 										{
@@ -21215,7 +22092,7 @@
 										{
 											"name": "Crimson Demons Breath {@recharge 5}",
 											"entries": [
-												"The fatalis exhales 90-foot line that is 10 feet wide. Each creature in that area must make a {@dc 23} Dexterity saving throw, taking 54 ({@damage 12d8}) fire damage plus 28 ({@dice 8d6}) necrotic on a failed save, or half as much damage on a successful one."
+												"The fatalis exhales 90-foot line that is 10 feet wide. Each creature in that area must make a {@dc 24} Dexterity saving throw, taking 54 ({@damage 12d8}) fire damage plus 28 ({@dice 8d6}) necrotic on a failed save, or half as much damage on a successful one."
 											]
 										},
 										{
@@ -21239,7 +22116,7 @@
 										{
 											"name": "Emperor's Roar {@recharge 5}",
 											"entries": [
-												"The fatalis calls down a giant bolt of red lightning enveloping the area around the fatalis with a bright red glow. Each creature in a 20-foot-radius, 100-foot-high cylinder centered on the ground below the fatalis must make a {@dc 23} Dexterity saving throw, taking 56 ({@damage 16d6}) lighting damage plus 22 ({@dice 5d8}) fire on a failed save, or half as much damage on a successful one."
+												"The fatalis calls down a giant bolt of red lightning enveloping the area around the fatalis with a bright red glow. Each creature in a 20-foot-radius, 100-foot-high cylinder centered on the ground below the fatalis must make a {@dc 24} Dexterity saving throw, taking 56 ({@damage 16d6}) lighting damage plus 22 ({@dice 5d8}) fire on a failed save, or half as much damage on a successful one."
 											]
 										},
 										{
@@ -21271,31 +22148,31 @@
 				{
 					"name": "Frightful Presence",
 					"entries": [
-						"Each creature of the fatalis's choice that is within 120 feet of the fatalis and aware of it must succeed on a {@dc 20} Wisdom saving throw or become {@condition frightened} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the fatalis's Frightful Presence for the next 24 hours."
+						"Each creature of the fatalis's choice that is within 120 feet of the fatalis and aware of it must succeed on a {@dc 21} Wisdom saving throw or become {@condition frightened} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the fatalis's Frightful Presence for the next 24 hours."
 					]
 				},
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 15 ft., one target. {@h}25 ({@damage 3d10 + 9}) piercing damage."
+						"{@atk mw} {@hit 17} to hit, reach 15 ft., one target. {@h}25 ({@damage 3d10 + 9}) piercing damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 10 ft., one target. {@h}19 ({@damage 3d6 + 9}) slashing damage."
+						"{@atk mw} {@hit 17} to hit, reach 10 ft., one target. {@h}19 ({@damage 3d6 + 9}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, 20 ft., one target. {@h}27 ({@damage 4d8 + 9}) bludgeoning damage."
+						"{@atk mw} {@hit 17} to hit, 20 ft., one target. {@h}27 ({@damage 4d8 + 9}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Fireball",
 					"entries": [
-						"The fatalis exhales a fireball radius within 120 ft. of its location. Each creature in a 10-foot radius Sphere centered on that point must make a {@dc 23} Dexterity saving throw. A target takes 31 ({@damage 9d6}) fire damage on a failed save, or half as much damage on a successful one."
+						"The fatalis exhales a fireball radius within 120 ft. of its location. Each creature in a 10-foot radius Sphere centered on that point must make a {@dc 24} Dexterity saving throw. A target takes 31 ({@damage 9d6}) fire damage on a failed save, or half as much damage on a successful one."
 					]
 				}
 			],
@@ -21303,7 +22180,7 @@
 				{
 					"name": "Detect",
 					"entries": [
-						"The fatalis makes a Wisdom (Perception) check."
+						"The fatalis makes a Wisdom ({@skill Perception}) check."
 					]
 				},
 				{
@@ -21579,7 +22456,7 @@
 															"You are immune to fire damage.",
 															"You can use an action to cast {@spell Melf's Minute Meteors|XGE} ({@dc 19}) from the weapon at will, requiring no material components.",
 															"Your weapons deal an extra {@damage 2d6} fire damage.",
-															"You can use the {@item hammer (u)|AGMH|hammer's Mighty Weapon property} once with any weapon."
+															"You can use the {@item hammer|AGMH}'s {@optfeature Mighty Weapon|AGMH} property once with any weapon."
 														]
 													},
 													"Once you use this property, you cannot use it again until the next dawn."
@@ -21776,7 +22653,6 @@
 			],
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Feline Inspiration",
@@ -22362,9 +23238,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"RW",
-				"AOE"
+				"RCH"
 			],
 			"conditionInflict": [
 				"prone"
@@ -22473,25 +23347,25 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}26 ({@damage 3d12 + 7}) piercing damage plus 5 ({@damage 1d10}) lightning damage. If the target is a Medium or smaller creature, it is {@condition Grappled} (escape {@dc 20}). Until this grapple ends, the target is {@condition restrained}, and the anjanath can't bite another target. "
+						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}26 ({@damage 3d12 + 7}) piercing damage plus 5 ({@damage 1d10}) lightning damage. If the target is a Medium or smaller creature, it is {@condition Grappled} (escape {@dc 20}). Until this grapple ends, the target is {@condition restrained}, and the anjanath can't bite another target. "
 					]
 				},
 				{
 					"name": "Electric Snot",
 					"entries": [
-						"{@atk rw} {@hit 9} to hit, range 20/60 ft., one target. {@h}22 ({@damage 4d10}) lightning damage."
+						"{@atk rw} {@hit 12} to hit, range 20/60 ft., one target. {@h}22 ({@damage 4d10}) lightning damage."
 					]
 				},
 				{
 					"name": "Stomp",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d8 + 7}) bludgeoning damage plus 5 ({@damage 1d10}) lightning damage and each creature within 5 feet of the target, must make a {@dc 19} dexterity saving throw, taking 5 ({@damage 1d10}) lightning damage on a failed save, or half as much on a successful one."
+						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d8 + 7}) bludgeoning damage plus 5 ({@damage 1d10}) lightning damage and each creature within 5 feet of the target, must make a {@dc 19} dexterity saving throw, taking 5 ({@damage 1d10}) lightning damage on a failed save, or half as much on a successful one."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}23 ({@damage 3d10 + 7}) bludgeoning damage."
+						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}23 ({@damage 3d10 + 7}) bludgeoning damage."
 					]
 				},
 				{
@@ -22507,8 +23381,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"RW",
-				"AOE"
+				"RW"
 			],
 			"damageTags": [
 				"P",
@@ -22693,7 +23566,7 @@
 										"type": "entries",
 										"name": "Fulgur Anjanath Hardfang",
 										"entries": [
-											"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+											"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
 										]
 									},
 									{
@@ -22733,7 +23606,7 @@
 			},
 			"conditionInflict": [
 				"restrained",
-				"grappled",
+				"Grappled",
 				"prone"
 			]
 		},
@@ -22878,7 +23751,7 @@
 				{
 					"name": "Quake (Costs 2 Actions)",
 					"entries": [
-						"The rajang reaches for the sky and slams its body onto the ground causing the ground to shake violently. Each creature within 30 feet of the rajang must succeed on a {@dc 22} Strength saving throw or be knocked {@condition prone}. Any creature that fails this save by 5 or more is also {@condition stunned} until the end of their next turn."
+						"The rajang reaches for the sky and slams its body onto the ground causing the ground to shake violently. Each creature within 30 feet of the rajang must succeed on a {@dc 21} Strength saving throw or be knocked {@condition prone}. Any creature that fails this save by 5 or more is also {@condition stunned} until the end of their next turn."
 					]
 				},
 				{
@@ -22948,7 +23821,7 @@
 											[
 												"9-13",
 												"6-13",
-												"Gold Rajang Pelt",
+												"Furious Rajang Pelt",
 												"(A,W)"
 											],
 											[
@@ -22991,7 +23864,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Gold Rajang Pelt",
+												"name": "Furious Rajang Pelt",
 												"entries": [
 													"You have resistance to lightning and thunder damage while you wear this armor."
 												]
@@ -23040,9 +23913,9 @@
 											},
 											{
 												"type": "entries",
-												"name": "Gold Rajang Pelt",
+												"name": "Furious Rajang Pelt",
 												"entries": [
-													"Your weapon deals an extra 1d8 lightning damage."
+													"Your weapon deals an extra {@damage 1d8} lightning damage."
 												]
 											},
 											{
@@ -23057,14 +23930,14 @@
 												"type": "entries",
 												"name": "Rajang Hardclaw",
 												"entries": [
-													"{@i Heroics.} While below 25% of your maximum hit points your weapon attacks deal 1d4 extra damage and you have resistance to all damage except psychic damage."
+													"{@i Heroics.} While below 25% of your maximum hit points your weapon attacks deal {@damage 1d4} extra damage and you have resistance to all damage except psychic damage."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Rajang Heart",
 												"entries": [
-													"Your weapon deals an extra 2d6 lightning damage."
+													"Your weapon deals an extra {@damage 2d6} lightning damage."
 												]
 											},
 											{
@@ -23571,7 +24444,6 @@
 			"passive": 11,
 			"cr": "16",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Trampling Charge",
@@ -23590,7 +24462,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The gammoth makes two attacks; one tusk attack and one trunk attack."
+						"The gammoth makes two attacks: one tusk attack and one trunk attack."
 					]
 				},
 				{
@@ -23608,7 +24480,7 @@
 				{
 					"name": "Trunk",
 					"entries": [
-						"{@atk mw} {@hit 11} to hit, reach 15 ft., one target. {@h}15 ({@damage 2d8 + 6}) bludgeoning damage and the target is {@condition grappled} (escape {@dc} 21)."
+						"{@atk mw} {@hit 11} to hit, reach 15 ft., one target. {@h}15 ({@damage 2d8 + 6}) bludgeoning damage and the target is {@condition grappled} (escape {@dc} 19)."
 					]
 				},
 				{
@@ -23775,7 +24647,7 @@
 												"type": "entries",
 												"name": "Gammoth Scalp",
 												"entries": [
-													"You have immunity to cold damage while you wear this armor."
+													"You are immune to cold damage while you wear this armor."
 												]
 											}
 										]
@@ -23826,7 +24698,7 @@
 												"type": "entries",
 												"name": "Gammoth Scalp",
 												"entries": [
-													"Your weapon deals an extra 1d8 cold damage."
+													"Your weapon deals an extra {@damage 1d8} cold damage."
 												]
 											}
 										]
@@ -23892,7 +24764,6 @@
 			"passive": 10,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Beak",
@@ -23953,7 +24824,7 @@
 											],
 											[
 												"16-19",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -23991,7 +24862,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -24236,7 +25107,6 @@
 			"passive": 10,
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Standing Leap",
@@ -24495,7 +25365,6 @@
 			"passive": 9,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Aggressive",
@@ -24579,7 +25448,7 @@
 											],
 											[
 												"19-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -24626,7 +25495,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -24986,9 +25855,6 @@
 			"traitTags": [
 				"Death Burst",
 				"Flyby"
-			],
-			"miscTags": [
-				"AOE"
 			]
 		},
 		{
@@ -25126,7 +25992,7 @@
 											],
 											[
 												"17-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -25166,7 +26032,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -25381,8 +26247,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RW",
-				"HPR"
+				"RW"
 			]
 		},
 		{
@@ -26118,12 +26983,11 @@
 			"passive": 16,
 			"cr": "13",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
 					"entries": [
-						"Multiattack. The glavenus makes two bite attacks and one tail slash attack, or it uses its sharpening and then its tail spin."
+						"The glavenus makes two bite attacks and one tail slash attack, or it uses its sharpening and then its tail spin."
 					]
 				},
 				{
@@ -27177,19 +28041,25 @@
 				{
 					"name": "Breath Weapons {@recharge 5}",
 					"entries": [
-						"The gogmazios uses one of the following breath weapons."
-					]
-				},
-				{
-					"name": "Fire Breath",
-					"entries": [
-						"The gogmazios exhales fire in a 90-foot line that is 5-feet wide. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 55 ({@damage 10d10}) fire damage on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Oil Breath",
-					"entries": [
-						"The gogmazios exhales tar in a 90-foot cone. That area becomes {@condition Tarred|MHMM} for one hour. Each creature in that enters the area or starts its turn in that area must make a {@dc 20} Strength saving throw, or become {@condition Tarred}."
+						"The gogmazios uses one of the following breath weapons.",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"name": "Fire Breath",
+									"entries": [
+										"The gogmazios exhales fire in a 90-foot line that is 5-feet wide. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 55 ({@damage 10d10}) fire damage on a failed save, or half as much damage on a successful one."
+									]
+								},
+								{
+									"name": "Oil Breath",
+									"entries": [
+										"The gogmazios exhales tar in a 90-foot cone. That area becomes {@condition Tarred|MHMM} for one hour. Each creature in that enters the area or starts its turn in that area must make a {@dc 20} Strength saving throw, or become {@condition Tarred}."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -27197,7 +28067,7 @@
 				{
 					"name": "Detect",
 					"entries": [
-						"The gogmazios makes a Wisdom (Perception) check."
+						"The gogmazios makes a Wisdom ({@skill Perception}) check."
 					]
 				},
 				{
@@ -27229,10 +28099,9 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Gogmazios is a massive Elder Dragon with a body structure similar in nature to that of {@creature Gore Magala|MHMM} and {@creature Shagaru Magala|MHMM}. It has a large, heavy head with red eyes and rows of sharp teeth. When it uses its Oil laser attack, a glowing pattern, reminiscent of a scowl, is present beneath its chin, giving it the semblance of a second face. Its wingarms feature membranes that almost completely retract when not in use, and its body is covered in thick, powerful scales, carapaces, and spines of an indigo colouration. Perhaps the most notable features of Gogmazios's body are the ever-present covering of a sticky, tar-like substance which it uses to incapacitate prey. It is unknown where Gogmazios exactly lives but it is theorized by scholars that it comes from swamps along with some mountainous habitats.",
-							"Despite Gogmazios's habitat being unknown, Gogmazios are known to feed sulfur, which can be found in gunpowder and explosives. This was discovered after one raided Dundroma's Weapon Warehouse for many years and was seen feeding on the explosives. From this it can be assumed that Gogmazios may also feed on ore though Gogmazios hasn't been seen interacting with other monsters so this is just a hypothesis by scholars.",
-							"Gogmazios aren't the most aggressive Elder Dragons, but certainly aren't harmless and will attack if threatened. Gogmazios are known to hibernate underground for a very long period of time, spanning to a few years or even several decades, when it has obtained enough food, but waking up to feed again when food is needed. This plus it destroying some villages while searching for food is the reason why it hasn't been seen very much by people.",
-							"An adult Gogmazios is approxiamtely 4920.5cm long and standing at a height at about 1708.5cm. Unlike most other Elder Dragons, Gogmazios has an extra pair of limbs that allow it to walk better and allow it to walk upright. From the large amounts of muscles found inside these limbs, Gogmazios is able to walk upright with very much ease and to battle some threats at close range. These extra pair of limbs even allow Gogmazios to fly with its powerful wings. The wings of Gogmazios aren't tattered. The oil on its body has actually stuck the wings to its arms due to it hardening. When greatly angered, the heat will cause the oil to evaporate from its wings and Gogmazios forces itself in the air to fly. Gogmazios don't fly easily and rarely ever fly. Gogmazios has oil circulating throughout its body, while some of the oil pours out of its body. The oil coming out of a Gogmazios is impurities, such as waste or sweat, from its skin due to its diet. The oil pours out from its chest and back, dripping onto the ground below it. This oil is very sticky, attaching to anything that it touches. Inside some of the oil is objects that were picked up by Gogmazios accidentally. These objects can be weapons, artifacts, arrows, and living organisms. Some of the oil has hardened on Gogmazios's body, increasing the strength of its scales and shell, giving it better defense against potential threats. Also, found inside of its body and inside its extra limbs are special organs that allow it to produce heated fire. Gogmazios uses this fire as a tool to ignite the oil and to make its attacks deadlier then before. When greatly enraged, Gogmazios's body temperature will increase greatly, making the oil it produces ignite faster and heat up faster without much warning.",
+							"Gogmazios is a massive Elder Dragon with a body structure similar in nature to that of {@creature Gore Magala|MHMM} and {@creature Shagaru Magala|MHMM}. An adult Gogmazios is approximately 4920.5cm long and standing at a height of about 1708.5cm. It has a large, heavy head with red eyes and rows of sharp teeth. When it uses its Oil laser attack, a glowing pattern, reminiscent of a scowl, is present beneath its chin, giving it the semblance of a second face. Its wingarms feature membranes that almost completely retract when not in use, and its body is covered in thick, powerful scales, carapaces, and spines of an indigo colouration. Perhaps the most notable features of Gogmazios's body are the ever-present covering of a sticky, tar-like substance which it uses to incapacitate prey. It is unknown where Gogmazios exactly lives but it is theorized by scholars that it comes from swamps along with some mountainous habitats.",
+							"Despite Gogmazios's habitat being unknown, Gogmazios are known to feed sulfur, which can be found in gunpowder and explosives. This was discovered after one raided Dundroma's Weapon Warehouse for many years and was seen feeding on the explosives. From this it can be assumed that Gogmazios may also feed on ore though Gogmazios hasn't been seen interacting with other monsters so this is just a hypothesis by scholars. Gogmazios aren't the most aggressive Elder Dragons, but certainly aren't harmless and will attack if threatened. Gogmazios are known to hibernate underground for a very long period of time, spanning to a few years or even several decades, when it has obtained enough food, but waking up to feed again when food is needed.",
+							"Unlike most other Elder Dragons, Gogmazios has an extra pair of limbs that allow it to walk better and allow it to walk upright. From the large amounts of muscles found inside these limbs, Gogmazios is able to walk upright with very much ease and to battle some threats at close range. These extra pair of limbs even allow Gogmazios to fly with its powerful wings. The wings of Gogmazios aren't tattered. The oil on its body has actually stuck the wings to its arms due to it hardening. When greatly angered, the heat will cause the oil to evaporate from its wings and Gogmazios forces itself in the air to fly. Gogmazios don't fly easily and rarely ever fly. Gogmazios has oil circulating throughout its body, while some of the oil pours out of its body. The oil coming out of a Gogmazios is impurities, such as waste or sweat, from its skin due to its diet. The oil pours out from its chest and back, dripping onto the ground below it. This oil is very sticky, attaching to anything that it touches. Inside some of the oil is objects that were picked up by Gogmazios accidentally. These objects can be weapons, artifacts, arrows, and living organisms. Some of the oil has hardened on Gogmazios's body, increasing the strength of its scales and shell, giving it better defense against potential threats. Also, found inside of its body and inside its extra limbs are special organs that allow it to produce heated fire. Gogmazios uses this fire as a tool to ignite the oil and to make its attacks deadlier then before. When greatly enraged, Gogmazios's body temperature will increase greatly, making the oil it produces ignite faster and heat up faster without much warning.",
 							{
 								"type": "inset",
 								"name": "Gogmazios",
@@ -28097,14 +28966,14 @@
 											[
 												"13-14",
 												"11",
-												"Frost Sac",
+												"Harag Frost Sac",
 												"(A,W)"
 											],
 											[
 												"15-16",
 												"-",
 												"Monster Toughbone",
-												"(A,W)"
+												"(O)"
 											],
 											[
 												"-",
@@ -28161,9 +29030,9 @@
 											},
 											{
 												"type": "entries",
-												"name": "Frost Sac",
+												"name": "Harag Frost Sac",
 												"entries": [
-													"You have immunity to cold damage while you wear this armor."
+													"You are immune to cold damage while you wear this armor."
 												]
 											},
 											{
@@ -28205,7 +29074,7 @@
 												"type": "entries",
 												"name": "Block of Ice",
 												"entries": [
-													"Your cold spells deal an extra 1d6 cold damage while you are attuned to this weapon."
+													"Your cold spells deal an extra {@damage 1d6} cold damage while you are attuned to this weapon."
 												]
 											},
 											{
@@ -28224,7 +29093,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Frost Sac",
+												"name": "Harag Frost Sac",
 												"entries": [
 													"You gain a +2 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +3 when the spell you are casting deals cold damage, such as the {@spell ice knife|XGE} or {@spell snilloc's snowball swarm|XGE} spell."
 												]
@@ -28247,7 +29116,7 @@
 												"type": "entries",
 												"name": "Harag Gem",
 												"entries": [
-													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra 1d4 bludgeoning damage. {@i (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")}"
+													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra {@damage 1d4} bludgeoning damage. {@i (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")}"
 												]
 											}
 										]
@@ -28975,6 +29844,7 @@
 				"MW"
 			],
 			"conditionInflict": [
+				"Incapacitated",
 				"incapacitated",
 				"prone"
 			]
@@ -29122,7 +29992,7 @@
 											[
 												"1-2",
 												"1-3",
-												"Monsterbone+",
+												"Monster Bone+",
 												"(O)"
 											],
 											[
@@ -29233,7 +30103,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Monsterbone+",
+												"name": "Monster Bone+",
 												"entries": [
 													"Rare weapon upgrade material."
 												]
@@ -29312,7 +30182,6 @@
 			"passive": 10,
 			"cr": "3",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Leader of the Pack",
@@ -29422,7 +30291,7 @@
 											[
 												"16-17",
 												"-",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -29523,7 +30392,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -29870,7 +30739,6 @@
 			"passive": 13,
 			"cr": "4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Full Belly",
@@ -29984,7 +30852,7 @@
 											[
 												"-",
 												"17-20",
-												"Monsterbone+",
+												"Monster Bone+",
 												"(O)"
 											]
 										]
@@ -30038,7 +30906,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Monsterbone+",
+												"name": "Monster Bone+",
 												"entries": [
 													"Rare weapon upgrade material."
 												]
@@ -30391,7 +31259,6 @@
 			"passive": 14,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Shock",
@@ -30565,7 +31432,6 @@
 			"passive": 10,
 			"cr": "2",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Brute",
@@ -30794,7 +31660,7 @@
 				"AOE"
 			],
 			"conditionInflict": [
-				"incapacitated",
+				"Incapacitated",
 				"poisoned",
 				"prone"
 			]
@@ -30855,7 +31721,6 @@
 			],
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
@@ -30985,9 +31850,7 @@
 				"P"
 			],
 			"miscTags": [
-				"MW",
-				"RW",
-				"THW"
+				"MW"
 			],
 			"conditionInflict": [
 				"restrained"
@@ -31376,6 +32239,12 @@
 			],
 			"trait": [
 				{
+					"name": "Amphibious",
+					"entries": [
+						"The hermitaur can breathe air and water."
+					]
+				},
+				{
 					"name": "Scuttle",
 					"entries": [
 						"As a bonus action, the hermitaur can moves up to its half speed in a straight line."
@@ -31400,7 +32269,7 @@
 				{
 					"name": "Retreat",
 					"entries": [
-						"After being hit by an attack, the hermitaur can take the dodge action until the start of its next turn by retreating into its shell and using its shield-like claws to protect its head."
+						"After being hit by an attack, the hermitaur can take the {@action dodge} action until the start of its next turn by retreating into its shell and using its shield-like claws to protect its head."
 					]
 				}
 			],
@@ -31431,7 +32300,7 @@
 											[
 												"Challenge Rating",
 												"1/2",
-												"Carves/Capture",
+												"Carves",
 												"1"
 											]
 										]
@@ -31521,8 +32390,7 @@
 				"C"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			],
 			"conditionInflict": [
 				"poisoned"
@@ -31764,7 +32632,7 @@
 				"formula": "14d10 + 28"
 			},
 			"speed": {
-				"walk": 40,
+				"walk": 30,
 				"fly": 40
 			},
 			"str": 16,
@@ -31777,17 +32645,17 @@
 				"athletics": "+6"
 			},
 			"conditionImmune": [
-				"incapacitated"
+				"incapacitated",
+				"unconscious"
 			],
 			"passive": 10,
 			"cr": "4",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The hypnocatrice makes three attacks, two with its Talons and one with its Peck attack."
+						"The hypnocatrice makes three attacks, two with its talons and one with its peck."
 					]
 				},
 				{
@@ -32072,7 +32940,6 @@
 			"passive": 10,
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Standing Leap",
@@ -32417,7 +33284,7 @@
 											],
 											[
 												"19-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -32464,7 +33331,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -32621,7 +33488,6 @@
 			"passive": 10,
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Pack Tactics",
@@ -32906,7 +33772,7 @@
 											],
 											[
 												"17-18",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -32958,7 +33824,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -33128,7 +33994,7 @@
 											],
 											[
 												"17-18",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -33180,7 +34046,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -33573,7 +34439,7 @@
 			],
 			"hp": {
 				"average": 553,
-				"formula": "36d20 + 360"
+				"formula": "27d20 + 270"
 			},
 			"speed": {
 				"walk": 20,
@@ -33668,13 +34534,13 @@
 				{
 					"name": "Body Slam",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 5 ft., one target. {@h}34 ({@damage 4d12 + 8}) bludgeoning damage."
+						"{@atk mw} {@hit 17} to hit, reach 5 ft., one target. {@h}34 ({@damage 4d12 + 8}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Tusks",
 					"entries": [
-						"{@atk mw} {@hit 16} to hit, reach 30 ft., one target. {@h}30 ({@damage 4d10 + 8}) piercing damage."
+						"{@atk mw} {@hit 17} to hit, reach 30 ft., one target. {@h}30 ({@damage 4d10 + 8}) piercing damage."
 					]
 				},
 				{
@@ -34289,7 +35155,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Uragaan is covered in a lustrous gold-colored hide. Its back is lined with hard crystals and its chin is plated with a rock-like shell, suggesting the Uragaan has evolved a tough exterior due to life in volcanic regions. Its underbelly is covered in a sticky, tar-like substance which it uses to affix explosive rocks to itself.",
+							"{@creature Uragaan|MHMM} is covered in a lustrous gold-colored hide. Its back is lined with hard crystals and its chin is plated with a rock-like shell, suggesting the Uragaan has evolved a tough exterior due to life in volcanic regions. Its underbelly is covered in a sticky, tar-like substance which it uses to affix explosive rocks to itself.",
 							"Uragaan's signature ability is to roll its body into a wheel to increase its speed and agility. The growths on their back stable this rolling ability. It will do this often in an attempt to crush the adventurer. Uragaan create a very effective weapon in the form of its chin by melting minerals and attaching them with lava, which it can use for breaking up rocks. The chin also evens its center of gravity so its legs can compensate for its heavy body. In a group of Uragaan, the one with the largest chin has the highest status among the group.",
 							"Uragaan is something of oddity in the food chain - it has almost no natural predators, but is not particularly predatory itself and has no competitors, preferring to consume vast amounts of plants and rock. The rocks that it feeds on are surprisingly nutrient rich, and its rock-hard lower jaw is perfectly designed to break them up, although it does make them awkward to swallow.",
 							{
@@ -34690,8 +35556,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"AOE"
+				"RCH"
 			]
 		},
 		{
@@ -35040,7 +35905,11 @@
 			},
 			"speed": {
 				"walk": 30,
-				"climb": 30
+				"climb": 30,
+				"fly": {
+					"number": 40,
+					"condition": "(glide)"
+				}
 			},
 			"str": 21,
 			"dex": 14,
@@ -35065,7 +35934,7 @@
 				{
 					"name": "Gliding",
 					"entries": [
-						"The kecha wacha can glide up to 40 feet instead of moving, when the kecha wacha glides, it loses 5 feet of altitude for every 5 feet of movement. At the end of its glide the kecha wacha falls to the ground if it is still in the air."
+						"When the kecha wacha glides, it loses 5 feet of altitude for every 5 feet of movement. At the end of its glide the kecha wacha falls to the ground if it is still in the air."
 					]
 				}
 			],
@@ -35085,7 +35954,7 @@
 				{
 					"name": "Mucus",
 					"entries": [
-						"{@atk rw} {@hit 8} to hit, range 30/120 ft., one target. {@h}10 ({@damage 3d6}) acid damage and the target is afflicted with {@disease waterblight|MHMM} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"{@atk rw} {@hit 8} to hit, range 30/120 ft., one target. {@h}10 ({@damage 3d6}) acid damage and the target is poisoned with {@condition waterblight|MHMM} for 1 minute."
 					]
 				},
 				{
@@ -35257,14 +36126,14 @@
 												"type": "entries",
 												"name": "Brute Bone",
 												"entries": [
-													"Your weapon deals an extra 1d4 bludgeoning damage."
+													"Your weapon deals an extra {@damage 1d4} bludgeoning damage."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Kecha Ear",
 												"entries": [
-													"While holding this weapon, you can use an action to speak its command word, to conjure a pair of kecha wacha ears that cover your weapon. While your weapon is covered it acts as a shield and cannot be used to attack, but retains all its abilities. You can speak the command word again, as a bonus action, to cause the weapon to revert to its normal form."
+													"While holding this weapon, you can use an action to speak its command word, to conjure a pair of kecha wacha ears that cover your weapon. While your weapon is covered it acts as a {@item shield|PHB} and cannot be used to attack, but retains all its abilities. You can speak the command word again, as a bonus action, to cause the weapon to revert to its normal form."
 												]
 											},
 											{
@@ -35303,8 +36172,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RW",
-				"AOE"
+				"RW"
 			]
 		},
 		{
@@ -35351,7 +36219,6 @@
 			"passive": 10,
 			"cr": "0",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Sure-footed",
@@ -35955,9 +36822,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"AOE",
-				"RW"
+				"RCH"
 			],
 			"conditionInflict": [
 				"paralyzed",
@@ -36015,7 +36880,6 @@
 			],
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Thighbone",
@@ -36168,9 +37032,6 @@
 			],
 			"spellcastingTags": [
 				"I"
-			],
-			"conditionInflict": [
-				"unconscious"
 			]
 		},
 		{
@@ -36266,7 +37127,7 @@
 				{
 					"name": "Control Lightning",
 					"entries": [
-						"The kirin can choose any location within 30 feet of it as the starting location of the lightning bolt spell."
+						"The kirin can choose any location within 30 feet of it as the starting location of the {@spell lightning bolt} spell."
 					]
 				}
 			],
@@ -36274,7 +37135,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The kirin makes three attacks. two with its hooves and one with its horn."
+						"The kirin makes three attacks: two with its hooves and one with its horn."
 					]
 				},
 				{
@@ -36327,46 +37188,28 @@
 				{
 					"name": "Spellcasting",
 					"headerEntries": [
-						"The kirin is a 18th-level spellcaster. Its spellcasting ability is Wisdom (spell save {@dc 17}, {@hit 9} to hit with spell attacks). The kirin has the following spells prepared:"
+						"The kirin is a 18th-level spellcaster. Its spellcasting ability is Wisdom (spell save {@dc 17}, {@hit 9} to hit with spell attacks). It regains its expended spell slots when it finishes a short or long rest. It knows the following spells:"
 					],
 					"spells": {
 						"0": {
 							"spells": [
 								"{@spell light}",
+								"{@spell shocking grasp}",
 								"{@spell thaumaturgy}",
-								"{@spell schocking grasp}",
 								"{@spell thunderclap|XGE}"
 							]
 						},
-						"1": {
-							"slots": 4,
-							"spells": [
-								"{@spell thunderwave}"
-							]
-						},
-						"2": {
-							"slots": 3,
-							"spells": []
-						},
-						"3": {
-							"slots": 3,
-							"spells": [
-								"{@spell thunder step|XGE}",
-								"{@spell call lightning}",
-								"{@spell lightning bolt}"
-							]
-						},
-						"4": {
-							"slots": 3,
-							"spells": [
-								"{@spell elemental bane|XGE} (lightning)",
-								"{@spell storm sphere|XGE}"
-							]
-						},
 						"5": {
+							"lower": 1,
 							"slots": 4,
 							"spells": [
-								"{@spell destructive wave}"
+								"{@spell call lightning}",
+								"{@spell destructive wave}",
+								"{@spell elemental bane|XGE} (lightning)",
+								"{@spell lightning bolt}",
+								"{@spell storm sphere|XGE}",
+								"{@spell thunder step|XGE}",
+								"{@spell thunderwave}"
 							]
 						}
 					},
@@ -36595,16 +37438,6 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			],
-			"damageTagsSpell": [
-				"A",
-				"B",
-				"C",
-				"F",
-				"L",
-				"N",
-				"R",
-				"T"
 			]
 		},
 		{
@@ -36868,7 +37701,6 @@
 			"passive": 12,
 			"cr": "4",
 			"page": 10,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Pounce",
@@ -37261,14 +38093,16 @@
 											"type": "entries",
 											"name": "Fire Lane",
 											"entries": [
-												"The kulve taroth rears up on her hind legs and releases an explosion of lava in a 120-foot line that is 10 feet wide. Each creature in that line must make a {@dc 26} Dexterity saving throw, taking 44 ({@damage 8d10}) fire damage and begin to burn on a failed save, or half as much damage on a successful one and does not burn. A creature that is burning takes 6 ({@damage 1d12}) fire damage at the start of their turn. A creature can use its action on its turn to dose the flames."
+												"The kulve taroth rears up on her hind legs and releases an explosion of lava in a 120-foot line that is 10 feet wide. Each creature in that line must make a {@dc 26} Dexterity saving throw, taking 44 ({@damage 8d10}) fire damage and begin to burn on a failed save, or half as much damage on a successful one and does not burn. A creature that is burning takes 6 ({@damage 1d12}) fire damage at the start of their turn. A creature can use its action on its turn to douse the flames."
 											]
 										},
 										{
 											"type": "entries",
 											"name": "Consecutive Molten Pools {@recharge 6}",
 											"entries": [
-												"The kulve taroth rears up slightly, fires a an orb of molten gold at two creatures within 60 feet of it. The orb impactsimpact, the orb impacts the ground at the feet of the targets creating a pool of molten gold that speads out in a 20-foot radius. That area becomes difficult terrain for the duration. When a creature moves into or within the area, it takes 6 ({@damage 1d12}) fire damage for every 5 feet it travels. At the start of the kulve taroth's next turn, the pool of molten gold begins to cool and harden. At the start of its 2nd turn after using this action, the molten gold hardens and restrains (escape {@dc 20}) any creature still standing within it."
+												"The kulve taroth rears up slightly, fires a an orb of molten gold at two creatures within 60 feet of it. The orb impacts the ground at the feet of the targets creating a pool of molten gold that speads out in a 20-foot radius. That area becomes difficult terrain for the duration. When a creature moves into or within the area, it takes 6 ({@damage 1d12}) fire damage for every 5 feet it travels.", 
+												"At the start of the kulve taroth's next turn, the pool of molten gold begins to cool and harden.", 
+												"At the start of its 2nd turn after using this action, the molten gold hardens and {@condition restrained|PHB|restrains} (escape {@dc 20}) any creature still standing within it."
 											]
 										}
 									]
@@ -37572,7 +38406,7 @@
 												"type": "entries",
 												"name": "Golden Nugget",
 												"entries": [
-													"A glittering white gold nugget from Kulve Taroth valued at 3,000 gp."
+													"A glittering white gold nugget from Kulve Taroth valued at 8,000 gp."
 												]
 											}
 										]
@@ -37676,7 +38510,7 @@
 				{
 					"name": "Wind Barrier",
 					"entries": [
-						"A barrier of strong wind surrounds the kushala daora in a 5-foot radius around it. The strong wind keeps fog, smoke, and other gases at bay. Small or smaller flying creatures or Objects can't pass through the wall. Loose, lightweight materials brought into the wall fly upward. Arrows, bolts, and other ordinary projectiles launched at the kushala daora are deflected upward and automatically miss. (Boulders hurled by Giants or siege engines, and similar projectiles, are unaffected.) Creatures in Gaseous Form can't pass through the barrier. When a Medium sized creature enters the Wind Barrier's area for the first time on a turn or starts its turn there, they must make a {@dc 19} Strength saving throw or be pushed back 10 feet. If a creature fails the saving throw by more than 5 they are also knocked {@condition prone}."
+						"A barrier of strong wind surrounds the kushala daora in a 5-foot radius around it. The strong wind keeps fog, smoke, and other gases at bay. Small or smaller flying creatures or Objects can't pass through the wall. Loose, lightweight materials brought into the wall fly upward. Arrows, bolts, and other ordinary projectiles launched at the kushala daora are deflected upward and automatically miss. (Boulders hurled by Giants or siege engines, and similar projectiles, are unaffected.) Creatures in {@spell Gaseous Form} can't pass through the barrier. When a Medium sized creature enters the Wind Barrier's area for the first time on a turn or starts its turn there, they must make a {@dc 19} Strength saving throw or be pushed back 10 feet. If a creature fails the saving throw by more than 5 they are also knocked {@condition prone}."
 					]
 				},
 				{
@@ -37708,20 +38542,20 @@
 				{
 					"name": "Barrage",
 					"entries": [
-						"The kushala daora rains the debris down to the ground in a 10-foot-radius, 20-foot-high cylinder centered on a point within 150 feet. Each creature in the cylinder must make a {@dc 16} Dexteriy saving throw. A creature takes 17 ({@damage 3d10}) bludgeoning damage and 17 ({@damage 3d10}) slashing damage on a failed save, or half as much damage on a successful one."
+						"The kushala daora rains the debris down to the ground in a 10-foot-radius, 20-foot-high cylinder centered on a point within 150 feet. Each creature in the cylinder must make a {@dc 16} Dexteriy saving throw. A creature takes 16 ({@damage 3d10}) bludgeoning damage and 16 ({@damage 3d10}) slashing damage on a failed save, or half as much damage on a successful one."
 					]
 				},
 				{
-					"name": "Tornado (1/Day)",
+					"name": "Tornado (Recharges after a short or long rest)",
 					"entries": [
-						"The kushala daora conjures an tornado that lasts for 1 minute. The tornado is a 20-foot-radius, 60-foot-high spiraling cylinder of wind centered on a location within 100 feet of the kushala daora. This cylinder becomes difficult terrain for the duration, even for flying creatures. Unattended objects in this cylinder that are Large or smaller are pulled towards the center. When a creature enters the tornado's area for the first time on a turn or starts its turn there, it is struck debris the tornado has picked up, and it must make a {@dc 19} Strength saving throw or taking 14 ({@damage 4d6}) bludgeoning damage plus 14 ({@damage 4d6}) slashing damage, they are pulled to the center of the cylinder, and are {@condition restrained} on a failed save, or half as much damage on a successful one and are not pulling into the center or {@condition restrained}.",
+						"The kushala daora conjures a tornado that lasts for 1 minute. The tornado is a 20-foot-radius, 60-foot-high spiraling cylinder of wind centered on a location within 100 feet of the kushala daora. This cylinder becomes difficult terrain for the duration, even for flying creatures. Unattended objects in this cylinder that are Large or smaller are pulled towards the center. When a creature enters the tornado's area for the first time on a turn or starts its turn there, it is struck by debris the tornado has picked up, and it must make a {@dc 19} Strength saving throw or taking 14 ({@damage 4d6}) bludgeoning damage plus 14 ({@damage 4d6}) slashing damage, they are pulled to the center of the cylinder, and are {@condition restrained} on a failed save. On a successful save the creature takes half as much damage and they are not pulling into the center or restrained.",
 						"On each of the kushala daoras turns, it must use its bonus action to move the tornado 30 feet in any direction."
 					]
 				},
 				{
 					"name": "Wind Tunnel {@recharge 5}",
 					"entries": [
-						"The kushala daora blast of strong wind in a 90 foot line that is 10 feet wide. Each creature in the line must succeed on a {@dc 19} Strength saving throw, taking 49 ({@damage 11d8}) force damage and be pushed 15 feet away in a direction following the line on a failed save or half as much on a successful one and pushed away. Any creature in the line must spend 2 feet of movement for every 1 foot it moves when moving closer to the kushala daora. The wind tunnel disperses gas or vapor, and it extinguishes candles, torches, and similar unprotected flames in the area. It causes protected flames, such as those of lanterns, to dance wildly and has a 50 percent chance to extinguish them."
+						"The kushala daora blast of strong wind in a 90 foot line that is 10 feet wide. Each creature in the line must succeed on a {@dc 19} Strength saving throw, taking 49 ({@damage 11d8}) thunder damage and be pushed 15 feet away in a direction following the line on a failed save or half as much on a successful one and pushed away. Any creature in the line must spend 2 feet of movement for every 1 foot it moves when moving closer to the kushala daora. The wind tunnel disperses gas or vapor, and it extinguishes candles, torches, and similar unprotected flames in the area. It causes protected flames, such as those of lanterns, to dance wildly and has a 50 percent chance to extinguish them."
 					]
 				}
 			],
@@ -37729,7 +38563,7 @@
 				{
 					"name": "Move",
 					"entries": [
-						"The kushala daora can move all dust devil up to 30 feet in any direction."
+						"The kushala daora can move all dust devils up to 30 feet in any direction."
 					]
 				},
 				{
@@ -38405,13 +39239,19 @@
 				{
 					"name": "Ice Walker",
 					"entries": [
-						"The Lagombi is accustomed to moving through the frozen tundras, as such it ignores difficult terrain for snow, ice, and other cold weather effects."
+						"The lagombi is accustomed to moving through the frozen tundras, as such it ignores difficult terrain for snow, ice, and other cold weather effects."
+					]
+				},
+				{
+					"name": "Keen Hearing",
+					"entries": [
+						"The lagombi has advantage on Wisdom ({@skill Perception}) checks that rely on hearing."
 					]
 				},
 				{
 					"name": "Slide",
 					"entries": [
-						"The Lacombi's reflexes and agility allow it to move with a burst of speed. When it moves on its turn in combat, it can double its speed while traveling in a straight line. If the Lacombi runs into a creature after moving at least 20 feet the creature must make a {@dc 13} Strength saving throw or be knocked {@condition prone}. The Lacombi cannot use this skill again until it moves 0 feet on one of its turns."
+						"The lagombi’s reflexes and agility allow it to move with a burst of speed. When it moves on its turn in combat, it can double its speed while traveling in a straight line. If the lacombi runs into a creature after moving at least 20 feet the creature must make a {@dc 13} Strength saving throw or be knocked {@condition prone}. The lacombi cannot use this skill again until it moves 0 feet on one of its turns."
 					]
 				}
 			],
@@ -38715,7 +39555,7 @@
 											[
 												"Challenge Rating",
 												"1/2",
-												"Carves/Capture",
+												"Carves",
 												"1"
 											]
 										]
@@ -39006,7 +39846,7 @@
 						"type": "entries",
 						"entries": [
 							"An Elder Dragon, albeit a gigantic specimen. Lao-Shan Lung was once considered the largest monster in the world until recently. Lao-Shan Lung specializes in feeding on different types of ore and minerals, no matter what region it goes to. Though its size surpasses most other species, it has one natural predator that is considered a myth. That predator is {@creature Fatalis|MHMM}.",
-							"Huge. One of the largest dragons ever documented, rivaled only by colossi such as {@creature Ceadeus|MHMM}, {@creature Dalamadur|MHMM}, Laviente, {@creature Jhen Mohran|MHMM} and Zorah Magdaros. Lao-Shan Lungs are very well armored, although their bellies are vulnerable, as are their heads. Their shells only thicken as the time passes by. A Lao-Shan Lung shell coloration is determined by the kind of mineral particles that float in the atmosphere and get attached to its body as the dragon ages: the ones who dwell in the mountains are colored red because of the abundance of iron particles, while the ones that live near the Volcanic Belt are mostly grey due to ash. Like most dragons, their roar is very loud and can affect adventurers a good distance away. Because of their size, getting stepped on or whipped by the tail is very damaging or possibly fatal if the adventurer's armor is low grade.",
+							"Huge. One of the largest dragons ever documented, rivaled only by colossi such as {@creature Ceadeus|MHMM}, {@creature Dalamadur|MHMM}, Laviente, {@creature Jhen Mohran|MHMM} and Zorah Magdaros. Lao-Shan Lungs are very well armored, although their bellies are vulnerable, as are their heads. Their shells only thicken as the time passes by. A Lao-Shan Lung shell coloration is determined by the kind of mineral particles that float in the atmosphere and get attached to its body as the dragon ages: the ones who dwell in the mountains are colored red because of the abundance of iron particles, while the ones that live near the Volcanic Belt are mostly grey due to ash. Like most dragons, their roar is very loud and can affect adventurers a good distance away. Because of their size, getting stepped on or whipped by the tail is very damaging or possibly fatal.",
 							"Extremely docile even when facing multiple foes. They appear to care little about adventurers, as they mainly ignore them on their way to the town fortress. That said, they will put in a great deal of effort to break the fort rather than simply run away. Despite their low aggression, their immense size poses a tremendous risk to adventurers in their general vicinity.",
 							{
 								"type": "inset",
@@ -40558,7 +41398,7 @@
 											],
 											[
 												"17-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -40598,7 +41438,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -40787,7 +41627,8 @@
 						"entries": [
 							"Lunastra is colored blue as opposed to {@creature Teostra|MHMM} who is red. Her horns are flatter and wider, making a sort of crown structure. They are known to breathe concentrated streams of fire, as well as cloak themselves in a scalding aura. Lunastra are high in the food chain, feeding on both coal, to fuel her fire abilities, and live prey like {@creature Apceros|MHMM}. Though Lunastra are powerful, they have to compete with other species like {@creature Rajang|MHMM}, {@creature Deviljho|MHMM}, and {@creature Akantor|MHMM}.",
 							"Lunastra, as fire dragons, naturally have expert control over fire. They can use this ability when hunting to ensure quick and devastating kills. Despite her large size, she is quick on foot and can easily chase down fast moving prey. Lunastra can also generate a fire aura around their bodies from their horns, which helps prevent brazen monsters like {@creature Tigrex|MHMM} from dealing serious damage to them. These adaptions enable Lunastra to become a formidable apex predator wherever she is. Their wings are covered in a powder that can be released and, at will, set a flame burning in the air resulting in explosions. This explosive powder is actually the Lunastra's old skin.",
-							"Lunastra are brutal female elder dragons, quick to attack at the first sign of trouble, though not as much as Teostra. In the ruins of the old Towers, Lunastra are commonly found in their nest together with Teostra. This suggest that both actually stay in the nest together and guard their young. Though both haven't been seen in the nest together, both of their footprints can be found in the old nests and the active nests together.",
+							"Lunastra are brutal female elder dragons, quick to attack at the first sign of trouble, though not as much as Teostra. In the ruins of the old Towers, Lunastra are commonly found in their nest together with Teostra.", 
+							"This suggests that both actually stay in the nest together and guard their young. Though both haven't been seen in the nest together, both of their footprints can be found in the old nests and the active nests together.",
 							{
 								"type": "inset",
 								"name": "Lunastra",
@@ -41064,7 +41905,6 @@
 			"passive": 9,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Aggressive",
@@ -41150,7 +41990,7 @@
 											],
 											[
 												"18-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -41197,7 +42037,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -41720,10 +42560,7 @@
 			"passive": 17,
 			"languages": [
 				"Giant Owl",
-				"understands Common",
-				"Elvish",
-				"Giant",
-				"Sylvan but can't speak"
+				"understands Common, Elvish, and Sylvan but can't speak them"
 			],
 			"cr": "9",
 			"page": 0,
@@ -41801,7 +42638,7 @@
 						"type": "entries",
 						"entries": [
 							"Malfestio superficially resembles an owl. Its body is covered in blue plumage with a grayish belly, a yellow collar, and a white face with a small beak and red eyes. On its head are long tufts that point back and are tipped with yellow. There are hints of yellow on its legs that end in scaly feet that have two talons and one small vestigial toe. Its wings have bright blue membranes. Along its wings are long blade-like claws. Its flattened tail ends in a three-pointed shape.",
-							"Malfestio is a nocturnal predator that uses its talons and wing claws to attack prey. Like Nargacuga, it sleeps in trees to avoid terrestrial predators. It can produce an ultrasound beam that can easily put prey to sleep. The claws along its wings are usually hidden but are revealed once the malfestio feels threatened.",
+							"Malfestio is a nocturnal predator that uses its talons and wing claws to attack prey. Like {@creature Nargacuga|MHMM}, it sleeps in trees to avoid terrestrial predators. It can produce an ultrasound beam that can easily put prey to sleep. The claws along its wings are usually hidden but are revealed once the malfestio feels threatened.",
 							{
 								"type": "inset",
 								"name": "Malfestio",
@@ -41981,7 +42818,7 @@
 												"type": "entries",
 												"name": "Malfestio Webbing",
 												"entries": [
-													"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+													"{@i Weakness Exploit.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a long rest."
 												]
 											},
 											{
@@ -42002,7 +42839,7 @@
 												"type": "entries",
 												"name": "Coma Sac",
 												"entries": [
-													"A Material that replaces the {@table plants|AGMH|sleep herb} when crafting {@item sleep coating|AGMH} or {@item sleep ammo (1)|AGMH|sleep ammo}."
+													"A Material that replaces the {@table plants|AGMH|sleep herb} when crafting {@item sleep coating|AGMH} or {@item sleep ammo (1)|AGMH|sleep ammo} (100 uses before it is destroyed)."
 												]
 											}
 										]
@@ -42081,7 +42918,6 @@
 			],
 			"cr": "1",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
@@ -42893,7 +43729,6 @@
 			"passive": 10,
 			"cr": "0",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Sure-footed",
@@ -43084,8 +43919,7 @@
 				"P"
 			],
 			"miscTags": [
-				"MW",
-				"AOE"
+				"MW"
 			],
 			"traitTags": [
 				"Illumination"
@@ -43133,7 +43967,6 @@
 			"passive": 9,
 			"cr": "0",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Mushroom Hunter",
@@ -43613,8 +44446,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"RW"
+				"RCH"
 			],
 			"conditionInflict": [
 				"paralyzed",
@@ -43629,7 +44461,7 @@
 				"H"
 			],
 			"type": {
-				"type": "dragon",
+				"type": "aberration",
 				"tags": [
 					"elder"
 				]
@@ -43717,25 +44549,32 @@
 				{
 					"name": "Broken Tentacles",
 					"entries": [
-						"A broken tentacle has had the bones protecting it destroyed reducing its AC by 2. (Size. Large, AC 20). Damaging a broken tentacle deals damage to the nakarkos. At the end of the nakarkos turn, a broken tentacle retracts into the ground. It reappears at the start of the nakarkos next turn with the bones of a new creature, roll a {@dice d4} to determine what type of tentacle it becomes. On a 1, Lagiacrus Tentacle; On a 2, Galvenus Tentacle; On a 3, Uragaan Tentacle; On a 4, Brachydios Tentacle."
+						"A broken tentacle has had the bones protecting it destroyed reducing its AC by 2. (Size. Large, AC 20). Damaging a broken tentacle deals damage to the nakarkos. At the end of the nakarkos turn, a broken tentacle retracts into the ground. It reappears at the start of the nakarkos next turn with the bones of a new creature, roll a {@dice d4} to determine what type of tentacle it becomes. On a 1, Lagiacrus Tentacle; On a 2, Glavenus Tentacle; On a 3, Uragaan Tentacle; On a 4, Brachydios Tentacle."
 					]
 				},
 				{
 					"name": "True Face",
 					"entries": [
-						"The Nakarkos is sunken into the ground, revealing only its body parts that are covered in dragon bone giving the appearance that it has \"two heads\" but nakarkos's true head is hidden away underground. When the nakarkos is below half of its maximum hit points (131), it will reveal its unprotected true face reducing its AC by 2 and replacing its multiattack and fire beam with."
-					]
-				},
-				{
-					"name": "Multiattack",
-					"entries": [
-						"The nakarkos makes two tentacle attacks and one beak attack. it can replace its tentacle attack with a sticky mucus attack."
-					]
-				},
-				{
-					"name": "Fire Beam {@recharge 5}",
-					"entries": [
-						"The nakarkos exhales a beam of fire in a 90-foot line that is 10-feet wide. Each creature in that line must make a {@dc 22} Dexterity saving throw, taking 50 ({@damage 9d10}) fire damage on a failed save, or half as much damage on a successful one."
+						"The Nakarkos is sunken into the ground, revealing only its body parts that are covered in dragon bone giving the appearance that it has \"two heads\" but nakarkos's true head is hidden away underground. When the nakarkos is below half of its maximum hit points (131), it will reveal its unprotected true face reducing its AC by 2 and replacing its multiattack and fire beam with:",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "item",
+									"name": "Multiattack",
+									"entries": [
+										"The nakarkos makes two tentacle attacks and one beak attack. It can replace its tentacle attack with a sticky mucus attack."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Fire Beam {@recharge 5}",
+									"entries": [
+										"The nakarkos exhales a beam of fire in a 90-foot line that is 10-feet wide. Each creature in that line must make a {@dc 22} Dexterity saving throw, taking 50 ({@damage 9d10}) fire damage on a failed save, or half as much damage on a successful one."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -43743,7 +44582,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The nakarkos makes two tentacle attacks. it can replace either of these attacks with a Sticky Mucus attack."
+						"The nakarkos makes two tentacle attacks. It can replace either of these attacks with a Sticky Mucus attack."
 					]
 				},
 				{
@@ -43761,43 +44600,53 @@
 				{
 					"name": "Fire Beam {@recharge 5}",
 					"entries": [
-						"The nakarkos tentacles releases two beams of fire, one from each tentacle. Each beam fires in a 45-foot line that is 5-feet wide. Each creature in either line must make a {@dc 22} Dexterity saving throw, taking 44 ({@damage 8d10}) fire damage on a failed save, or half as much damage on a successful one."
+						"The nakarkos tentacles release two beams of fire, one from each tentacle. Each beam fires in a 45-foot line that is 5-feet wide. Each creature in either line must make a {@dc 22} Dexterity saving throw, taking 44 ({@damage 8d10}) fire damage on a failed save, or half as much damage on a successful one."
 					]
 				},
 				{
 					"name": "Tentacles",
 					"entries": [
-						"The nakarkos uses one of the following tentacle attacks depending on which bones they are using."
-					]
-				},
-				{
-					"name": "Broken Tentacle",
-					"entries": [
-						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}17 ({@damage 3d6 + 7}) bludgeoning damage."
-					]
-				},
-				{
-					"name": "Lagiacrus Tentacle",
-					"entries": [
-						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) piercing damage plus 5 ({@damage 1d10}) lightning damage."
-					]
-				},
-				{
-					"name": "Galvenus Tentacle",
-					"entries": [
-						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) slashing damage plus 5 ({@damage 1d10}) fire damage."
-					]
-				},
-				{
-					"name": "Uragaan Tentacle",
-					"entries": [
-						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}28 ({@damage 6d6 + 7}) blugeoning damage."
-					]
-				},
-				{
-					"name": "Brachydios Tentacle",
-					"entries": [
-						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) bludgeoning damage and each creature within 5 feet of the target, including the target, must make a {@dc 20} Dexterity saving throw, taking 7 ({@damage 2d6}) fire damage on a failed save, or half as much on a successful one."
+						"The nakarkos uses one of the following tentacle attacks depending on which bones they are using:",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "item",
+									"name": "Broken Tentacle",
+									"entries": [
+										"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}17 ({@damage 3d6 + 7}) bludgeoning damage."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Lagiacrus Tentacle",
+									"entries": [
+										"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) piercing damage plus 5 ({@damage 1d10}) lightning damage."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Glavenus Tentacle",
+									"entries": [
+										"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) slashing damage plus 5 ({@damage 1d10}) fire damage."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Uragaan Tentacle",
+									"entries": [
+										"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}28 ({@damage 6d6 + 7}) blugeoning damage."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Brachydios Tentacle",
+									"entries": [
+										"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) bludgeoning damage and each creature within 5 feet of the target, including the target, must make a {@dc 20} Dexterity saving throw, taking 7 ({@damage 2d6}) fire damage on a failed save, or half as much on a successful one."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -44021,8 +44870,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"AOE",
-				"RW"
+				"AOE"
 			],
 			"conditionInflict": [
 				"grappled",
@@ -44433,13 +45281,7 @@
 						]
 					}
 				]
-			},
-			"conditionInflict": [
-				"prone"
-			],
-			"damageTagsSpell": [
-				"B"
-			]
+			}
 		},
 		{
 			"name": "Nargacuga",
@@ -44810,7 +45652,7 @@
 			"wis": 18,
 			"cha": 16,
 			"save": {
-				"str": "+16",
+				"str": "+14",
 				"dex": "+9",
 				"wis": "+11"
 			},
@@ -44876,19 +45718,19 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 14} to hit, reach 10 ft., one target. {@h}25 ({@damage 4d8 + 7}) piercing damage."
+						"{@atk mw} {@hit 14} to hit, reach 5 ft., one target. {@h}25 ({@damage 4d8 + 7}) piercing damage."
 					]
 				},
 				{
 					"name": "Horn",
 					"entries": [
-						"{@atk mw} {@hit 14} to hit, reach 5 ft., one target. {@h}29 ({@damage 4d10 + 7}) bludgeoning damage."
+						"{@atk mw} {@hit 14} to hit, reach 10 ft., one target. {@h}29 ({@damage 4d10 + 7}) bludgeoning damage."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"{@atk mw} {@hit 14} to hit, reach 5 ft., one target. {@h}14 ({@damage 2d6 + 7}) slashing damage."
+						"{@atk mw} {@hit 14} to hit, reach 10 ft., one target. {@h}14 ({@damage 2d6 + 7}) slashing damage."
 					]
 				},
 				{
@@ -46123,7 +46965,7 @@
 										"type": "entries",
 										"name": "Nightshade Paolumu Fellwing",
 										"entries": [
-											"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+											"{@i Weakness Exploit.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a long rest."
 										]
 									},
 									{
@@ -46732,7 +47574,6 @@
 			"passive": 10,
 			"cr": "7",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Blind Panic",
@@ -47030,7 +47871,6 @@
 			"passive": 9,
 			"cr": "2",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Blind Panic",
@@ -47617,7 +48457,6 @@
 			"passive": 10,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Trampling Charge",
@@ -47818,7 +48657,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The pukei-pukei makes two tongue attacks and one tail attack. It can replace any one of these with its poison spit attack."
+						"The pukei-pukei makes three attacks: two with its tongue and one with its tail. It can replace any one of these with its poison spit attack."
 					]
 				},
 				{
@@ -47836,13 +48675,13 @@
 				{
 					"name": "Poison Spit",
 					"entries": [
-						"{@atk rw} {@hit 4} to hit, range 30/120 ft., one target. {@h}10 ({@damage 3d6}) poison damage and the target must pass a {@dc 13} Constitution saving throw, or become {@condition poisoned} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+						"{@atk rw} {@hit 4} to hit, range 30/120 ft., one target. {@h}10 ({@damage 3d6}) poison damage and the target must succeed on a {@dc 12} Constitution saving throw, or become {@condition poisoned} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Poison Spray {@recharge 5}",
 					"entries": [
-						"The pukei-pukei sprays poisonous gas from its tail in a 30-foot cone. Each creature in that area must make a {@dc 13} Constitution saving throw, or become {@condition poisoned} and take 27 ({@damage 6d8}) poison damage on a failed save, or half as much damage and are not {@condition poisoned} on a successful one."
+						"The pukei-pukei sprays poisonous gas from its tail in a 30-foot cone. Each creature in that area must make a {@dc 12} Constitution saving throw, or take 27 ({@damage 6d8}) poison damage and become {@condition poisoned} for 1 minute on a failed save, or half as much damage and are not {@condition poisoned} on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -48079,6 +48918,358 @@
 			]
 		},
 		{
+			"name": "Pumpkin Uragaan",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"brute"
+				]
+			},
+			"group": [
+				"Brute Wyverns"
+			],
+			"environment": [
+				"desert",
+				"mountain",
+				"underdark"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 17,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 123,
+				"formula": "13d12 + 39"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 19,
+			"dex": 10,
+			"con": 16,
+			"int": 5,
+			"wis": 12,
+			"cha": 6,
+			"skill": {
+				"perception": "+5"
+			},
+			"passive": 15,
+			"cr": "10",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Glowing Chin",
+					"entries": [
+						"The uragaan's Jack-o'-lantern chin glows from its eyes and mouth, releasing bright light in a 30-foot cone and dim light for an additional 30 feet."
+					]
+				},
+				{
+					"name": "Rise Again (1/day)",
+					"entries": [
+						"When the uragaan is reduced to 0 hit points, it resurrects on initiative count 20 (losing initiative ties). When it resurrects, the uragaan's hit points are healed to its maximum, its type is changed from wyvern to undead, and it gains the undead fortitude trait.",
+						{
+							"type": "homebrew",
+							"entries": [
+								"Presented for reference, the {@creature zombie}'s {@b Undead Fortitude} trait:",
+								"{@i If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead.}"
+							]
+						}
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The uragaan makes one tail attack and two chin slam attacks. Or it makes three attacks with its pumpkin toss."
+					]
+				},
+				{
+					"name": "Jack-o'-lantern Chin Slam",
+					"entries": [
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}17 ({@damage 3d8 + 4}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Pumpkin Toss",
+					"entries": [
+						"{@atk rw} {@hit 8} to hit, range 40/120 ft., one target. {@h}17 ({@damage 3d8 + 4}) bludgeoning damage and the target is covered in pumpkin guts."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 8} to hit, reach 5 ft., one target. {@h}20 ({@damage 3d10 + 4}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Roll {@recharge 5}",
+					"entries": [
+						"The uragaan rolls its body into a wheel and moves up to its speed, during this move it may move through other creatures without provoking opportunity attacks. Any creatures the Uragaan moves through must succeed on a {@dc 16} Dexterity saving throw or take 28 ({@damage 8d6}) bludgeoning damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Emit Flames",
+					"entries": [
+						"(2/per Long rest). The uragaan releases a wave of fire from its underside in a 10-foot radius around it. Each creature in that area must make a {@dc 15} Dexterity saving throw, taking 21 ({@damage 6d6}) fire damage and catches fire on a failed save or half as much on a successful one and does not catch fire. Until someone takes an action to douse the fire, the creature takes 3 ({@damage 1d6}) fire damage at the start of each of its turns."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"The pumpkin uragaan possesses a near identical body shape to the normal {@creature uragaan|MHMM}, yet has a different coloration. Its back and belly are a dark purple while the rest of its body is a pumpkin orange. Its chin is no longer plated with a rock-like shell, but instead is covered by a large jack-o'-lantern.",
+							"It has been said that on All Hallows' Eve, a pumpkin uragaan appears in a great pumpkin patch on the outskirts of one of the many villages in the old world. By dawn, the village is left burning, broken, and covered in pumpkin; and the pumpkin uragaan vanishes, until the next All Hallows' Eve.",
+							{
+								"type": "inset",
+								"name": "Pumpkin Uragaan",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"10",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-4",
+												"Pumpkin.U Carapace",
+												"(A,W)"
+											],
+											[
+												"5-8",
+												"P.Firecell Stone",
+												"(A,W)"
+											],
+											[
+												"9-11",
+												"Pumpkin.U Scale",
+												"(W)"
+											],
+											[
+												"12-14",
+												"Pumpkin.U Scute",
+												"(A,W)"
+											],
+											[
+												"15-16",
+												"Pumpkin Flame Sac",
+												"(A,W)"
+											],
+											[
+												"17-18",
+												"Pumpkin.U Marrow",
+												"(A)"
+											],
+											[
+												"19",
+												"Pumpkin.U Jaw",
+												"(W)"
+											],
+											[
+												"20",
+												"Pumpkin.U Ruby",
+												"(A)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Carapace",
+												"entries": [
+													"{@i Constitution.} The duration from slowing effects, such as the {@spell slow} spell or a copper dragon's breath attack, are reduced by half while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "P.Firecell Stone",
+												"entries": [
+													"When you must succeed on a saving throw or be knocked {@condition prone}, you do so with advantage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Scute",
+												"entries": [
+													"{@i Health Boost.} While wearing this armor, your hit point maximum increases by 1 for each character level you have."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin Flame Sac",
+												"entries": [
+													"While you are attuned to this armor, you can use a bonus action to speak its command word and exhale fire at a target within 30 feet of you. The target must make a {@dc 16} Dexterity saving throw, taking {@damage 4d6} fire damage on a failed save, or half as much damage on a successful one.",
+													"Once used, this property cannot be used again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Marrow",
+												"entries": [
+													"{@i Guts+.} When you are reduced to 0 hit points but not killed outright, you can drop to 1 hit point instead. Once you use this property, you can't use it again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Ruby",
+												"entries": [
+													"{@i Mushroomancer+.} While wearing this armor you can digest {@table mushrooms|AGMH} that would otherwise be inedible and gain their advantageous effects. The more pumpkin uragaan materials equipped in your armor or trinkets, the more mushrooms you can eat.",
+													{
+														"type": "list",
+														"name": "1 pumpkin uragaan material",
+														"items": [
+															"Blue Mushroom, {@i Restores a 1d4 hit points.}",
+															"Toadstool, {@i You regain 1 hit points at the start of each of your turns for 1 minute.}"
+														]
+													},
+													{
+														"type": "list",
+														"name": "2 pumpkin uragaan material",
+														"items": [
+															"Nitroshroom, {@i Your Strength score increases by +2 for 1 minute.}",
+															"Parashroom, {@i Your AC becomes 13 + your Dexterity modifier for the next 8 hours.}"
+														]
+													},
+													{
+														"type": "list",
+														"name": "3 pumpkin uragaan material",
+														"items": [
+															"Chaos Mushroom, {@i You are {@condition poisoned} for 1 hour, and gain 5 temporary hit points per character level for the next 10 minutes.}",
+															"Bindshroom, {@i Your speed increases by 15 feet for 1 hour.}",
+															"Exciteshroom, {@i Provides one of the other mushroom effects, roll a d6 to see which one:}",
+															{
+																"type": "list",
+																"style": "list-decimal",
+																"items": [
+																	"Blue Mushroom",
+																	"Toadstool",
+																	"Nitroshroom",
+																	"Parashroom",
+																	"Chaos Mushroom",
+																	"Bindshroom"
+																]
+															}
+														]
+													}
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Carapace",
+												"entries": [
+													"This weapon acts as a focus for your spellcasting."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "P.Firecell Stone",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d6} fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Scale",
+												"entries": [
+													"{@i Pumpkin Carver.} While you are attuned to this armor, you can carve a creature of CR 8 or lower 1 extra time."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Scute",
+												"entries": [
+													"{@i Partbreaker+1.} You deal an extra {@damage 1d6} damage when you critically hit with this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin Flame Sac",
+												"entries": [
+													"This weapon has 4 runes. While holding it, you can use an action to expend 1 or more of its runes to cast the {@spell flaming sphere} spell (save DC 13) from it. For 1 rune, you cast the 1st-level version of the spell. You can increase the spell slot level by one for each additional rune you expend. A flaming sphere takes the form of a flaming jack-o'-lantern when cast in this way.",
+													"This weapon regains 1d4 expended runes daily at dawn. If you expend the weapon's last rune, roll a d20. On a 1, the runes cannot recharge for a week."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Jaw",
+												"entries": [
+													"{@i Resentment.} Until the end of your turn, you gain a +1 bonus to attack and damage rolls against any creature that has damaged you since the end of your last turn."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/BPVN7mr.png",
+			"damageTags": [
+				"B",
+				"F"
+			],
+			"miscTags": [
+				"MW",
+				"RW",
+				"AOE"
+			],
+			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
 			"name": "Qurupeco",
 			"size": [
 				"L"
@@ -48129,7 +49320,7 @@
 			"cha": 16,
 			"save": {
 				"cha": "+6",
-				"con": "+5"
+				"con": "+4"
 			},
 			"skill": {
 				"performance": "+6"
@@ -48144,7 +49335,7 @@
 				{
 					"name": "Sensitive Ears",
 					"entries": [
-						"The qurupeco ears are very sensitive, Thunder skills or spells used within 60 feet of the qurupeco cause it to be {@condition Stunned} until the start of its next turn."
+						"If the qurupeco takes thunder damage or a thunder spell is used within 60 feet of it, it must succeed on a {@dc 15} Constitution saving throw or become {@condition stunned} until the start of its next turn."
 					]
 				}
 			],
@@ -48152,7 +49343,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The qurupeco makes three attacks, one with its flint and two with its peck."
+						"The qurupeco makes three attacks: one with its flint and two with its peck."
 					]
 				},
 				{
@@ -48395,9 +49586,6 @@
 			],
 			"spellcastingTags": [
 				"I"
-			],
-			"damageTagsSpell": [
-				"Y"
 			]
 		},
 		{
@@ -48486,7 +49674,7 @@
 				{
 					"name": "Fire Breath {@recharge 5}",
 					"entries": [
-						"The rachnoid exhales fire in a 15-foot line that is 5-feet wide. Each creature in that line must make a {@dc 12} Dexterity saving throw, taking 7 ({@damage 2d6}) fire damage on a failed save, or half as much damage on a successful one."
+						"The rachnoid exhales fire in a 15-foot line that is 5-feet wide. Each creature in that line must make a {@dc l2} Dexterity saving throw, taking 7 ({@damage 2d6}) fire damage on a failed save, or half as much damage on a successful one."
 					]
 				}
 			],
@@ -48644,7 +49832,7 @@
 				{
 					"ac": 15,
 					"from": [
-						"19 with Bone Armor"
+						"19 with bone armor"
 					]
 				}
 			],
@@ -48671,7 +49859,6 @@
 			"passive": 15,
 			"cr": "10",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Bone Armor",
@@ -48684,7 +49871,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The radobaan makes one Tail attack and two Chin Slam attacks."
+						"The radobaan makes one tail attack and two chin slam attacks."
 					]
 				},
 				{
@@ -48702,13 +49889,13 @@
 				{
 					"name": "Roll {@recharge 5}",
 					"entries": [
-						"The radobaan rolls its body into a wheel and moves up to its speed, during this move it may move through other creatures without provoking opportunity attacks. Any creatures the Uragaan moves through must succeed on a {@dc 17} Dexterity saving throw or take 42 ({@damage 12d6}) slashing damage and be knocked {@condition prone}."
+						"The radobaan rolls its body into a wheel and moves up to its speed, during this move it may move through other creatures without provoking opportunity attacks. Any creatures the radobaan moves through must succeed on a {@dc 17} Dexterity saving throw or take 42 ({@damage 12d6}) slashing damage and be knocked {@condition prone}."
 					]
 				},
 				{
 					"name": "Sleeping Gas (2/Day)",
 					"entries": [
-						"The radobaan releases sleeping gas from its underside. All creatures within 15 ft. must make a {@dc 16} Constitution saving throw or, they fall {@condition Unconscious} until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake"
+						"The radobaan releases sleeping gas from its underside. All creatures within 15 ft. must make a {@dc 16} Constitution saving throw or, they fall {@condition unconscious} until the spell ends, the sleeper takes damage, or someone uses an action to shake or slap the sleeper awake."
 					]
 				}
 			],
@@ -48720,7 +49907,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Radobaan looks very similar to Uragaan in many aspects but has its own unique features. Unlike Uragaan, Radobaan is covered in a tar-like substance that sticks rows of bones onto its body. These bones vary in size throughout the Radobaan's body but the most distinctive ones are on its legs. The bones on its legs are the horns of Diablos. Though the bones aren't as strong as ore, they are lighter. This lighter weight makes Radobaan faster than Uragaan. Despite not eating ore, Radobaan still has a massive chin like Uragaan. Like Uragaan, Radobaan can roll into a wheel and run over enemies.",
+							"Radobaan looks very similar to {@creature Uragaan|MHMM} in many aspects but has its own unique features. Unlike Uragaan, Radobaan is covered in a tar-like substance that sticks rows of bones onto its body. These bones vary in size throughout the Radobaan's body but the most distinctive ones are on its legs. The bones on its legs are the horns of {@creature Diablos|MHMM}. Though the bones aren't as strong as ore, they are lighter. This lighter weight makes Radobaan faster than Uragaan. Despite not eating ore, Radobaan still has a massive chin like Uragaan. Like Uragaan, Radobaan can roll into a wheel and run over enemies.",
 							"It also can emit coma-inducing gas from its body like Uragaan. Radobaan can be fairly calm unless provoked by a threat unlike their ore eating relatives the Uraagan which will become hostile regardless of being threatened or not. Once provoked, they will turn violent.",
 							{
 								"type": "inset",
@@ -48861,7 +50048,7 @@
 												"type": "entries",
 												"name": "R.Sleep Sac",
 												"entries": [
-													"A Material that replaces the {@table plants|AGMH|sleep herb} when crafting {@item tranq bomb|AGMH}s or {@item tranq ammo (1)|AGMH|tranq ammo}."
+													"A Material that replaces the {@table plants|AGMH|sleep herb} when crafting {@item tranq bomb|AGMH}s or {@item tranq ammo (1)|AGMH|tranq ammo}. (100 uses)."
 												]
 											}
 										]
@@ -48944,7 +50131,6 @@
 			"passive": 9,
 			"cr": "22",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Detonate",
@@ -48978,7 +50164,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The brachydios makes three attacks, one with its horn and two with its fist."
+						"The brachydios makes three attacks: one with its horn and two with its fist."
 					]
 				},
 				{
@@ -49028,7 +50214,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Theorized to have grown isolated in a special environment, Raging Brachydios is a rare special Brachydios individual that has abnormal activation of its Slime Mold.",
+							"Theorized to have grown isolated in a special environment, Raging Brachydios is a rare special {@creature Brachydios|MHMM} individual that has abnormal activation of its Slime Mold.",
 							"Raging Brachydios is a predator capable of taking on and even killing other large predatory monsters, just like Brachydios. In line with their chosen habitat and absurd strength, Raging Brachydios will encounter far more dangerous foes than regular Brachydios, but will fight them and potentially win nonetheless.",
 							"Raging Brachydios have many of the same adaptions as Brachydios, however, there is a few differences between them. Raging Brachydios are extremely large compared to normal Brachydios, but are only slightly slower than them. This size difference stems from their advanced age. The main adaption that puts them apart from normal Brachydios is the large amount of slime mold found on their body.",
 							"This Ancient slime mold is not only more active then regular slime mold, but also explodes far more violently. This provides Raging Brachydios far more potent explosions that those of its peers. This forces Raging Brachydios to develop its own special Indestructible Ebonshell, to withstand its own explosions, lest it kill itself. This in turn provides it nigh-impenetrable protection from the natural weaponry of nearly all other living creatures.",
@@ -49182,7 +50368,7 @@
 												"type": "entries",
 												"name": "Brachydios Lash",
 												"entries": [
-													"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+													"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
 												]
 											},
 											{
@@ -49200,7 +50386,7 @@
 													{
 														"type": "list",
 														"items": [
-															"When a creature must succeed on a saving throw or become {@condition stunned} by the effect of one of your weapon attacks, they make the save with disadvantage.",
+															"Once per turn when a creature must succeed on a saving throw or become {@condition stunned} by the effect of one of your weapon attacks, they make the save with disadvantage.",
 															"Once per turn when you hit a creature with this weapon, it must make a {@dc 12} Constitution saving throw or gain one level of {@condition exhaustion}. A creature cannot gain more than 2 levels of exhaustion from this weapon's property."
 														]
 													}
@@ -49297,7 +50483,7 @@
 				"walk": 40,
 				"climb": 40
 			},
-			"str": 24,
+			"str": 23,
 			"dex": 12,
 			"con": 23,
 			"int": 12,
@@ -49536,9 +50722,9 @@
 											},
 											{
 												"type": "entries",
-												"name": "Rajang Blackfur ",
+												"name": "Rajang Blackfur",
 												"entries": [
-													"Your weapon deals an extra 1d6 lightning damage."
+													"Your weapon deals an extra {@damage 1d6} lightning damage."
 												]
 											},
 											{
@@ -49607,7 +50793,7 @@
 												"type": "entries",
 												"name": "Gold Rajang Pelt",
 												"entries": [
-													"Your weapon deals an extra 1d8 lightning damage."
+													"Your weapon deals an extra {@damage 1d8} lightning damage."
 												]
 											}
 										]
@@ -49629,7 +50815,8 @@
 				"AOE"
 			],
 			"conditionInflict": [
-				"prone"
+				"prone",
+				"stunned"
 			]
 		},
 		{
@@ -50079,8 +51266,7 @@
 			"miscTags": [
 				"MW",
 				"RW",
-				"AOE",
-				"RCH"
+				"AOE"
 			],
 			"traitTags": [
 				"Spider Climb",
@@ -50864,7 +52050,6 @@
 			"passive": 11,
 			"cr": "1/4",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
@@ -51452,8 +52637,7 @@
 				"C"
 			],
 			"miscTags": [
-				"MW",
-				"AOE"
+				"MW"
 			],
 			"conditionInflict": [
 				"poisoned"
@@ -51587,8 +52771,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The nergigante can use its frightful presence. It then makes four attacks: one with its bite,",
-						"one with its horn, and two with its claws. "
+						"The nergigante can use its frightful presence. It then makes four attacks: one with its bite, one with its horn, and two with its claws. "
 					]
 				},
 				{
@@ -51631,7 +52814,7 @@
 					"name": "Spiked Explosion",
 					"entries": [
 						"The spikes on the nergigante explode outward in a 40-foot-sphere around it. Each creature in that area must make a {@dc 24} Dexterity saving throw, taking 10 ({@damage 3d6}) piercing damage and begin to bleed from a vicious wound on a failed save or half as much damage and do not bleed on a successful one.",
-						"A creature that suffers from a vicious wound loses 4 ({@dice 1d8}) hit points at the start of each of its turns. Each time the creature suffers from another vicious wound, the damage dealt by the wound increases by 4 ({@dice 1d8}). Any creature can take an action to stanch the wound with a successful {@dc 18} Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
+						"A creature that suffers from a vicious wound loses 4 ({@dice 1d8}) hit points at the start of each of its turns. Each time the creature suffers from another vicious wound, the damage dealt by the wound increases by 4 ({@dice 1d8}). Any creature can take an action to stanch the wound with a successful {@dc 18} Wisdom ({@skill Medicine}) check. The wound also closes if the target receives magical healing."
 					]
 				},
 				{
@@ -52531,10 +53714,10 @@
 			],
 			"fluff": {
 				"entries": [
-					"Savage Deviljho are rare special Deviljho individuals that are abnormally old with an extreme hunger. They can be found practically anywhere like then normal deviljho, and easily assert themselves as super predators that rival elder dragons in any conceivable habitat they find themselves in and are challenged by little.",
-					"The Savage Deviljho has many of the same adaptions as a normal Deviljho, however, has a few minor differences. Savage Deviljho are noticeably always enraged. This due to",
-					"the Savage Deviljho being extremely hungry and constantly needing to feed. Their face is covered like a mask of dragon element, giving it a more sinister look and the hide and the blood of savage deviljho is black in color due to the effects of this element.",
+					"Savage Deviljho are rare special {@creature Deviljho|MHMM} individuals that are abnormally old with an extreme hunger. They can be found practically anywhere like then normal deviljho, and easily assert themselves as super predators that rival elder dragons in any conceivable habitat they find themselves in and are challenged by little.",
+					"The Savage Deviljho has many of the same adaptations as a normal Deviljho, however, has a few minor differences. Savage Deviljho are noticeably always enraged. This due to being extremely hungry and constantly needing to feed. Their face is covered like a mask of dragon element, giving it a more sinister look and the hide and the blood of savage deviljho is black in color due to the effects of this element.",
 					"The savage deviljho is an even more brutal and rabid monster than the ordinary variety due to its unrelenting hunger. The black blood may drive the savage deviljho to such heightened aggression, even causing it to become a 'rogue' killing machine.",
+					"With its appearance in the New World, Savage Deviljho's supreme height in the food chain is finally confirmed. The infamous Variant of the World Eater has been seen directly confronting Elder Dragons like {@creature Velkhana|MHMM}, {@creature Namielle|MHMM} and {@creature Blackveil Vaal Hazak|MHMM}, resulting in violent elemental clashes that often end explosively in stalemates. Perhaps even more terrifyingly, the Savage Deviljho's physical prowess has increased to the point which it can feasibly stand against the immensely powerful Elder Dragon Variant {@creature Ruiner Nergigante|MHMM}, one which specializes in unyielding physical strength.",
 					{
 						"type": "inset",
 						"name": "Savage Deviljho",
@@ -52680,7 +53863,7 @@
 										"type": "entries",
 										"name": "Savage Talon",
 										"entries": [
-											"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+											"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
 										]
 									},
 									{
@@ -52818,7 +54001,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The yian garuga makes three attack: two with its peck and one with its tail. Or it makes three fire ball attacks."
+						"The yian garuga makes three attacks: two with its peck and one with its tail. Or it makes three fire ball attacks."
 					]
 				},
 				{
@@ -52882,10 +54065,9 @@
 			],
 			"fluff": {
 				"entries": [
-					"In terms of appearance, scarred yian garuga is virtually identical to yian garuga. The main difference between the two is that one of this monster's ears is missing and Scarred Yian Garuga received a scar across its face. ",
-					"The scarred yian garuga hunt almost exclusively at night, using its deadly poison or stabbing its prey to finish off its victim. It is just as aggressive as the yian garuga, but has",
-					"adapted its attacks over its many battles, including the ability to unleash a barrage of small fire balls whilst its in the air. If hunting another predatory species such as a velocidrome, Yian Garuga will first stun the creature with its roar before launching any attacks.",
-					"Azure Rathalos, Pink Rathian, Tigrex, Nargacuga, and the rare Rajang are fierce competitors of the Bird Wyverns and are even capable of killing them if an opportunity were to arise. However, being one of if not the most feared member of the Bird Wyvern class these creatures are fully capable of defending themselves against potential threats.",
+					"In terms of appearance, scarred yian garuga is virtually identical to {@creature yian garuga|MHMM}. The main difference between the two is that one of this monster's ears is missing and Scarred Yian Garuga received a scar across its face.",
+					"The scarred yian garuga hunt almost exclusively at night, using its deadly poison or stabbing its prey to finish off its victim. It is just as aggressive as the yian garuga, but has adapted its attacks over its many battles, including the ability to unleash a barrage of small fire balls whilst its in the air. If hunting another predatory species such as a {@creature velocidrome|MHMM}, Yian Garuga will first stun the creature with its roar before launching any attacks.",
+					"Azure Rathalos, Pink Rathian, {@creature Tigrex|MHMM}, {@creature Nargacuga|MHMM}, and the rare {@creature Rajang|MHMM} are fierce competitors of the Bird Wyverns and are even capable of killing them if an opportunity were to arise. However, being one of if not the most feared member of the Bird Wyvern class these creatures are fully capable of defending themselves against potential threats.",
 					{
 						"type": "inset",
 						"name": "Scarred Yian Garuga",
@@ -53520,7 +54702,6 @@
 			"passive": 9,
 			"cr": "3",
 			"page": 0,
-			"senses": null,
 			"action": [
 				{
 					"name": "Multiattack",
@@ -53770,7 +54951,6 @@
 			"passive": 11,
 			"cr": "11",
 			"page": 0,
-			"senses": null,
 			"trait": [
 				{
 					"name": "Drone Slave",
@@ -54007,8 +55187,7 @@
 				"C"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			],
 			"conditionInflict": [
 				"grappled",
@@ -54310,8 +55489,7 @@
 				"P"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			],
 			"conditionInflict": [
 				"restrained"
@@ -54758,8 +55936,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"RW",
-				"AOE"
+				"RW"
 			],
 			"conditionInflict": [
 				"prone"
@@ -54823,14 +56000,14 @@
 				"Deep Speech",
 				"Draconic",
 				"Sylvan",
-				"Abyssal"
+				"Telepathy 120 ft."
 			],
 			"languageTags": [
 				"C",
 				"DS",
 				"DR",
 				"S",
-				"AB"
+				"TP"
 			],
 			"save": {
 				"str": "+14",
@@ -54911,7 +56088,7 @@
 										{
 											"name": "Frozen Hide",
 											"entries": [
-												"The shah dalamadur hide repels most attacks. It has resistance to all damage except psychic."
+												"The shah dalamadur hide repels most attacks. It has resistance to all damage except psychic damage."
 											]
 										}
 									]
@@ -55010,10 +56187,9 @@
 			],
 			"fluff": {
 				"entries": [
-					"Shah dalamadur is the undisputed apex predator of its habitat. Although its diet is unknown, it is almost certainly carnivorous, and herbivorous monsters such as aptonoth, conga, and rhenoplos would be easy prey. Given its incredible size, predators such as tigrex, deviljho, stygian zinogre, azure rathalos, rajang and even the infamous shagaru magala would most likely avoid the beast at all costs.",
-					"Shah dalamadur are far more aggressive than any mere dalamadur due to them being in a sort of defenseless state after molting.",
-					"Shah dalamadur sport a lighter, sand-colored hide with redorange spines after molting out of their old skin. After molting, shah dalamadur have no control over their metabolism, meaning their body temperature will constantly change. When cold, a shah dalamadur's hide can repel most attacks. When hot, the hide of a shah dalamadur is vulnerable to most attacks. From their body temperature constantly changing, shah dalamadur are able to perform an ability never seen before by a normal dalamadur. Shah dalamadur are able to burn the very ground with their powerful heated metabolism",
-					"through just about any part of their body that is heated.",
+					"Shah dalamadur is the undisputed apex predator of its habitat. Although its diet is unknown, it is almost certainly carnivorous, and herbivorous monsters such as {@creature aptonoth|MHMM}, {@creature conga|MHMM}, and {@creature rhenoplos|MHMM} would be easy prey. Given its incredible size, predators such as {@creature tigrex|MHMM}, {@creature deviljho|MHMM}, stygian zinogre, azure rathalos, {@creature rajang|MHMM} and even the infamous {@creature shagaru magala|MHMM} would most likely avoid the beast at all costs.",
+					"Shah dalamadur are far more aggressive than any mere {@creature dalamadur|MHMM} due to them being in a sort of defenseless state after molting.",
+					"Shah dalamadur sport a lighter, sand-colored hide with red-orange spines after molting out of their old skin. After molting, shah dalamadur have no control over their metabolism, meaning their body temperature will constantly change. When cold, a shah dalamadur's hide can repel most attacks. When hot, the hide of a shah dalamadur is vulnerable to most attacks. From their body temperature constantly changing, shah dalamadur are able to perform an ability never seen before by a normal dalamadur. Shah dalamadur are able to burn the very ground with their powerful heated metabolism through just about any part of their body that is heated. This heat can leave behind powerful flames with just a single touch.",
 					{
 						"type": "inset",
 						"name": "Shah Dalamadur",
@@ -55096,7 +56272,7 @@
 									[
 										"16-17",
 										"S.Dalam Tail Shell",
-										"(A,W)"
+										"(W)"
 									],
 									[
 										"18-19",
@@ -55967,8 +57143,7 @@
 					"ac": 20,
 					"from": [
 						"natural armor"
-					],
-					"braces": true
+					]
 				}
 			],
 			"hp": {
@@ -56492,6 +57667,12 @@
 			],
 			"trait": [
 				{
+					"name": "Amphibious",
+					"entries": [
+						"The shen gaoren can breathe air and water."
+					]
+				},
+				{
 					"name": "Legendary Resistance (3/Day)",
 					"entries": [
 						"If the shen gaoren fails a saving throw, it can choose to succeed instead."
@@ -56518,7 +57699,7 @@
 				{
 					"name": "Armored Legs",
 					"entries": [
-						"The shen gaoren has 4 legs stretching 30 feet up. Each leg can be attacked (AC 16; 25 hit points; immunity to poison and psychic damage, resistances to bludgeoning, piercing, and slashing from nonmagical weapons). Damaging a leg deals no damage to the shen gaoren. Reducing all four legs to 0 hit points causes the shen gaoren to immediately use its reaction to collaspse. 3 rounds after the shen gaoren uses collapse, its legs heal to their maximum hp and the shen gaoren can stand up."
+						"The shen gaoren has 4 legs stretching 30 feet up. Each leg can be attacked (AC 16; 25 hit points; immunity to poison and psychic damage, resistances to bludgeoning, piercing, and slashing from nonmagical weapons). Damaging a leg deals no damage to the shen gaoren. Reducing all four legs to 0 hit points causes the shen gaoren to immediately use its reaction to {@i collapse}. 3 rounds after the shen gaoren uses {@i collapse}, its legs heal to their maximum hp and the shen gaoren can stand up."
 					]
 				}
 			],
@@ -56526,7 +57707,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The shen gaoren can use its Summon Hermitaurs. It then makes six attacks. four with its legs and two with its claw attack. It can replace any of these attacks with a Acid Spit attack, so long as the Lao Shun Shell is not destroyed."
+						"The shen gaoren can use its Summon Hermitaurs. It then makes six attacks. four with its legs and two with its claw attack. It can replace any of these attacks with its acid spit, so long as the lao shun shell is not destroyed."
 					]
 				},
 				{
@@ -56554,15 +57735,15 @@
 					]
 				},
 				{
-					"name": "Collaspe",
+					"name": "Collapse",
 					"entries": [
-						"The shen gaoren falls {@condition prone} for 3 rounds crushing any creature under or around it. While {@condition prone} in this way, the shen gaoren may still move up to half its movement speed and creatures do not gain advantage on melee weapon attack against the shen gaoren. Any creatures under or within 5 feet of the shen gaoren must succeed on a {@dc 20} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 28 ({@damage 4d8 + 10}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the shen gaoren's space into an unoccupied space of the creature's choice. If no unoccupied space is with in range, the creature instead falls {@condition prone} in the shen gaoren's space."
+						"The shen gaoren falls {@condition prone} for 3 rounds crushing any creature under or around it. While {@condition prone} in this way, the shen gaoren may still move up to half its movement speed and creatures do not gain advantage on melee weapon attack against the shen gaoren. Any creatures under or within 5 feet of the shen gaoren must succeed on a {@dc 20} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 28 ({@damage 4d8 + 10}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the shen gaoren's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls {@condition prone} in the shen gaoren's space."
 					]
 				},
 				{
 					"name": "Acid Spray (Recharge 5-6, only usable while prone and Lao Shun Skull is not destroyed)",
 					"entries": [
-						"The shen gaoren releases a high pressure stream of poison from its shell and turns 360 degrees around. Each creature, on the ground, in 30-foot radius of shen gaoren must make a {@dc 15} Dexterity saving throw, taking 99 ({@damage 18d10}) acid damage on a failed save, or half as much damage on a successful one."
+						"The shen gaoren releases a high pressure stream of poison from its shell and turns 360 degrees around. Each creature, on the ground, in a 30-foot radius of shen gaoren must make a {@dc 17} Dexterity saving throw, taking 99 ({@damage 18d10}) acid damage on a failed save, or half as much damage on a successful one."
 					]
 				}
 			],
@@ -56582,14 +57763,15 @@
 				{
 					"name": "Shake Off (Costs 2 Actions)",
 					"entries": [
-						"The shen gaoren thrashes around in an attempt to throw any object or creature that is on its body. Each creature on the shen gaoren must make a {@dc 20} Strength or Dexterity saving throw (creature's choice), or be thrown off the shen gaoren taking 21 ({@damage 6d6}) fall damage upon hitting the ground."
+						"The shen gaoren thrashes around in an attempt to throw any object or creature that is on its body. Each creature on the shen gaoren must make a {@dc 20} Strength or Dexterity saving throw (creature's choice), or be thrown off the shen gaoren taking 21 ({@damage 6d6}) fall damage upon hitting the ground. A creature that fails its save by 5 or more, also falls {@condition prone}."
 					]
 				}
 			],
 			"traitTags": [
 				"Legendary Resistances",
 				"Magic Resistance",
-				"Siege Monster"
+				"Siege Monster",
+				"Amphibious"
 			],
 			"actionTags": [
 				"Multiattack"
@@ -56716,7 +57898,7 @@
 												"type": "entries",
 												"name": "Gaoren Shell",
 												"entries": [
-													"Your weapon deals an extra 1d8 acid damage."
+													"Your weapon deals an extra {@damage 1d8} acid damage."
 												]
 											},
 											{
@@ -56885,8 +58067,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"AOE",
-				"RW"
+				"AOE"
 			],
 			"conditionInflict": [
 				"restrained",
@@ -56969,6 +58150,12 @@
 			],
 			"trait": [
 				{
+					"name": "Amphibious",
+					"entries": [
+						"The ceanataur can breathe air and water."
+					]
+				},
+				{
 					"name": "Scuttle",
 					"entries": [
 						"As a bonus action, the shogun ceanataur can moves up to its speed in a straight line."
@@ -56979,25 +58166,25 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The shogun ceanataur makes two claw attacks. It can use Poison Spit in place of any melee attack."
+						"The shogun ceanataur makes two claw attacks. It can use poison spit in place of any melee attack."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d10 + 4}) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a {@dc 16} Constitution saving throw or lose 3 ({@dice 1d6}) hit points at the start of each of its turns due to an bloody wound. Each time the shogun ceanataur hits the wounded target with this attack, the damage dealt by the wound increases by 3 ({@dice 1d6}). Any creature can take an action to stanch the wound with a successful {@dc 14} Wisdom ({@skill Medicine}) check. The wound also closes if the target receives magical healing."
+					]
+				},
+				{
+					"name": "Poison Spit",
+					"entries": [
+						"{@atk rw} {@hit 9} to hit, range 30/120 ft., one target. {@h}17 ({@damage 7d4}) poison damage. On a hit, the target must make a {@dc 17} Constitution saving throw or become {@condition poisoned} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				},
 				{
 					"name": "Hydropump {@recharge 5}",
 					"entries": [
 						"The shogun ceanataur releases a high pressure stream of water from the back of its shell in an 60-foot line that is 5 feet wide. Each creature in that line must make a {@dc 17} Dexterity saving throw, taking 44 ({@damage 8d10}) cold damage on a failed save, or half as much damage and not on a successful one."
-					]
-				},
-				{
-					"name": "Claws",
-					"entries": [
-						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d10 + 4}) slashing damage. If the target is a creature other than an undead or a construct, it must succeed on a {@dc 16} Constitution saving throw or lose 3 ({@dice 1d6}) hit points at the start of each of its turns due to an bloody wound. Each time the shogun ceanataur hits the wounded target with this attack, the damage dealt by the wound increases by 3 ({@dice 1d6}). Any creature can take an action to stanch the wound with a successful {@dc 14} Wisdom (Medicine) check. The wound also closes if the target receives magical healing."
-					]
-				},
-				{
-					"name": "Poison Spit",
-					"entries": [
-						"{@atk rw} {@hit 9} to hit, reach 30/120 ft., one target. {@h}17 ({@damage 7d4}) poison damage. On a hit, the target must make a {@dc 17} Constitution saving throw or become {@condition poisoned} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
 					]
 				}
 			],
@@ -57011,7 +58198,7 @@
 				{
 					"name": "Spit",
 					"entries": [
-						"The shogun ceanataur makes a Poison Spit attack."
+						"The shogun ceanataur makes a poison spit attack."
 					]
 				},
 				{
@@ -57023,6 +58210,9 @@
 			],
 			"actionTags": [
 				"Multiattack"
+			],
+			"traitTags": [
+				"Amphibious"
 			],
 			"senseTags": [
 				"D",
@@ -57209,8 +58399,7 @@
 			"miscTags": [
 				"AOE",
 				"MW",
-				"RCH",
-				"RW"
+				"RCH"
 			],
 			"conditionInflict": [
 				"poisoned"
@@ -57228,7 +58417,7 @@
 				]
 			},
 			"group": [
-				"Flying Wyvern"
+				"Flying Wyverns"
 			],
 			"environment": [
 				"arctic"
@@ -57713,8 +58902,7 @@
 			],
 			"miscTags": [
 				"MW",
-				"RCH",
-				"RW"
+				"RCH"
 			],
 			"legendary": [
 				{
@@ -58430,12 +59618,7 @@
 				{
 					"name": "Find Shell (Costs 2 Actions)",
 					"entries": [
-						"The somnacanth finds a random shell. Roll a d3 and consult the table below."
-					]
-				},
-				{
-					"name": "Shells",
-					"entries": [
+						"The somnacanth finds a random shell. Roll a d3 and consult the table below.",
 						{
 							"type": "table",
 							"colLabels": [
@@ -58783,7 +59966,6 @@
 					"name": "Active State (Mythic Trait)",
 					"entries": [
 						"The alatreon has three states it can take. They are the dragon state, fire state, and the ice state. Each state provides benefits and detriments depending on which state it is in, as shown below:",
-						"The alatreon begins combat in either the fire state or ice state. When it begins combat in the fire state, the order of the states it changes into is: fire, dragon, ice, dragon and then repeats. When it starts in the ice stage, the order is: ice, dragon, fire, dragon and then repeats.",
 						{
 							"type": "list",
 							"items": [
@@ -58810,6 +59992,7 @@
 								}
 							]
 						},
+						"The alatreon begins combat in either the fire state or ice state. When it begins combat in the fire state, the order of the states it changes into is: fire, dragon, ice, dragon and then repeats. When it starts in the ice stage, the order is: ice, dragon, fire, dragon and then repeats.",
 						"Whenever the alatreon hit points are reduced by 100 in its current active state it changes its state to the next one in the order and uses a special reaction to use its element burst. This special reaction can be used even if the alatreon has already used its reaction this round."
 					]
 				},
@@ -59041,7 +60224,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Within the New World, the alatreon has taken on a unique form of water element alongside its four existing elements. The alatreon is also capable of creating unique ice structures that explode when struck. Finally, alatreon's mastery over the elements has been enhanced beyond what was previously known, allowing the alatreon to take on unique active forms based on three core elements; fire state, ice state and dragon state. When transitioning between its dragon state and either fire or ice state, alatreon will generate an immense pool of elemental energy, eventually allowing it to execute a devastating burst of elements known as the Escaton Judgment, decimating any who are unfortunate enough to be within the vicinity of this tremendous power.",
+							"Within the New World, the {@creature alatreon|MHMM} has taken on a unique form of water element alongside its four existing elements. The alatreon is also capable of creating unique ice structures that explode when struck. Finally, alatreon's mastery over the elements has been enhanced beyond what was previously known, allowing the alatreon to take on unique active forms based on three core elements; fire state, ice state and dragon state. When transitioning between its dragon state and either fire or ice state, alatreon will generate an immense pool of elemental energy, eventually allowing it to execute a devastating burst of elements known as the Escaton Judgment, decimating any who are unfortunate enough to be within the vicinity of this tremendous power.",
 							{
 								"type": "inset",
 								"name": "Tempered Alatreon",
@@ -59174,7 +60357,7 @@
 												"type": "entries",
 												"name": "Azure Dragonsphire",
 												"entries": [
-													"You have immunity to force damage and resistances to necrotic damage while you wear this armor."
+													"You are immune to force damage and resistant to necrotic damage while you wear this armor."
 												]
 											}
 										]
@@ -59202,7 +60385,7 @@
 												"type": "entries",
 												"name": "Alatreon Pallium",
 												"entries": [
-													"{@i (Ranged weapon only) Critical Eye+2.} Your weapon attacks critical hit range is increased by 3."
+													"{@i Critical Eye+2.} Your weapon attacks critical hit range is increased by 3."
 												]
 											},
 											{
@@ -59337,8 +60520,7 @@
 			],
 			"miscTags": [
 				"AOE",
-				"MW",
-				"RCH"
+				"MW"
 			],
 			"conditionInflict": [
 				"prone"
@@ -59789,7 +60971,7 @@
 						"type": "entries",
 						"name": "A Chameleos's Lair",
 						"entries": [
-							"The Forest-Dwelling Chameleos very rarely share their territory with other dragons. With its ability to become invisible at will, it steals the treasures from anything that attempts to invade and take over. A chameleos lair is sometimes confused with the a green dragon's lair due to both of them having a perpetual fog hanging in the air, the chameleos carrying a sweeter whiff of its poison mist. Tiny mushrooms, known has toadstool, litter the ground releasing poisonous spores at the slightest touch. Growing bigger as you deeper into the forest.",
+							"The Forest-Dwelling Chameleos very rarely share their territory with other dragons. With its ability to become invisible at will, it steals the treasures from anything that attempts to invade and take over. A chameleos lair is sometimes confused with a green dragon's lair due to both of them having a perpetual fog hanging in the air, the chameleos carrying a sweeter whiff of its poison mist. Tiny mushrooms, known has toadstool, litter the ground releasing poisonous spores at the slightest touch. Growing bigger as you deeper into the forest.",
 							"At the center of the forest, the chameleos chooses a grove typically covered in mushrooms. The tree lining the grove are sparse, allowing the chameleos to move freely in and out. A hole has been dug out in the middle and has been filled with the treasures the chameleos has gathered from lost folk, adventurers, and anything else it has stolen in its travels."
 						]
 					}
@@ -60365,12 +61547,16 @@
 					]
 				}
 			],
+			"mythicHeader": [
+				"When the Fatalis' mythic trait is activated, it takes flight, without provoking attacks of opportunity, and hovers 600 feet above the ground before releasing a gout of hellfire in a 600-foot line that is 10 feet wide. When the hellfire hit a creature or object it spreads out in a 150-foot radius. A creature that starts its turn in the flames must make a {@dc 27} Dexterity saving throw, taking 22 ({@damage 4d10}) fire damage on a failed saved or half as much damage on a successful one.",
+				"On subsequent turns, while the Fatalis's temporary hit points are above 0, Fatalis can't move from the space it is in and must use its action to maintain the gout of flames. As part of the same action Fatalis can change the direction of the hellfire. When Fatalis's temporary hit points are reduced to 0, it flinches and the gout of hellfire ends.",
+				"On the Fatalis's 5th turn, if it is still exhaling hellfire, it must use its action to release one final empowered gout of flames. Each creature in the flames area must make a {@dc 27} Dexterity saving throw, taking 196 ({@damage 56d6}) fire damage on a failed save, or half as much damage on a successful one. The final gout of flames ignite flammable objects in that area that aren't being worn or carried, and it begins to melt all cover and parts of structures in the flames area."
+			],
 			"mythic": [
 				{
+					"name": "",
 					"entries": [
-						"When the Fatalis' mythic trait is activated, it takes flight, without provoking attacks of opportunity, and hovers 600 feet above the ground before releasing a gout of hellfire in a 600-foot line that is 10 feet wide. When the hellfire hit a creature or object it spreads out in a 150-foot radius. A creature that starts its turn in the flames must make a {@dc 27} Dexterity saving throw, taking 22 ({@damage 4d10}) fire damage on a failed saved or half as much damage on a successful one.",
-						"On subsequent turns, while the Fatalis's temporary hit points are above 0, Fatalis can't move from the space it is in and must use its action to maintain the gout of flames. As part of the same action Fatalis can change the direction of the hellfire. When Fatalis's temporary hit points are reduced to 0, it flinches and the gout of hellfire ends.",
-						"On the Fatalis's 5th turn, if it is still exhaling hellfire, it must use its action to release one final empowered gout of flames. Each creature in the flames area must make a {@dc 27} Dexterity saving throw, taking 196 ({@damage 56d6}) fire damage on a failed save, or half as much damage on a successful one. The final gout of flames ignite flammable objects in that area that aren't being worn or carried, and it begins to melt all cover and parts of structures in the flames area."
+						""
 					]
 				}
 			],
@@ -60443,7 +61629,7 @@
 										"rows": [
 											[
 												"Challenge Rating",
-												"30",
+												"28",
 												"Carves",
 												"9"
 											]
@@ -60661,7 +61847,7 @@
 															"You are immune to fire damage.",
 															"You can use an action to cast {@spell Melf's Minute Meteors|XGE} ({@dc 19}) from the weapon at will, requiring no material components.",
 															"Your weapons deal an extra {@damage 2d6} fire damage.",
-															"You can use the {@item hammer (u)|AGMH|hammer's Mighty Weapon property} once with any weapon."
+															"You can use the {@item hammer|AGMH}'s {@optfeature Mighty Weapon|AGMH} property once with any weapon."
 														]
 													},
 													"Once you use this property, you cannot use it again until the next dawn."
@@ -60887,7 +62073,7 @@
 				{
 					"name": "Legendary Resistance (3/Day)",
 					"entries": [
-						"If the kirin fails a saving throw, it can choose to succeed in stead."
+						"If the kirin fails a saving throw, it can choose to succeed instead."
 					]
 				},
 				{
@@ -60961,7 +62147,7 @@
 						"{@spell gust of wind}",
 						"{@spell jump}",
 						"{@spell see invisibility}",
-						"{@spell thunderstep|XGE}",
+						"{@spell thunder step|XGE}",
 						"{@spell thunderwave} (at 5th-level)"
 					],
 					"daily": {
@@ -61227,16 +62413,6 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			],
-			"damageTagsSpell": [
-				"A",
-				"B",
-				"C",
-				"F",
-				"L",
-				"N",
-				"R",
-				"T"
 			]
 		},
 		{
@@ -61645,8 +62821,7 @@
 			],
 			"miscTags": [
 				"RCH",
-				"AOE",
-				"MW"
+				"AOE"
 			],
 			"conditionInflict": [
 				"prone"
@@ -62074,13 +63249,7 @@
 						]
 					}
 				]
-			},
-			"conditionInflict": [
-				"prone"
-			],
-			"damageTagsSpell": [
-				"B"
-			]
+			}
 		},
 		{
 			"name": "Tempered Teostra",
@@ -62445,14 +63614,14 @@
 												"type": "entries",
 												"name": "T.Teostra Claw",
 												"entries": [
-													"Your weapon deals an extra 1d10 fire damage."
+													"Your weapon deals an extra {@damage 1d10} fire damage."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "T.Teostra Webbing",
 												"entries": [
-													"{@i Weakness Exploit+ (fire).} Your weapon deals max damage to a creature that is vulnerable to fire or this weapons damage type."
+													"While attuned to this weapon, your fire spells bypass a creatures resistance and deal half damage to a creature that is immune to fire damage."
 												]
 											},
 											{
@@ -62669,21 +63838,28 @@
 				{
 					"name": "Breath Weapons",
 					"entries": [
-						"The velkhana uses one of the following breath weapons. They share their recharge."
-					]
-				},
-				{
-					"name": "Cold Breath {@recharge 5}",
-					"entries": [
-						"The velkhana exhales an icy blast in a 90-foot line that is 5 feet wide. That area is covered in rime for 1 minute and each creature in that line must make a {@dc 23} Dexterity saving throw, taking 66 ({@damage 12d10}) cold damage on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Hoarfrost Breath {@recharge 5}",
-					"entries": [
-						"The velkhana exhales an icy blast of hoarfrost in a 60-foot cone. The area is covered in rime for 1 minute and each creature in that area must make a {@dc 23} Constitution saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much damage on a successful one.",
-						"Additionally, four 1 foot thick, 10-foot-square walls of ice form within the area and last for 10 minutes. If the wall is formed on a creature's space, the creature is pushed to one side of the wall and must make a {@dc 19} Dexterity saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much on a successful one.",
-						"Each 10-foot section of the wall has 12 AC and 30 hit points, and is vulnerable to fire damage. If damaged to 0 hit points, it leaves a hole filled with freezing air. The first time a creature moves through the air on a turn, it makes a {@dc 22} Constitution save, taking 17 ({@damage 5d6}) cold damage on a failed save or half as much on a successful one."
+						"The velkhana uses one of the following breath weapons.",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Cold Breath {@recharge 5}",
+									"entries": [
+										"The velkhana exhales an icy blast in a 90-foot line that is 5 feet wide. That area is covered in rime for 1 minute and each creature in that line must make a {@dc 23} Dexterity saving throw, taking 66 ({@damage 12d10}) cold damage on a failed save, or half as much damage on a successful one."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Hoarfrost Breath {@recharge 5}",
+									"entries": [
+										"The velkhana exhales an icy blast of hoarfrost in a 60-foot cone. The area is covered in rime for 1 minute and each creature in that area must make a {@dc 23} Constitution saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much damage on a successful one.",
+										"Additionally, four 1 foot thick, 10-foot-square walls of ice form within the area and last for 10 minutes. If the wall is formed on a creature's space, the creature is pushed to one side of the wall and must make a {@dc 19} Dexterity saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much on a successful one.",
+										"Each 10-foot section of the wall has 12 AC and 30 hit points, and is vulnerable to fire damage. If damaged to 0 hit points, it leaves a hole filled with freezing air. The first time a creature moves through the air on a turn, it makes a {@dc 22} Constitution save, taking 17 ({@damage 5d6}) cold damage on a failed save or half as much on a successful one."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
@@ -62718,7 +63894,7 @@
 			],
 			"fluff": {
 				"entries": [
-					"Velkhana is a traditional dragon with the slim, upright body structure of elder Dragons like {@creature kushala daora|MHMM}. Its scales and shell are a unique crystalline blue. Its head has a tiara-like crown of small horns. It summons ice to cover its wings, limbs, and tail. Its thin, lance-like tail is highly flexible and can jab at enemies.",
+					"{@creature Velkhana|MHMM} is a traditional dragon with the slim, upright body structure of elder Dragons like {@creature kushala daora|MHMM}. Its scales and shell are a unique crystalline blue. Its head has a tiara-like crown of small horns. It summons ice to cover its wings, limbs, and tail. Its thin, lance-like tail is highly flexible and can jab at enemies.",
 					"Velkhana freely controls ice and cold wind, and can cover wide areas in ice in an instant. It breathes beams of supercooled fluid that can instantly freeze monsters. When covered in its ice armor, ice crystals form nearby, and when struck by Velkhana's ice breath they form large spires that soon explode. Small ice platforms sometimes form, which can be jumped off of. Occasionally, spikes of ice rain from clouds close to the ground when it is enraged.",
 					{
 						"type": "inset",
@@ -62840,7 +64016,7 @@
 										"type": "entries",
 										"name": "T.Velkhana Crystal",
 										"entries": [
-											"You have immunity to cold damage while you wear this armor."
+											"You are immune to cold damage while you wear this armor."
 										]
 									}
 								]
@@ -62890,7 +64066,7 @@
 										"type": "entries",
 										"name": "T.Velkhana Crystal",
 										"entries": [
-											"{@i Coalescence+.} Whenever you succeed on a saving throw to end a condition, you gain a +2 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra 1d6 cold, fire, or lightning damage (your choice) until the end of your next turn."
+											"{@i Coalescence+.} Whenever you succeed on a saving throw to end a condition, you gain a +2 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra {@damage 1d6} cold, fire, or lightning damage (your choice) until the end of your next turn."
 										]
 									}
 								]
@@ -62922,8 +64098,8 @@
 						"type": "insetReadaloud",
 						"name": "T.Velkhana Divinity",
 						"entries": [
-							"{@b Set bonus (2):} When you critically hit with a weapon or spell that deals cold damage, you deal an extra 1d8 cold damage.",
-							"{@b Set bonus (4):} An aura of frost builds when your weapon is sheathed for at least 1 minute. When you draw this weapon, it deals an extra 1d8 cold damage for the next 4 rounds."
+							"{@b Set bonus (2):} When you critically hit with a weapon or spell that deals cold damage, you deal an extra {@damage 1d8} cold damage.",
+							"{@b Set bonus (4):} An aura of frost builds when your weapon is sheathed for at least 1 minute. When you draw this weapon, it deals an extra {@damage 1d8} cold damage for the next 4 rounds."
 						]
 					}
 				]
@@ -63109,7 +64285,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Teostra is a dragon with leonine features and a fiery coloration. It has a grand mane, large fangs, and a pair of horns that curve backward. Its wings are covered in fur. Teostra is the male counterpart to Lunastra. Being predatory Elder Dragons Teostra are powerful top predators and are easily capable of killing weaker animals such as {@creature Aptonoth|MHMM}, {@creature Conga|MHMM}, {@creature Bulldrome|MHMM}, {@creature Iodrome|MHMM}, {@creature Apceros|MHMM}, and {@creature Cephadrome|MHMM}. Armed with razor sharp claws and flesh ripping teeth these Elder Dragons make short work of prey and smaller predators.",
+							"Teostra is a dragon with leonine features and a fiery coloration. It has a grand mane, large fangs, and a pair of horns that curve backward. Its wings are covered in fur. Teostra is the male counterpart to {@creature Lunastra|MHMM}. Being predatory Elder Dragons Teostra are powerful top predators and are easily capable of killing weaker animals such as {@creature Aptonoth|MHMM}, {@creature Conga|MHMM}, {@creature Bulldrome|MHMM}, {@creature Iodrome|MHMM}, {@creature Apceros|MHMM}, and {@creature Cephadrome|MHMM}. Armed with razor sharp claws and flesh ripping teeth these Elder Dragons make short work of prey and smaller predators.",
 							"Possessing mastery over flame, there are few creatures that can hope to last against Teostra for long. To defend itself, the Teostra also utilizes a heat shield which damages enemies that get too close. To keep its flame powers going, they consume coal in volcanic environments. It also has detachable wing scales or powder that explode when ignited from a spark made when Teostra bites. It uses these to defend itself from attackers, although they give little protection against enemies with resilience to extreme heat such as {@creature Akantor|MHMM} or {@creature Lavasioth|MHMM}.",
 							"Teostra can even use the powder for many close range attacks but more skilled Teostra have learnt to use the powder at long range. When Teostra angered, it will fly into the air and ignite the powder all at once. When the powder is all ignited, Teostra will be covered in a large burst of fire, that is sometimes referred to as the Supernova.",
 							"{@creature tempered teostra|MHMM|Some extremely rare individuals} have more control over their flaming powers than most. They have a different appearance also including more yellow wing webbing, a more reddish mane, red claws, orange tail end and golden eyes. New flame techniques include leaving pockets of explosive powder across the area in the air as it fights and setting them all a flame at will.",
@@ -63272,7 +64448,7 @@
 												"type": "entries",
 												"name": "Teostra Webbing",
 												"entries": [
-													"{@i Weakness Exploit.} Your weapon deals max damage to a creature that is vulnerable to this weapons damage type."
+													"{@i Weakness Exploit.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a long rest."
 												]
 											},
 											{
@@ -63403,7 +64579,7 @@
 			},
 			"speed": {
 				"walk": 30,
-				"burrow": 20
+				"swim": 30
 			},
 			"str": 16,
 			"dex": 8,
@@ -63656,7 +64832,7 @@
 												"type": "entries",
 												"name": "Tetranadon Hide",
 												"entries": [
-													"{@i (Monk only)} While you are attuned to this armor, you may spend one minute contemplating the patterns etched on this weapon's surface and regain 1 expended ki point. Once you use this property, you cannot use it again until you finish a long rest."
+													"{@i (Monk only)} While you are attuned to this armor, you may spend one minute contemplating the patterns etched on this weapon's surface and regain a number of expended ki points equal to half your proficiency modifier. Once you use this property, you cannot use it again until you finish a long rest."
 												]
 											},
 											{
@@ -63780,7 +64956,8 @@
 			},
 			"speed": {
 				"walk": 30,
-				"burrow": 20
+				"burrow": 20,
+				"swim": 30
 			},
 			"str": 18,
 			"dex": 14,
@@ -63792,6 +64969,12 @@
 			"cr": "4",
 			"page": 0,
 			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The tetsucabra can breathe air and water."
+					]
+				},
 				{
 					"name": "Standing Leap",
 					"entries": [
@@ -63841,7 +65024,7 @@
 						"entries": [
 							"Tetsucabra is a large Amphibian with a striking orange and indigo coloration. Its lower jaw harbors large tusks along with a large set of molars that are capable of crushing prey with ease. Tetsucabra also has a spiky stubby tail that swells up when angered.",
 							"The scales of a Tetsucabra is used mainly for camouflage inside caves and on them is a special oil that holds heat. Despite the look of the scales, its skin is actually flexible yet hard somewhat resembling an actual toad's skin. A Tetsucabra's skull is robust and durable enough to take a lot of damage from threats of all sorts. Though the Tetsucabra has two large tusks, these are not used for hunting. The primary function of these tusks is for defense and as means to manipulate the environment. The tusks themselves are capable weapons, but the Tetsucabra is also capable of hefting up heavy boulders. The Tetsucabra flings these boulders out of the way of its path but it can also use this as a method of attack to injure predator and prey alike. It uses these boulders as a shield against predators and hunters to prevent attacks. It also uses this to enclose small, tight areas, making it harder to maneuver. Another fact about the Tetsucabra is its ability to spit a glob of fluid at prey items. This sticky material acts as a powerful adhesive, sticking to the body and ground like glue. Even for a hunter, the adhesive quality of this material is not very strong, but it makes every movement a labor and greatly weakens the prey, leading to a reduction in stamina. When the Tetsucabra exerts itself, its tail inflates, possibly to help it balance itself as it picks up large boulders and rocks. The legs of a Tetsucabra help it perform powerful leaps, lunges, and jumps in the air to help it either ambush prey or to reach steep slopes out of its reach. A Tetsucabra's claws are powerful enough to break rock with ease and can destroy powerful armor.",
-							"Tetsucabra are highly aggressive, territorial monsters though their ecology is much like a frog. The amphibians are well-known for attacking and eating anything that moves in their line of sight and leaping from ponds in order to grab potential prey. Despite being found in ponds, they spend most of their time on land, which could suggest that they patrol their territory on land, much like Zamtrios. During the breeding season male Tetsucabra will create large holes to impress females so that they'll lay their eggs in them. When the female lays her eggs in the pit the male will quickly fertilize them. After fertilizing the eggs the male will then carry them in his mouth and he will not eat anything until the offspring are fully developed.",
+							"Tetsucabra are highly aggressive, territorial monsters though their ecology is much like a frog. The amphibians are well-known for attacking and eating anything that moves in their line of sight and leaping from ponds in order to grab potential prey. Despite being found in ponds, they spend most of their time on land, which could suggest that they patrol their territory on land, much like {@creature Zamtrios|MHMM}. During the breeding season male Tetsucabra will create large holes to impress females so that they'll lay their eggs in them. When the female lays her eggs in the pit the male will quickly fertilize them. After fertilizing the eggs the male will then carry them in his mouth and he will not eat anything until the offspring are fully developed.",
 							{
 								"type": "inset",
 								"name": "Tetsucabra",
@@ -63978,13 +65161,6 @@
 											},
 											{
 												"type": "entries",
-												"name": "Tetranadon Beak",
-												"entries": [
-													"When you make an unarmed strike while attuned to this weapon, and roll a 20 for the attack roll, the target is pushed 5 feet away from you."
-												]
-											},
-											{
-												"type": "entries",
 												"name": "Dignified Skull",
 												"entries": [
 													"{@i (Ranged weapon only) Deadeye.} Your weapon's normal attack range is increased by 20 feet."
@@ -64008,7 +65184,7 @@
 												"type": "entries",
 												"name": "Paddock Oil",
 												"entries": [
-													"When this oil is applied to the skin, the target gains {@sense tremorsense|MM} out to 30 feet for 1 hour."
+													"When this oil is applied to the skin, the target gains {@sense tremorsense} out to 30 feet for 1 hour."
 												]
 											},
 											{
@@ -64027,6 +65203,9 @@
 				]
 			},
 			"tokenUrl": "https://i.imgur.com/ZIaUuBZ.png",
+			"traitTags": [
+				"Amphibious"
+			],
 			"damageTags": [
 				"P",
 				"B"
@@ -64094,6 +65273,12 @@
 				"acrobatics": "+6",
 				"perception": "+8"
 			},
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"senseTags": [
+				"SD"
+			],
 			"passive": 18,
 			"resist": [
 				"cold",
@@ -64494,7 +65679,7 @@
 							},
 							{
 								"type": "insetReadaloud",
-								"name": "Thunder Serpent Narwa Material Bonus*",
+								"name": "Narwa Material Bonus*",
 								"entries": [
 									"When a character has 2+ narwa materials socketed into their equipment they gain each of the following the {@i Thunder Alignment} bonuses.",
 									"{@b Thunder Alignment (2 materials).} You have resistance to lightning damage while you wear this armor.",
@@ -65327,7 +66512,7 @@
 											[
 												"1-5",
 												"1-5",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -65426,7 +66611,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon armor upgrade material."
 												]
@@ -66224,7 +67409,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The Uragaan makes one Tail attack and two Chin Slam attacks."
+						"The Uragaan makes one tail attack and two chin slam attacks."
 					]
 				},
 				{
@@ -66363,7 +67548,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "U.Firecell Stone ",
+												"name": "U.Firecell Stone",
 												"entries": [
 													"{@i Shield.} While you are attuned to this armor and you use a reaction that would increase your AC, you gain an additional +1 bonus to your AC until the start of your next turn."
 												]
@@ -66429,14 +67614,14 @@
 												"type": "entries",
 												"name": "Uragaan Scute",
 												"entries": [
-													"{@i Partbreaker.} You deal an extra 1d4 damage when you critically hit with this weapon."
+													"{@i Partbreaker.} You deal an extra {@damage 1d4} damage when you critically hit with this weapon."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Flame Sac",
 												"entries": [
-													"When you cast a spell that deals fire damage, it deals an extra 1d4 fire damage."
+													"When you cast a spell that deals fire damage, it deals an extra {@damage 1d4} fire damage."
 												]
 											},
 											{
@@ -66743,7 +67928,7 @@
 				{
 					"name": "Regeneration",
 					"entries": [
-						"The vaal hazak regains 30 hit points at the start of its turn if it has at least 1 hit point. If the vaal hazak takes radiant damage or damage from holy water, this trait doesn't function at the start of the vaal hazak's next turn."
+						"The vaal hazak regains 30 hit points at the start of its turn if it has at least 1 hit point. If the vaal hazak takes radiant damage or damage from {@item holy water (flask)|PHB|holy water}, this trait doesn't function at the start of the vaal hazak's next turn."
 					]
 				}
 			],
@@ -66775,13 +67960,20 @@
 				{
 					"name": "Effluvium Breath {@recharge 5}",
 					"entries": [
-						"The vaal hazak exhales a cloud of effluvium bacteria in a 90-foot cone. Each creature in that line must make a {@dc 20} Constitution saving throw, taking 70 ({@damage 20d6}) necrotic damage and are cursed as if by the bestow curse spell for 1 minute on a failed save, or half as much damage on a successful one and are not cursed."
+						"The vaal hazak exhales a cloud of effluvium bacteria in a 90-foot cone. Each creature in that line must make a {@dc 20} Constitution saving throw, taking 70 ({@damage 20d6}) necrotic damage and are cursed as if by the {@spell bestow curse} spell for 1 minute on a failed save, or half as much damage on a successful one and are not cursed."
 					]
 				},
 				{
 					"name": "Return from the Dead (3/day)",
 					"entries": [
-						"The vaal hazak raises a recently deceased CR 6 or lower creature from the dead to fight by its side. A creature raised in this way is considered undead, heals to its hit point maximum and gains the undead fortitude trait."
+						"The vaal hazak raises a recently deceased CR 6 or lower creature from the dead to fight by its side. A creature raised in this way is considered undead, heals to its hit point maximum and gains the undead fortitude trait.",
+						{
+							"type": "homebrew",
+							"entries": [
+								"Presented for reference, the {@creature zombie}'s {@b Undead Fortitude} trait:",
+								"{@i If damage reduces the zombie to 0 hit points, it must make a Constitution saving throw with a DC of 5 + the damage taken, unless the damage is radiant or from a critical hit. On a success, the zombie drops to 1 hit point instead.}"
+							]
+						}
 					]
 				}
 			],
@@ -66906,7 +68098,7 @@
 											[
 												"19",
 												"Vaal Hazak Tail",
-												"(W)"
+												"(A)"
 											],
 											[
 												"20",
@@ -66987,7 +68179,7 @@
 												"type": "entries",
 												"name": "Vaal Hazak Talon",
 												"entries": [
-													"Your weapon deals an extra 1d10 necrotic damage."
+													"Your weapon deals an extra {@damage 1d10} necrotic damage."
 												]
 											},
 											{
@@ -66999,7 +68191,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Vaal Hazak Wing ",
+												"name": "Vaal Hazak Wing",
 												"entries": [
 													"You gain a +3 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +4 when the spell you are casting deals necrotic damage."
 												]
@@ -67017,7 +68209,7 @@
 												"type": "entries",
 												"name": "Vaal Hazak Gem",
 												"entries": [
-													"{@i (Cleric only)} The weapon has 10 runes. While holding it, you can use an action to expend 1 or more of its runes to cast one of the following spells from it, using your spell save DC: {@spell Animate Dead} (3 runes). {@spell bestow curse} (3 runes), {@spell contagion} (5 runes), or {@spell raise dead} (10 runes).",
+													"{@i (Cleric only)} The weapon has 10 runes. While holding it, you can use an action to expend 1 or more of its runes to cast one of the following spells from it, using your spell save DC: {@spell animate dead} (3 runes). {@spell bestow curse} (3 runes), {@spell contagion} (5 runes), or {@spell raise dead} (10 runes).",
 													"The weapon regains 1d6 + 4 expended runes daily at dawn. If you expend the last runes, roll a d20. On a 1. the weapon cannot regain any runes for one week."
 												]
 											}
@@ -67119,8 +68311,15 @@
 				"perception": "+10"
 			},
 			"passive": 20,
+			"conditionImmune": [
+				"charmed",
+				"frightened"
+			],
+			"languages": [
+				"Draconic"
+			],
 			"cr": "16",
-			"page": 136,
+			"page": 0,
 			"trait": [
 				{
 					"name": "Brutal Wings",
@@ -67132,6 +68331,12 @@
 					"name": "Legendary Resistance (2/Day)",
 					"entries": [
 						"If the valstrax fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "The Red Comet",
+					"entries": [
+						"The valstrax doesn't provoke opportunity attacks when it takes the {@action Dash} action."
 					]
 				}
 			],
@@ -67161,15 +68366,15 @@
 					]
 				},
 				{
-					"name": "Firebolt",
+					"name": "Dragonbolt",
 					"entries": [
-						"{@atk rw} {@hit 8} to hit, reach 80/320 ft., one target. {@h}14 ({@damage 4d6}) fire damage."
+						"{@atk rw} {@hit 8} to hit, reach 80/320 ft., one target. {@h}14 ({@damage 4d6}) necrotic damage."
 					]
 				},
 				{
 					"name": "Ignition {@recharge 5}",
 					"entries": [
-						"The valstrax spread its wings out around itself and ignites them. Fire spreads out from the wings in a 20-foot radius around the valstrax. Each creature in that area must make a {@dc 17} Dexterity saving throw, taking 40 ({@damage 9d8}) fire damage on a failed save or half as much on a successful one."
+						"The valstrax spread its wings out around itself and ignites them. Fire spreads out from the wings in a 20-foot radius around the valstrax. Each creature in that area must make a {@dc 17} Dexterity saving throw, taking 40 ({@damage 9d8}) necrotic damage on a failed save or half as much on a successful one."
 					]
 				}
 			],
@@ -67177,7 +68382,7 @@
 				{
 					"name": "Detect",
 					"entries": [
-						"The valstrax makes a Wisdom (Perception) Check."
+						"The valstrax makes a Wisdom ({@skill Perception}) Check."
 					]
 				},
 				{
@@ -67189,12 +68394,15 @@
 				{
 					"name": "Dragon Rush (Costs 2 Actions)",
 					"entries": [
-						"The valstrax moves up to half its fly speed in a straight line, during this move it may move through other creatures without provoking attacks of opportunity. Any creatures the valstrax moves through must succeed on a {@dc 17} Dexterity saving throw or take 22 ({@damage 4d8 + 4}) slashing damage and 10 ({@damage 3d6}) fire damage and are knocked {@condition prone} on a failed save. On a successful save, the target takes half damage and is not knocked {@condition prone}."
+						"The valstrax moves up to half its fly speed in a straight line, during this move it may move through other creatures without provoking attacks of opportunity. Any creatures the valstrax moves through must succeed on a {@dc 17} Dexterity saving throw or take 22 ({@damage 4d8 + 4}) slashing damage and 10 ({@damage 3d6}) necrotic damage and are knocked {@condition prone} on a failed save. On a successful save, the target takes half damage and is not knocked {@condition prone}."
 					]
 				}
 			],
 			"actionTags": [
 				"Multiattack"
+			],
+			"languageTags": [
+				"DR"
 			],
 			"fluff": {
 				"entries": [
@@ -67219,7 +68427,7 @@
 										"Challenge Rating",
 										"16",
 										"Carves/Capture",
-										"6"
+										"4"
 									]
 								]
 							},
@@ -67344,7 +68552,7 @@
 										"type": "entries",
 										"name": "Valstrax Hardclaw",
 										"entries": [
-											"Your weapon deals an extra 1d6 piercing damage."
+											"Your weapon deals an extra {@damage 1d6} piercing damage."
 										]
 									},
 									{
@@ -67358,7 +68566,7 @@
 										"type": "entries",
 										"name": "Shimmering Dragonfluid",
 										"entries": [
-											"{@i Crisis+.} While suffering from an abnormal status effect, such as {@condition poisoned}, burning, slowed, {@condition blinded}, etc, all attacks and spells deal an extra 1d12 spell or weapon damage."
+											"{@i Crisis+.} While suffering from an abnormal status effect, such as {@condition poisoned}, burning, slowed, {@condition blinded}, etc, all attacks and spells deal an extra {@damage 1d12} spell or weapon damage."
 										]
 									},
 									{
@@ -67372,7 +68580,7 @@
 										"type": "entries",
 										"name": "Ruby Dragon Mindstone",
 										"entries": [
-											"Your weapon deals an extra 1d8 piercing damage."
+											"Your weapon deals an extra {@damage 1d8} piercing damage."
 										]
 									}
 								]
@@ -67541,30 +68749,36 @@
 					]
 				},
 				{
-					"name": "Breath Weapons",
+					"name": "Breath Weapons {@recharge 5}",
 					"entries": [
-						"The velkhana uses one of the following breath weapons.They share their recharge."
-					]
-				},
-				{
-					"name": "Cold Breath {@recharge 5}",
-					"entries": [
-						"The velkhana exhales an icy blast in a 90-foot line that is 5 feet wide. That area is covered in rime for 1 minute and each creature in that line must make a {@dc 21} Dexterity saving throw, taking 66 ({@damage 12d10}) cold damage on a failed save, or half as much damage on a successful one."
-					]
-				},
-				{
-					"name": "Hoarfrost Breath {@recharge 5}",
-					"entries": [
-						"The velkhana exhales an icy blast of hoarfrost in a 60-foot cone. The area is covered in rime for 1 minute and each creature in that area must make a {@dc 21} Constitution saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much damage on a successful one.",
-						"Additionally, three 1 foot thick, 10-foot-square walls of ice form within the area and last for 10 minutes. If the wall is formed on a creature's space, the creature is pushed to one side of the wall and must make a {@dc 19} Dexterity saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much on a successful one.",
-						"Each 10-foot section of the wall has 12 AC and 30 hit points, and is vulnerable to fire damage. If damaged to 0 hit points, it leaves a hole filled with freezing air. The first time a creature moves through the air on a turn, it makes a {@dc 21} Constitution save, taking 17 ({@damage 5d6}) cold damage on a failed save or half as much on a successful one."
+						"The velkhana uses one of the following breath weapons.",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Cold Breath",
+									"entries": [
+										"The velkhana exhales an icy blast in a 90-foot line that is 5 feet wide. That area is covered in rime for 1 minute and each creature in that line must make a {@dc 21} Dexterity saving throw, taking 66 ({@damage 12d10}) cold damage on a failed save, or half as much damage on a successful one."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Hoarfrost Breath",
+									"entries": [
+										"The velkhana exhales an icy blast of hoarfrost in a 60-foot cone. The area is covered in rime for 1 minute and each creature in that area must make a {@dc 21} Constitution saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much damage on a successful one.",
+										"Additionally, three 1 foot thick, 10-foot-square walls of ice form within the area and last for 10 minutes. If the wall is formed on a creature's space, the creature is pushed to one side of the wall and must make a {@dc 19} Dexterity saving throw, taking 28 ({@damage 8d6}) cold damage on a failed save, or half as much on a successful one.",
+										"Each 10-foot section of the wall has 12 AC and 30 hit points, and is vulnerable to fire damage. If damaged to 0 hit points, it leaves a hole filled with freezing air. The first time a creature moves through the air on a turn, it makes a {@dc 21} Constitution save, taking 17 ({@damage 5d6}) cold damage on a failed save or half as much on a successful one."
+									]
+								}
+							]
+						}
 					]
 				}
 			],
 			"miscTags": [
 				"RCH",
-				"AOE",
-				"MW"
+				"AOE"
 			],
 			"actionTags": [
 				"Breath Weapon",
@@ -67714,7 +68928,7 @@
 										"type": "entries",
 										"name": "Velkhana Crystal",
 										"entries": [
-											"You have immunity to cold damage while you wear this armor."
+											"You are immune to cold damage while you wear this armor."
 										]
 									}
 								]
@@ -67764,7 +68978,7 @@
 										"type": "entries",
 										"name": "Velkhana Crystal",
 										"entries": [
-											"{@i Coalescence.} Whenever you succeed on a saving throw to end a condition, you gain a +1 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra 1d4 cold, fire, or lightning damage (your choice) until the end of your next turn."
+											"{@i Coalescence.} Whenever you succeed on a saving throw to end a condition, you gain a +1 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra {@damage 1d4} cold, fire, or lightning damage (your choice) until the end of your next turn."
 										]
 									}
 								]
@@ -67796,8 +69010,8 @@
 						"type": "insetReadaloud",
 						"name": "Velkhana Divinity",
 						"entries": [
-							"{@b Set bonus (2):} When you critically hit with a weapon or spell that deals cold damage, you deal an extra 1d6 cold damage.",
-							"{@b Set bonus (4):} An aura of frost builds when your weapon is sheathed for at least 1 minute. When you draw this weapon, it deals an extra 1d6 cold damage for the next 4 rounds."
+							"{@b Set bonus (2):} When you critically hit with a weapon or spell that deals cold damage, you deal an extra {@damage 1d6} cold damage.",
+							"{@b Set bonus (4):} An aura of frost builds when your weapon is sheathed for at least 1 minute. When you draw this weapon, it deals an extra {@damage 1d6} cold damage for the next 4 rounds."
 						]
 					}
 				]
@@ -68227,7 +69441,7 @@
 											],
 											[
 												"19-20",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											]
 										]
@@ -68274,7 +69488,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -68952,9 +70166,6 @@
 			"traitTags": [
 				"Death Burst",
 				"Flyby"
-			],
-			"miscTags": [
-				"AOE"
 			]
 		},
 		{
@@ -69635,7 +70846,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The volvidon makes three attacks: one tongue attack and two claw attacks."
+						"The volvidon makes three attacks: one with its tongue and two with its claw."
 					]
 				},
 				{
@@ -69653,7 +70864,7 @@
 				{
 					"name": "Rollout {@recharge 5}",
 					"entries": [
-						"The volvidon curls up into a ball, releasing any {@condition grappled} creature, and moves up to double its speed in a straight line. If the Volvidon passes through a creatures space, that creature must make make a {@dc 13} Dexterity saving throw, taking 21 ({@damage 6d6}) bludgeoning damage and are knocked {@condition prone} on a failed save. On a successful save, the target takes half damage and is not knocked {@condition prone}."
+						"The volvidon curls up into a ball, releasing any {@condition grappled} creature, and moves up to double its speed in a straight line. While moving, the volvidon is immune to fire damage. If the Volvidon passes through a creatures space, that creature must make make a {@dc 13} Dexterity saving throw, taking 21 ({@damage 6d6}) bludgeoning damage and be knocked {@condition prone} on a failed save. On a successful save, the target takes half damage and is not knocked {@condition prone}."
 					]
 				}
 			],
@@ -69665,7 +70876,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Volvidon have a special armor on their backs, protecting them from attacks while also being very flexible. It possesses an extremely long, chameleon-like tongue which is covered in sticky saliva. Being a Fanged Beast, the Volvidon uses attacks similar to those of Arzuros and Lagombi. It is known to pull prey and foes toward its mouth using its long tongue. In addition to aiding transportation, its ability to roll up into a ball allows it to crush foes during combat. It will typically avoid trouble, but if cornered, Volvidon can be surprisingly aggressive.",
+							"Volvidon have a special armor on their backs, protecting them from attacks while also being very flexible. It possesses an extremely long, chameleon-like tongue which is covered in sticky saliva. Being a Fanged Beast, the Volvidon uses attacks similar to those of {@creature Arzuros|MHMM} and {@creature Lagombi|MHMM}. It is known to pull prey and foes toward its mouth using its long tongue. In addition to aiding transportation, its ability to roll up into a ball allows it to crush foes during combat. It will typically avoid trouble, but if cornered, Volvidon can be surprisingly aggressive.",
 							"Since it feeds mainly on {@creature Bnahabra|MHMM} and {@creature Altaroth|MHMM}, it is able to convert the paralyzing toxins the insects naturally produce in to its own system due to a specialized organ located in its mouth along with a smelly gas. This being done, now its own saliva has the same paralytic qualities, aiding it in its defense against predators.",
 							"Volvidon are relatively calm, unless disturbed by predators. At the first sight of trouble the large Fanged Beast will roll up and if possible quickly roll away, but if cornered Volvidon can be surprisingly aggressive. These creatures should not be underestimated by hunters as they can send any inexperienced or arrogant hunter to an early grave.",
 							{
@@ -69787,7 +70998,7 @@
 												"type": "entries",
 												"name": "Sharpened Fang+",
 												"entries": [
-													"Your weapon deals an extra 1d4 slashing damage."
+													"Your weapon deals an extra {@damage 1d4} slashing damage."
 												]
 											},
 											{
@@ -70362,7 +71573,7 @@
 												"type": "entries",
 												"name": "Ibushi Horn",
 												"entries": [
-													"You have immunity to thunder damage while you wear this armor."
+													"You are immune to thunder damage while you wear this armor."
 												]
 											},
 											{
@@ -70432,7 +71643,7 @@
 												"type": "entries",
 												"name": "Ibushi Bluespike",
 												"entries": [
-													"{@i Wind Slash.} This weapon has 10 runes that it regains daily at dawn. Before you make your first attack on your turn with this weapon, you can expend one or more runes to extend its reach by 10 feet for each rune expended. This weapon deals thunder damage instead of its normal weapon damage when you hit a target outside of its normal reach and the target takes an extra 1d6 thunder damage."
+													"{@i Wind Slash.} This weapon has 10 runes that it regains daily at dawn. Before you make your first attack on your turn with this weapon, you can expend one or more runes to extend its reach by 10 feet for each rune expended. This weapon deals thunder damage instead of its normal weapon damage when you hit a target outside of its normal reach and the target takes an extra {@damage 1d6} thunder damage."
 												]
 											},
 											{
@@ -71225,7 +72436,7 @@
 											],
 											[
 												"17-18",
-												"Sm Monsterbone",
+												"Sm Monster Bone",
 												"(O)"
 											],
 											[
@@ -71277,7 +72488,7 @@
 										"items": [
 											{
 												"type": "entries",
-												"name": "Sm Monsterbone",
+												"name": "Sm Monster Bone",
 												"entries": [
 													"Uncommon weapon upgrade material."
 												]
@@ -71703,7 +72914,7 @@
 				"walk": 40,
 				"fly": 80
 			},
-			"str": 23,
+			"str": 24,
 			"dex": 10,
 			"con": 27,
 			"int": 3,
@@ -71767,23 +72978,23 @@
 				{
 					"name": "Bite",
 					"entries": [
-						"{@atk mw} {@hit 14} to hit, reach 10 ft., one target. {@h}27 ({@damage 4d8 + 9}) piercing damage. If the target is a creature, it is {@condition grappled} (escape {@dc 19}). Until this grapple ends, the target is {@condition restrained}, and the xeno'jiiva can't bite another target."
+						"{@atk mw} {@hit 15} to hit, reach 10 ft., one target. {@h}25 ({@damage 4d8 + 7}) piercing damage. If the target is a creature, it is {@condition grappled} (escape {@dc 19}). Until this grapple ends, the target is {@condition restrained}, and the xeno'jiiva can't bite another target."
 					]
 				},
 				{
 					"name": "Claw",
 					"entries": [
-						"{@atk mw} {@hit 14} to hit, reach 5 ft., one target. {@h}19 ({@damage 3d6 + 9}) slashing damage."
+						"{@atk mw} {@hit 15} to hit, reach 5 ft., one target. {@h}17 ({@damage 3d6 + 7}) slashing damage."
 					]
 				},
 				{
 					"name": "Tail",
 					"entries": [
-						"{@atk mw} {@hit 14} to hit, reach 15 ft., one target. {@h}31 ({@damage 4d10 + 9}) bludgeoning damage."
+						"{@atk mw} {@hit 15} to hit, reach 15 ft., one target. {@h}29 ({@damage 4d10 + 7}) bludgeoning damage."
 					]
 				},
 				{
-					"name": "Blue Firebolt",
+					"name": "Blue Flames",
 					"entries": [
 						"{@atk rw} {@hit 8} to hit, range 80/320 ft., one target. {@h}36 ({@damage 8d8}) fire damage."
 					]
@@ -71811,7 +73022,7 @@
 				{
 					"name": "Detect",
 					"entries": [
-						"The xeno'jiiva makes a Wisdom (Perception) check."
+						"The xeno'jiiva makes a Wisdom ({@skill Perception}) check."
 					]
 				},
 				{
@@ -71858,7 +73069,7 @@
 							"If its heat organ is left to produce large amounts of energy, and the build-up of it reaches a certain level, an explosion of energy will engulf Xeno'jiiva's body. In this state, portions of Xeno'jiiva's body are covered in blue flames, and its strength, as well as the amount of energy it uses, is increased. Xeno'jiiva becomes unstable when it builds up too much energy inside of its body, affecting its mass, so it needs to release as much as possible. Xeno'jiiva is known to become exhausted for a long period of time after releasing so much energy.",
 							"Although Xeno'jiiva is already an adult, it's believed that it'll further change as it grows. Scholars in the commission theorize that Xeno'jiiva will lose its transparent skin as it further grows and that it'll be able to generate energy infinitely in its body via its heat organ, meaning it won't ever need to feed on other creatures for subsistence. They also think that Xeno'jiiva could learn to maintain a high energy state permanently over time. Since much about Xeno'jiiva is still a mystery, it's up in the air whether it could become stronger in the future or not.",
 							"Xeno'jiiva can attract other Elder Dragons to its location with its immense energy pulses or special pheromones, causing the Elder Crossing to happen every ten years instead of every hundred. This also causes the geography of an area, the New World, in this case, to change constantly from all the natural phenomena, which is caused by other Elder Dragons, going off at once. From it feeding on the bioenergy of dead Elder Dragons for decades, it has gained enough power to be considered the Emperor of Elder Dragons and could bring mass destruction to whole ecosystems if one was ever allowed to leave its nest.",
-							"Xeno'jiiva is immediately hostile the moment it emerges from its cocoon, making it dangerous to other species. Although it had just awakened, its powers are already considered to be great compared to most Elder Dragons, but it can't control all of its energy. It's believed that if Xeno'jiiva was left alone to master its powers it would've been a greater threat.",
+							"Xeno'jiiva is immediately hostile the moment it emerges from its cocoon, making it dangerous to other species. Although it had just awakened, its powers are already considered to be great compared to most Elder Dragons, but it can't control all of its energy. It's believed that if Xeno'jiiva was left alone to master its powers it would've been {@creature safi'jiiva|MHMM|a greater threat}.",
 							{
 								"type": "inset",
 								"name": "Xeno'jiiva",
@@ -71998,21 +73209,21 @@
 												"type": "entries",
 												"name": "Xeno'jiiva Shell",
 												"entries": [
-													"{@i (Bow only) Special Ammo Boost +2.} Your coating now coats up to 30 arrows and your dragonpiercer deals an extra 3d6 piercing damage."
+													"{@i (Bow only) Special Ammo Boost +2.} Your coating now coats up to 30 arrows and your dragonpiercer deals an extra {@damage 3d6} piercing damage."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Xeno'jiiva Soulscale",
 												"entries": [
-													"{@i Partbreaker+4.} You deal an extra 1d12 weapon damage when you critically hit with this weapon."
+													"{@i Partbreaker+4.} You deal an extra {@damage 1d12} weapon damage when you critically hit with this weapon."
 												]
 											},
 											{
 												"type": "entries",
 												"name": "Xeno'jiiva Claw",
 												"entries": [
-													"Your weapon deals an extra 1d10 force damage."
+													"Your weapon deals an extra {@damage 1d10} force damage."
 												]
 											},
 											{
@@ -72163,8 +73374,7 @@
 			"miscTags": [
 				"MW",
 				"RCH",
-				"AOE",
-				"RW"
+				"AOE"
 			],
 			"conditionInflict": [
 				"restrained",
@@ -72301,15 +73511,9 @@
 			],
 			"legendary": [
 				{
-					"name": "Summon Great Thunderbugs",
+					"name": "Summon Great Thunderbugs or Fire Plume",
 					"entries": [
-						"The yama tsukami uses its Summon Great Thunderbugs"
-					]
-				},
-				{
-					"name": "Fire Plume",
-					"entries": [
-						"The yama tsukami uses its Fire Plume."
+						"The yama tsukami uses its Summon Great Thunderbugs or Fire Plume."
 					]
 				},
 				{
@@ -72348,7 +73552,8 @@
 						"entries": [
 							"Yama Tsukami is an unusual Elder Dragon with an octopus-like body. It is covered in moss, algae, and other plant life, and boasts a set of four thick tentacles. In addition, it possesses two large whiskers and an oddly human-like set of teeth and gums. It produces gas within its body in order to keep itself afloat.",
 							"Yama Tsukami are constantly traveling through different areas in order to find suitable fertile land for them to feed on, even traveling over vast seas. Yama Tsukami is a dangerous monster that can potentially swallow a whole village or town. However it is believed that the winds in environments can send Yama Tsukami unintentionally into some areas so it might not intentionally be heading to attack towns. Though, most heavily forested areas are most at risk of getting eaten by a Yama Tsukami. Strangely around parts of a Great Forest, Yama Tsukami of different colors and sizes have been seen. Its theorized that they are either adults and juveniles, subspecies, or just environmental conditions. Most believe that it is due to environmental conditions that there are many different Yama Tsukami.",
-							"Yama Tsukami's most notable adaption is its ability to float with no obvious method of propulsion. From the large amounts of dirt and rotting flesh that a Yama Tsukami has swallowed, it all produces a gas inside its body that allows it to float in the air without wings. It is able to control the amount of gas it uses and able to use it as a rudder as it floats in the air. It can even use the gas as a weapon and as a defensive shield. Despite being able to control it, Yama Tsukami can be knocked out the air if enough damage is done to it and even by crashing into the ground randomly. The creature has four large tentacles that may serve as multipurpose appendages. These tentacles are light yet very slimy It could use these to snare prey, uproot plants, or anchor itself to landmasses or trees. At the end of these tentacles, there seem to be claws. It also uses them like whips when defending itself, crushing anything that tries to challenge it. Yama Tsukami also has a pair of large whiskers, which it uses as tentacles as well. Yama Tsukami has the parasitic Dragonwood and the mysterious Dragonmoss growing from its back along with trees and many different plants. The exact cause of this is its feeding on forest and on lakes along with its blood which is the nutrients for many different species of plants. Due to this, Yama Tsukami have become a \"special\" environment for some living things such as the {@creature Great Thunderbug|MHMM}. Sometimes as it eats whole forests and lakes, Yama Tsukami will also suck up or eat Great Thunderbugs that are caught in its mouth. From the Yama Tsukami being a \"special\" environment for them, they become quite different from the normal Great Thunderbugs and develop differently compared to them. They even seem to develop a bond with Yama Tsukami and will defend it from any potential threats. Yama Tsukami have incredibly long lifespans numbering in the thousands of years.",
+							"Yama Tsukami's most notable adaption is its ability to float with no obvious method of propulsion. From the large amounts of dirt and rotting flesh that a Yama Tsukami has swallowed, it all produces a gas inside its body that allows it to float in the air without wings. It is able to control the amount of gas it uses and able to use it as a rudder as it floats in the air. It can even use the gas as a weapon and as a defensive shield. Despite being able to control it, Yama Tsukami can be knocked out the air if enough damage is done to it and even by crashing into the ground randomly. The creature has four large tentacles that may serve as multipurpose appendages. These tentacles are light yet very slimy It could use these to snare prey, uproot plants, or anchor itself to landmasses or trees. At the end of these tentacles, there seem to be claws. It also uses them like whips when defending itself, crushing anything that tries to challenge it.",
+							"Yama Tsukami also has a pair of large whiskers, which it uses as tentacles as well. Yama Tsukami has the parasitic Dragonwood and the mysterious Dragonmoss growing from its back along with trees and many different plants. The exact cause of this is its feeding on forest and on lakes along with its blood which is the nutrients for many different species of plants. Due to this, Yama Tsukami have become a \"special\" environment for some living things such as the {@creature Great Thunderbug|MHMM}. Sometimes as it eats whole forests and lakes, Yama Tsukami will also suck up or eat Great Thunderbugs that are caught in its mouth. From the Yama Tsukami being a \"special\" environment for them, they become quite different from the normal Great Thunderbugs and develop differently compared to them. They even seem to develop a bond with Yama Tsukami and will defend it from any potential threats. Yama Tsukami have incredibly long lifespans numbering in the thousands of years.",
 							{
 								"type": "inset",
 								"name": "Yama Tsukami",
@@ -72438,7 +73643,7 @@
 												"type": "entries",
 												"name": "Dragonmoss",
 												"entries": [
-													"While wearing this armor, your Strength score changes to 25."
+													"While wearing this armor, your Strength score changes to 25. If your Strength is already equal to or greater than 25, the material has no effect on you."
 												]
 											},
 											{
@@ -72525,10 +73730,10 @@
 				"AOE"
 			],
 			"conditionInflict": [
-				"grappled",
-				"restrained",
+				"Grappled",
+				"Restrained",
 				"prone",
-				"blinded"
+				"Blinded"
 			]
 		},
 		{
@@ -72611,7 +73816,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The yian garuga makes three attack: two with its peck and one with its tail."
+						"The yian garuga makes three attacks: two with its peck and one with its tail."
 					]
 				},
 				{
@@ -72645,8 +73850,8 @@
 			"fluff": {
 				"entries": [
 					"The Yian Garuga is highly aggressive Bird Wyvern that has a striking purple coloration, large defensive spikes and an extremely tough shell. Its beak is sharp and jagged, and it possesses a silver mane around the edge of its face.",
-					"Yian Garuga is a close relative of the Yian Kut-ku that possesses a poisonous tail club and can produce ear-splitting roars to stop foes in their tracks. It is quite crafty, and is known to rationally observe their prey, even when angered. They are not to be taken lightly.",
-					"Yian Garuga hunt almost exclusively at night, using its deadly poison or stabbing its prey with its sharp beak to finish off its victim. If hunting another predatory species such as a Velocidrome.",
+					"Yian Garuga is a close relative of the {@creature Yian Kut-ku|MHMM} that possesses a poisonous tail club and can produce ear-splitting roars to stop foes in their tracks. It is quite crafty, and is known to rationally observe their prey, even when angered. They are not to be taken lightly.",
+					"Yian Garuga hunt almost exclusively at night, using its deadly poison or stabbing its prey with its sharp beak to finish off its victim. When hunting another predatory species such as {@creature Velocidrome|MHMM}, Yian Garuga will let out a ear-deafening roar before launching an attack.",
 					"Very war-like in nature, Yian Garuga are a monster that is best avoided. Yian Garuga are very solitary creatures though, they have rarely been seen in groups possibly during a mating season, the groups consisting of more than two have been seen on islands. After mating, a female will sometimes seek out a Yian Kut-Ku nest, destroy the eggs, and then lay its own eggs in the nest for the oblivious Kut-Ku to raise and care for. This shows that a female Garuga can be a Brood Parasite like a real-world cuckoo bird. Yian Garuga perform this behavior due to their poor parental behavior.",
 					{
 						"type": "inset",
@@ -72903,15 +74108,15 @@
 			],
 			"ac": [
 				{
-					"ac": 13,
+					"ac": 14,
 					"from": [
 						"natural armor"
 					]
 				}
 			],
 			"hp": {
-				"average": 75,
-				"formula": "10d10 + 20"
+				"average": 90,
+				"formula": "12d10 + 24"
 			},
 			"speed": {
 				"walk": 30,
@@ -72921,25 +74126,25 @@
 			"dex": 16,
 			"con": 14,
 			"int": 8,
-			"wis": 12,
+			"wis": 14,
 			"cha": 6,
 			"skill": {
-				"perception": "+3"
+				"perception": "+4"
 			},
-			"passive": 13,
+			"passive": 14,
 			"cr": "3",
 			"page": 0,
 			"trait": [
 				{
 					"name": "Sensitive Ears",
 					"entries": [
-						"If the yian kut-ku takes thunder damage or a thunder spell is used within 60 feet of it, it is {@condition stunned} until the start of its next turn."
+						"If the yian kut-ku takes thunder damage or a thunder spell is used within 60 feet of it, it must succeed on a {@dc 15} Constitution saving throw or become {@condition stunned} until the start of its next turn."
 					]
 				},
 				{
 					"name": "Charge",
 					"entries": [
-						"If the yian kut-ku moves at least 20 feet straight toward a target and then hits it with a Body Slam Attack on the same turn, the target takes an extra 19 ({@damage 3d12}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 13} Strength saving throw or be knocked {@condition prone}."
+						"If the yian kut-ku moves at least 20 feet straight toward a target and then hits it with a Body Slam Attack on the same turn, the target takes an extra 6 ({@damage 1d12}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 13} Strength saving throw or be knocked {@condition prone}."
 					]
 				}
 			],
@@ -72947,7 +74152,7 @@
 				{
 					"name": "Multiattack",
 					"entries": [
-						"The yian kut-ku makes two Peck attacks and one tail attack."
+						"The yian kut-ku makes two attacks: one with its peck and one with its tail."
 					]
 				},
 				{
@@ -73605,7 +74810,7 @@
 										"type": "entries",
 										"name": "Y.Gammoth Shell",
 										"entries": [
-											"Your weapon deals an extra 1d4 cold damage."
+											"Your weapon deals an extra {@damage 1d4} cold damage."
 										]
 									},
 									{
@@ -75460,8 +76665,7 @@
 				"P"
 			],
 			"miscTags": [
-				"MW",
-				"RW"
+				"MW"
 			]
 		},
 		{
@@ -75499,7 +76703,8 @@
 			},
 			"speed": {
 				"walk": 20,
-				"burrow": 30
+				"burrow": 30,
+				"swim": 30
 			},
 			"str": 15,
 			"dex": 12,
@@ -75522,6 +76727,12 @@
 			],
 			"trait": [
 				{
+					"name": "Amphibious",
+					"entries": [
+						"The zamite can breathe air and water."
+					]
+				},
+				{
 					"name": "Pack Tactics",
 					"entries": [
 						"The zamite has advantage on an attack roll against a creature if at least one of the zamite's allies is within 5 feet of the creature and the ally isn't {@condition incapacitated}."
@@ -75537,6 +76748,7 @@
 				}
 			],
 			"traitTags": [
+				"Amphibious",
 				"Pack Tactics"
 			],
 			"senseTags": [
@@ -75548,7 +76760,7 @@
 					{
 						"type": "entries",
 						"entries": [
-							"It is a small, shark-like creature whose relatively large mouth houses many rows of teeth made for attacking prey and hunters. Zamite have been sighted in a number of different stages of development, with some having fully developed legs, while others slide on their bellies. During battle, Zamite can grow larger when it ingests bodily fluids. These fluids also allow Zamites to grow legs if they are ingested by the individuals without limbs. Zamite behave just like Giggi in the manner of aggressively attacking any possible food source and draining them of their vital fluids.",
+							"It is a small, shark-like creature whose relatively large mouth houses many rows of teeth made for attacking prey and hunters. Zamite have been sighted in a number of different stages of development, with some having fully developed legs, while others slide on their bellies. During battle, Zamite can grow larger when it ingests bodily fluids. These fluids also allow Zamites to grow legs if they are ingested by the individuals without limbs. Zamite behave just like {@creature Giggi|MHMM} in the manner of aggressively attacking any possible food source and draining them of their vital fluids.",
 							{
 								"type": "inset",
 								"name": "Zamite",
@@ -75706,7 +76918,8 @@
 			},
 			"speed": {
 				"walk": 40,
-				"burrow": 40
+				"burrow": 40,
+				"swim": 40
 			},
 			"str": 17,
 			"dex": 12,
@@ -75729,6 +76942,12 @@
 				"tremorsense 60 ft."
 			],
 			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The zamtrios can breathe air and water."
+					]
+				},
 				{
 					"name": "Expand (2/Day)",
 					"entries": [
@@ -75780,8 +76999,8 @@
 					{
 						"type": "entries",
 						"entries": [
-							"Zamtrios is a large, quadrupedal monster with grey-blue skin and yellow fins. It is superficially shark-like in appearance, with a long, pointed snout and a mouth filled with multiple rows of sharp teeth. As the adult form of Zamite, its limbs are powerful and fully-developed. Its skin is extremely elastic in order to accommodate its inflation abilities.",
-							"Zamtrios is a powerful predator, but these Fanged Beasts mostly feed on plants, nuts, and mushrooms though they will sometimes eat meat. From the size of the Lagombi, its very possible Zamtrios would try to hunt them. Though Zamtrios prefer to feed on smaller helpless prey, they are still quite dangerous in their own right. Zamtrios have even been found to feed on Plesioth in tropical waters. The massive and aggressive Gammoth can seriously injure, if not outright kill the Amphibian if confronted.",
+							"Zamtrios is a large, quadrupedal monster with grey-blue skin and yellow fins. It is superficially shark-like in appearance, with a long, pointed snout and a mouth filled with multiple rows of sharp teeth. As the adult form of {@creature Zamite|MHMM}, its limbs are powerful and fully-developed. Its skin is extremely elastic in order to accommodate its inflation abilities.",
+							"Zamtrios is a powerful predator, but these Fanged Beasts mostly feed on plants, nuts, and mushrooms though they will sometimes eat meat. From the size of the {@creature Lagombi|MHMM}, its very possible Zamtrios would try to hunt them. Though Zamtrios prefer to feed on smaller helpless prey, they are still quite dangerous in their own right. Zamtrios have even been found to feed on {@creature Plesioth|MHMM} in tropical waters. The massive and aggressive {@creature Gammoth|MHMM} can seriously injure, if not outright kill the Amphibian if confronted.",
 							"Zamtrios is a very strange Amphibian with many bizarre adaptions. Zamtrios now lacks the sharp spike its juvenile form has but now is able to produce a type of \"armor\". It is able to produce this armor by secreting a special fluid from its skin that eventually freezes around it forming this icy armor. This armor acts as a secondary protection against threats and also acts as weapon. When it forms this armor, it will also produce a long, rigid spike made of ice on top of its head, replacing the spike it once had, and spike on its tail as another weapon. When its not using its icy armor it will use freezing water to attack threats or prey from a distance and will spit balls of snow at them to stop their movement. Zamtrios have an under layer of skin directly under their skin used to replace previous old one. Their teeth, like saws, cut up prey just by rubbing against them.",
 							"When Zamtrios is damaged greatly while it has its icy armor, it will go through one of the most dramatic changes in nature. When greatly damaged, Zamtrios will greatly expand its body and inflate its body to several times its original body size. It goes through this change to intimidate an attacker and is able to do this from gas that it produces from inside its body. The downside to this is that Zamtrios becomes more susceptible to attacks while inflated and its maneuverability is dramatically decreased.",
 							"Zamtrios primarily spend most of their time in the water or under ice, constantly roaming around their territory and searching for prey. Like the Zamites, Zamtrios have huge appetites and have a single mind set on finding prey and to kill or eat any intruders in their territory. If Zamtrios have an enemy in their sight, they may actually chase them for miles upon miles of ice. During the breeding season Zamtrios will come together and mate. When female Zamtrios have mated they will then lay their eggs within the ice.",
@@ -75944,7 +77163,7 @@
 												"type": "entries",
 												"name": "Paddock Oil",
 												"entries": [
-													"When applied to the skin, the target gains {@sense tremorsense|MM} out to 30 feet for 1 hour."
+													"When applied to the skin, the target gains {@sense tremorsense} out to 30 feet for 1 hour."
 												]
 											}
 										]
@@ -75960,6 +77179,9 @@
 				"P",
 				"S",
 				"C"
+			],
+			"traitTags": [
+				"Amphibious"
 			],
 			"miscTags": [
 				"MW",


### PR DESCRIPTION
Brings AGMH in line with 6/15 version as updated on Reddit, and some updates to MHMM.

In addition to the last AGMH pull request, this one covers updates to the dungbomb, feats, artificer infusions, and the new jungle statblock, overworld travel rules, and monstie sidekick class. 

The MHMM updates should cover relatively recent changes up until the Fanged Wyverns. More to come later.