### PR TITLE
BREW-255: Converted LaserLlama's Alternate Ranger

### DIFF
--- a/class/LaserLlama; Alternate Ranger.json
+++ b/class/LaserLlama; Alternate Ranger.json
@@ -1,0 +1,4240 @@
+{
+    "_meta": {
+		"sources": [
+			{
+				"json": "LLAR",
+				"abbreviation": "LLAR",
+				"full": "Alternate Ranger",
+				"authors": [
+					"LaserLlama"
+				],
+				"convertedBy": [
+					"ProfForp#0242"
+				],
+                "color": "2BAE2A",
+				"version": "3.7.1",
+				"url": "https://www.gmbinder.com/share/-M7iu19Af89SH2G_5RGa",
+				"targetSchema": "1.1.0"
+			},
+            {
+				"json": "LLAR:E",
+				"abbreviation": "LLAR:E",
+				"full": "Alternate Ranger Expanded",
+				"authors": [
+					"LaserLlama"
+				],
+				"convertedBy": [
+					"ProfForp#0242"
+				],
+                "color": "2BAE2A",
+				"version": "3.7.1",
+				"url": "https://www.gmbinder.com/share/-MW4c30CbGMWLRNgJxgb",
+				"targetSchema": "1.1.0"
+			}
+		],
+        "dependencies": {
+            "spell": [
+                "PHB",
+                "XGE",
+                "TCE"
+            ]
+        },
+        "optionalFeatureTypes": {
+            "FS:AR": "Fighting Style; Alternate Ranger",
+            "LL:BHE": "Bounty Hunter Exploits",
+            "LL:SK": "Survivalist Knacks"
+        },
+		"dateAdded": 1658237901,
+		"dateLastModified": 1658432790
+	},
+    "class": [
+        {
+            "name": "Ranger (Alternate)",
+			"source": "LLAR",
+            "fluff": [
+                {
+                    "name": "Alternate Ranger",
+                    "type": "section",
+                    "entries": [
+                        "Lorem Ipsum"
+                    ]
+                }
+            ],
+			"hd": {
+				"number": 1,
+				"faces": 10
+			},
+			"proficiency": [
+				"str",
+				"dex"
+			],
+            "startingProficiencies": {
+				"armor": [
+					"light",
+					"medium",
+					"{@item shield|phb|shields}"
+				],
+				"weapons": [
+					"simple",
+					"martial"
+				],
+				"skills": [
+					{
+						"choose": {
+							"from": [
+								"animal handling",
+								"athletics",
+                                "history",
+								"insight",
+								"investigation",
+                                "medicine",
+								"nature",
+								"perception",
+								"stealth",
+								"survival"
+							],
+							"count": 3
+						}
+					}
+				]
+			},
+            "startingEquipment": {
+				"additionalFromBackground": true,
+				"default": [
+					"(a) {@item chain shirt|phb} and a {@item shield|phb} or (b) {@item leather armor|phb}",
+					"(a) two {@item shortsword|phb|shortswords} or (b) two {@filter simple melee weapons|items|source=phb|category=basic|type=simple weapon;melee weapon=sand}",
+                    "(a) a {@item longbow|phb} and a {@item quiver|phb} of {@item arrows (20)|phb|20 arrows} or (b) a {@filter martial weapon|items|source=phb|category=basic|type=martial weapon}",
+                    "(a) a {@item dungeoneer's pack|phb} or (b) an {@item explorer's pack|phb}"
+				],
+				"defaultData": [
+					{
+						"a": [
+							"chain shirt|phb",
+                            "shield|phb"
+						],
+						"b": [
+							"leather armor|phb"
+						]
+					},
+					{
+						"a": [
+							{
+								"item": "shortsword|phb",
+								"quantity": 2
+							}
+						],
+						"b": [
+							{
+								"equipmentType": "weaponSimpleMelee",
+								"quantity": 2
+							}
+						]
+					},
+					{
+						"a": [
+							"longbow|phb",
+							"arrows (20)|phb"
+						],
+                        "b": [
+                            {
+								"equipmentType": "weaponMartial"
+							}
+                        ]
+					},
+					{
+						"a": [
+							"dungeoneer's pack|phb"
+						],
+						"b": [
+							"explorer's pack|phb"
+						]
+					}
+				]
+			},
+			"multiclassing": {
+				"requirements": {
+					"wis": 13,
+					"or": [
+                        {
+                            "str": 13,
+                            "dex": 13
+                        }
+                    ]
+				},
+				"proficienciesGained": {
+					"armor": [
+						"light",
+						"medium",
+						"{@item shield|phb|shields}"
+					],
+					"skills": [
+						{
+							"choose": {
+								"from": [
+                                    "animal handling",
+                                    "athletics",
+                                    "history",
+                                    "insight",
+                                    "investigation",
+                                    "medicine",
+                                    "nature",
+                                    "perception",
+                                    "stealth",
+                                    "survival"
+                                ],
+								"count": 1
+							}
+						}
+					],
+					"weapons": [
+						"simple",
+						"martial"
+					]
+				}
+			},
+            "classFeatures": [
+                "Survivalist Knacks|Ranger (Alternate)|LLAR|1",
+                "Wilderness Expertise|Ranger (Alternate)|LLAR|1",
+                "Fighting Style|Ranger (Alternate)|LLAR|2",
+                "Favored Foe|Ranger (Alternate)|LLAR|2",
+                "Spellcasting|Ranger (Alternate)|LLAR|2",
+                {
+                    "classFeature": "Ranger Archetype|Ranger (Alternate)|LLAR|3",
+                    "gainSubclassFeature": true
+                },
+                "Ability Score Improvement|Ranger (Alternate)|LLAR|4",
+                "Extra Attack|Ranger (Alternate)|LLAR|5",
+                "Favored Foe Improvement|Ranger (Alternate)|LLAR|6",              
+                {
+                    "classFeature": "Ranger Archetype Feature|Ranger (Alternate)|LLAR|7",
+                    "gainSubclassFeature": true
+                },
+                "Ability Score Improvement|Ranger (Alternate)|LLAR|8",
+                "Wilderness Expertise|Ranger (Alternate)|LLAR|10",                
+                {
+                    "classFeature": "Ranger Archetype Feature|Ranger (Alternate)|LLAR|11",
+                    "gainSubclassFeature": true
+                },
+                "Ability Score Improvement|Ranger (Alternate)|LLAR|12",
+                "Favored Foe Improvement|Ranger (Alternate)|LLAR|14",  
+                {
+                    "classFeature": "Ranger Archetype Feature|Ranger (Alternate)|LLAR|15",
+                    "gainSubclassFeature": true
+                },
+                "Ability Score Improvement|Ranger (Alternate)|LLAR|16",
+                "Favored Foe Improvement|Ranger (Alternate)|LLAR|18",
+                "Feral Senses|Ranger (Alternate)|LLAR|18",
+                "Ability Score Improvement|Ranger (Alternate)|LLAR|19",
+                "Foe Slayer|Ranger (Alternate)|LLAR|20"
+            ],
+            "subclassTitle": "Ranger Archetype",
+            "classTableGroups": [
+                {
+                    "colLabels": [
+                        "{@filter 1st|spells|level=1|class=Ranger (LLAR)}",
+                        "{@filter 2nd|spells|level=2|class=Ranger (LLAR)}",
+                        "{@filter 3rd|spells|level=3|class=Ranger (LLAR)}",
+                        "{@filter 4th|spells|level=4|class=Ranger (LLAR)}",
+                        "{@filter 5th|spells|level=5|class=Ranger (LLAR)}",
+                        "{@filter Knacks Known|optionalfeatures|feature type=LL:SK}"
+                    ],
+                    "rows": [
+                        [
+                            "-",
+                            "-",
+                            "-",
+                            "-",
+                            "-",
+                            "2"
+                        ],
+                        [
+                            "2",
+                            "-",
+                            "-",
+                            "-",
+                            "-",
+                            "2"
+                        ],
+                        [
+                            "3",
+                            "-",
+                            "-",
+                            "-",
+                            "-",
+                            "3"
+                        ],
+                        [
+                            "3",
+                            "-",
+                            "-",
+                            "-",
+                            "-",
+                            "3"
+                        ],
+                        [
+                            "4",
+                            "2",
+                            "-",
+                            "-",
+                            "-",
+                            "3"
+                        ],
+                        [
+                            "4",
+                            "2",
+                            "-",
+                            "-",
+                            "-",
+                            "4"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "-",
+                            "-",
+                            "-",
+                            "4"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "-",
+                            "-",
+                            "-",
+                            "4"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "2",
+                            "-",
+                            "-",
+                            "5"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "2",
+                            "-",
+                            "-",
+                            "5"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "-",
+                            "-",
+                            "5"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "-",
+                            "-",
+                            "6"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "1",
+                            "-",
+                            "6"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "1",
+                            "-",
+                            "7"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "2",
+                            "-",
+                            "7"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "2",
+                            "-",
+                            "8"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "3",
+                            "1",
+                            "8"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "3",
+                            "1",
+                            "9"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "3",
+                            "2",
+                            "9"
+                        ],
+                        [
+                            "4",
+                            "3",
+                            "3",
+                            "3",
+                            "2",
+                            "10"
+                        ]
+                    ]
+                }
+            ],
+			"spellcastingAbility": "wis",
+			"casterProgression": "1/2",
+            "classSpells": [
+                "absorb elements|xge",
+                "alarm",
+                "animal friendship",
+                "beast bond|xge",
+                "cure wounds",
+                "detect magic",
+                "detect poison and disease",
+                "ensnaring strike",
+                "entangle",
+                "expeditious retreat",
+                "fog cloud",
+                "goodberry",
+                "hail of thorns",
+                "jump",
+                "longstrider",
+                "purify food and drink",
+                "searing smite",
+                "snare|xge",
+                "speak with animals",
+                "zephyr strike|xge",
+                "aid",
+                "animal messenger",
+                "barkskin",
+                "beast sense",
+                "continual flame",
+                "cordon of arrows",
+                "darkvision",
+                "enhance ability",
+                "find traps",
+                "gust of wind",
+                "healing spirit|xge",
+                "lesser restoration",
+                "locate animals or plants",
+                "locate object",
+                "magic weapon",
+                "pass without trace",
+                "protection from poison",
+                "silence",
+                "spike growth",
+                "summon beast|tce",
+                "blinding smite",
+                "conjure animals",
+                "conjure barrage",
+                "daylight",
+                "dispel magic",
+                "elemental weapon",
+                "flame arrows|xge",
+                "leomund's tiny hut",
+                "lightning arrow",
+                "meld into stone",
+                "nondetection",
+                "plant growth",
+                "revivify",
+                "speak with plants",
+                "summon fey|tce",
+                "water breathing",
+                "water walk",
+                "wind wall",
+                "conjure woodland beings",
+                "death ward",
+                "divination",
+                "dominate beast",
+                "freedom of movement",
+                "grasping vine",
+                "guardian of nature|xge",
+                "locate creature",
+                "staggering smite",
+                "stoneskin",
+                "summon elemental|tce",
+                "awaken",
+                "commune with nature",
+                "conjure volley",
+                "contagion",
+                "greater restoration",
+                "steel wind strike|xge",
+                "swift quiver",
+                "tree stride",
+                "wrath of nature|xge"
+            ]
+        }
+    ],
+    "classFeature": [
+        {
+            "name": "Survivalist Knacks",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 1,
+            "entries": [
+                "In the wild you have gathered bits of primal knowledge that bolster your exploration, hunting, and tracking skills, known as {@filter Survivalist Knacks|optionalfeatures|feature type=LL:SK}. At 1st level, you learn two Knacks of your choice from the list at the end of this class description.",
+                "You learn additional Knacks as you gain ranger levels, as shown in the Knacks Known column on the Ranger table.",
+                "Each time you gain a level in this class, you can choose one of the Knacks you know and replace it with another Knack of your choice for which you meet the prerequisites."
+            ]
+        },
+        {
+            "name": "Wilderness Expertise",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 1,
+            "entries": [
+                "Your skill in the wild is without peer. At 1st level, choose one of your skill proficiencies you gained from the ranger class skill list. Your proficiency bonus is doubled for any ability check you make that uses that skill. You also learn to speak, read, and write one additional language of your choice. Most rangers learn the language spoken by the enemies they hunt."
+            ]
+        },
+        {
+            "name": "Fighting Style",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 2,
+            "entries": [
+                "Your skill in battle surpasses that of most warriors. At 2nd level you gain a Fighting Style of your choice from the list below. You can't learn a Fighting Style more than once, even if another feature allows you to learn another Fighting Style.",
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Archery|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Defensive Fighting|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Dual Wielding|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Dueling|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Featherweight Fighting|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Protection|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Marine Fighting|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Melee Marksman|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Strongbow|LLAR"
+                },
+                {
+                    "type": "refOptionalfeature",
+                    "optionalfeature": "Versatile Fighting|LLAR"
+                },
+                {
+                    "type": "inset",
+                    "name": "Additional Fighting Styles",
+                    "entries": [
+                        "The Alternate Ranger class is compatible with all official Fighting Styles found in published content."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Favored Foe",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 2,
+            "entries": [
+                "You are able to hunt as a creature of the wild. Starting at 2nd level, when you hit a creature with a weapon attack, you can expend a spell slot to mark it as your favored foe. Each time you hit your favored foe with a weapon attack (including the attack used to mark it) you deal extra damage based on the spell slot you expended, as indicated in the table below.",
+                {
+                    "type": "table",
+                    "colLabels": [
+                        "Spell Slot",
+                        "Damage"
+                    ],
+                    "colStyles": [
+                        "col-5 text-center",
+                        "col-5 text-center"
+                    ],
+                    "rows": [
+                        [
+                            "1st-level",
+                            "{@dice 1d6}"
+                        ],
+                        [
+                            "2nd-level",
+                            "{@dice 1d8}"
+                        ],
+                        [
+                            "3rd-level",
+                            "{@dice 1d10}"
+                        ],
+                        [
+                            "4th-level",
+                            "{@dice 1d12}"
+                        ]
+                    ]
+                },
+                "The creature remains your favored foe for 1 hour. Your mark ends early if the creature dies or you mark another creature.",
+                "At certain levels the mark's duration increases: at 6th level (8 hours), 14th level (24 hours), and 18th level (indefinite)."
+            ]
+        },
+        {
+            "name": "Spellcasting",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 2,
+            "entries": [
+                "At 2nd level, you can draw on the magic present in nature to cast spells. See the Player's Handbook for the rules of spellcasting, and the {@filter ranger spell list|spells|class=Ranger (LLAR)} at the end of this class.",
+                {
+					"type": "entries",
+					"name": "Preparing and Casting Spells",
+					"entries": [
+						"The Ranger table above shows how many spell slots you have to cast spells. To cast a {@filter ranger spell|spells|class=Ranger (LLAR)} of 1st-level or higher, you must expend a slot of the spell's level or higher. You regain all of your expended spell slots when you finish a long rest.",
+						"At the end of each long rest, you prepare the list of spells that are available for you to cast, choosing from the ranger spell list. You prepare a number of ranger spells equal to your Wisdom modifier + half your ranger level, rounded down. The spells must be of a level for which you have spell slots.",
+                        "For example, if you are a 5th level ranger, you have four 1st-level and two 2nd-level spell slots. With 14 Wisdom, you can prepare any four spells of 1st or 2nd-level. If you prepare {@spell cure wounds}, you can cast it using a 1st or 2nd-level slot. Casting a spell doesn't remove it from your prepared spells."
+					]
+				},
+                {
+					"type": "entries",
+					"name": "Spellcasting Ability",
+					"entries": [
+						"Wisdom is your spellcasting ability for your ranger spells, since your magic come from the natural world. You use your Wisdom whenever a spell refers to your spellcasting ability. You also use your Wisdom modifier when you set the saving throw DC or make an attack roll for a ranger spell.",
+						{
+							"type": "abilityDc",
+							"name": "Spell",
+							"attributes": [
+								"wis"
+							]
+						},
+						{
+							"type": "abilityAttackMod",
+							"name": "Spell",
+							"attributes": [
+								"wis"
+							]
+						}
+					]
+				},
+                {
+					"type": "entries",
+					"name": "Spellcasting Focus",
+					"entries": [
+						"You can use a druidic focus as a spellcasting focus for your ranger spells. See the Player’s Handbook for examples."
+					]
+				},
+                {
+					"type": "entries",
+					"name": "Preparing and Casting Spells",
+					"entries": [
+						"Your knowledge of the natural world allows you to draw out its innate magic. You can cast a ranger spell as a ritual if that spell has the ritual tag and you have the spell prepared."
+					]
+				}
+            ]
+        },
+        {
+            "name": "Ranger Archetype",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "At 3rd level, choose an Archetype that best represents your skills.",
+                "The Ranger Archetype you choose grants you features at 3rd level, and again when you reach 7th, 11th, and 15th level."
+            ]
+        },
+        {
+            "name": "Ability Score Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 4,
+            "entries": [
+                "When you reach 4th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+                "If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+            ]
+        },
+        {
+            "name": "Extra Attack",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 5,
+            "entries": [
+                "Beginning at 5th level, you can attack twice, instead of once, whenever you take the {@action Attack} action on your turn."
+            ]
+        },
+        {
+            "name": "Favored Foe Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 6,
+            "entries": [
+                "At 6th level, your Favored Foe mark can last up to 8 hours."
+            ]
+        },
+        {
+            "name": "Ranger Archetype Feature",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 7,
+            "entries": [
+                "At 7th level, you gain a feature granted by your Ranger Archetype."
+            ]
+        },
+        {
+            "name": "Ability Score Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 8,
+            "entries": [
+                "When you reach 8th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+                "If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+            ]
+        },
+        {
+            "name": "Wilderness Expertise",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 10,
+            "entries": [
+                "At 10th level, you select another ranger class skill you are proficient in to gain the benefits of this feature, and you learn to speak, read, and write another language of your choice."
+            ]
+        },
+        {
+            "name": "Ranger Archetype Feature",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 11,
+            "entries": [
+                "At 11th level, you gain a feature granted by your Ranger Archetype."
+            ]
+        },
+        {
+            "name": "Ability Score Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 12,
+            "entries": [
+                "When you reach 12th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+                "If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+            ]
+        },
+        {
+            "name": "Favored Foe Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 14,
+            "entries": [
+                "At 14th level, your Favored Foe mark can last up to 24 hours."
+            ]
+        },
+        {
+            "name": "Ranger Archetype Feature",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 15,
+            "entries": [
+                "At 15th level, you gain a feature granted by your Ranger Archetype."
+            ]
+        },
+        {
+            "name": "Ability Score Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 16,
+            "entries": [
+                "When you reach 16th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+                "If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+            ]
+        },
+        {
+            "name": "Favored Foe Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 18,
+            "entries": [
+                "At 18th level, your Favored Foe mark can last indefinitely."
+            ]
+        },
+        {
+            "name": "Feral Senses",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 18,
+            "entries": [
+                "You hunt as an apex predator, never losing track of your prey. Starting at 18th level, you cannot have disadvantage on an attack roll targeting a creature within 30 feet of you."
+            ]
+        },
+        {
+            "name": "Ability Score Improvement",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 19,
+            "entries": [
+                "When you reach 19th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+                "If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+            ]
+        },
+        {
+            "name": "Foe Slayer",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "level": 20,
+            "entries": [
+                "You are a hunter of legendary status. At 20th level, when you hit your favored foe with a weapon attack you deal additional damage equal to your Wisdom modifier (minimum of +1)."
+            ]
+        }
+    ],
+    "subclass": [
+        {
+            "name": "Beast Master",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Beast Master",
+            "subclassFeatures": [
+                "Beast Master|Ranger (Alternate)|LLAR|Beast Master|LLAR|3",
+                "Exceptional Training|Ranger (Alternate)|LLAR|Beast Master|LLAR|7",
+                "Bestial Fury|Ranger (Alternate)|LLAR|Beast Master|LLAR|11",
+                "Primal Bond|Ranger (Alternate)|LLAR|Beast Master|LLAR|15"
+            ],
+            "subclassSpells": [
+                "beast bond|xge",
+                "speak with animals",
+                "beast sense",
+                "warding bond",
+                "haste",
+                "protection from energy",
+                "death ward",
+                "freedom of movement",
+                "awaken",
+                "commune with nature"
+            ]
+        },
+        {
+            "name": "Hunter",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Hunter",
+            "subclassFeatures": [
+                "Hunter|Ranger (Alternate)|LLAR|Hunter|LLAR|3",
+                "Defensive Tactics|Ranger (Alternate)|LLAR|Hunter|LLAR|7",
+                "Multiattack|Ranger (Alternate)|LLAR|Hunter|LLAR|11",
+                "Superior Hunter's Defense|Ranger (Alternate)|LLAR|Hunter|LLAR|15"
+            ],
+            "subclassSpells": [
+                "expeditious retreat",
+                "snare|xge",
+                "cordon of arrows",
+                "pass without trace",
+                "conjure barrage", 
+                "nondetection",
+                "freedom of movement", 
+                "locate creature",
+                "conjure volley", 
+                "swift quiver"
+            ]
+        },
+        {
+            "name": "Spellbreaker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Spellbreaker",
+            "subclassFeatures": [
+                "Spellbreaker|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3",
+                "Arcane Defense|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|7",
+                "Mage Breaker|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|11",
+                "Mantle of the Master|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|15"
+            ],
+            "subclassSpells": [
+                "absorb elements|xge", 
+                "detect magic",
+                "blindness/deafness", 
+                "silence",
+                "counterspell", 
+                "dispel magic",
+                "arcane eye", 
+                "otiluke's resilient sphere",
+                "dispel evil and good", 
+                "wall of force"
+            ]
+        },
+        {
+            "name": "Shadowbane",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Shadowbane",
+            "subclassFeatures": [
+                "Shadowbane|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3",
+                "Supernatural Resilience|Ranger (Alternate)|LLAR|Shadowbane|LLAR|7",
+                "Spellsunder|Ranger (Alternate)|LLAR|Shadowbane|LLAR|11",
+                "Ruthless Counter|Ranger (Alternate)|LLAR|Shadowbane|LLAR|15"
+            ],
+            "subclassSpells": [
+                "compelled duel", 
+                "protection from evil and good",
+                "see invisibility", 
+                "zone of truth",
+                "magic circle", 
+                "protection from energy",
+                "banishment", 
+                "mordenkainen's faithful hound",
+                "dispel evil and good", 
+                "hold monster"
+            ]
+        },
+        {
+            "name": "Gloom Stalker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Gloom Stalker",
+            "subclassFeatures": [
+                "Gloom Stalker|Ranger (Alternate)|LLAR|Gloom Stalker|LLAR|3",
+                "Iron Mind|Ranger|PHB|Gloom Stalker|XGE|7",
+                "Stalker's Flurry|Ranger|PHB|Gloom Stalker|XGE|11",
+                "Shadowy Dodge|Ranger|PHB|Gloom Stalker|XGE|15"
+            ],
+            "subclassSpells": [
+                "cause fear|xge",
+                "disguise self",
+                "darkness",
+                "rope trick",
+                "fear",
+                "nondetection",
+                "greater invisibility",
+                "phantasmal killer",
+                "mislead",
+                "seeming"
+            ]
+        },
+        {
+            "name": "Horizon Walker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Horizon Walker",
+            "subclassFeatures": [
+                "Horizon Walker|Ranger (Alternate)|LLAR|Horizon Walker|LLAR|3",
+                "Ethereal Step|Ranger|PHB|Horizon Walker|XGE|7",
+                "Distant Strike|Ranger|PHB|Horizon Walker|XGE|11",
+                "Spectral Defense|Ranger|PHB|Horizon Walker|XGE|15"
+            ],
+            "subclassSpells": [
+                "alarm",
+                "protection from evil and good",
+                "misty step",
+                "rope trick",
+                "haste",
+                "magic circle",
+                "banishment",
+                "dimension door",
+                "banishing smite",
+                "teleportation circle"
+            ]
+        },
+        {
+            "name": "Fey Wanderer",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Fey Wanderer",
+            "subclassFeatures": [
+                "Fey Wanderer|Ranger (Alternate)|LLAR|Fey Wanderer|LLAR|3",
+                "Beguiling Twist|Ranger|PHB|Fey Wanderer|TCE|7",
+                "Fey Reinforcements|Ranger|PHB|Fey Wanderer|TCE|11",
+                "Misty Wanderer|Ranger|PHB|Fey Wanderer|TCE|15"
+            ],
+            "subclassSpells": [
+                "cause fear|xge",
+                "charm person",
+                "enthrall",
+                "misty step",
+                "dispel magic",
+                "fear",
+                "charm monster|xge",
+                "dimension door",
+                "geas",
+                "mislead"
+            ]
+        },
+        {
+            "name": "Swarmkeeper",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Swarmkeeper",
+            "subclassFeatures": [
+                "Swarmkeeper|Ranger (Alternate)|LLAR|Swarmkeeper|LLAR|3",
+                "Writhing Tide|Ranger|PHB|Swarmkeeper|TCE|7",
+                "Mighty Swarm|Ranger|PHB|Swarmkeeper|TCE|11",
+                "Swarming Dispersal|Ranger|PHB|Swarmkeeper|TCE|15"
+            ],
+            "subclassSpells": [
+                "mage hand",
+                "entangle",
+                "faerie fire",
+                "spider climb",
+                "web",
+                "fly",
+                "gaseous form",
+                "arcane eye",
+                "giant insect",
+                "bigby's hand",
+                "insect plague"
+            ]
+        },
+        {
+            "name": "Drakewarden",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Drakewarden",
+            "subclassFeatures": [
+                "Drakewarden|Ranger|PHB|Drakewarden|FTD|3",
+                "Drakewarden Magic|Ranger (Alternate)|LLAR|Drakewarden|LLAR|3",
+                "Bond of Fang and Scale|Ranger|PHB|Drakewarden|FTD|7",
+                "Drake's Breath|Ranger|PHB|Drakewarden|FTD|11",
+                "Perfected Bond|Ranger|PHB|Drakewarden|FTD|15"
+            ],
+            "subclassSpells": [
+                "thaumaturgy",
+                "absorb elements|xge",
+                "command",
+                "dragon's breath|xge",
+                "warding bond",
+                "elemental weapon",
+                "fear",
+                "dominate beast",
+                "elemental bane|xge",
+                "awaken",
+                "dominate person"
+            ]
+        },
+        {
+            "name": "Bounty Hunter",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Bounty Hunter",
+            "subclassFeatures": [
+                "Bounty Hunter|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|3",
+                "Dead or Alive|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|7",
+                "Improved Exploits (d6)|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|7",
+                "Unwavering|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|11",
+                "Improved Exploits (d8)|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|15",
+                "The Most Dangerous Game|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|15"
+            ]
+        },
+        {
+            "name": "Grim Warden",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Grim Warden",
+            "subclassFeatures": [
+                "Grim Warden|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3",
+                "Dark Augmentation|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|7",
+                "Improved Crimson Brand|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|11",
+                "Sanguine Mastery|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|15"
+            ],
+            "subclassSpells": [
+                "bane",
+                "hex",
+                "hold person",
+                "shadow blade|xge",
+                "bestow curse",
+                "vampiric touch",
+                "blight",
+                "shadow of moil|xge",
+                "enervation|xge",
+                "hold monster"
+            ]
+        },
+        {
+            "name": "Nomad",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Nomad",
+            "subclassFeatures": [
+                "Nomad|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3",
+                "Memory of One Thousand Steps|Ranger (Alternate)|LLAR|Nomad|LLAR:E|7",
+                "Expunging Strike (2d4)|Ranger (Alternate)|LLAR|Nomad|LLAR:E|11",
+                "Strange Movement|Ranger (Alternate)|LLAR|Nomad|LLAR:E|11",
+                "Mystical Burst|Ranger (Alternate)|LLAR|Nomad|LLAR:E|15"
+            ],
+            "subclassSpells": [
+                "comprehend languages",
+                "disguise self",
+                "detect thoughts",
+                "misty step",
+                "clairvoyance",
+                "tongues",
+                "dimension door",
+                "divination",
+                "commune",
+                "seeming"
+            ]
+        },
+        {
+            "name": "Stargazer",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Stargazer",
+            "subclassFeatures": [
+                "Stargazer|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|3",
+                "Threads of Fate|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|7",
+                "Starlight Strikes|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|11",
+                "Resplendent Soul|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|15"
+            ],
+            "subclassSpells": [
+                "vicious mockery",
+                "inflict wounds",
+                "guidance",
+                "bless",
+                "minor illusion",
+                "longstrider",
+                "shillelagh",
+                "compelled duel",
+                "primal savagery|xge",
+                "guiding bolt",
+                "mind spike|xge",
+                "moonbeam",
+                "beacon of hope",
+                "clairvoyance",
+                "divination",
+                "guardian of faith",
+                "dawn|xge",
+                "wall of light|xge"
+            ]
+        },
+        {
+            "name": "Wrangler",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "shortName": "Wrangler",
+            "subclassFeatures": [
+                "Wrangler|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|3",
+                "Bring to Heel|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|7",
+                "Improved Monster Tamer|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|11",
+                "Wrangler of Legends|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|15"
+            ],
+            "subclassSpells": [
+                "charm person",
+                "command",
+                "calm emotions",
+                "summon beast|tce",
+                "conjure animals",
+                "slow",
+                "charm monster|xge",
+                "dominate beast",
+                "awaken",
+                "hold monster"
+            ]
+        }
+    ],
+    "subclassFeature": [
+        {
+            "name": "Beast Master",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Beast Master",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "Rangers who develop intense bonds of trust with the natural world have been known to attract the attention of guardian nature spirits known as primal beasts. These shapeshifting defenders of the wilderness join forces with rangers that they perceive as worthy. Primal beasts fight side by side with their partner, changing their shape to face the challenge at hand.",
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Beast Master Magic|Ranger (Alternate)|LLAR|Beast Master|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Primal Companion|Ranger (Alternate)|LLAR|Beast Master|LLAR|3"
+				}
+            ]
+        },
+        {
+            "name": "Beast Master Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Beast Master",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Beast Master feature}",
+                "You learn the following spells at the ranger levels noted in the table below. They count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells you prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Beast Master Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell beast bond|xge}, {@spell speak with animals}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell beast sense}, {@spell warding bond}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell haste}, {@spell protection from energy}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell death ward}, {@spell freedom of movement}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell awaken}, {@spell commune with nature}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Primal Companion",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Beast Master",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Beast Master feature}",
+                "At 3rd level, you gain a beast companion with markings that indicate its primal origin. It is friendly to you and obeys your commands. You choose the form it takes, selecting one of the stat blocks at the end of this class: {@creature Beast of the Cave|LLAR}, {@creature Beast of the Land|LLAR}, {@creature Beast of the Sea|LLAR}, or {@creature Beast of the Sky|LLAR}. These stat blocks use your proficiency bonus (PB) in several places.",
+                "In combat, the beast acts during your turn. It can move and use its reaction on its own, but the only action it takes is the {@action Dodge} action, unless you use a bonus action to command it to take an action from its stat block, or another action. If you take the {@action Attack} action, you can sacrifice one of your attacks to command the primal beast to take the {@action Attack} action. If you are {@condition incapacitated}, your beast can take any action it chooses.",
+                "If your primal beast has died within the last hour, you can touch it and expend a spell slot of 1st-level or higher. After 1 minute, it returns to life with all its hit points restored.",
+                "When you finish a long rest, you can cause your primal beast to take on a new form, choosing a new stat block and appearance for it. Your primal beast vanishes if you die."
+            ]
+        },
+        {
+            "name": "Exceptional Training",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Beast Master",
+            "subclassSource": "LLAR",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Beast Master feature}",
+                "Starting at 7th level, both you and your primal beast can use a reaction to grant the other advantage on any saving throw they are forced to make, so long as you can see each other.",
+                "Also, your beast's attacks count as magical for the sake of overcoming resistance and immunity to non-magical attacks."
+            ]
+        },
+        {
+            "name": "Bestial Fury",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Beast Master",
+            "subclassSource": "LLAR",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Beast Master feature}",
+                "Your presence inspires primal fury. Beginning at 11th level, when you command your beast to take the {@action Attack} action, it can make two natural weapon attacks as part of that action."
+            ]
+        },
+        {
+            "name": "Primal Bond",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Beast Master",
+            "subclassSource": "LLAR",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Beast Master feature}",
+                "The bond with your beast has reached its apex. Starting at 15th level, when you cast a ranger spell that targets yourself, you can grant your beast the effects of that spell, without expending another spell slot, as long as it is within 30 feet."
+            ]
+        },
+        {
+            "name": "Hunter",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Hunter",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "Rangers are as varied as the lands that they hail from. Some use their knowledge of the wilderness to become guides and naturalists. Others make use their skills to become trackers or traders. Some wander the countryside, while others stand as guardians of sacred forests. While they fulfill varies roles, deep down inside every ranger beats the heart of a Hunter.",
+                "Marauding hordes of Orcs, vile trolls, great and terrible dragons, or great beasts of the wild, it matters not to a true Hunter. They always find a way to overcome their quarry.",
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hunter Magic|Ranger (Alternate)|LLAR|Hunter|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hunter's Prey|Ranger (Alternate)|LLAR|Hunter|LLAR|3"
+				}
+            ]
+        },
+        {
+            "name": "Hunter Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Hunter",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Hunter feature}",
+                "You learn the following spells at the ranger levels noted in the table below. They count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Hunter Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell expeditious retreat}, {@spell snare|xge}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell cordon of arrows}, {@spell pass without trace}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell conjure barrage}, {@spell nondetection}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell freedom of movement}, {@spell locate creature}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell conjure volley}, {@spell swift quiver}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Hunter's Prey",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Hunter",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Hunter feature}",
+                "You have specialized your fighting style to counter certain monsters. At 3rd level, you gain one of the following features:",
+                {
+                    "type": "entries",
+                    "name": "Colossus Slayer",
+                    "entries": [
+                        "Once per turn when you hit a creature that has less than its maximum hit points with a weapon attack, you can deal an additional {@dice 1d8} damage on hit."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Crippling Strike",
+                    "entries": [
+                        "Once per turn when you hit a creature with a weapon attack, you can force it to make a Constitution saving throw against your ranger save DC. On a failed save, its speed is reduced to 0 until the start of your next turn."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Giant Killer",
+                    "entries": [
+                        "When a creature that is at least one size larger then you hits or misses you with an attack, you can make one attack against that creature as a reaction."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Horde Breaker",
+                    "entries": [
+                        "Once per turn when you make a weapon attack against a creature, you can make on additional attack with the same weapon against another creature within 5 feet of your original target and within the range of your weapon."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Defensive Tactics",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Hunter",
+            "subclassSource": "LLAR",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Hunter feature}",
+                "You have honed your skills to better protect yourself from your foes. At 7th level, you gain one of the following features:",
+                {
+                    "type": "entries",
+                    "name": "Escape the Horde",
+                    "entries": [
+                        "When a creature targets you with an opportunity attack, they have disadvantage on their attack roll so long as you can see the attacking creature."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Iron Will",
+                    "entries": [
+                        "You have advantage on saving throws to resist the {@condition charmed}, {@condition frightened}, and {@condition stunned} conditions."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Multiattack Defense",
+                    "entries": [
+                        "When a creature hits you with an attack, you gain a +4 bonus to your Armor Class against all attacks made by that creature for the rest of the turn."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Stout Frame",
+                    "entries": [
+                        "As a reaction when you take bludgeoning, piercing, or slashing damage you reduce the damage by an amount equal to your Constitution modifier (minimum of 1)."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Multiattack",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Hunter",
+            "subclassSource": "LLAR",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Hunter feature}",
+                "You have mastered specialized techniques to thwart your foes. At 11th level, you gain one of the following features:",
+                {
+                    "type": "entries",
+                    "name": "Rapid Strike",
+                    "entries": [
+                        "If you take the {@action Attack} action on your turn and have advantage on an attack roll against against one of the targets, you can forgo the advantage for that roll to make one additional weapon attack against that target, as part of the same action. You can do so no more than once per turn."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Volley",
+                    "entries": [
+                        "As an action, you can make a ranged attack against any number of creatures within 10 feet of a point within your weapon's range. You roll a separate attack roll for each target, and you must have ammunition for each individual attack."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Whirlwind Attack",
+                    "entries": [
+                        "As an action, you can make a melee attack against any number of creatures within range of your melee weapon. Make a separate attack roll for each target."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Superior Hunter's Defense",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Hunter",
+            "subclassSource": "LLAR",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Hunter feature}",
+                "You have mastered defending yourself from wild and vicious prey. At 15th level, you gain one of the following features:",
+                {
+                    "type": "entries",
+                    "name": "Evasion",
+                    "entries": [
+                        "When you are subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw, and only half damage if you fail."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Stand Against the Tide",
+                    "entries": [
+                        "As a reaction when a creature misses you with a melee attack, you can force it to repeat the same attack against another creature within its reach."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Uncanny Dodge",
+                    "entries": [
+                        "When a creature you can see hits you with an attack, you can use your reaction to halve the damage you would take from that attack."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Spellbreaker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "Spellbreakers are a small, but dedicated, fraternity of rangers that specialize in hunting mages who use their arcane power for evil. While most pursue the life of a Spellbreaker for noble reasons, there are some who seek to destroy anyone with the potential to use magic. Most Spellbreakers work in secrecy, only striking when success is a certainty. When one wrong move could end in disintegration, there is no room for error.",
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellbreaker Magic|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellsight|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Reflect Spell|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3"
+				}
+            ]
+        },
+        {
+            "name": "Spellbreaker Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Spellbreaker feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Spellbreaker Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell absorb elements|xge}, {@spell detect magic}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell blindness/deafness}, {@spell silence}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell counterspell}, {@spell dispel magic}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell arcane eye}, {@spell otiluke's resilient sphere}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell dispel evil and good}, {@spell wall of force}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Spellsight",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Spellbreaker feature}",
+                "At 3rd level, you learn to detect the innate arcane potential of others. As a bonus action, choose a creature you can see. You learn its spellcasting ability and its highest level spell slot.",
+                "Once you use this feature you must finish a short or long rest before you can use it again. If you have no remaining uses you can expend a 1st-level spell slot to use it again."
+            ]
+        },
+        {
+            "name": "Reflect Spell",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Spellbreaker feature}",
+                "Also at 3rd level, you can cast {@spell absorb elements|xge} at 1st-level, without expending a spell slot a total number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.",
+                "When do so and your next melee weapon attack is against creature whose spell you absorbed, you treat the additional damage from absorb elements as its maximum amount."
+            ]
+        },
+        {
+            "name": "Arcane Defense",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Spellbreaker feature}",
+                "Starting at 7th level, when you make a saving throw to resist a spell or magical effect, you gain a bonus to your saving throw equal to your Wisdom modifier (minimum of +1)."
+            ]
+        },
+        {
+            "name": "Mage Breaker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Spellbreaker feature}",
+                "Starting at 11th level, when you mark a spellcaster as your favored foe, you gain the following additional benefits:",
+                {
+                    "type": "list",
+                    "items": [
+                        "Both the damage of your weapon attacks and the extra damage from favored foe becomes force damage.",
+                        "When you hit your favored foe with a weapon attack, they have disadvantage on their Constitution saving throws they make to maintain concentration on their spells.",
+                        "When you hit your favored foe with a weapon attack, you can immediately end your favored foe mark, causing your attack to deal maximum damage, instead of rolling."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Mantle of the Master",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Spellbreaker",
+            "subclassSource": "LLAR",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Spellbreaker feature}",
+                "Your training has reached its apex, and you are considered a master Spellbreaker. Starting at 15th level, you are resistant to all damage from spells and other magical effects."
+            ]
+        },
+        {
+            "name": "Shadowbane",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "Every culture tells stories of evil spirits and monsters that live just beyond the walls of civilization. Thanks to the quiet watch of dedicated rangers, these terrible monsters remain nothing more than a story. These guardian rangers take up the mantle of Shadowbane, vowing to protect the innocent from the things of the night. They seek out vampires, evil fey, werewolves, and other such vile creatures and destroy them.",
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Shadowbane Magic|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Slayer's Mark|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Sinister Insight|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3"
+				}
+            ]
+        },
+        {
+            "name": "Shadowbane Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Shadowbane feature}",
+                "You the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Shadowbane Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell compelled duel}, {@spell protection from evil and good}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell see invisibility}, {@spell zone of truth}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell magic circle}, {@spell protection from energy}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell banishment}, {@spell mordenkainen's faithful hound}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell dispel evil and good}, {@spell hold monster}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Slayer's Mark",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Shadowbane feature}",
+                "When you adopt this Archetype at 3rd level, you can mark a creature as your favored foe without expending a spell slot. They are marked as if you had expended a 1st-level spell slot.",
+                "Once you use this feature to mark a creature, you must finish a short or long rest before you can use it again."
+            ]
+        },
+        {
+            "name": "Sinister Insight",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Shadowbane feature}",
+                "Starting at 3rd level, when you mark a target as your favored foe, you can enhance the mark with dark magics. Once per turn, when you hit that creature with a weapon attack, you can learn one of the following characteristics of your choice:",
+                {
+                    "type": "table",
+                    "colStyles": [
+                        "col-5 text-center",
+                        "col-5 text-center"
+                    ],
+                    "rows": [
+                        [
+                            "Armor Class",
+                            "Damage Vulnerability"
+                        ],
+                        [
+                            "Current Hit Points",
+                            "Saving Throw Proficiency"
+                        ],
+                        [
+                            "Damage Immunity",
+                            "Skill Proficiency"
+                        ],
+                        [
+                            "Damage Resistance",
+                            "Spellcasting Ability"
+                        ]
+                    ]
+                },
+                "Once you enhance your favored foe mark in this way, you must finish a short or long rest before you can do so again."
+            ]
+        },
+        {
+            "name": "Supernatural Resilience",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Shadowbane feature}",
+                "Your resolute focus allows you to better resist the creatures you hunt. Beginning at 7th level, whenever your favored foe forces you to make a saving throw, you add {@dice 1d6} to your roll.",
+                "When you reach 15th level, this bonus becomes {@dice 2d6}."
+            ]
+        },
+        {
+            "name": "Spellsunder",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Shadowbane feature}",
+                "You have learned how to thwart magic that might help your sinister foes escape your grasp. Starting at 11th level, when a creature you can see with in 60 feet casts a spell or attempts to teleport, you can use your reaction to force them to make a Wisdom saving throw. On a failure, the spell or teleport fails.",
+                "Your favored foe has disadvantage on their saving throw.",
+                "Once you use this reaction, you must finish a short or long rest before you can use it again. If you have no uses left, you can expend a spell slot of 1st-level or higher to use it again."
+            ]
+        },
+        {
+            "name": "Ruthless Counter",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Shadowbane",
+            "subclassSource": "LLAR",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Shadowbane feature}",
+                "Starting at 15th level, you can counter the attempts of your foes to harm you. As a reaction when your favored foe forces you to make a saving throw, you can make one weapon attack targeting them, before you make the saving the saving throw. On hit, you automatically succeed on your saving throw."
+            ]
+        },
+        {
+            "name": "Gloom Stalker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Gloom Stalker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "Gloom Stalkers are at home in the darkest places: deep under the earth, in gloomy alleyways, in primeval forests, and wherever else the light dims. Most folk enter such places with trepidation, but a Gloom Stalker ventures boldly into the darkness, seeking to ambush threats before they can reach the broader world. Such rangers are often found in the Underdark, but they will go any place where evil lurks in the shadows.",
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Gloom Stalker Magic|Ranger (Alternate)|LLAR|Gloom Stalker|LLAR|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Dread Ambusher|Ranger|PHB|Gloom Stalker|XGE|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Umbral Sight|Ranger|PHB|Gloom Stalker|XGE|3"
+				}
+            ]
+        },
+        {
+            "name": "Gloom Stalker Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Gloom Stalker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Gloom Stalker Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell cause fear|xge}, {@spell disguise self}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell darkness}, {@spell rope trick}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell fear}, {@spell nondetection}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell greater invisibility}, {@spell phantasmal killer}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell mislead}, {@spell seeming}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Horizon Walker",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Horizon Walker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Horizon Walker Magic|Ranger (Alternate)|LLAR|Horizon Walker|LLAR|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Detect Portal|Ranger|PHB|Horizon Walker|XGE|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Planar Warrior|Ranger|PHB|Horizon Walker|XGE|3"
+                }
+            ]
+        },
+        {
+            "name": "Horizon Walker Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Horizon Walker",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Horizon Walker Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell alarm}, {@spell protection from evil and good}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell misty step}, {@spell rope trick}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell haste}, {@spell magic circle}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell banishment}, {@spell dimension door}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell banishing smite}, {@spell teleportation circle}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Fey Wanderer",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Fey Wanderer",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Dreadful Strikes|Ranger|PHB|Fey Wanderer|TCE|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Fey Wanderer Magic|Ranger (Alternate)|LLAR|Fey Wanderer|LLAR|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Otherworldly Glamour|Ranger|PHB|Fey Wanderer|TCE|3"
+                }
+            ]
+        },
+        {
+            "name": "Fey Wanderer Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Fey Wanderer",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Fey Wanderer feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Fey Wanderer Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell cause fear|xge}, {@spell charm person}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell enthrall}, {@spell misty step}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell dispel magic}, {@spell fear}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell charm monster|xge}, {@spell dimension door}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell geas}, {@spell mislead}"
+                        ]
+                    ]
+                },
+                "You also possess a preternatural blessing from a fey ally or a place of fey power. Choose your blessing from the Feywild Gifts table or determine it randomly.",
+                {
+                    "type": "table",
+                    "caption": "Feywild Gifts",
+                    "colLabels": [
+                        "{@dice d6}",
+                        "Gift"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "1",
+                            "Illusory butterflies flutter around you while you take a short or long rest."
+                        ],
+                        [
+                            "2",
+                            "Fresh, seasonal flowers sprout from your hair each dawn."
+                        ],
+                        [
+                            "3",
+                            "You faintly smell of cinnamon, lavender, nutmeg, or another comforting herb or spice."
+                        ],
+                        [
+                            "4",
+                            "Your shadow dances while no one is looking directly at it."
+                        ],
+                        [
+                            "5",
+                            "Horns or antlers sprout from your head."
+                        ],
+                        [
+                            "6",
+                            "Your skin and hair change color to match the season at each dawn."
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Swarmkeeper",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Swarmkeeper",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "Feeling a deep connection to the environment around them, some rangers reach out through their magical connection to the world and bond with a swarm of nature spirits. The swarm becomes a potent force in battle, as well as helpful company for the ranger. Some Swarmkeepers are outcasts or hermits, keeping to themselves and their attendant swarms rather than dealing with the discomfort of others. Other Swarmkeepers enjoy building vibrant communities that work for the mutual benefit of all those they consider part of their swarm.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Gathered Swarm|Ranger|PHB|Swarmkeeper|TCE|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Swarmkeeper Magic|Ranger (Alternate)|LLAR|Swarmkeeper|LLAR|3"
+                }
+            ]
+        },
+        {
+            "name": "Swarmkeeper Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Swarmkeeper",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Swarmkeeper feature}",
+                "You learn the {@spell mage hand} cantrip if you don't already know it. When you cast it, the hand takes the form of your swarming nature spirits.",
+                "You also learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+					"type": "table",
+					"caption": "Swarmkeeper Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell entangle}, {@spell faerie fire}"
+						],
+						[
+							"5th",
+							"{@spell spider climb}, {@spell web}"
+						],
+						[
+							"9th",
+							"{@spell fly}, {@spell gaseous form}"
+						],
+						[
+							"13th",
+							"{@spell arcane eye}, {@spell giant insect}"
+						],
+						[
+							"17th",
+							"{@spell bigby's hand}, {@spell insect plague}"
+						]
+					]
+				}
+            ]
+        },
+        {
+            "name": "Drakewarden Magic",
+            "source": "LLAR",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Drakewarden",
+            "subclassSource": "LLAR",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Drakewarden feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+					"type": "table",
+					"caption": "Drakewarden Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell absorb elements|xge}, {@spell command}"
+						],
+						[
+							"5th",
+							"{@spell dragon's breath|xge}, {@spell warding bond}"
+						],
+						[
+							"9th",
+							"{@spell elemental weapon}, {@spell fear}"
+						],
+						[
+							"13th",
+							"{@spell dominate beast}, {@spell elemental bane|xge}"
+						],
+						[
+							"17th",
+							"{@spell awaken}, {@spell dominate person}"
+						]
+					]
+				}
+            ]
+        },
+        {
+            "name": "Bounty Hunter",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "entries": [
+                "Bounty Hunters protect humanoids from their own. Trained to hunt in cities and towns, they can track their prey through the dark alleyways and underbellies of any town or city. Trained to use various martial techniques, these rangers can confidently confront and subdue any dangerous humanoid.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Ear to the Ground|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Martial Exploits|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|3"
+                }
+            ]
+        },
+        {
+            "name": "Ear to the Ground",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Bounty Hunter feature}",
+                "Starting at 3rd level, once you spend a long rest in a settlement, city, or town you have advantage on any ability checks you make to gather information on contacts or factions, and to navigate the underworld of that settlement.",
+                "You have also learned the language of the criminal world. You can identify, read, and communicate in {@language Thieves' Cant|phb}."
+            ]
+        },
+        {
+            "name": "Martial Exploits",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Bounty Hunter feature}",
+                "You have studied various martial exploits to better counter humanoid foes. At 3rd level, you gain the following features:",
+                {
+                    "type": "entries",
+                    "name": "Exploits",
+                    "entries": [
+                        "You learn two {@filter Exploits|optionalfeatures|feature type=LL:BHE} of your choice from this list at the end of this Archetype description. You can use only one Exploit per attack. When you gain a ranger level, you can replace one of your Exploits with another of your choice."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Exploit Dice",
+                    "entries": [
+                        "You have two Exploit Dice, which are {@dice d4}s for you. You must expend an Exploit Die to use an Exploit. You regain all expended Dice when you finish a short or long rest."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Saving Throws",
+                    "entries": [
+                        "Some of your Exploits require your target to make a saving throw to resist their effects:",
+                        {
+                            "type": "abilityDc",
+                            "name": "Exploit",
+                            "attributes": [
+                                "str",
+                                "dex"
+                            ]
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Dead or Alive",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Bounty Hunter feature}",
+                "Starting at 7th level, when you make a Strength ({@skill Athletics}) check to initiate or maintain a grapple or shove a creature {@condition prone}, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1).",
+                "Also, being within 5 feet of a hostile creature doesn't impose disadvantage on your ranged attack rolls with {@item net|phb|nets}."
+            ]
+        },
+        {
+            "name": "Improved Exploits (d6)",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Bounty Hunter feature}",
+                "Your skills improve. Upon reaching 7th level, you gain one additional Exploit Die, and your Exploit Dice become {@dice d6}s. You also learn two additional {@filter Exploits|optionalfeatures|feature type=LL:BHE} of your choice."
+            ]
+        },
+        {
+            "name": "Unwavering",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Bounty Hunter feature}",
+                "You are a master of disabling foes. Starting at 11th level, when your favored foe misses you with a melee attack, you can force it to make a Dexterity saving throw as a reaction. On a failed save, it falls {@condition prone}, and if you have a free hand you can choose to automatically grapple the creature."
+            ]
+        },
+        {
+            "name": "Improved Exploits (d8)",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Bounty Hunter feature}",
+                "At 15th level, your skills increase further. You gain another Exploit Die (for a total of four), and your Exploit Dice become {@dice d8}s. You also learn two more {@filter Exploits|optionalfeatures|feature type=LL:BHE} of your choice."
+            ]
+        },
+        {
+            "name": "The Most Dangerous Game",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Bounty Hunter",
+            "subclassSource": "LLAR:E",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Bounty Hunter feature}",
+                "Your supernatural instincts allow you to predict your foe's attacks. Beginning at 15th level, any time you take damage from your favored foe, the damage is reduced by an amount equal to your Wisdom modifier (minimum of 1 hit point)."
+            ]
+        },
+        {
+            "name": "Grim Warden",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Grim Warden feature}",
+                "Sometimes it takes a monster to destroy a monster. Rangers that take up the mantle of Grim Warden undergo a dark alchemical ritual, known as the Warden's Rite, to enhance their physical abilities. They sacrifice any chance they have at a normal life, mingling their blood with that of monsters, in order to gain dark, unnatural power to destroy their foes.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Grim Warden Magic|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Warden's Rite|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Crimson Brand|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3"
+                },
+                {
+                    "type": "inset",
+                    "name": "Blood Hunter, Dissected",
+                    "entries": [
+                        "The Blood Hunter class contains many risky mechanics that are difficult to manage. The Grim Warden is an attempt to adapt the themes of the class while staying in line with the design of 5e."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Grim Warden Magic",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Grim Warden feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Grim Warden Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell bane}, {@spell hex}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell hold person}, {@spell shadow blade|xge}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell bestow curse}, {@spell vampiric touch}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell blight}, {@spell shadow of moil|xge}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell enervation|xge}, {@spell hold monster}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Warden's Rite",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Grim Warden feature}",
+                "At 3rd level, you undergo the Warden's Rite, an alchemical ritual that suffuses your blood with sinister magic. You gain proficiency with {@item alchemist's supplies|phb} and in the {@skill Religion} skill.",
+                "In addition, whenever you make an Intelligence ({@skill Religion}) check related to fiends, undead creatures, or necromancy magic you can add double your proficiency bonus to the roll."
+            ]
+        },
+        {
+            "name": "Crimson Brand",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Grim Warden feature}",
+                "Starting at 3rd level, you can draw upon the dark magic in your blood to empower your weapon attacks with your life force. When you hit a creature with a melee weapon attack, you can expend ranger Hit Dice as part of the attack to deal necrotic damage to the target, in addition to the weapon's damage. The extra necrotic damage is {@dice 1d8} for one Hit Die, plus {@dice 1d8} for each additional Hit Die you expend as part of the attack. The maximum amount of Hit Dice you can expend is equal to your Wisdom modifier (minimum of 1 Hit Die).",
+                "The additional necrotic damage dealt by this your Crimson Brand increases by {@dice 1d8} if the target is a fiend or undead."
+            ]
+        },
+        {
+            "name": "Dark Augmentation",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Grim Warden feature}",
+                "You have learned to exert greater control over the sinister magic that flows in your veins, enhancing your physical abilities. Starting at 7th level, when you make a Strength, Dexterity, or Constitution ability check, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1).",
+                "In addition, your movement speed increases by 5 feet."
+            ]
+        },
+        {
+            "name": "Improved Crimson Brand",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Grim Warden feature}",
+                "Beginning at 11th level, the dark magic in your blood seeps into your weapon strikes. Once on each of your turns when you hit a creature with a melee weapon attack, you can deal an additional {@dice 1d8} necrotic damage to the target."
+            ]
+        },
+        {
+            "name": "Sanguine Mastery",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Grim Warden",
+            "subclassSource": "LLAR:E",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Grim Warden feature}",
+                "Your Warden's Rite manifests its full potential. Beginning at 15th level, you have advantage on saving throws to resist the frightened condition, and you are always under the effects of the {@spell protection from evil and good|phb} spell while conscious."
+            ]
+        },
+        {
+            "name": "Nomad",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Nomad feature}",
+                "Nomads have a desire to learn all they can and spend their lives uncovering hidden lore. Their minds are in a meditative state that allows them to perceive a strange, living web of knowledge known as the Noosphere. This web links all who follow the way of the Nomad, and allows them to access knowledge and skills from far off places and distant lives.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Nomadic Magic|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Expunging Strike (1d4)|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Web of Knowledge|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3"
+                },
+                {
+                    "type": "inset",
+                    "name": "Optional Rule: Psionic Spellcasting",
+                    "entries": [
+                        "For the mechanics to match the fantasy of a ranger who wields the psionic power of the Noosphere, consider replacing all Wisdom-based ranger class and Nomad Archetype features with Intelligence."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Nomadic Magic",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Nomad feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "X Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell comprehend languages}, {@spell disguise self}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell detect thoughts}, {@spell misty step}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell clairvoyance}, {@spell tongues}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell dimension door}, {@spell divination}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell commune}, {@spell seeming}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Expunging Strike (1d4)",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Nomad feature}",
+                "Starting at 3rd level, you can erase yourself from minds of your foes with a strike. Once on each of your turns when you hit a creature with a weapon attack, you can force them to make an Intelligence saving throw in addition to the attack's damage. On a failed save, it takes {@dice 1d4} psychic damage, and it cannot perceive you until the start of your next turn."
+            ]
+        },
+        {
+            "name": "Web of Knowledge",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Nomad feature}",
+                "When you adopt this Archetype at 3rd level, you learn to draw from the Noosphere, a living web of knowledge that connects all Nomads, past, present, and future. At the end of each long rest, you learn one language, or you gain proficiency with one tool or skill of your choice. You retain knowledge of that tool, skill, or language until you finish your next long rest.",
+                "When you reach 11th level in this class, you gain two instances of this feature at the end of each long rest."
+            ]
+        },
+        {
+            "name": "Memory of One Thousand Steps",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Nomad feature}",
+                "Beginning at 7th level, you are able to partially merge your consciousness with the Noosphere to avoid harm. When you are hit by an attack, you can use your reaction to disappear into Noosphere, causing the triggering attack to miss. You then immediately reappear in an unoccupied space that you occupied at some point since the start of your previous turn.",
+                "Once you use this reaction, you must finish a short or long rest before you can use it again. If you have no uses left, you can expend a spell slot of 2nd-level or higher to use it again."
+            ]
+        },
+        {
+            "name": "Expunging Strike (2d4)",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Nomad feature}",
+                "Starting at 11th level, the psychic damage from your Expunging Strike feature becomes {@dice 2d4}."
+            ]
+        },
+        {
+            "name": "Strange Movement",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Nomad feature}",
+                "Beginning at 11th level, you can use a bonus action to expend your remaining movement and teleport a number of feet equal to double your remaining movement, appearing in an unoccupied space you can see.",
+                "You can use this ability a number of times equal to your Wisdom modifier (minimum of once), and you regain all uses when you finish a long rest."
+            ]
+        },
+        {
+            "name": "Mystical Burst",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Nomad",
+            "subclassSource": "LLAR:E",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Nomad feature}",
+                "When you travel through the Noosphere you can assault your foes with its psionic power. Beginning at 15th level, when you teleport with one of your Nomadic Magic spells or one of your Nomad features, creatures of your choice within 10 feet of the point where you appear must succeed on an Intelligence saving throw or take {@dice 2d8} psychic damage."
+            ]
+        },
+        {
+            "name": "Stargazer",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Stargazer",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "entries": [
+                "Mortals have always looked to the stars for stories of the past, and some believe that in observing the motions of the cosmos one can predict fate. Stargazers are rangers who spend their lives studying the stars and can draw on their radiant power.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Celestial Guidance|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Stargazer Magic|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|3"
+                }
+            ]
+        },
+        {
+            "name": "Celestial Guidance",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Stargazer",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Stargazer feature}",
+                "Your life is guided by the great constellations of the night sky. Starting at 3rd level, you cannot become lost, even by magical means, so long as you can see the stars or the night sky.",
+                "Also at the end of each long rest, you attune yourself to one of the constellations from the table below. While attuned to a constellation, you know the cantrip and 1st-level spell that correspond to that constellation. Both count as ranger spells for you, you always have them prepared, and they don't count against the total number of spells you prepare each day.",
+                "You can cast your constellation spell at 1st-level without expending a spell slot or material components a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.",
+                {
+                    "type": "table",
+                    "caption": "Constellation Spells",
+                    "colLabels": [
+                        "Constellation",
+                        "Cantrip",
+                        "1st-level Spell"
+
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-5 text-center",
+                        "col-5 text-center"
+                    ],
+                    "rows": [
+                        [
+                            "Adder",
+                            "{@spell vicious mockery}",
+                            "{@spell inflict wounds}"
+                        ],
+                        [
+                            "Elephant",
+                            "{@spell guidance}",
+                            "{@spell bless}"
+                        ],
+                        [
+                            "Hare",
+                            "{@spell minor illusion}",
+                            "{@spell longstrider}"
+                        ],
+                        [
+                            "Stag",
+                            "{@spell shillelagh}",
+                            "{@spell compelled duel}"
+                        ],
+                        [
+                            "Wolf",
+                            "{@spell primal savagery|xge}",
+                            "{@spell guiding bolt}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Stargazer Magic",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Stargazer",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Stargazer feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Stargazer Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "Constellation Spells"
+                        ],
+                        [
+                            "5th",
+                            "{@spell mind spike|xge}, {@spell moonbeam}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell beacon of hope}, {@spell clairvoyance}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell divination}, {@spell guardian of faith}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell dawn|xge}, {@spell wall of light|xge}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Threads of Fate",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Stargazer",
+            "subclassSource": "LLAR:E",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Stargazer feature}",
+                "Starting at 7th level, you can use your insight into the stars to twist the threads of fate. When you, or another creature you that can see within 30 feet, makes an ability check or saving throw, you can add your Wisdom modifier (minimum of +1) to the result of the roll as a reaction. You can use this action after the roll, but before you know if the roll succeeds or fails.",
+                "You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest."
+            ]
+        },
+        {
+            "name": "Starlight Strikes",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Stargazer",
+            "subclassSource": "LLAR:E",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Stargazer feature}",
+                "Starting at 11th level, you can enter a trance, filling your eyes with starlight and allowing the celestial bodies of the night sky to guide your attacks. As a bonus action, you can enter this trance which lasts for 1 minute. Once per turn when you make an attack roll while you are in this trance, you can treat a d20 roll of 9 or lower as a 10.",
+                "Once you use this ability you must finish a long rest before you can use it again. If you have no uses remaining, you can expend a spell slot of 3rd-level or higher to use it again."
+            ]
+        },
+        {
+            "name": "Resplendent Soul",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Stargazer",
+            "subclassSource": "LLAR:E",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15-level Stargazer feature}",
+                "At 15th level, your very being is suffused with starlight. As a reaction, when a creature you can see within 30 feet hits you with an attack, you can release a targeted flash of starlight and force the attacker to make a Constitution saving throw. On a failed save, the target takes {@dice 3d10} radiant damage and is {@condition blinded} until the start of its next turn. On a successful save, the target takes half damage and is not blinded.",
+                "You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all uses when you finish a long rest. If you have no uses left, you can expend a spell slot of 1st-level or higher to use it again."
+            ]
+        },
+        {
+            "name": "Wrangler",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Wrangler",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "entries": [
+                "{@i 3rd-level Wrangler feature}",
+                "While most rangers have some skill with animals, those who pursue the life of a Wrangler dedicate their lives to training wild beasts. Their deep knowledge of animal behavior allows them to tame and control all sorts of fantastical creatures.",
+                "These rugged and wild rangers are always on the lookout for ever more strange and exotic creatures to befriend.",
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Wrangler Magic|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|3"
+                },
+                {
+                    "type": "refSubclassFeature",
+                    "subclassFeature": "Monster Tamer|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|3"
+                }
+            ]
+        },
+        {
+            "name": "Wrangler Magic",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Wrangler",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Wrangler feature}",
+                "You learn the following spells at the ranger levels noted in the table below. These spells count as ranger spells for you, you always have them prepared, and they don't count against the total number of ranger spells that you can prepare each day.",
+                {
+                    "type": "table",
+                    "caption": "Wrangler Spells",
+                    "colLabels": [
+                        "Ranger Level",
+                        "Spells"
+                    ],
+                    "colStyles": [
+                        "col-2 teWranglert-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@spell charm person}, {@spell command}"
+                        ],
+                        [
+                            "5th",
+                            "{@spell calm emotions}, {@spell summon beast|tce}"
+                        ],
+                        [
+                            "9th",
+                            "{@spell conjure animals}, {@spell slow}"
+                        ],
+                        [
+                            "13th",
+                            "{@spell charm monster|xge}, {@spell dominate beast}"
+                        ],
+                        [
+                            "17th",
+                            "{@spell awaken}, {@spell hold monster}"
+                        ]
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Monster Tamer",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Wrangler",
+            "subclassSource": "LLAR:E",
+            "level": 3,
+            "header": 2,
+            "entries": [
+                "{@i 3rd-level Wrangler feature}",
+                "When you adopt this Archetype, you gain exceptional insight into wild animals. At 3rd level you gain the following benefits:",
+                {
+                    "type": "list",
+                    "items": [
+                        "Your weapon attacks against beasts and monstrosities score a critical hit on a roll of 19 or 20 on the d20.",
+                        "You have advantage on Strength ({@skill Athletics}) checks to grapple, climb, or wrestle beasts and monstrosities.",
+                        "Any {@filter enchantment spell you have prepared that targets a humanoid|spells|class=ranger (llar)|subclass=ranger (alternate): wrangler (llar:e)|school=e|affects creature types=humanoid} can also target beasts and monstrosities."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Bring to Heel",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Wrangler",
+            "subclassSource": "LLAR:E",
+            "level": 7,
+            "header": 2,
+            "entries": [
+                "{@i 7th-level Wrangler feature}",
+                "You can bend creatures of the wild to your will. Beginning at 7th level, when a beast or monstrosity that is charmed by you makes a saving throw to end its charmed condition, you can impose disadvantage on its saving throw as a reaction.",
+                "You can also command the monsters you tame. Any beast or monstrosity charmed by you acts during your turn for the duration of your charm, and if you are within 30 feet and the creature can hear you, you can use your action to command it to take one of the actions from its stat block."
+            ]
+        },
+        {
+            "name": "Improved Monster Tamer",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Wrangler",
+            "subclassSource": "LLAR:E",
+            "level": 11,
+            "header": 2,
+            "entries": [
+                "{@i 11th-level Wrangler feature}",
+                "Beginning at 11th level, your Wrangler features now affect any celestial, dragon, fey, fiend, giant, plant, or ooze with an Intelligence score less than or equal to your ranger level.",
+                "Also, you can command any beast or monstrosity charmed by you to take an action from its stat block as a bonus action."
+            ]
+        },
+        {
+            "name": "Wrangler of Legends",
+            "source": "LLAR:E",
+            "className": "Ranger (Alternate)",
+            "classSource": "LLAR",
+            "subclassShortName": "Wrangler",
+            "subclassSource": "LLAR:E",
+            "level": 15,
+            "header": 2,
+            "entries": [
+                "{@i 15th-level Wrangler feature}",
+                "Once you charm a creature, there is little it can do to escape. Starting at 15th level, enchantment spells you cast on beasts and monstrosities last until your concentration is broken.",
+                "Short and long rests don't break your concentration on enchantment spells you cast on beasts or monstrosities."
+            ]
+        }
+    ],
+    "optionalfeature": [
+        {
+            "name": "Archery",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "You gain a +2 bonus to attack rolls with ranged weapons."
+            ]
+        },
+        {
+            "name": "Defensive Fighting",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "While you are wearing armor or wielding a shield, you gain a +1 bonus to your Armor Class."
+            ]
+        },
+        {
+            "name": "Dual Wielding",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "When you take the Attack action while two-weapon fighting, you can make a single additional attack with your off-hand weapon as part of your action instead of your bonus action, adding your ability modifier to the damage of this attack."
+            ]
+        },
+        {
+            "name": "Dueling",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with it."
+            ]
+        },
+        {
+            "name": "Featherweight Fighting",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "While wielding only light weapons, your speed increases by 10 feet and you gain a +1 bonus to damage rolls, so long as you aren't wearing medium or heavy armor, or using a shield."
+            ]
+        },
+        {
+            "name": "Protection",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "When a creature you can see attacks a target within 5 feet of you, you can impose disadvantage on their attack roll as a reaction. You must be wielding a melee weapon or a shield."
+            ]
+        },
+        {
+            "name": "Marine Fighting",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "When you are not wearing medium or heavy armor, or using a shield, you have a swimming speed equal to your movement speed, and you gain a +1 bonus to your Armor Class."
+            ]
+        },
+        {
+            "name": "Melee Marksman",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "When you make a ranged attack targeting a creature within 5 feet of you, you do not have disadvantage on the attack roll.",
+                "If you make a ranged attack against a creature within 5 feet, you can strike the creature with your ranged weapon as a bonus action, dealing {@dice 1d4} bludgeoning damage on hit."
+            ]
+        },
+        {
+            "name": "Strongbow",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "You can use your Strength score, in place of Dexterity, for your attack and damage rolls with longbows and shortbows."
+            ]
+        },
+        {
+            "name": "Versatile Fighting",
+            "source": "LLAR",
+            "featureType": [
+                "FS:AR"
+            ],
+            "entries": [
+                "When wielding a versatile weapon with two hands you gain a +2 bonus to damage rolls. When wielding a versatile weapon with one hand, and nothing in your other hand, you gain a +1 bonus to both your attack rolls and your Armor Class.",
+                "You can also make a shove or unarmed strike attack as a bonus action so long as you have a free hand to do so."
+            ]
+        },
+        {
+            "name": "Blinding Shot",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:BHE"
+            ],
+            "entries": [
+                "As a bonus action, you can expend an Exploit Die and force a creature within 10 feet to make a Constitution saving throw. On a failed save, it takes piercing damage equal to your Exploit Die and is blinded until the start of your next turn."
+            ]
+        },
+        {
+            "name": "Crippling Strike",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:BHE"
+            ],
+            "entries": [
+                "When you hit a creature with a melee weapon attack, you can expend an Exploit Die and force it to make a Dexterity saving throw. On a failure, it takes extra damage equal to your Exploit Die and its movement speed is reduced to 0 until the beginning of your next turn."
+            ]
+        },
+        {
+            "name": "Dirty Hit",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:BHE"
+            ],
+            "entries": [
+                "When you hit a creature with a weapon attack, you can expend an Exploit Die and force it to make a Constitution saving throw. On a failure, it takes extra damage equal to your Exploit Die, and until the start of your next turn, it cannot take reactions and its movement speed is halved."
+            ]
+        },
+        {
+            "name": "Disarm",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:BHE"
+            ],
+            "entries": [
+                "When you hit a creature with a weapon attack, you can expend an Exploit Die to force them to make a Strength saving throw. On a failed save, the creature takes additional damage equal to your Exploit Die, and it drops one item that it is currently holding (your choice) at its feet."
+            ]
+        },
+        {
+            "name": "Sweeping Strike",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:BHE"
+            ],
+            "entries": [
+                "When you hit a creature with a melee weapon attack, you can expend an Exploit Die to force it to make a Dexterity saving throw. On a failed save, it falls prone and takes bludgeoning damage equal to your Exploit Die. Creatures more than one size larger than you have advantage on this saving throw."
+            ]
+        },
+        {
+            "name": "Take Down",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:BHE"
+            ],
+            "entries": [
+                "As a bonus action, you can expend an Exploit Die to make a Shove or Grapple attack against a creature within your reach, adding your Exploit Die to your roll."
+            ]
+        },
+        {
+            "name": "Alpine Adept",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You are amazingly surefooted. You gain a 30 foot climbing speed, and you can use your reaction to reduce any falling damage you take by an amount equal to your ranger level. If you already have a climbing speed it increases by 10 feet."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Aquatic Adept",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You can swim through the water like a native creature of the sea. You gain a 30 foot swimming speed, and while you are underwater, you can hold your breath for up to 1 hour. If you already have a swimming speed it increases by 10 feet."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Explorer I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have advantage on Wisdom ({@skill Survival}) checks to navigate the wild, forage for food and water, and avoid becoming lost."
+            ]
+        },
+        {
+            "name": "Explorer II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "At the end of a long rest, you can attune to the surrounding environment. Examples include, but are not limited to: arctic, coast, desert, forest, grassland, mountain, or swamp. While in your attuned environment you gain the following benefits:",
+                {
+                    "type": "list",
+                    "items": [
+                        "You have advantage on Intelligence and Wisdom checks related to the native plants, animals, or ecosystem.",
+                        "You find twice as much food when foraging or hunting.",
+                        "You cannot be surprised unless you are {@condition incapacitated}.",
+                        "You gain a bonus to your initiative rolls equal to your Wisdom modifier (minimum of 1)."
+                    ]
+                }
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Explorer I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Herbalist I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have a deep knowledge of plants and their healing properties. You have advantage on Intelligence ({@skill Nature}) checks to identify the medicinal properties of plants, and Wisdom ({@skill Medicine}) checks made to stabilize creatures."
+            ]
+        },
+        {
+            "name": "Herbalist II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have learned to use natural plants and herbs to create healing potions. You gain proficiency with the {@item herbalism kit|phb}.",
+                "At the end of a long rest, you can use a herbalism kit to create a {@item potion of healing}. It retains its potency for a number of days equal to your proficiency bonus, after which it spoils."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Herbalist I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Herbalist III",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "When you take a short rest, you and any friendly creatures who rest with you, regain an extra {@dice 1d8} hit points as long as they expend at least one of their Hit Dice to regain hit points."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Herbalist II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Natural Regeneration",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "During a short rest, you can recover spell slots of a combined level equal to your Wisdom modifier. Once you do so, you must finish a long rest before you can use this feature again."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 14,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Slayer I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You can use a bonus action on your turn to mark a creature as your favored foe, without hitting them with an attack.",
+                "You also have advantage on Wisdom ({@skill Perception}) and Wisdom (@skill Survival}) checks to track your favored foe."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Slayer II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Your tracking abilities have become supernaturally accurate. You always know the exact direction and distance of your favored foe while you are on the same plane of existence."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Slayer I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Slayer III",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Once per turn, when you hit your favored foe with a weapon attack, you can force it to make a Constitution saving throw. On a failed save, it is {@condition blinded}, {@condition deafened}, {@condition frightened}, {@condition poisoned}, or {@condition restrained} (your choice) until the start of your next turn."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 14,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Slayer II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Stalker I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You are a master at covering your tracks. While moving at a normal pace, you and up to five other creatures who travel with you, produce no tracks nor scent, and you cannot be tracked by mundane means unless you wish to be."
+            ]
+        },
+        {
+            "name": "Stalker II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have learned to hunt your prey while remaining unseen. You can take the {@action Hide} action as a bonus action on your turn."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Stalker I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Stalker III",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You cannot be tracked, even by magic. You are always under the effects of the {@spell nondetection} spell, and you can't be tracked divination magic or magical means unless you wish to be."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 9,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Stalker II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Stalker IV",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You can ward yourself to briefly disappear from sight. When you take the {@action Hide} action, you, along with anything you are wearing or carrying, become {@condition invisible} until the start of your next turn. This ends early if you attack or cast a spell."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 14,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Stalker III"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Strider I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You ignore the effects of difficult terrain imposed by natural environments, such as undergrowth, snow, or marshlands. Additionally, you and up to five other creatures who travel with you do not have your travel slowed by difficult terrain."
+            ]
+        },
+        {
+            "name": "Strider II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Once in your sights, you pursue your quarries relentlessly. You can take the {@action Dash} action as a bonus action on your turn."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Strider I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Strider III",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You can surmount almost any obstacle that would block your path. Your base movement speed increases by 10 feet, and you ignore the effects of difficult terrain imposed by spells, magical phenomena, and any other magical effect."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Strider II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Strider IV",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You move through the world unhindered by even the most powerful magic and restraints. You are always under the effects of the {@spell freedom of movement} spell while conscious."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 14,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Strider III"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Survivor I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Your time in the wilds has hardened your physical body. As a bonus action on your turn, you can grant yourself temporary hit points equal to your Constitution modifier (minimum of 1)."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Survivor II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Your body can rapidly recover from injury. When you expend a Hit Die to regain hit points, you regain additional hit points equal to your Wisdom modifier (minimum of 1 hit point)."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 9,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Survivor I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Survivor III",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You persevere even in the face of death. When you make a death saving throw, you can add your Wisdom modifier to the roll (minimum of +1). If the result of your roll is 20 or higher, you treat it as if you had rolled a 20 on the d20."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 14,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Survivor II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Trapper",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "As an action, you can set a hidden trap made out of natural materials in an adjacent 5-foot space. The first creature that moves into the space must make a Dexterity saving throw against your ranger spell save DC or become restrained.",
+                "The creature repeat the saving throw at the start of each turn, ending the effect on a success. A creature can detect a trap by succeeding on an Investigation check against your ranger spell save DC. You can have a number of active traps equal to your Wisdom modifier (minimum of 1 trap)."
+            ]
+        },
+        {
+            "name": "Wild Insights I",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have a way with wild animals. You can communicate simple ideas to beasts using sounds and gestures, and you have advantage on Wisdom ({@skill Animal Handling}) checks that target animals or beasts that are friendly towards you."
+            ]
+        },
+        {
+            "name": "Wild Insights II",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have bound yourself with a minor nature spirit. You learn the {@spell find familiar} spell. It counts as a ranger spell for you, you always have it prepared, and it doesn't count against the total number of spells you prepare each day. When you cast this spell your summoned familiar is a fey creature."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Wild Insights I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Wild Insights III",
+            "source": "LLAR",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "The power of your nature spirit grows. When you cast {@spell find familiar}, it can take the form of {@filter any beast of CR 1/2 or lower|bestiary|Challenge Rating=[&0;&1/2]|type=beast}."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 9,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Wild Insights II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Arctic Adept",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have learned to survive the frozen tundra. You, and up to five creatures who travel with you have advantage on saving throws to resist the negative effects of arctic environments.",
+                "In addition, you gain resistance to cold damage."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Desert Adept",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You can survive the scorching desert. You, and up to five creatures who travel with you have advantage on saving throws to resist the negative effects of desert environments.",
+                "In addition, you gain resistance to fire damage."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Fell Handed I",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "When you score a critical hit with a weapon attack against a creature, you have advantage on the next attack you make against that creature before the end of your next turn."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Fell Handed II",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "When you score a critical hit against a creature, your critical hit range for attack rolls against that creature expands by 1.",
+                "For example, after you score a critical hit against a creature for the first time, you now score a critical hit when you roll a 19 or 20 when making an attack roll against that creature."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 9,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Fell Handed I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Jungle Adept",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have learned to survive the hostile jungle. You, and up to five creatures who travel with you have advantage on saving throws to resist the negative effects of jungle environments.",
+                "In addition, you gain resistance to poison damage."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Ranger Knight I",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Though you spend your time in the wilderness you still have some military training. You gain proficiency in heavy armor."
+            ]
+        },
+        {
+            "name": "Ranger Knight II",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "Though you are a warrior of the wild you understand chivalry and politics. Whenever you make an Intelligence ({@skill History}) or Charisma ({@skill Persuasion}) check you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Ranger Knight I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Rider I",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have advantage on Wisdom ({@skill Animal Handling}) checks to control your mount, and mounting or dismounting from a trained mount only costs you 5 feet of your movement."
+            ]
+        },
+        {
+            "name": "Rider II",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You have special skill at training animals. You have advantage on Wisdom ({@skill Animal Handling}) checks to domesticate wild animals, and you can train a mount in half the normal time."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Rider I"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Rider III",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You are a master of mounted combat. When you are riding your mount and it is hit by an attack, you can use your reaction to become the target of that attack instead.",
+                "In addition, when you or your mount are forced to make a Dexterity saving throw, you can use your reaction to grant both you and your mount advantage on the saving throw."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Rider II"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Underground Adept",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You are especially skilled at navigating the winding tunnels under the earth. You gain darkvision with a range of 60 feet. If you already have darkvision its range increases by 60 feet.",
+                "Also, you can close your eyes and gain tremmorsense in a 60 foot radius. Within that radius you can sense anything touching the ground. This special sense lasts for 1 minute, or until you open your eyes. Once you use this action you must finish a short or long rest before you can use it again."
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 6,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "Woodsman I",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You are familiar with forests, trees, and timber of all kinds. You gain proficiency with {@item woodcarver's tools|phb}, and you have advantage on any Intelligence ({@skill Nature}) checks to identify, recall information, and construct things from wood.",
+                "In addition, when you hit a tree or raw timber with a melee weapon attack, it becomes an automatic critical hit."
+            ]
+        },
+        {
+            "name": "Woodsman II",
+            "source": "LLAR:E",
+            "featureType": [
+                "LL:SK"
+            ],
+            "entries": [
+                "You can identify the strengths and weak points of wooden objects and creatures. You gain the following benefits:",
+                {
+                    "type": "list",
+                    "items": [
+                        "You gain proficiency with {@item carpenter's tools|phb}. Anything you construct from wood has twice as many hit points.",
+                        "At the end of each long rest, if you have timber available, you can craft a total number of {@item club|phb|clubs}, {@item greatclub|phb|greatclubs}, {@item javelin|phb|javelins}, and {@item quarterstaff|phb|quarterstaffs} equal to your proficiency bonus.",
+                        "When you hit a plant with a {@item battleaxe|phb} or {@item greataxe|phb}, you roll your damage twice and take the higher of the two rolls."
+                    ]
+                }
+            ],
+            "prerequisite": [
+                {
+                    "level": {
+                        "level": 3,
+                        "class":{
+                            "name": "Ranger (Alternate)",
+                            "source":"LLAR",
+                            "visible": true
+                        }
+                    },
+                    "feature": [
+                        "Woodsman I"
+                    ]
+                }
+            ]
+        }
+    ],
+    "monster": [
+        {
+            "name": "Beast of the Cave",
+            "source": "LLAR",
+            "summonedByClass": "Ranger (Alternate)|LLAR",
+            "size": [
+                "M"
+            ],
+            "type": "beast",
+            "alignment": [
+                "N"
+            ],
+            "ac": [
+                {
+                    "special": "13 + PB (natural armor)"
+                }
+            ],
+            "hp": {
+                "special": "5 + five times your ranger level (the beast has a number of hit dice [d8s] equal to your ranger level)"
+            },
+            "speed": {
+                "walk": 30,
+                "burrow": 10
+            },
+            "str": 14,
+            "dex": 14,
+            "con": 13,
+            "int": 8,
+            "wis": 14,
+            "cha": 11,
+            "senses": [
+                "darkvision 120 ft.",
+                "tremorsense 30 ft."
+            ],
+            "passive": 12,
+            "languages": [
+                "understands the languages you speak"
+            ],
+            "pbNote": "equals your bonus",
+            "trait": [
+                {
+                    "name": "Primal Bond",
+                    "entries": [
+                        "You can add your PB to any ability check or saving throw that the beast makes."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Claw",
+                    "entries": [
+                        "{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d6 + 2 + PB} piercing or slashing damage (your choice)."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Beast of the Land",
+            "source": "LLAR",
+            "summonedByClass": "Ranger (Alternate)|LLAR",
+            "size": [
+                "M"
+            ],
+            "type": "beast",
+            "alignment": [
+                "N"
+            ],
+            "ac": [
+                {
+                    "special": "13 + PB (natural armor)"
+                }
+            ],
+            "hp": {
+                "special": "5 + five times your ranger level (the beast has a number of hit dice [d8s] equal to your ranger level)"
+            },
+            "speed": {
+                "walk": 40,
+                "climb": 40
+            },
+            "str": 14,
+            "dex": 14,
+            "con": 15,
+            "int": 8,
+            "wis": 14,
+            "cha": 11,
+            "senses": [
+                "darkvision 60 ft."
+            ],
+            "passive": 12,
+            "languages": [
+                "understands the languages you speak"
+            ],
+            "pbNote": "equals your bonus",
+            "trait": [
+                {
+                    "name": "Charge",
+                    "entries": [
+                        "If the beast moves at least 20 feet toward a target and then hits it with a maul attack on the same turn, the target takes an extra {@dice 1d8} slashing damage. If the target is a Large or smaller creature, it must succeed on a Strength saving throw against your spell save DC or be knocked {@condition prone}."
+                    ]
+                },
+                {
+                    "name": "Primal Bond",
+                    "entries": [
+                        "You can add your PB to any ability check or saving throw that the beast makes."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Maul",
+                    "entries": [
+                        "{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d8 + 2 + PB} piercing or slashing damage (your choice)."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Beast of the Sea",
+            "source": "LLAR",
+            "summonedByClass": "Ranger (Alternate)|LLAR",
+            "size": [
+                "M"
+            ],
+            "type": "beast",
+            "alignment": [
+                "N"
+            ],
+            "ac": [
+                {
+                    "special": "13 + PB (natural armor)"
+                }
+            ],
+            "hp": {
+                "special": "5 + five times your ranger level (the beast has a number of hit dice [d8s] equal to your ranger level)"
+            },
+            "speed": {
+                "walk": 10,
+                "swim": 60
+            },
+            "str": 14,
+            "dex": 14,
+            "con": 15,
+            "int": 8,
+            "wis": 14,
+            "cha": 11,
+            "senses": [
+                "darkvision 60 ft."
+            ],
+            "passive": 12,
+            "languages": [
+                "understands the languages you speak"
+            ],
+            "pbNote": "equals your bonus",
+            "trait": [
+                {
+                    "name": "Amphibious",
+                    "entries": [
+                        "The beast can breathe in air and water."
+                    ]
+                },
+                {
+                    "name": "Binding Strike",
+                    "entries": [
+                        "When the beast hits a Large or smaller creature with its Pseudopod, it can choose to grapple the target (escape DC equal to your spell save DC). Until this grapple ends, the beast can't use its Pseudopod attack on another target."
+                    ]
+                },
+                {
+                    "name": "Primal Bond",
+                    "entries": [
+                        "You can add your PB to any ability check or saving throw that the beast makes."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Pseudopod",
+                    "entries": [
+                        "{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d6 + 2 + PB} piercing or bludgeoning damage (your choice)."
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "Beast of the Sky",
+            "source": "LLAR",
+            "summonedByClass": "Ranger (Alternate)|LLAR",
+            "size": [
+                "S"
+            ],
+            "type": "beast",
+            "alignment": [
+                "N"
+            ],
+            "ac": [
+                {
+                    "special": "13 + PB (natural armor)"
+                }
+            ],
+            "hp": {
+                "special": "4 + five times your ranger level (the beast has a number of hit dice [d6s] equal to your ranger level)"
+            },
+            "speed": {
+                "walk": 10,
+                "fly": 60
+            },
+            "str": 6,
+            "dex": 16,
+            "con": 13,
+            "int": 8,
+            "wis": 14,
+            "cha": 11,
+            "senses": [
+                "darkvision 60 ft."
+            ],
+            "passive": 12,
+            "languages": [
+                "understands the languages you speak"
+            ],
+            "pbNote": "equals your bonus",
+            "trait": [
+                {
+                    "name": "Flyby",
+                    "entries": [
+                        "The beast doesn't provoke opportunity attacks when it flies out of an enemies reach."
+                    ]
+                },
+                {
+                    "name": "Primal Bond",
+                    "entries": [
+                        "You can add your PB to any ability check or saving throw that the beast makes."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Shred",
+                    "entries": [
+                        "{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d4 + 3 + PB} piercing or slashing damage (your choice)."
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/class/LaserLlama; Alternate Ranger.json
+++ b/class/LaserLlama; Alternate Ranger.json
@@ -45,7 +45,7 @@
             "LL:SK": "Survivalist Knacks"
         },
 		"dateAdded": 1658237901,
-		"dateLastModified": 1658432790
+		"dateLastModified": 1658437320
 	},
     "class": [
         {
@@ -56,7 +56,40 @@
                     "name": "Alternate Ranger",
                     "type": "section",
                     "entries": [
-                        "Lorem Ipsum"
+                        "As the graying man made his way through the underbrush of the forest his faded green cloak made him nearly invisible. The exceptionally large troll he had been stalking through the night had finally stopped to rest. As the great brute laid down to sleep, a silent green shape emerged from the trees to snuff out the life of the hideous monster.",
+                        "As the massive blue dragon descended upon the small town, a small half-elven man rolled out of the path of a blast of lightning. With the small hairs on the back of their neck still standing up from the residual electricity, the practiced hunter knocked an arrow and let it fly in the direction of the terrible beast. As the biting dart struck true, the azure dragon let out a horrible roar and plummeted to the ground where it lay in a broken heap.",
+                        "As the massive owlbear slowly lumbered toward the tiny hamlet that she called home, a small halfling girl whistled to her companion in the brush. At her signal, a giant hound that seemed to be more fur then anything else, leaped out from hiding and stood defiantly in front of the owlbear. Distracted by her partner, the owlbear was caught completely unawares by the diminutive ranger. Once their foe was unconscious, the halfling and her dog released the great owlbear miles away where it could live without menacing the town they protected."
+                    ]
+                },
+                {
+                    "name": "Defenders of Balance",
+                    "type": "section",
+                    "entries": [
+                        "Rangers spend their lives between two worlds. On one hand they stand as guardians of civilization, protecting those who dwell on the edges of society. On the other, rangers are expert survivalists, deeply acquainted with the flora and fauna of the natural world. Rangers protect the balance between society and the wilderness. When wild creatures wander from their natural habitat, rangers will track them down before they can harm innocent farmers and travelers. When people encroach upon the wilderness, rangers will push back against industry and expansion that doesn't respect the natural balance.",
+                        "Rangers dedicate their lives to guarding the places where civilization and the wilderness meet, never fully joining either of the worlds that they spend their lives defending."
+                    ]
+                },
+                {
+                    "name": "Prepared for Anything",
+                    "type": "section",
+                    "entries": [
+                        "Ready to face any challenge, rangers are survivalists at their core. The wilderness is a harsh place, and those who cannot adapt to their surroundings will die. In the wild, rangers learn to be adaptable. Drawing on their knowledge of the natural world, their connection to primal magic, and the skills passed down to them by their mentors, there is rarely a challenge a ranger cannot overcome with enough time to prepare.",
+                        "Each ranger has their own philosophy on how they fit into the interconnected web that is the natural world. Some view themselves as apex predators, using their marital skill and ruthless hunting abilities to keep the wild in line. Others see themselves as humble servants of nature that serve the wild."
+                    ]
+                },
+                {
+                    "type": "entries",
+                    "name": "Creating Your Ranger",
+                    "entries": [
+                        "Consider the nature of your ranger's training. Did you train with a mentor, wandering the wilds together, learning all you could? Or did you forge your primal connection to the natural world on your own? What is it that motivates your ranger? Do you have a vendetta against a certain type of monster? Are you a warrior of the wild who feels more comfortable in the silence of the forest then in city streets or sleepy towns?",
+                        "No matter their origin, almost all rangers take up a life of adventuring to impart their knowledge of the wild to the next generation. Often, in their later years, these wild warriors will take on an apprentice, passing on all they know and so that the safety of the wilderness is secured for years to come.",
+                        {
+                            "type": "entries",
+                            "name": "Quick Build",
+                            "entries": [
+                                "You can make a ranger quickly by using these suggestions. First, make Dexterity your highest ability score, followed by your Wisdom. Second, choose the outlander background."
+                            ]
+                        }
                     ]
                 }
             ],


### PR DESCRIPTION
Converted both LaserLlama's Alternate Ranger class, as well as their Alternate Ranger: Expanded document. The .json contains both sources, with all classes, subclasses, and optional features included in the source documents.