### PR TITLE
Updated Alternate Fighter file to v2.5.1

### DIFF
--- a/class/LaserLlama; Alternate Fighter.json
+++ b/class/LaserLlama; Alternate Fighter.json
@@ -6,14 +6,15 @@
 				"abbreviation": "LLAF",
 				"full": "Alternate Fighter",
 				"authors": [
-					"/u/laserllama"
+					"LaserLlama"
 				],
 				"convertedBy": [
-					"Lxran#2292"
+					"Lxran#2292",
+                    "ProfForp#0242"
 				],
-				"version": "2.0.0",
+				"version": "2.5.1",
 				"color": "4f4771",
-				"url": "https://www.patreon.com/posts/54316404",
+				"url": "https://www.gmbinder.com/share/-MSfA82gv8V69JAoqFVq",
 				"targetSchema": "1.2"
 			},
 			{
@@ -21,38 +22,33 @@
 				"abbreviation": "LLAF:E",
 				"full": "Alternate Fighter: Expanded",
 				"authors": [
-					"/u/laserllama"
+					"LaserLlama"
 				],
 				"convertedBy": [
-					"Lxran#2292"
+					"Lxran#2292",
+                    "ProfForp#0242"
 				],
-				"version": "2.0.0",
+				"version": "2.5.1",
 				"color": "4f4771",
-				"url": "https://www.patreon.com/posts/54316404",
+				"url": "https://www.gmbinder.com/share/-MUkP55cdNMTFYMKlDUL",
 				"targetSchema": "1.2"
 			}
 		],
 		"dateAdded": 1627694791,
-		"dateLastModified": 1627757547,
+		"dateLastModified": 1658869178,
 		"optionalFeatureTypes": {
-			"LLAF:FS": "Alternate Fighter; Fighting Style",
-			"LLAF:ME": "Alternate Fighter; Martial Exploit",
-			"LLAF:ME:AK": "Alternate Fighter; Martial Exploit; Arcane Knight",
-			"LLAF:ME:Ca": "Alternate Fighter; Martial Exploit; Cavalier",
-			"LLAF:ME:Ch": "Alternate Fighter; Martial Exploit; Champion",
-			"LLAF:ME:Co": "Alternate Fighter; Martial Exploit; Commander",
-			"LLAF:ME:EK": "Alternate Fighter; Martial Exploit; Echo Knight",
-			"LLAF:ME:M": "Alternate Fighter; Martial Exploit; Marksman",
-			"LLAF:ME:Gua": "Alternate Fighter; Martial Exploit; Guardian",
-			"LLAF:ME:Gue": "Alternate Fighter; Martial Exploit; Guerilla",
-			"LLAF:ME:PactW": "Alternate Fighter; Martial Exploit; Pact Warrior",
-			"LLAF:ME:PsiW": "Alternate Fighter; Martial Exploit; Psi Warrior",
-			"LLAF:QMR": "Alternate Fighter; Quartermaster Rations",
-			"LLAF:ME:RK": "Alternate Fighter; Martial Exploit; Rune Knight",
-			"LLAF:ME:S": "Alternate Fighter; Martial Exploit; Samurai",
-			"LLAF:TKSCH": "Alternate Fighter; Tinker Knight Schematics"
-		},
-		"_dateLastModifiedHash": "9cfb07fbd6"
+            "FS:AF": "Fighting Style; Alternate Fighter",
+			"LL:ASA": "Arcane Shot (Alternate Fighter)",
+			"LL:RNA": "Rune Knight Rune (Alternate Fighter)",
+            "LL:ME": "Martial Exploit",
+            "LL:1DE": "1st Degree Exploit",
+            "LL:2DE": "2nd Degree Exploit",
+            "LL:3DE": "3rd Degree Exploit",
+            "LL:4DE": "4th Degree Exploit",
+            "LL:5DE": "5th Degree Exploit",
+			"LL:QMR": "Quartermaster Rations",
+			"LL:TKS": "Tinker Knight Schematics"
+		}
 	},
 	"book": [
 		{
@@ -65,10 +61,21 @@
 			"group": "homebrew",
 			"contents": [
 				{
-					"name": "The Alternate Fighter"
+					"name": "The Alternate Fighter",
+					"headers": [
+						"Warrior Archetypes",
+						"Alternate Archetypes"
+					]
 				},
 				{
-					"name": "Alternate Fighter Builds"
+					"name": "Martial Exploits",
+					"headers": [
+						"1st-Degree Exploits",
+						"2nd-Degree Exploits",
+						"3rd-Degree Exploits",
+						"4th-Degree Exploits",
+						"5th-Degree Exploits"
+					]
 				}
 			]
 		},
@@ -85,10 +92,37 @@
 					"name": "Alternate Fighter Expanded"
 				},
 				{
-					"name": "Warrior Archetypes"
+					"name": "Additional Fighting Styles"
 				},
 				{
-					"name": "Exclusive Exploits"
+					"name": "Addtional Martial Exploits",
+					"headers": [
+						"1st-Degree Exploits",
+						"2nd-Degree Exploits",
+						"3rd-Degree Exploits",
+						"4th-Degree Exploits",
+						"5th-Degree Exploits"
+					]
+				},
+				{
+					"name": "Martial Feats"
+				},
+				{
+					"name": "Alternate Fighter Builds",
+					"headers": [
+						"Blade Master",
+						"Bodyguard",
+						"Gladiator",
+						"Knight",
+						"Marine",
+						"Medic",
+						"Mystic",
+						"Peacekeeper",
+						"Pugilist"
+					]
+				},
+				{
+					"name": "Warrior Archetypes"
 				}
 			]
 		}
@@ -100,461 +134,11 @@
 			"ruleType": "V",
 			"page": 1,
 			"entries": [
-				"Some Fighting Styles, especially those here, are specific in application. Consider allowing fighters in your game to re-train their Fighting Style over a few long rests to adjust to the challenges ahead."
+				"Some Fighting Styles have specific uses. Consider allowing the fighters in your game to re-train their Fighting Style over a few long rests, or a single long rest if they are high level, to adjust their technique."
 			]
 		}
 	],
 	"bookData": [
-		{
-			"id": "LLAF:E",
-			"source": "LLAF:E",
-			"data": [
-				{
-					"type": "section",
-					"name": "Alternate Fighter Expanded",
-					"page": 1,
-					"entries": [
-						"The unyielding fighter is a staple in nearly every fantasy story. The warrior who's knowledge of weapons of all kinds is only xceeded by their skill with said weapons on the battlefield.",
-						"In 5e, the fighter class, while mechanically balanced, falls short of the classic fighter fantasy. My Alternate Fighter Class is an attempt to have the mechanics of the fighter match the fantasy of playing a true master of battle. Found here are more options for the class, including additional Fighting Styles, Martial Exploits, Alternate Fighter Builds, six Archetypes, and Archetype Exploits for official Archetypes.",
-						{
-							"type": "entries",
-							"name": "Additional Fighting Styles",
-							"page": 1,
-							"entries": [
-								"Martial warriors of all types usually adopt a signature fighting technique. The options presented below are available to the Alternate Fighter, in addition to the options presented withthe base class. You cannot select a Fighting Style more than once, even if a feature lets you choose again.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Berserkergang|LLAF:E}",
-										"{@optfeature Heavyweight Fighting|LLAF:E}",
-										"{@optfeature Mounted Warrior|LLAF:E}",
-										"{@optfeature Pit Fighting|LLAF:E}",
-										"{@optfeature Shield Warrior|LLAF:E}"
-									]
-								},
-								{
-									"type": "inset",
-									"name": "Alternate Rule: Style Re-Training",
-									"entries": [
-										"Some Fighting Styles, especially those here, are specific in application. Consider allowing fighters in your game to re-train their Fighting Style over a few long rests to adjust to the challenges ahead."
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Additional Martial Exploits",
-							"page": 2,
-							"entries": [
-								"Listed below are additional Exploits available to the Alternate Fighter, based on spells that already exist in 5e. Some, or all, of these Exploits may fit the tone of your game. Make sure to check with your GM before learning one of these Exploits.",
-								"If a Martial Exploit has fighter level prerequisite, you canlearn it at the same time you meet its level prerequisites.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Hurl|LLAF:E}",
-										"{@optfeature Shattering Slam|LLAF:E}",
-										"{@optfeature Zephyr Focus|LLAF:E}",
-										"{@optfeature Flaming Shot|LLAF:E}",
-										"{@optfeature Shattering Wave|LLAF:E}",
-										"{@optfeature Erupting Slam|LLAF:E}",
-										"{@optfeature Rain of Arrows|LLAF:E}",
-										"{@optfeature Cataclysmic Slam|LLAF:E}",
-										"{@optfeature Gale Force Strike|LLAF:E}",
-										"{@optfeature Storm of Arrows|LLAF:E}",
-										"{@optfeature Legendary Exploit|LLAF:E}"
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Alternate Fighter Builds",
-							"page": 3,
-							"entries": [
-								"One of the goals of the Alternate Fighter class was to bring the versatility of the Battle Master Archetype found in the Player's Handbook to ever fighter. Depending on a fighter's Archetype, Fighting Style, and Martial Exploit choices, they reflect any warrior type from popular fiction and fantasy.",
-								"Each build suggests an Archetype, Fighting Styles, Martial Exploits, and Feats, all of which come from this document, the Alternate Fighter, the {@i Player's Handbook}, {@i Xanathar's Guide to Everything}* or {@i Tasha's Cauldron of Everything}**.",
-								{
-									"type": "entries",
-									"name": "Blade Master",
-									"page": 3,
-									"entries": [
-										"Blade masters are hermits who wander the world looking to aid the common folk with their skills. Masters of many forms, they only draw their blade when they are prepared to kill.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Alternate Fighter|LLAF|Swordsage|Swordsage|LLAF:E}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Classical Swordplay|LLAF}, {@optfeature Versatile Fighting|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Defensive Stance|LLAF}, {@optfeature Disarm|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Riposte|LLAF}, {@optfeature Swordsman's Grace|LLAF}"
-												],
-												[
-													"Feats:",
-													"{@feat Alert}, {@feat Mobile}, {@feat Great Weapon Master}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Bodyguard",
-									"page": 3,
-									"entries": [
-										"You have trained to defend important figures and to escort precious cargo. When you are near, no foe, no matter their strength or abilities, can threaten that which you protect.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Alternate Fighter|LLAF|Guardian|Guardian|LLAF:E}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Interception|TCE}*, {@optfeature Protection|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Disarm|LLAF}, {@optfeature Disorienting Blow|LLAF}, {@optfeature Menacing Cry|LLAF}, {@optfeature Sweeping Strike|LLAF}, {@optfeature Taunt|LLAF}"
-												],
-												[
-													"Feats:",
-													"{@feat Alert}, {@feat Crusher|TCE}, {@feat Sentinel}, {@feat Shield Master}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Chosen One",
-									"page": 3,
-									"entries": [
-										"You were selected at birth by a powerful extraplanar entity or mortal faction. Your actions are blessed, and you have a way of succeeding at a task or feat when all others fail.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Fighter|PHB|Samurai|Samurai|XGE}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Dueling|LLAF}, {@optfeature Improvised Fighting|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Brace Up|LLAF}, {@optfeature Critical Strike|LLAF:E}, {@optfeature Feat of Strength|LLAF}, {@optfeature Regal Spirit|LLAF:E}, {@optfeature Warrior's Reflexes|LLAF}"
-												],
-												[
-													"Feats:",
-													"{@feat Alert}, {@feat Inspiring Leader}, {@feat Lucky}, {@feat Mobile}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Cult Blade",
-									"page": 3,
-									"entries": [
-										"Trained by servants of strange gods and eldritch beings, you are the elite warrior of a cult. When your sinister masters need something done, or someone slain, you are the go to.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Alternate Fighter|LLAF|Pact Warrior|Pact Warrior|LLAF:E}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Dueling|LLAF}, {@optfeature Great Weapon Fighting|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Arcane Smite|LLAF}, {@optfeature Dirty Hit|LLAF}, {@optfeature Eldritch Insight|LLAF:E}, {@optfeature Spellguard|LLAF}, {@optfeature Zephyr Focus|LLAF:E}"
-												],
-												[
-													"Feats:",
-													"{@feat Mage Slayer}, {@feat Skulker}, {@feat War Caster}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Lancer",
-									"page": 3,
-									"entries": [
-										"You are a master of mounted combat who has trained from birth to fight from atop a fearsome beast of war. You are adept at running down foes and leading charges in battle.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Fighter|PHB|Cavalier|Cavalier|XGE}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Great Weapon Fighting|LLAF}, {@optfeature Mounted Warrior|LLAF:E}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Cavalier's Training|LLAF:E}, {@optfeature Martial Focus|LLAF}, {@optfeature Skilled Rider|LLAF:E}, {@optfeature Taunt|LLAF}, {@optfeature Weakening Blow|LLAF}"
-												],
-												[
-													"Feats:",
-													"{@feat Heavy Armor Master}, {@feat Mounted Combatant}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Marine",
-									"page": 3,
-									"entries": [
-										"Marines are warriors who are trained to fight at sea or on the decks of ships. They can be elite sailors who defend precious cargo, or ruthless pirates who pillage all they come across.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Alternate Fighter|LLAF|Guerilla|Guerilla|LLAF:E}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Classical Swordplay|LLAF}, {@optfeature Marine Fighting|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Adapt|LLAF:E}, {@optfeature Charlatan's Guile|LLAF}, {@optfeature Dirty Hit|LLAF}, {@optfeature Feat of Strength|LLAF}, {@optfeature Mighty Leap|LLAF}, {@optfeature Overcome|LLAF:E}"
-												],
-												[
-													"Feats:",
-													"{@feat Alert}, {@feat Skill Expert|TCE}, {@feat Slasher|TCE}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Medic",
-									"page": 3,
-									"entries": [
-										"Medics are masters of keeping their allies in top condition, assuaging their hurts, and keeping spirits high in battle.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Alternate Fighter|LLAF|Quartermaster|Quartermaster|LLAF:E}"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Defensive Fighting|LLAF}, {@optfeature Protection|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Brace Up|LLAF}, {@optfeature Feat of Strength|LLAF}, {@optfeature First Aid|LLAF}, {@optfeature Suppressing Strike|LLAF}, {@optfeature Take Down|LLAF}, {@optfeature Taunt|LLAF}"
-												],
-												[
-													"Feats:",
-													"{@feat Chef|TCE}, {@feat Healer}, {@feat Inspiring Leader}"
-												]
-											]
-										}
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Mystic",
-									"page": 3,
-									"entries": [
-										"Mystics are guardians of peace and prosperity that are raised from birth to make use of their psionic potential in battle. They are pacifists who only use violence as a last resort.",
-										{
-											"type": "table",
-											"colStyles": [
-												"col-3",
-												"col-9"
-											],
-											"rows": [
-												[
-													"Archetype:",
-													"{@class Fighter|PHB|Psi Knight|Psi Knight|TCE}*"
-												],
-												[
-													"Fighting Style:",
-													"{@optfeature Blind Fighting|TCE}, {@optfeature Versatile Fighting|LLAF}"
-												],
-												[
-													"Exploits:",
-													"{@optfeature Awakened Mind|LLAF:E}, {@optfeature Defensive Stance|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Psi Warrior's Aura|LLAF:E}, {@optfeature Zephyr Focus|LLAF:E}"
-												],
-												[
-													"Feats:",
-													"{@feat Alert}, {@feat Resilient|PHB|Resilient (Wisdom)}, {@feat Sentinel}"
-												]
-											]
-										}
-									]
-								}
-							]
-						}
-					]
-				},
-				{
-					"type": "section",
-					"name": "Warrior Archetypes",
-					"page": 4,
-					"entries": [
-						"Choose one of the following Warrior Archetypes that best represents the training and skill of your fighter: {@class Alternate Fighter|LLAF|Guardian|Guardian|LLAF:E}, {@class Alternate Fighter|LLAF|Guerrilla|Guerrilla|LLAF:E}, {@class Alternate Fighter|LLAF|Pact Warrior|Pact Warrior|LLAF:E}, {@class Alternate Fighter|LLAF|Quartermaster|Quartermaster|LLAF:E}, or {@class Alternate Fighter|LLAF|Tinker Knight|Tinker Knight|LLAF:E}."
-					]
-				},
-				{
-					"type": "section",
-					"name": "Exclusive Exploits",
-					"page": 12,
-					"entries": [
-						"Below are exclusive Martial Exploits for official Archetypes published after the {@i Players Handbook}: Cavalier, Samurai, Arcane Archer, Echo Knight, Psi Warrior, and Rune Knight.",
-						{
-							"type": "entries",
-							"name": "Cavalier Exploits",
-							"page": 12,
-							"entries": [
-								"The Exploits below are exclusive to fighters of the Cavalier Archetype. Cavalier Exploits focus on defending their allies and making use of their trained mounts in combat.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Cavalier's Training|LLAF:E}",
-										"{@optfeature Mounted Strike|LLAF:E}",
-										"{@optfeature Skilled Rider|LLAF:E}"
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Samurai Exploits",
-							"page": 12,
-							"entries": [
-								"The Exploits below are exclusive to fighters of the Samurai Archetype. Samurai Exploits focus on their regal demeanor in diplomacy and relentless fighting spirit on the battlefield.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Critical Strike|LLAF:E}",
-										"{@optfeature Regal Spirit|LLAF:E}",
-										"{@optfeature Samurai's Nobility|LLAF:E}"
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Arcane Archer",
-							"page": 12,
-							"entries": [
-								"If you play an Arcane Archer with the Alternate Fighter class, treat the Arcane Shots as Archetype Exclusive Exploits that are available to be learned whenever you learn a new Exploit.",
-								"Also, If you have no uses of Arcane Shot remaining, you can expend an Exploit Die to use an additional Arcane Shot as part of that attack. However, when you expend an Exploit Die to use an Arcane Shot in this way, any damage dealt by the Arcane Shot you use is replaced by two rolls of your Exploit Die, instead of the normal damage of that Shot."
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Echo Knight Exploits",
-							"page": 12,
-							"entries": [
-								"The Exploits listed below are exclusive to fighters of the Echo Knight Archetype. Echo Knight Exploits focus on strange shadow magic which they can use to duplicate themselves.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Echo Knight's Esoterica|LLAF:E}",
-										"{@optfeature Enhanced Echo|LLAF:E}",
-										"{@optfeature Shadow Transposition|LLAF:E}"
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Psi Warrior Exploits",
-							"page": 12,
-							"entries": [
-								"The Exploits listed below are exclusive to fighters of the Psi Warrior Archetype. Psi Warrior Exploits focus on combing their wondrous psionic power with deadly martial skill.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Awakened Mind|LLAF:E}",
-										"{@optfeature Psi Warrior's Aura|LLAF:E}",
-										"{@optfeature Psionic Stength|LLAF:E}"
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Rune Knight Exploits",
-							"page": 12,
-							"entries": [
-								"The Exploits listed below are exclusive to the Rune Knight Archetype. Rune Knight Exploits focus on channeling the ancient and powerful runic magic of the giants and dragons.",
-								{
-									"type": "list",
-									"columns": 3,
-									"items": [
-										"{@optfeature Rune Knight's Knowledge|LLAF:E}",
-										"{@optfeature Runic Endurance|LLAF:E}",
-										"{@optfeature Runic Lore|LLAF:E}"
-									]
-								}
-							]
-						}
-					]
-				}
-			]
-		},
 		{
 			"id": "LLAF",
 			"source": "LLAF",
@@ -564,22 +148,450 @@
 					"name": "The Alternate Fighter",
 					"page": 1,
 					"entries": [
-						"The Alternate Fighter class, which is presented in this supplement can be found in the {@class Alternate Fighter|LLAF|Classes} page."
+						"The Alternate Fighter class, which is presented in this supplement can be found in the {@class Alternate Fighter|LLAF|Classes} page.",
+						{
+							"type": "entries",
+							"page": 4,
+							"name": "Warrior Archetypes",
+							"entries": [
+								"At 3rd level, a fighter chooses one of the following Archetypes that best represents their training and skills: Arcane Knight, Champion, Commander, Marksman, or Master at Arms.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@class Alternate Fighter|LLAF|Arcane Knight|Arcane Knight|LLAF}",
+										"{@class Alternate Fighter|LLAF|Champion|Champion|LLAF}",
+										"{@class Alternate Fighter|LLAF|Commander|Commander|LLAF}",
+										"{@class Alternate Fighter|LLAF|Marksman|Marksman|LLAF}",
+										"{@class Alternate Fighter|LLAF|Master at Arms|Master at Arms|LLAF}"
+									]
+								},
+								{
+									"type": "inset",
+									"name": "Additional Warrior Archetypes",
+									"entries": [
+										"Looking for more options? Check out the {@book Alternate Fighter: Expanded|LLAF:E} for eight additional Archetypes, including Guardian, Quartermaster, and Swordsage!"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 14,
+							"name": "Alternate Archetypes",
+							"entries": [
+								"Below are changes to the official Martial Archetypes so they work with the Alternate Fighter. Detailed here are the Arcane Archer, Cavalier, Echo Knight, Rune Knight, and Samurai.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@class Alternate Fighter|LLAF|Alternate Arcane Archer|Arcane Archer|LLAF}",
+										"{@class Alternate Fighter|LLAF|Alternate Cavalier|Cavalier|LLAF}",
+										"{@class Alternate Fighter|LLAF|Alternate Samurai|Samurai|LLAF}",
+										"{@class Alternate Fighter|LLAF|Alternate Echo Knight|Echo Knight|LLAF}",
+										"{@class Alternate Fighter|LLAF|Alternate Rune Knight|Rune Knight|LLAF}"
+									]
+								},
+								{
+									"type": "inset",
+									"name": "Where is the Psi Warrior?",
+									"entries": [
+										"Looking to play an Alternate Fighter with Psionic abilities? Make sure you check out the {@book Alternate Fighter: Expanded|LLAF:E}, which includes the Mystic Warrior Archetype - a Psionic, Intelligence-based, spell point caster akin to the Arcane Knight."
+									]
+								}
+							]
+						}
 					]
 				},
 				{
 					"type": "section",
-					"name": "Alternate Fighter Builds.",
-					"page": 13,
+					"name": "Martial Exploits",
+					"page": 9,
 					"entries": [
-						"One of the goals of the Alternate Fighter class was to bring the versatility of the Battle Master Archetype found in the {@i Player's Handbook} to ever fighter. Depending on a fighter's Archetype, Fighting Style, and Martial Exploit choices, they can reflect any warrior from popular fiction and fantasy.",
+						"Below are the Exploits available to the fighter. If an Exploit has a prerequisite, like a minimum Ability Score or level, you can learn it at the same time you meet the prerequisites.",
+						{
+							"type": "entries",
+							"page": 9,
+							"name": "1st-Degree Exploits",
+							"entries": [
+								"Exploits of the 1st-degree are minor techniques slightly more complicated then swinging a weapon. They can be learned by warriors with modest training and have no level prerequisite.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Blinding Strike|LLAF}",
+										"{@optfeature Brace Up|LLAF}",
+										"{@optfeature Charlatan's Guile|LLAF}",
+										"{@optfeature Commander's Presence|LLAF}",
+										"{@optfeature Crippling Strike|LLAF}",
+										"{@optfeature Disarm|LLAF}",
+										"{@optfeature Feat of Strength|LLAF}",
+										"{@optfeature Feint|LLAF}",
+										"{@optfeature First Aid|LLAF}",
+										"{@optfeature Heroic Fortitude|LLAF}",
+										"{@optfeature Hurl|LLAF}",
+										"{@optfeature Keen Observation|LLAF}",
+										"{@optfeature Lightstep|LLAF}",
+										"{@optfeature Martial Focus|LLAF}",
+										"{@optfeature Menacing Shout|LLAF}",
+										"{@optfeature Mighty Leap|LLAF}",
+										"{@optfeature Mighty Thrust|LLAF}",
+										"{@optfeature Precision Strike|LLAF}",
+										"{@optfeature Riposte|LLAF}",
+										"{@optfeature Ruthless Strike|LLAF}",
+										"{@optfeature Scholar's Insight|LLAF}",
+										"{@optfeature Skilled Rider|LLAF}",
+										"{@optfeature Survivalist's Craft|LLAF}",
+										"{@optfeature Sweeping Strike|LLAF}",
+										"{@optfeature Wild Strike|LLAF}"
+									]
+								},
+								{
+									"type": "inset",
+									"name": "Additional Martial Exploits",
+									"entries": [
+										"Check out the {@book Alternate Fighter: Expanded|LLAF:E} for a multitude of additional Martial Exploits, including Advanced Martial Exploits based on spell effects."
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 11,
+							"name": "2nd-Degree Exploits",
+							"entries": [
+								"Exploits of the second degree represent the absolute peak of martial skill that is achievable by a warrior without dedicated training, or significant experience in combat. These Exploits can be learned by any fighter of 5th level or higher.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Aggressive Strike|LLAF}",
+										"{@optfeature Concussive Blow|LLAF}",
+										"{@optfeature Crushing Strike|LLAF}",
+										"{@optfeature Defensive Stance|LLAF}",
+										"{@optfeature Dirty Hit|LLAF}",
+										"{@optfeature Execute|LLAF}",
+										"{@optfeature Flaming Shot|LLAF}",
+										"{@optfeature Heroic Will|LLAF}",
+										"{@optfeature Redirect|LLAF}",
+										"{@optfeature Shield Impact|LLAF}",
+										"{@optfeature Suppressing Strike|LLAF}",
+										"{@optfeature Take Cover|LLAF}",
+										"{@optfeature Volley|LLAF}",
+										"{@optfeature Warrior's Challenge|LLAF}",
+										"{@optfeature Whirlwind Strike|LLAF}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 12,
+							"name": "3rd-Degree Exploits",
+							"entries": [
+								"Exploits of this degree are only able to be mastered by elite warriors who dedicate their lives to training. They can only be learned by fighters of 9th level or higher. Each 3rd-degree Exploit can only be used once per short or long rest.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Disorienting Blow|LLAF}",
+										"{@optfeature Heroic Focus|LLAF}",
+										"{@optfeature Mythic Athleticism|LLAF}",
+										"{@optfeature Resilient Body|LLAF}",
+										"{@optfeature Thunderous Shot|LLAF}",
+										"{@optfeature War Cry|LLAF}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 13,
+							"name": "4th-Degree Exploits",
+							"entries": [
+								"Exploits of the fourth degree are techniques only mastered by the most powerful warriors in an entire kingdom. These can only be learned by fighters of 13th level or higher. Each 4th-degree Exploit can only be used once per short or long rest.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Expert Determination|LLAF}",
+										"{@optfeature Fluid Movements|LLAF}",
+										"{@optfeature Staggering Blow|LLAF}",
+										"{@optfeature Quick Draw|LLAF}",
+										"{@optfeature Unbreakable|LLAF}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 13,
+							"name": "5th-Degree Exploits",
+							"entries": [
+								"Exploits of this degree are feats of skill that rival demigods. These Exploits can only be learned by fighters of 17th level or higher, and each can only be used once per short or long rest.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Storm of Arrows|LLAF}",
+										"{@optfeature Steel Wind Slash|LLAF}"
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"id": "LLAF:E",
+			"source": "LLAF:E",
+			"data": [
+				{
+					"type": "section",
+					"name": "Alternate Fighter Expanded",
+					"page": 1,
+					"entries": [
+						"In 5e, the fighter, while mechanically balanced, falls short of the fantasy it tries to capture. The {@class Alternate Fighter|LLAF} strives to capture the fantasy of playing a master of battle. Included below are additional options for the Alternate Fighter class:",
+						{	
+							"type": "entries",
+							"entries": [
+								{
+									"type": "entries",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Additional Fighting Styles",
+											"entries": [
+												"The Fighting Styles included with the Alternate Fighter emulate the most common forms of combat. Fighting Styles included here can be more exotic, specific, or dangerous for those who makes use of them."
+											]
+										}
+									]
+								}
+							]	
+						},
+						{	
+							"type": "entries",
+							"entries": [
+								{
+									"type": "entries",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Advanced Martial Exploits",
+											"entries": [
+												"The Exploits included here may be harder to learn, or require a specific master to teach. Advanced Exploits are more fantastical in nature, and are balanced based on spells that exist in 5e."
+											]
+										}
+									]
+								}
+							]	
+						},	
+						{	
+							"type": "entries",
+							"entries": [
+								{
+									"type": "entries",
+									"entries": [			
+										{
+											"type": "entries",
+											"name": "Martial Feats",
+											"entries": [
+												"The feats included here allow all player characters to share in the abilities of the Alternate Fighter."
+											]
+										}
+									]
+								}
+							]	
+						},
+						{	
+							"type": "entries",
+							"entries": [
+								{
+									"type": "entries",
+									"entries": [
+										{
+											"type": "entries",
+											"name": "Additional Warrior Archetypes",
+											"entries": [
+												"Included below are nine additional Archetypes for fighters to choose from at 3rd level."
+											]
+										}
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Additional Fighting Styles",
+					"page": 1,
+					"entries": [
+						"The following Fighting Styles are available to the Alternate Fighter, in addition those presented with the base class.",
+						{
+							"type": "list",
+							"columns": 3,
+							"items": [
+								"{@optfeature Berserkergang|LLAF:E}",
+								"{@optfeature Heavyweight Fighting|LLAF:E}",
+								"{@optfeature Mariner|LLAF:E}",
+								"{@optfeature Mountaineer|LLAF:E}",
+								"{@optfeature Mounted Warrior|LLAF:E}",
+								"{@optfeature Pit Fighting|LLAF:E}",
+								"{@optfeature Shield Warrior|LLAF:E}",
+								"{@optfeature Standard Bearer|LLAF:E}",
+								"{@optfeature Wrestler|LLAF:E}"
+							]
+						},
+						{
+							"type": "inset",
+							"name": "Alternate Rule: Style Re-Training",
+							"entries": [
+								"Some Fighting Styles, especially those here, are specific in application. Consider allowing fighters in your game to re-train their Fighting Style over a few long rests to adjust to the challenges ahead."
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Addtional Martial Exploits",
+					"page": 2,
+					"entries": [
+						"Listed below are additional Martial Exploits available to the Alternate Fighter. Each time you gain a level, you can replace one Exploit you know with another Exploit of your choice.",
+						{
+							"type": "entries",
+							"page": 2,
+							"name": "1st-Degree Exploits",
+							"entries": [
+								"Exploits of the 1st-degree are minor techniques slightly more complicated then swinging a weapon. They can be learned by warriors with modest training and have no level prerequisite.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Aristocratic Education|LLAF:E}",
+										"{@optfeature Lunge|LLAF:E}",
+										"{@optfeature Navigator's Know-how|LLAF:E}",
+										"{@optfeature Reposition|LLAF:E}",
+										"{@optfeature Street Smarts|LLAF:E}",
+										"{@optfeature Take Down|LLAF:E}",
+										"{@optfeature Tinker's Intuition|LLAF:E}",
+										"{@optfeature Warding Strike|LLAF:E}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 2,
+							"name": "2nd-Degree Exploits",
+							"entries": [
+								"Exploits of the second degree represent the absolute peak of martial that is skill achievable by a warrior without dedicated training, or significant experience in combat. Exploits of this level can be learned by any fighter of 5th level or higher.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Glancing Blow|LLAF:E}",
+										"{@optfeature Immovable Stance|LLAF:E}",
+										"{@optfeature Improvised Skill|LLAF:E}",
+										"{@optfeature Intimidating Command|LLAF:E}",
+										"{@optfeature Shattering Slam|LLAF:E}",
+										"{@optfeature Thunderous Blow|LLAF:E}",
+										"{@optfeature Trick Shot|LLAF:E}",
+										"{@optfeature Weakening Blow|LLAF:E}",
+										"{@optfeature Zephyr Slash|LLAF:E}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 3,
+							"name": "3rd-Degree Exploits",
+							"entries": [
+								"Exploits of this degree are only able to be mastered by elite warriors who dedicate their lives to training. They can only be learned by fighters of 9th level or higher. Each 3rd-degree Exploit can only be used once per short or long rest.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Daring Rescue|LLAF:E}",
+										"{@optfeature Destructive Slam|LLAF:E}",
+										"{@optfeature Gale Force Slash|LLAF:E}",
+										"{@optfeature Inspirational Speech|LLAF:E}",
+										"{@optfeature Recruit Mercenary|LLAF:E}",
+										"{@optfeature Survey Settlement|LLAF:E}",
+										"{@optfeature Survey Wilderness|LLAF:E}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 4,
+							"name": "4th-Degree Exploits",
+							"entries": [
+								"Exploits of the fourth degree are techniques only mastered by the most powerful warriors in an entire kingdom These can only be learned by fighters of 13th level or higher. Each 4th-degree Exploit can only be used once per short or long rest.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Equip Militia|LLAF:E}",
+										"{@optfeature Sundering Strike|LLAF:E}"
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"page": 4,
+							"name": "5th-Degree Exploits",
+							"entries": [
+								"Exploits of this degree are feats of skill that rival demigods. They can only be learned by fighters of 17th level or higher, and each can only be used once per short or long rest.",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@optfeature Banishing Strike|LLAF:E}",
+										"{@optfeature Cataclysmic Slam|LLAF:E}",
+										"{@optfeature Mythic Focus|LLAF:E}",
+										"{@optfeature Vorpal Strike|LLAF:E}"
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Martial Feats",
+					"page": 5,
+					"entries": [
+						"The feats here allow all characters to share in the abilities of the Alternate Fighter. If your game uses Feats, these can be selected in place of an Ability Score Improvement features.",
+						{
+							"type": "list",
+							"columns": 3,
+							"items": [
+								"{@feat Masterful Technique|LLAF:E}",
+								"{@feat Martial Training|LLAF:E}",
+								"{@feat Signature Technique|LLAF:E}",
+								"{@feat Signature Weapon|LLAF:E}"
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Alternate Fighter Builds",
+					"page": 6,
+					"entries": [
+						"One of the goals of the Alternate Fighter class was to bring the versatility of the Battle Master Archetype found in the {@i Player's Handbook} to every fighter. Depending on a fighter's Archetype, Fighting Style, and Martial Exploit choices, they can reflect any warrior from popular fiction and fantasy.",
 						"The Alternate Fighter builds below suggest particular groupings of Archetypes, Fighting Styles, Martial Exploits, and Feats, all of which are from the Alternate Fighter, the {@i Player's Handbook}, or {@i Tasha's Cauldron of Everything}*.",
 						{
 							"type": "entries",
-							"name": "Duelist",
-							"page": 13,
+							"name": "Blade Master",
+							"page": 6,
 							"entries": [
-								"You are a true student of the blade, and have specialized yours kills for single combat. You often seek out the most powerful foes you can find in order to test your skills against them.",
+								"You are a true student of the blade, and have specialized your skills for single combat. You often seek out the most powerful foes you can find in order to test your skills against them.",
 								{
 									"type": "table",
 									"colStyles": [
@@ -589,7 +601,7 @@
 									"rows": [
 										[
 											"Archetype:",
-											"{@class Alternate Fighter|LLAF|Master at Arms|Master at Arms|LLAF}"
+											"{@class Alternate Fighter|LLAF|Swordsage|Swordsage|LLAF:E}"
 										],
 										[
 											"Fighting Style:",
@@ -597,11 +609,44 @@
 										],
 										[
 											"Exploits:",
-											"{@optfeature Defensive Stance|LLAF}, {@optfeature Disarm|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Riposte|LLAF}, {@optfeature Weakening Blow|LLAF}"
+											"{@optfeature Disarm|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Feint|LLAF}, {@optfeature Warrior's Challenge|LLAF}, {@optfeature Zephyr Slash|LLAF:E}"
 										],
 										[
 											"Feats:",
-											"{@feat Defensive Duelist}, {@feat Piercer|TCE}, {@feat Slasher|TCE}"
+											"{@feat Defensive Duelist}, {@feat Mobile}, {@feat Piercer|TCE}"
+										]
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Bodyguard",
+							"page": 6,
+							"entries": [
+								"You have trained to defend important figures and to escort precious cargo. When you are near, no foe, no matter their strength or abilities, can threaten that which you protect.",
+								{
+									"type": "table",
+									"colStyles": [
+										"col-3",
+										"col-9"
+									],
+									"rows": [
+										[
+											"Archetype:",
+											"{@class Alternate Fighter|LLAF|Guardian|Guardian|LLAF:E}"
+										],
+										[
+											"Fighting Style:",
+											"{@optfeature Protection|LLAF}, {@optfeature Shield Warrior|LLAF:E}"
+										],
+										[
+											"Exploits:",
+											"{@optfeature Disarm|LLAF}, {@optfeature First Aid|LLAF}, {@optfeature Reposition|LLAF:E}, {@optfeature Warding Strike|LLAF:E}, {@optfeature Shield Impact|LLAF}"
+										],
+										[
+											"Feats:",
+											"{@feat Alert}, {@feat Sentinel}, {@feat Shield Master}"
 										]
 									]
 								}
@@ -610,7 +655,7 @@
 						{
 							"type": "entries",
 							"name": "Gladiator",
-							"page": 13,
+							"page": 6,
 							"entries": [
 								"You are as much of an entertainer as you are a fighter. Often masters of exotic weapons and fighting styles, gladiators seek to build their reputation as wondrously extravagant warriors.",
 								{
@@ -626,15 +671,15 @@
 										],
 										[
 											"Fighting Style:",
-											"{@optfeature Dual Wielding|LLAF}, {@optfeature Featherweight Fighting|LLAF}"
+											"{@optfeature Dual Wielding|LLAF}, {@optfeature Pit Fighting|LLAF:E}"
 										],
 										[
 											"Exploits:",
-											"{@optfeature Concussive Blow|LLAF}, {@optfeature Disarm|LLAF}, {@optfeature Menacing Cry|LLAF}, {@optfeature Ruthless Strike|LLAF}, {@optfeature Taunt|LLAF}"
+											"{@optfeature Disarm|LLAF}, {@optfeature Feat of Strength|LLAF}, {@optfeature Menacing Shout|LLAF}, {@optfeature Sweeping Strike|LLAF}, {@optfeature Warrior's Challenge|LLAF}"
 										],
 										[
 											"Feats:",
-											"{@feat Dual Wielder}, {@feat Great Weapon Master}"
+											"{@feat Dual Wielder}, {@feat Signature Technique|LLAF:E}"
 										]
 									]
 								}
@@ -643,7 +688,7 @@
 						{
 							"type": "entries",
 							"name": "Knight",
-							"page": 13,
+							"page": 6,
 							"entries": [
 								"The classical knight seeks to embody the virtues of chivalry, both on and off the battlefield. They are noble warriors who support their allies and are able to navigate high society.",
 								{
@@ -663,7 +708,7 @@
 										],
 										[
 											"Exploits:",
-											"{@optfeature Brace Up|LLAF}, {@optfeature First Aid|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Warlord's Presence|LLAF}, {@optfeature Warrior's Willpower|LLAF}"
+											"{@optfeature Brace Up|LLAF}, {@optfeature First Aid|LLAF}, {@optfeature Scholar's Insight|LLAF}, {@optfeature Skilled Rider|LLAF}, {@optfeature Heroic Will|LLAF}"
 										],
 										[
 											"Feats:",
@@ -675,8 +720,107 @@
 						},
 						{
 							"type": "entries",
+							"name": "Marine",
+							"page": 6,
+							"entries": [
+								"Marines are warriors who are trained to fight at sea or on the decks of ships. They can be elite sailors who defend precious cargo, or ruthless pirates who pillage all they come across.",
+								{
+									"type": "table",
+									"colStyles": [
+										"col-3",
+										"col-9"
+									],
+									"rows": [
+										[
+											"Archetype:",
+											"{@class Alternate Fighter|LLAF|Guerrilla|Guerrilla|LLAF:E}"
+										],
+										[
+											"Fighting Style:",
+											"{@optfeature Featherweight Fighting|LLAF}, {@optfeature Mariner|LLAF:E}"
+										],
+										[
+											"Exploits:",
+											"{@optfeature Dirty Hit|LLAF}, {@optfeature Feat of Strength|LLAF}, {@optfeature Lightstep|LLAF}, {@optfeature Navigator's Know-How|LLAF:E}, {@optfeature Improvised Skill|LLAF:E}"
+										],
+										[
+											"Feats:",
+											"{@feat Keen Mind}, {@feat Linguist}, {@feat Resilient|PHB|Resilient (Dexterity)}"
+										]
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Medic",
+							"page": 6,
+							"entries": [
+								"Medics are masters of keeping their allies in top condition, assuaging their hurts, and keeping spirits high in battle.",
+								{
+									"type": "table",
+									"colStyles": [
+										"col-3",
+										"col-9"
+									],
+									"rows": [
+										[
+											"Archetype:",
+											"{@class Alternate Fighter|LLAF|Quartermaster|Quartermaster|LLAF:E}"
+										],
+										[
+											"Fighting Style:",
+											"{@optfeature Defensive Fighting|LLAF}, {@optfeature Improvised Fighting|LLAF}"
+										],
+										[
+											"Exploits:",
+											"{@optfeature Brace Up|LLAF}, {@optfeature Feat of Strength|LLAF}, {@optfeature First Aid|LLAF}, {@optfeature Take Down|LLAF:E}, {@optfeature Redirect|LLAF}, {@optfeature Shield Impact|LLAF}"
+										],
+										[
+											"Feats:",
+											"{@feat Chef|TCE}, {@feat Healer}, {@feat Inspiring Leader}"
+										]
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Mystic",
+							"page": 6,
+							"entries": [
+								"Mystics are wandering guardians of peace and prosperity that are raised from birth to wield their psionic potential in battle. Mystics are pacifists who only use violence as a last resort.",
+								{
+									"type": "table",
+									"colStyles": [
+										"col-3",
+										"col-9"
+									],
+									"rows": [
+										[
+											"Archetype:",
+											"{@class Alternate Fighter|LLAF|Mystic Warrior|Mystic Warrior|LLAF:E}"
+										],
+										[
+											"Fighting Style:",
+											"{@optfeature Blind Fighting|TCE}, {@optfeature Versatile Fighting|LLAF}"
+										],
+										[
+											"Exploits:",
+											"{@optfeature Aristocratic Education|LLAF:E}, {@optfeature Defensive Stance|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Heroic Will|LLAF}, {@optfeature Zephyr Slash|LLAF:E}"
+										],
+										[
+											"Feats:",
+											"{@feat Alert}, {@feat Resilient|PHB|Resilient (Wisdom)}, {@feat Sentinel}"
+										]
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
 							"name": "Peacekeeper",
-							"page": 13,
+							"page": 6,
 							"entries": [
 								"Often found patrolling remote territories and other lawless lands, peacekeepers use their finely honed skills and deadly accuracy with firearms to enforce the law wherever they go.",
 								{
@@ -696,11 +840,11 @@
 										],
 										[
 											"Exploits:",
-											"{@optfeature Marksman's Gaze|LLAF}, {@optfeature Blinding Shot|LLAF}, {@optfeature Dirty Hit|LLAF}, {@optfeature Piercing Shot|LLAF}, {@optfeature Precision Shot|LLAF}"
+											"{@optfeature Blinding Shot|LLAF:E}, {@optfeature Crippling Shot|LLAF:E}, {@optfeature Martial Focus|LLAF}, {@optfeature Take Down|LLAF:E}, {@optfeature Trick Shot|LLAF:E}"
 										],
 										[
 											"Feats:",
-											"{@feat Alert}, {@feat Gunner|TCE}, {@feat Sharpshooter}"
+											"{@feat Alert}, {@feat Gunner|TCE}, {@feat Piercer|TCE}, {@feat Sharpshooter}"
 										]
 									]
 								}
@@ -709,7 +853,7 @@
 						{
 							"type": "entries",
 							"name": "Pugilist",
-							"page": 13,
+							"page": 6,
 							"entries": [
 								"You have honed your body into a deadly weapon. While other unarmed warriors rely on their speed to strike, you use your raw power to rain devastating blows down on your foes.",
 								{
@@ -725,150 +869,40 @@
 										],
 										[
 											"Fighting Style:",
-											"{@optfeature Unarmed Fighting|TCE}*, {@optfeature Wrestler|LLAF}"
+											"{@optfeature Unarmed Fighting|LLAF}, {@optfeature Wrestler|LLAF:E}"
 										],
 										[
 											"Exploits:",
-											"{@optfeature Concussive Blow|LLAF}, {@optfeature Brace Up|LLAF}, {@optfeature Dirty Hit|LLAF}, {@optfeature Menacing Cry|LLAF}, {@optfeature Riposte|LLAF}, {@optfeature Take Down|LLAF}, {@optfeature Taunt|LLAF}"
+											"{@optfeature Brace Up|LLAF}, {@optfeature Disarm|LLAF}, {@optfeature Hurl|LLAF}, {@optfeature Feint|LLAF}, {@optfeature Mighty Thrust|LLAF}, {@optfeature Thunderous Blow|LLAF:E}"
 										],
 										[
 											"Feats:",
-											"{@feat Crusher|TCE}, {@feat Durable}, {@feat Tavern Brawler}, {@optfeature Tough}"
+											"{@feat Crusher|TCE}, {@feat Durable}, {@feat Tavern Brawler}, {@feat Tough}"
 										]
 									]
 								}
 							]
-						},
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Warrior Archetypes",
+					"page": 7,
+					"entries": [
+						"Choose one of the following Warrior Archetypes that best represents the skill set and training of your fighter: Crusader, Guardian, Guerrilla, Master of Hounds, Mystic Warrior, Quartermaster, Swordsage, Tinker Knight, or Witch Knight.",
 						{
-							"type": "entries",
-							"name": "Shock Trooper",
-							"page": 13,
-							"entries": [
-								"You will lead a charge into fortified enemy lines or stand strong against terrifying monsters. You attack with abandon looking to slay your foes with deadly speed and power.",
-								{
-									"type": "table",
-									"colStyles": [
-										"col-3",
-										"col-9"
-									],
-									"rows": [
-										[
-											"Archetype:",
-											"{@class Alternate Fighter|LLAF|Champion|Champion|LLAF}"
-										],
-										[
-											"Fighting Style:",
-											"{@optfeature Great Weapon Fighting|LLAF}, {@optfeature Dueling|LLAF}"
-										],
-										[
-											"Exploits:",
-											"{@optfeature Crippling Strike|LLAF}, {@optfeature Menacing Cry|LLAF}, {@optfeature Mighty Leap|LLAF}, {@optfeature Reckless Strike|LLAF}, {@optfeature Ruthless Strike|LLAF}"
-										],
-										[
-											"Feats:",
-											"{@feat Charger}, {@feat Great Weapon Master}, {@optfeature Tough}"
-										]
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Sniper",
-							"page": 13,
-							"entries": [
-								"You are a master of ranged combat and prefer to strike from afar. Known for your ability with longbows and crossbows, you strike your foes down before they know of your presence.",
-								{
-									"type": "table",
-									"colStyles": [
-										"col-3",
-										"col-9"
-									],
-									"rows": [
-										[
-											"Archetype:",
-											"{@class Alternate Fighter|LLAF|Marksman|Marksman|LLAF}"
-										],
-										[
-											"Fighting Style:",
-											"{@optfeature Archery|LLAF}, {@optfeature Melee Marksman|LLAF}"
-										],
-										[
-											"Exploits:",
-											"{@optfeature Lightstep|LLAF}, {@optfeature Piercing Shot|LLAF}, {@optfeature Precision Shot|LLAF}, {@optfeature Survivalist's Cunning|LLAF}, {@optfeature Volley|LLAF}"
-										],
-										[
-											"Feats:",
-											"{@feat Alert}, {@feat Crossbow Expert}, {@optfeature Sharpshooter}"
-										]
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Spellsword",
-							"page": 13,
-							"entries": [
-								"Spellswords are the elite warriors of archmages and other powerful spellcasters. They are trained to wield evocation magic to deadly effect, eliminating the foes of their master.",
-								{
-									"type": "table",
-									"colStyles": [
-										"col-3",
-										"col-9"
-									],
-									"rows": [
-										[
-											"Archetype:",
-											"{@class Alternate Fighter|LLAF|Arcane Knight|Arcane Knight|LLAF}"
-										],
-										[
-											"Fighting Style:",
-											"{@optfeature Great Weapon Fighting|LLAF}, {@optfeature Versatile Fighting|LLAF}"
-										],
-										[
-											"Exploits:",
-											"{@optfeature Arcane Smite|LLAF}, {@optfeature Disorienting Blow|LLAF}, {@optfeature Martial Focus|LLAF}, {@optfeature Spellguard|LLAF}, {@optfeature Suppressing Strike|LLAF}"
-										],
-										[
-											"Feats:",
-											"{@feat Elemental Adept}, {@feat Mage Slayer}, {@optfeature War Caster}"
-										]
-									]
-								}
-							]
-						},
-						{
-							"type": "entries",
-							"name": "Warlord",
-							"page": 13,
-							"entries": [
-								"Warlords are master tacticians who guide their allies with their shrewd insight, both on and off the battlefield. While other warriors wield swords, warlord's wield other fighters.",
-								{
-									"type": "table",
-									"colStyles": [
-										"col-3",
-										"col-9"
-									],
-									"rows": [
-										[
-											"Archetype:",
-											"{@class Alternate Fighter|LLAF|Commander|Commander|LLAF}"
-										],
-										[
-											"Fighting Style:",
-											"{@optfeature Classical Swordplay|LLAF}, {@optfeature Defensive Fighting|LLAF}"
-										],
-										[
-											"Exploits:",
-											"{@optfeature Commander's Insight|LLAF}, {@optfeature Disarm|LLAF}, {@optfeature First Aid|LLAF}, {@optfeature Maneuvering Command|LLAF}, {@optfeature Weakening Blow|LLAF}"
-										],
-										[
-											"Feats:",
-											"{@feat Inspiring Leader}, {@feat Keen Mind}, {@optfeature Linguist}"
-										]
-									]
-								}
+							"type": "list",
+							"columns": 3,
+							"items": [
+								"{@class Alternate Fighter|LLAF|Crusader|Crusader|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Guardian|Guardian|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Guerrilla|Guerrilla|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Master of Hounds|Master of Hounds|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Mystic Warrior|Mystic Warrior|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Quartermaster|Quartermaster|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Tinker Knight|Tinker Knight|LLAF:E}",
+								"{@class Alternate Fighter|LLAF|Witch Knight|Witch Knight|LLAF:E}"
 							]
 						}
 					]
@@ -1016,7 +1050,7 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 4
+										"faces": 6
 									}
 								]
 							},
@@ -1029,7 +1063,7 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 4
+										"faces": 6
 									}
 								]
 							},
@@ -1037,19 +1071,6 @@
 						],
 						[
 							3,
-							{
-								"type": "dice",
-								"toRoll": [
-									{
-										"number": 1,
-										"faces": 4
-									}
-								]
-							},
-							3
-						],
-						[
-							4,
 							{
 								"type": "dice",
 								"toRoll": [
@@ -1068,7 +1089,20 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 6
+										"faces": 8
+									}
+								]
+							},
+							3
+						],
+						[
+							4,
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 1,
+										"faces": 8
 									}
 								]
 							},
@@ -1081,7 +1115,7 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 6
+										"faces": 8
 									}
 								]
 							},
@@ -1094,7 +1128,7 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 6
+										"faces": 8
 									}
 								]
 							},
@@ -1133,7 +1167,7 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 8
+										"faces": 10
 									}
 								]
 							},
@@ -1146,7 +1180,7 @@
 								"toRoll": [
 									{
 										"number": 1,
-										"faces": 8
+										"faces": 10
 									}
 								]
 							},
@@ -1306,19 +1340,19 @@
 				{
 					"source": "LLAF",
 					"type": "section",
-					"name": "Alternate Fighter",
+					"name": "The Fighter",
 					"page": 1,
 					"entries": [
-						"The young guard quietly slipped past his comrades out the back door of the armory where the townsfolk were hiding. A bandit gang had come upon the town suddenly that morning, and their captain had issued a challenge. If a warrior from the town could best him in single combat, his gang of bandits would leave peacefully. Even though the young man had only joined the town guard one season ago, he could already best every other guard with the sword. To the surprise of the townsfolk, he drew his sword, muttered a prayer, and stepped forward to defend his home.",
-						"A graying dwarf surveyed the enemy camp as the sun began to set. Along with three of her best soldiers, she had come to the edge of the enemy camp with the intent to rout the army or die in the attempt. In a fully pitched battle, the small band of dwarves she commanded wouldn't stand a chance against this great host. However, if her group of elite soldiers followed her orders to the letter, they had a chance to cut off the head of the army before it came to all out battle. For what could be her final mission, she gripped the haft of her battleaxe and gave the order to move out.",
-						"The flamboyant elven gladiator paused for a moment, basking in the roar of the crowd. He remembered his first gladiatorial match in the underground arena, surrounded by drunken pirates and slavers. Now he performed for the king and queen amidst the bustle of the largest city in the kingdom. The time to savor this moment was over, and in a flash, he wheeled around and plunged his gilded spear into the heart of his opponent, ending what would be the final fight of his gladiatorial career and earning his freedom.",
+						"The young guard quietly slipped past his comrades out the back door of the armory where the townsfolk were hiding. A bandit gang had come upon their village suddenly that morning, and their leader had issued a challenge. If a warrior from the town could best him in single combat, his gang of bandits would leave peacefully. Even though the young human had only joined the town guard one season ago, he could already best every other guard with the sword. To the surprise of the townsfolk, he drew his sword, muttered a prayer, and stepped forward to defend his home.",
+						"A graying dwarf surveyed the enemy camp as the sun began to set. Along with three of her best soldiers, she had made her way to the enemy general's tent with the intent to rout the army or die in the attempt. In a fully pitched battle, the small band of dwarves under her command wouldn't stand a chance against this great host. However, if her group of elite soldiers followed her orders to the letter, they had a chance to cut off the head of the army before it came to battle. For what could be her final mission, she gripped her battleaxe and gave the order to move out.",
+						"The flamboyant elven gladiator paused for a brief moment, basking in the cheers of the crowd. He remembered his first gladiatorial match in the underground arena, surrounded by drunken pirates and slavers. Now he performed for the king and queen amidst the bustle of the largest metropolis in the kingdom. After savoring the moment, he whirled about and plunged his gilded spear into his opponent's heart, ending what would be his final fight and earning him his freedom.",
 						{
 							"type": "entries",
 							"name": "Masters of the Battlefield",
 							"page": 1,
 							"entries": [
-								"Not every city guard, militia member, or professional soldier is considered to be a true fighter. Born with an innate talent with the armaments of war, and a keen battle instinct, a true fighter cannot resist the call of battle and adventure. Often coming from the ranks of elite officers, trained bodyguards, veteran mercenaries, and dedicated knights, true fighters are known for their masterful training and skill in battle.",
-								"Dungeon delving, monster slaying, and other dangerous work common among adventurers is second nature for a fighter. Something deep within them compels them to seek out conflict and throw themselves into the midst of it. Often champions of fair competition, and feats of physical might, fighters make for loyal companions and deadly foes."
+								"Not every city guardsman, mercenary, or professional soldier is considered to be a true fighter. Born with the innate talent for war and keen battle instincts, a born fighter cannot resist the call of the battlefield. Hailing from the ranks of military officers, elite bodyguards, veteran mercenaries, and anointed knights, fighters are known for their masterful skill in battle.",
+								"Dungeon delving, monster slaying, and other dangerous work common amongst adventurers is second nature for a fighter. Something deep within them compels them to seek out conflict and throw themselves into the midst of it. Often champions of fair competition, fighters make for loyal allies."
 							]
 						},
 						{
@@ -1327,7 +1361,7 @@
 							"page": 1,
 							"entries": [
 								"Every fighter can swing an axe, fence with a rapier, cut down a foe with a longsword, and use a bow with a high degree of skill. Likewise, a fighter is adept with shields and every form of armor. Fighters wield their weapons and armor of choice as an extension of their very self, transforming into beautiful yet deadly whirls of sharpened steel on the battlefield.",
-								"While they all have skill in battle, the nature of a fighter's training can greatly vary. Some cultivate immense physical might, crushing their foes with overwhelming blows. Some prefer to strike from afar, slaying their enemies before they are aware of their presence. Others use their knowledge of tactics to coordinate their allies. A rare few augment their martial abilities with limited, but potent, arcane spells."
+								"While they all have skill in battle, the nature of a fighter's training can greatly vary. Some cultivate immense physical might, crushing their foes with overwhelming blows. Some prefer to strike from afar, slaying their enemies before they are aware of their presence. Others use tactical insights to coordinate their allies. And a rare few augment their martial abilities with limited, but potent, arcane spells."
 							]
 						},
 						{
@@ -1335,7 +1369,43 @@
 							"name": "Creating Your Fighter",
 							"page": 1,
 							"entries": [
-								"As you build your fighter, think about two related elements of your character's background: Where did you get your combat training, and what sets you apart from the mundane warriors around you? Were you particularly ruthless? Did you get extra help from a mentor, perhaps because of your exceptional dedication? What drove you to this training in the first place? A threat to your homeland, a thirst for revenge, or a need to prove yourself might all have been factors."
+								"When creating a fighter, the most important thing to consider is where they gained their skill with the armaments of war. Are you the scion of a noble house, trained from birth by the best warriors in your family's employ? Are you a gladiator who fought for sport, forced to learn to fight or perish? Did you come from nothing and earn food, shelter, and coin at the tip of your sword as a member of a mercenary company?",
+                                "Also, consider your fighter's style of combat and how the way you fight sets you apart from other warriors. Are you a artist with your weapons, gracefully flowing about the field of battle? Are you especially ruthless, reveling in the chaos and carnage of war? Or, do you fight with honor and respect, only challenging those that you deem your equal with the sword?",
+                                {
+                                    "type": "inset",
+                                    "name": "Multiclassing and the Fighter",
+                                    "entries": [
+                                        "If your group uses the optional multiclassing rule, here's what you need to know if you choose to take your first level in the fighter class.",
+                                        {
+                                            "type": "entries",
+                                            "name": "Ability Score Minimum",
+                                            "entries": [
+                                                "As a multiclass character, you must have at least a Strength (or Dexterity) score of 13 to take a level in this class, or to take a level in another class if you are already a fighter."
+                                            ]
+                                        },
+                                        {
+                                            "type": "entries",
+                                            "name": "Proficiencies",
+                                            "entries": [
+                                                "If fighter isn't your initial class, here are the proficiencies you gain when you take your first level as a fighter: light armor, medium armor, shields, simple weapons and martial weapons."
+                                            ]
+                                        },
+                                        {
+                                            "type": "entries",
+                                            "name": "Exploits",
+                                            "entries": [
+                                                "If you have another feature that allows you to learn and perform Exploits, add all of your Exploit Dice together into one pool, and they all become the size of your largest Exploit Die. You can then use any of these Exploit Dice to perform any Exploits you know from either source."
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    "type": "entries",
+                                    "name": "Quick Build",
+                                    "entries": [
+                                        "You can make a fighter quickly by using these suggestions. First, depending on the weapons you wish to use, make your Strength (heavy or melee weapons) or your Dexterity (ranged weapons or dual wielding) your highest ability score, followed by Constitution. Second, choose the {@background soldier|phb} background."
+                                    ]
+                                }
 							]
 						}
 					]
@@ -1356,7 +1426,7 @@
 				"booming blade|tce",
 				"chill touch",
 				"control flames|xge",
-				"firebolt",
+				"fire bolt",
 				"green-flame blade|tce",
 				"gust|xge",
 				"light",
@@ -1369,8 +1439,9 @@
 				"thunderclap|xge",
 				"true strike",
 				"absorb elements|xge",
-				"armor of Agathys",
+				"armor of agathys",
 				"burning hands",
+                "catapult|xge",
 				"chromatic orb",
 				"compelled duel",
 				"earth tremor|xge",
@@ -1383,12 +1454,13 @@
 				"shield",
 				"thunderous smite",
 				"thunderwave",
-				"aganazzar's scorcher",
+				"aganazzar's scorcher|xge",
 				"branding smite",
 				"darkness",
 				"flame blade",
 				"gust of wind",
 				"magic weapon",
+                "misty step",
 				"protection from poison",
 				"scorching ray",
 				"shatter",
@@ -1409,7 +1481,7 @@
 				"fire shield",
 				"freedom of movement",
 				"ice storm",
-				"Otiluke's resilient sphere",
+				"otiluke's resilient sphere",
 				"staggering smite",
 				"storm sphere|xge"
 			],
@@ -1442,34 +1514,34 @@
 				0,
 				3,
 				4,
-				4,
-				4,
+				5,
 				5,
 				6,
 				6,
 				7,
+				7,
 				8,
 				8,
+				9,
 				9,
 				10,
 				10,
 				11,
 				11,
-				11,
 				12,
-				13
+				12
 			],
 			"subclassTableGroups": [
 				{
 					"subclasses": [
 						{
 							"name": "Arcane Knight",
-							"source": "AltF"
+							"source": "LLAF"
 						}
 					],
 					"colLabels": [
-						"{@filter Cantrips Known|spells|level=0|subclass=Alternate Fighter: Arcane Knight (AltF)}",
-						"{@filter Spells Known|spells|subclass=Alternate Fighter: Arcane Knight (AltF)}"
+						"{@filter Cantrips Known|spells|level=0|subclass=Alternate Fighter: Arcane Knight (LLAF)}",
+						"{@filter Spells Known|spells|subclass=Alternate Fighter: Arcane Knight (LLAF)}"
 					],
 					"rows": [
 						[
@@ -1490,11 +1562,7 @@
 						],
 						[
 							2,
-							4
-						],
-						[
-							2,
-							4
+							5
 						],
 						[
 							2,
@@ -1509,6 +1577,10 @@
 							6
 						],
 						[
+							2,
+							7
+						],
+						[
 							3,
 							7
 						],
@@ -1519,6 +1591,10 @@
 						[
 							3,
 							8
+						],
+						[
+							3,
+							9
 						],
 						[
 							3,
@@ -1542,15 +1618,11 @@
 						],
 						[
 							3,
-							11
-						],
-						[
-							3,
 							12
 						],
 						[
 							3,
-							13
+							12
 						]
 					]
 				},
@@ -1710,8 +1782,10 @@
 			"subclassFeatures": [
 				"Champion|Alternate Fighter|LLAF|Champion|LLAF|3",
 				"Remarkable Athlete|Alternate Fighter|LLAF|Champion|LLAF|7",
-				"Additional Fighting Style|Alternate Fighter|LLAF|Champion|LLAF|10",
-				"Paragon of Might|Alternate Fighter|LLAF|Champion|LLAF|15",
+				"Brutal Critical|Alternate Fighter|LLAF|Champion|LLAF|10",
+				"Mighty Warrior Improvement|Alternate Fighter|LLAF|Champion|LLAF|15",
+				"Remarkable Athlete Improvement|Alternate Fighter|LLAF|Champion|LLAF|15",
+				"Brutal Critical Improvement|Alternate Fighter|LLAF|Champion|LLAF|15",
 				"Legendary Champion|Alternate Fighter|LLAF|Champion|LLAF|18"
 			]
 		},
@@ -1755,10 +1829,109 @@
 			"subclassFeatures": [
 				"Master at Arms|Alternate Fighter|LLAF|Master at Arms|LLAF|3",
 				"Consistent Skill|Alternate Fighter|LLAF|Master at Arms|LLAF|7",
-				"Advanced Technique|Alternate Fighter|LLAF|Master at Arms|LLAF|7",
+				"Master of Forms|Alternate Fighter|LLAF|Master at Arms|LLAF|7",
+				"Fluid Stances (2)|Alternate Fighter|LLAF|Master at Arms|LLAF|7",
 				"Masterful Surge|Alternate Fighter|LLAF|Master at Arms|LLAF|10",
-				"Superior Technique|Alternate Fighter|LLAF|Master at Arms|LLAF|15",
+				"Fluid Stances (3)|Alternate Fighter|LLAF|Master at Arms|LLAF|15",
+				"Master of Forms (2)|Alternate Fighter|LLAF|Master at Arms|LLAF|15",
+				"Master of Forms (3)|Alternate Fighter|LLAF|Master at Arms|LLAF|18",
 				"Warrior of Legend|Alternate Fighter|LLAF|Master at Arms|LLAF|18"
+			]
+		},
+		{
+			"name": "Alternate Arcane Archer",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 14,
+			"shortName": "Arcane Archer",
+			"subclassFeatures": [
+				"Arcane Archer|Alternate Fighter|LLAF|Arcane Archer|LLAF|3",
+				"Magic Ammunition|Alternate Fighter|LLAF|Arcane Archer|LLAF|7",
+				"Curving Shot|Alternate Fighter|LLAF|Arcane Archer|LLAF|7",
+				"Additional Arcane Shot Option|Fighter|PHB|Arcane Archer|XGE|7",
+				"Additional Arcane Shot Option|Fighter|PHB|Arcane Archer|XGE|10",
+				"Ever-Ready Shot|Fighter|PHB|Arcane Archer|XGE|15",
+				"Additional Arcane Shot Option|Fighter|PHB|Arcane Archer|XGE|15",
+				"Additional Arcane Shot Option|Fighter|PHB|Arcane Archer|XGE|18"
+			]
+		},
+		{
+			"name": "Alternate Cavalier",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 14,
+			"shortName": "Cavalier",
+			"subclassFeatures": [
+				"Cavalier|Alternate Fighter|LLAF|Cavalier|LLAF|3",
+				"Warding Maneuver|Alternate Fighter|LLAF|Cavalier|LLAF|7",
+				"Hold the Line|Fighter|PHB|Cavalier|XGE|10",
+				"Ferocious Charger|Alternate Fighter|LLAF|Cavalier|LLAF|15",
+				"Vigilant Defender|Fighter|PHB|Cavalier|XGE|18"
+			]
+		},
+		{
+			"name": "Alternate Samurai",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 15,
+			"shortName": "Samurai",
+			"subclassFeatures": [
+				"Samurai|Alternate Fighter|LLAF|Samurai|LLAF|3",
+				"Elegant Courtier|Fighter|PHB|Samurai|XGE|7",
+				"Tireless Spirit|Fighter|PHB|Samurai|XGE|10",
+				"Rapid Strike|Fighter|PHB|Samurai|XGE|15",
+				"Strength before Death|Fighter|PHB|Samurai|XGE|18"
+			]
+		},
+		{
+			"name": "Alternate Echo Knight",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 15,
+			"shortName": "Echo Knight",
+			"subclassFeatures": [
+				"Echo Knight|Alternate Fighter|LLAF|Echo Knight|LLAF|3",
+				"Echo Avatar|Fighter|PHB|Echo Knight|EGW|7",
+				"Shadow Martyr|Fighter|PHB|Echo Knight|EGW|10",
+				"Reclaim Potential|Alternate Fighter|LLAF|Echo Knight|LLAF|15",
+				"Legion of One|Fighter|PHB|Echo Knight|EGW|18"
+			]
+		},
+		{
+			"name": "Alternate Rune Knight",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 15,
+			"shortName": "Rune Knight",
+			"subclassFeatures": [
+				"Rune Knight|Alternate Fighter|LLAF|Rune Knight|LLAF|3",
+				"Runic Shield|Fighter|PHB|Rune Knight|TCE|7",
+				"Additional Rune Known|Fighter|PHB|Rune Knight|TCE|7",
+				"Great Stature|Fighter|PHB|Rune Knight|TCE|10",
+				"Additional Rune Known|Fighter|PHB|Rune Knight|TCE|10",
+				"Master of Runes|Fighter|PHB|Rune Knight|TCE|15",
+				"Additional Rune Known|Fighter|PHB|Rune Knight|TCE|15",
+				"Runic Juggernaut|Fighter|PHB|Rune Knight|TCE|18"
+			]
+		},
+		{
+			"name": "Crusader",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 7,
+			"shortName": "Crusader",
+			"subclassFeatures": [
+				"Crusader|Alternate Fighter|LLAF|Crusader|LLAF:E|3",
+				"Renewed Fervor|Alternate Fighter|LLAF|Crusader|LLAF:E|7",
+				"Zealous Fury|Alternate Fighter|LLAF|Crusader|LLAF:E|10",
+				"Righteous Judgment|Alternate Fighter|LLAF|Crusader|LLAF:E|15",
+				"Legendary Crusader|Alternate Fighter|LLAF|Crusader|LLAF:E|18"
 			]
 		},
 		{
@@ -1766,7 +1939,7 @@
 			"source": "LLAF:E",
 			"className": "Alternate Fighter",
 			"classSource": "LLAF",
-			"page": 4,
+			"page": 8,
 			"shortName": "Guardian",
 			"subclassFeatures": [
 				"Guardian|Alternate Fighter|LLAF|Guardian|LLAF:E|3",
@@ -1777,27 +1950,219 @@
 			]
 		},
 		{
-			"name": "Guerilla",
+			"name": "Guerrilla",
 			"source": "LLAF:E",
 			"className": "Alternate Fighter",
 			"classSource": "LLAF",
-			"page": 5,
-			"shortName": "Guerilla",
+			"page": 9,
+			"shortName": "Guerrilla",
 			"subclassFeatures": [
-				"Guerilla|Alternate Fighter|LLAF|Guerilla|LLAF:E|3",
-				"By Land or Sea|Alternate Fighter|LLAF|Guerilla|LLAF:E|7",
-				"Adaptable Fighting Style|Alternate Fighter|LLAF|Guerilla|LLAF:E|10",
-				"Unwavering|Alternate Fighter|LLAF|Guerilla|LLAF:E|15",
-				"Legendary Guerilla|Alternate Fighter|LLAF|Guerilla|LLAF:E|18"
+				"Guerrilla|Alternate Fighter|LLAF|Guerrilla|LLAF:E|3",
+				"By Land or Sea|Alternate Fighter|LLAF|Guerrilla|LLAF:E|7",
+				"Adaptable Fighting Style|Alternate Fighter|LLAF|Guerrilla|LLAF:E|10",
+				"Unwavering|Alternate Fighter|LLAF|Guerrilla|LLAF:E|15",
+				"Legendary Guerrilla|Alternate Fighter|LLAF|Guerrilla|LLAF:E|18"
 			]
 		},
 		{
-			"name": "Pact Warrior",
+			"name": "Master of Hounds",
 			"source": "LLAF:E",
 			"className": "Alternate Fighter",
 			"classSource": "LLAF",
-			"page": 6,
-			"shortName": "Pact Warrior",
+			"page": 9,
+			"shortName": "Master of Hounds",
+			"subclassFeatures": [
+				"Master of Hounds|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|3",
+				"Iron Jaws|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|7",
+				"Steadfast Companion|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|10",
+				"Canine Fury|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|15",
+				"Hound of Legend|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|18"
+			]
+		},
+		{
+			"name": "Mystic Warrior",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 11,
+			"shortName": "Mystic Warrior",
+			"subclassTableGroups": [
+				{
+					"subclasses": [
+						{
+							"name": "Mystic Warrior",
+							"source": "LLAF:E"
+						}
+					],
+					"colLabels": [
+						"Spells Known",
+						"Psi Points",
+						"Mental Limit"
+					],
+					"rows": [
+						[
+							0,
+							0,
+							0
+						],
+						[
+							0,
+							0,
+							0
+						],
+						[
+							2,
+							2,
+							"1st"
+						],
+						[
+							2,
+							3,
+							"1st"
+						],
+						[
+							3,
+							3,
+							"1st"
+						],
+						[
+							3,
+							4,
+							"1st"
+						],
+						[
+							4,
+							4,
+							"2nd"
+						],
+						[
+							4,
+							5,
+							"2nd"
+						],
+						[
+							5,
+							5,
+							"2nd"
+						],
+						[
+							5,
+							6,
+							"2nd"
+						],
+						[
+							5,
+							6,
+							"2nd"
+						],
+						[
+							5,
+							7,
+							"2nd"
+						],
+						[
+							6,
+							7,
+							"3rd"
+						],
+						[
+							6,
+							8,
+							"3rd"
+						],
+						[
+							6,
+							8,
+							"3rd"
+						],
+						[
+							6,
+							9,
+							"3rd"
+						],
+						[
+							7,
+							9,
+							"3rd"
+						],
+						[
+							7,
+							10,
+							"3rd"
+						],
+						[
+							7,
+							10,
+							"4th"
+						],
+						[
+							7,
+							11,
+							"4th"
+						]
+					]
+				}
+			],
+			"subclassFeatures": [
+				"Mystic Warrior|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|3",
+				"Phase Step|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|7",
+				"Inscrutable Mind|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|10",
+				"Greater Telekinesis|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|15",
+				"Legendary Mystic|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|18"
+			]
+		},
+		{
+			"name": "Quartermaster",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 12,
+			"shortName": "Quartermaster",
+			"subclassFeatures": [
+				"Quartermaster|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3",
+				"Dependable|Alternate Fighter|LLAF|Quartermaster|LLAF:E|7",
+				"Improved Rations|Alternate Fighter|LLAF|Quartermaster|LLAF:E|10",
+				"Ever Ready|Alternate Fighter|LLAF|Quartermaster|LLAF:E|15",
+				"Iron Stomach|Alternate Fighter|LLAF|Quartermaster|LLAF:E|18"
+			]
+		},
+		{
+			"name": "Swordsage",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 14,
+			"shortName": "Swordsage",
+			"subclassFeatures": [
+				"Swordsage|Alternate Fighter|LLAF|Swordsage|LLAF:E|3",
+				"Heightened Reflexes|Alternate Fighter|LLAF|Swordsage|LLAF:E|7",
+				"Improved Battle Trance|Alternate Fighter|LLAF|Swordsage|LLAF:E|10",
+				"Legendary Swordsage (d6)|Alternate Fighter|LLAF|Swordsage|LLAF:E|15",
+				"Legendary Swordsage (d8)|Alternate Fighter|LLAF|Swordsage|LLAF:E|18"
+			]
+		},
+		{
+			"name": "Tinker Knight",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 14,
+			"shortName": "Tinker Knight",
+			"subclassFeatures": [
+				"Tinker Knight|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|3",
+				"Tinker's Expertise|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|7",
+				"Mechanical Synergy|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|10",
+				"Flexible Innovation|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|15",
+				"Masterwork Inventions|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|18"
+			]
+		},
+		{
+			"name": "Witch Knight",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"page": 16,
+			"shortName": "Witch Knight",
 			"spellcastingAbility": "cha",
 			"subclassSpells": [
 				{
@@ -1853,7 +2218,7 @@
 				{
 					"subclasses": [
 						{
-							"name": "Pact Warrior",
+							"name": "Witch Knight",
 							"source": "LLAF:E"
 						}
 					],
@@ -1880,166 +2245,119 @@
 							1,
 							2,
 							1,
-							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							1,
 							2,
 							2,
-							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
-						],
-						[
-							1,
-							3,
-							2,
-							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							1,
 							3,
 							2,
-							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
+						],
+						[
+							1,
+							3,
+							2,
+							"{@filter 1st|spells|level=1|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							1,
 							4,
 							2,
-							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							1,
 							4,
 							2,
-							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							1,
 							5,
 							2,
-							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							5,
 							2,
-							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							5,
 							2,
-							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							5,
 							2,
-							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 2nd|spells|level=2|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							6,
 							2,
-							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							6,
 							2,
-							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							6,
 							2,
-							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							6,
 							2,
-							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							7,
 							2,
-							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							7,
 							2,
-							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 3rd|spells|level=3|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							7,
 							2,
-							"{@filter 4th|spells|level=4|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 4th|spells|level=4|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						],
 						[
 							2,
 							7,
 							2,
-							"{@filter 4th|spells|level=4|subclass=Alternate Fighter: Pact Warrior (LLAF:E)}"
+							"{@filter 4th|spells|level=4|subclass=Alternate Fighter: Witch Knight (LLAF:E)}"
 						]
 					]
 				}
 			],
 			"subclassFeatures": [
-				"Pact Warrior|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|3",
-				"Otherworldly Step|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|7",
-				"Enchanted Strikes|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|10",
-				"Improved Sanguine Offering|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|15",
-				"Profane Sacrifice|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|18"
-			]
-		},
-		{
-			"name": "Quartermaster",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"page": 8,
-			"shortName": "Quartermaster",
-			"subclassFeatures": [
-				"Quartermaster|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3",
-				"Dependable|Alternate Fighter|LLAF|Quartermaster|LLAF:E|7",
-				"Improved Rations|Alternate Fighter|LLAF|Quartermaster|LLAF:E|10",
-				"Ever Ready|Alternate Fighter|LLAF|Quartermaster|LLAF:E|15",
-				"Iron Stomach|Alternate Fighter|LLAF|Quartermaster|LLAF:E|18"
-			]
-		},
-		{
-			"name": "Swordsage",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"page": 9,
-			"shortName": "Swordsage",
-			"subclassFeatures": [
-				"Swordsage|Alternate Fighter|LLAF|Swordsage|LLAF:E|3",
-				"Heightened Reflexes|Alternate Fighter|LLAF|Swordsage|LLAF:E|7",
-				"Additional Martial Exploit|Alternate Fighter|LLAF|Swordsage|LLAF:E|7",
-				"Improved Battle Trance|Alternate Fighter|LLAF|Swordsage|LLAF:E|10",
-				"Legendary Swordsage (d6)|Alternate Fighter|LLAF|Swordsage|LLAF:E|15",
-				"Additional Martial Exploit|Alternate Fighter|LLAF|Swordsage|LLAF:E|18",
-				"Legendary Swordsage (d8)|Alternate Fighter|LLAF|Swordsage|LLAF:E|18"
-			]
-		},
-		{
-			"name": "Tinker Knight",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"page": 9,
-			"shortName": "Tinker Knight",
-			"subclassFeatures": [
-				"Tinker Knight|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|3",
-				"Tinker's Expertise|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|7",
-				"Mechanical Synergy|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|10",
-				"Flexible Innovation|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|15",
-				"Masterwork Inventions|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|18"
+				"Witch Knight|Alternate Fighter|LLAF|Witch Knight|LLAF:E|3",
+				"Otherworldly Step|Alternate Fighter|LLAF|Witch Knight|LLAF:E|7",
+				"Enchanted Strikes|Alternate Fighter|LLAF|Witch Knight|LLAF:E|10",
+				"Improved Sanguine Offering|Alternate Fighter|LLAF|Witch Knight|LLAF:E|15",
+				"Profane Sacrifice|Alternate Fighter|LLAF|Witch Knight|LLAF:E|18"
 			]
 		}
 	],
@@ -2052,8 +2370,8 @@
 			"page": 2,
 			"level": 1,
 			"entries": [
-				"At 1st level you choose a Fighting Style that best reflects your training. You cannot select a Fighting Style more than once, even if a feature allows you to select another Fighting Style.",
-				"Whenever you gain a level in this class, you can switch yourFighting Style for another Fighting Style of your choice.",
+				"At 1st level, choose the Fighting Style from the options below that best reflect your martial training and skill with weapons. You cannot select a Fighting Style more than once, even if a feature allows you to select an additional Fighting Style.",
+				"Whenever you gain a level in this class, you can switch your Fighting Style for another Fighting Style of your choice.",
 				{
 					"type": "options",
 					"count": 1,
@@ -2061,6 +2379,10 @@
 						{
 							"type": "refOptionalfeature",
 							"optionalfeature": "Archery|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Berserkergang|LLAF:E"
 						},
 						{
 							"type": "refOptionalfeature",
@@ -2088,15 +2410,15 @@
 						},
 						{
 							"type": "refOptionalfeature",
+							"optionalfeature": "Heavyweight Fighting|LLAF:E"
+						},
+						{
+							"type": "refOptionalfeature",
 							"optionalfeature": "Improvised Fighting|LLAF"
 						},
 						{
 							"type": "refOptionalfeature",
-							"optionalfeature": "Protection|LLAF"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Marine Fighting|LLAF"
+							"optionalfeature": "Mariner|LLAF:E"
 						},
 						{
 							"type": "refOptionalfeature",
@@ -2104,19 +2426,55 @@
 						},
 						{
 							"type": "refOptionalfeature",
+							"optionalfeature": "Mountaineer|LLAF:E"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Mounted Warrior|LLAF:E"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Pit Fighting|LLAF:E"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Protection|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Shield Warrior|LLAF:E"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Standard Bearer|LLAF:E"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Strongbow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Thrown Weapon Fighting|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Unarmed Fighting|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
 							"optionalfeature": "Versatile Fighting|LLAF"
 						},
 						{
 							"type": "refOptionalfeature",
-							"optionalfeature": "Wrestler|LLAF"
+							"optionalfeature": "Wrestler|LLAF:E"
 						}
 					]
 				},
 				{
 					"type": "inset",
-					"name": "Additional Fighting Styles",
+					"name": "Alternate Rule: Style Re-Training",
 					"entries": [
-						"The Alternate Fighter class is compatible with all official Fighting Styles found in published content."
+						"Some Fighting Styles have specific uses. Consider allowing the fighters in your game to re-train their Fighting Style over a few long rests, or a single long rest if they are high level, to adjust their technique."
 					]
 				}
 			]
@@ -2130,7 +2488,7 @@
 			"level": 1,
 			"entries": [
 				"Starting at 1st level, you can use a bonus action to regain hit points equal to {@dice 1d10} + your fighter level. Once you do so, you must finish a short or long rest before you can do so again.",
-				"When you reach 14th level in this class, you can use this feature twice before you must finish a short or long rest."
+				"When you reach 14th level in this class, you can use your Second Wind feature twice between each short or long rest."
 			]
 		},
 		{
@@ -2152,14 +2510,14 @@
 			"page": 3,
 			"level": 2,
 			"entries": [
-				"At 2nd level, your dedication to training sets you apart from other warriors. This skill is represented by Marital Exploits that you can use in combination with your attacks and ability checks. They are fueled by a pool of special Exploit Dice.",
+				"At 2nd level, you have begun to master unique techniques to enhance your martial skill, both on and off the field of battle.",
 				{
 					"type": "entries",
 					"name": "Exploit Dice",
 					"page": 3,
 					"entries": [
-						"The Fighter table shows how many Exploit Dice you have to perform your Martial Exploits. To use an Exploit, you must expend one of these Dice. You regain all of your expended Exploit Dice when you finish a short or long rest.",
-						"Your Exploit Dice begin as {@dice d4}s, and increase in size as you gain levels in this class, as indicated in the Fighter table."
+						"The Fighter table shows how many Exploit Dice you have to perform the Exploits you know. To use an Exploit, you must expend one of these Dice. You can only use one Exploit per attack, ability check, or saving throw, and you regain your expended Exploit Dice when you finish a short or long rest.",
+						"Your Exploit Dice begin as {@dice d6}s, and increase in size as you gain levels in this class, as indicated in the Fighter table."
 					]
 				},
 				{
@@ -2167,8 +2525,8 @@
 					"name": "Exploits Known",
 					"page": 3,
 					"entries": [
-						"You know two Exploits of your choice from the list at the end of this class description. The Exploits Known column of the Fighter table shows when you learn more Exploits of your choice. When you gain a level, you can choose one Exploit you know and replace it with another Exploit of your choice.",
-						"{@note The list of the exploits can be found {@filter here|optionalfeatures|feature type=LLAF:ME}"
+						"You know two {@filter Exploits|optionalfeatures|feature type=LL:ME} of your choice from the list at the end of this class. The Exploits Known column of the Fighter table shows when you learn more Exploits of your choice. To learn an Exploit you must meet any prerequisites it may have, like a minimum Ability Score or a minimum fighter level.",
+						"Whenever you gain a fighter level, you can replace one of the Exploits you know with another {@filter Exploit|optionalfeatures|feature type=LL:ME} of your choice."
 					]
 				},
 				{
@@ -2197,7 +2555,7 @@
 			"page": 4,
 			"level": 3,
 			"entries": [
-				"Starting at 3rd level, you can measure the martial prowess of other creatures in comparison to your own skill. As an action, choose a creature you can see within 60 feet. You then learn if the creature is your equal, superior, or inferior in regards to one of the following attributes of your choice:",
+				"Beginning at 3rd level, you can measure the skills of others in comparison to your own. As an action, choose a creature you can see within 60 feet. You learn if it is your equal, superior, or inferior in regards to one of the following attributes:",
 				{
 					"type": "table",
 					"colStyles": [
@@ -2235,21 +2593,14 @@
 			"page": 4,
 			"level": 3,
 			"entries": [
-				"At 3rd level, choose one of the following Warrior Archetypes that best represents your skills and training: Arcane Knight, Champion, Commander, Marksman, or Master at Arms.",
+				"At 3rd level, choose one of the following Warrior Archetypes that best represents your skills and training from the list of available archetypes.",
 				"The Warrior Archetype you choose grants you features at 3rd level and again at 7th, 10th, 15th, and 18th level.",
 				{
 					"type": "entries",
 					"name": "Archetype Exploits",
 					"page": 4,
 					"entries": [
-						"Each Warrior Archetype grants access to exclusive Archetype Exploits; detailed at the end of each Archetype description. When you learn a new Exploit, you can choose to learn an Archetype Exploit, or one from the list at the end of this class."
-					]
-				},
-				{
-					"type": "inset",
-					"name": "Additional Options",
-					"entries": [
-						"Check out the Alternate Fighter: Expanded for six additional Archetypes and Exploits for the official Archetypes published after the Player's Handbook ."
+						"Each Archetype has a list of Archetype Exploits you learn at the fighter levels noted in your Archetype's description. They don't count against your total number of Exploits Known and can't be switched out for other Exploits. If you don't meet an Archetype Exploit's prerequisites, you learn it regardless."
 					]
 				}
 			]
@@ -2379,7 +2730,7 @@
 			"level": 5,
 			"entries": [
 				"Beginning at 5th level, you can attack twice, instead of once, whenever you take the {@action Attack} action on your turn.",
-				"When you reach certain levels in this class, the number of attacks you can make as part of the Attack action increases; at 11th level (3 attacks) and at 17th level (4 attacks)."
+				"When you reach certain levels in this class, the number of attacks you can make as part of your Attack action increases; at 11th level (3 attacks) and at 17th level (4 attacks)."
 			]
 		},
 		{
@@ -2412,7 +2763,8 @@
 			"page": 4,
 			"level": 6,
 			"entries": [
-				"Starting at 6th level, you can push yourself beyond mortal limits, if only for a moment. On your turn, you can take one additional action as part of that current turn. Once you use this feature, you must finish a short or long rest before you can use it again. Upon reaching 20th level, you can use this feature twice per short or long rest, but only once per turn."
+				"Starting at 6th level, you can push yourself past your limits, if only for a moment. On your turn, you can take one additional action on that current turn. Once you do so, you must finish a short or long rest before you can use this feature again.",
+				"When you reach 20th level, you can use this feature twice between each short or long rest, but only once per turn."
 			]
 		},
 		{
@@ -2434,8 +2786,8 @@
 			"page": 4,
 			"level": 9,
 			"entries": [
-				"Beginning at 9th level, when you fail a saving throw, you can choose to re-roll that saving throw, possibly turning a failure into a success. Once you turn a failure into a success, you must finish a long rest before you can use this feature again.",
-				"This feature can be used twice between long rests starting at 13th level, and three times per long rest at 17th level."
+				"Your fighting spirit allows you to grasp success from the jaws of defeat. Beginning at 9th level, when you fail a saving throw, you can choose to succeed instead. Once you use this feature you must finish a long rest before you can use it again.",
+				"At certain fighter levels you can use this feature additional times between each long rest. You can use this feature twice starting at 13th level, and three times starting at 17th level."
 			]
 		},
 		{
@@ -2468,1511 +2820,11 @@
 			"page": 4,
 			"level": 20,
 			"entries": [
-				"Your skill in battle rivals that of legendary heroes. Upon reaching 20th level in this class, when you begin your turn with none of your Exploit Dice remaining, you immediately regain one of your expended Exploit Dice."
+				"Upon reaching 20th level, your skills in combat are those of a hero of legend. When you start your turn with no Exploit Dice remaining, you immediately regain an expended Exploit Die."
 			]
 		}
 	],
 	"subclassFeature": [
-		{
-			"name": "Tinker Knight",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 3,
-			"entries": [
-				"The fighters known as Tinker Knights seek an unorthodox form of martial skill. Rather than master martial techniques they look to augment their physical ability with mechanical inventions and innovative weaponry. Though they spend most of their time theorizing, tinkering, and experimenting with new Schematics, Tinker Knights and their inventive arsenals are a force to be reckoned with on the field of battle.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Bonus Proficiencies|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Inventive Arsenal|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "inset",
-					"name": "Tinker's Knight in Your Setting",
-					"entries": [
-						"Tinker Knights are a strange type of warrior who value brains over brawn. While the descriptive text here describes metal gears and springs, they can just as easily create their wondrous inventions with rocks, crystals, bones, sticks, and scales."
-					]
-				}
-			]
-		},
-		{
-			"name": "Bonus Proficiencies",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"When you adopt this Archetype at 3rd level, you gain the skill to maintain your inventions. You gain proficiency with {@item tinker's tools|phb|tinker's} and {@item smith's tools|phb}. If you already proficient with these tools, you gain proficiency with another set of tools of your choice."
-			]
-		},
-		{
-			"name": "Inventive Arsenal",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"You have come up with a cacophony of strange modifications for weapons and armor, known as Schematics. At 3rd level, you learn two {@filter Schematics|optionalfeatures|feature type=LLAF:TKSCH} of your choice from the list at the end of this Archetype. When you gain a level, you can replace one Schematic you know with another of your choice.",
-				"As you gain levels in this class, your number of Schematics known grows; at 7th level (3), 10th level (4), and 15th level (5).",
-				"At the end of each a long rest, you can touch a number of objects equal to your number of Schematics Known and you modify each object with the features of one Schematic. These features last until the end of your next long rest. An object can only be modified by one Schematic at a time, and it must meet the requirements in the Schematic's description.",
-				"If a Schematic has a level requirement, you can learn it at the same time you meet the requirement.",
-				{
-					"type": "entries",
-					"name": "Saving Throws",
-					"page": 10,
-					"entries": [
-						"If a Schematic requires a saving throw, your Schematic save DC is calculated as follows:",
-						{
-							"type": "abilityDc",
-							"name": "Schematic",
-							"attributes": [
-								"int"
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Tinker's Expertise",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Your skills rival the best of innovators. Starting at 7th level, your proficiency bonus is doubled for any ability check you make that uses your proficiency with {@item tinker's tools|phb|tinker's} or {@item smith's tools|phb}.",
-				"In addition, items modified by your Schematics count as magical for overcoming resistances and immunities, and you can apply your Schematics to magic weapons and armor."
-			]
-		},
-		{
-			"name": "Mechanical Synergy",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Your modifications work in tandem. Beginning at 10th level, you can apply two Schematics to one object, so long as the object meets the prerequisites for both Schematics."
-			]
-		},
-		{
-			"name": "Flexible Innovation",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"Your inventive arsenal can adjust to meet the challenges at hand. Starting at 15th level, at the end of a short rest, you can transfer a Schematic from one object to another, so long as the new object meets the prerequisites. If a Schematic has a limited amount of charges, the number of expended charges remains the same when transferred.",
-				"In addition, you can apply up to three Schematics to one object, so long as it meets all the Schematic prerequisites."
-			]
-		},
-		{
-			"name": "Masterwork Inventions",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Tinker Knight",
-			"page": 10,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Your innovations are wondrous in their effects. Beginning at 18th level, a weapon modified by a Schematic gains a +1 bonus to attack and damage rolls for each Schematic applied to it, and a set of armor modified by a Schematic gains a +1 bonus to Armor Class for each Schematic applied to it.",
-				"Weapons and armor modified by your Schematics cannot gain a bonus greater then +3, regardless of any bonuses the item may have had before applying your Schematics."
-			]
-		},
-		{
-			"name": "Swordsage",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 3,
-			"entries": [
-				"Swordsage, blade master, sword saint; expert warriors who dedicate their lives to mastering the art of war have had many names throughout history. Only drawing their weapon when they are prepared to kill, Swordsages dole out death only when necessary. They are always looking to improve their technique, mastering ever more impressive martial skills.",
-				"Legends say that these reclusive masters take only one apprentice in their lifetime, passing on everything they know to a single student. Other folk tales tell of elusive sages who only take on the most promising young warriors. What everthe origin of your skill, you are a Swordsage of legend, and your title inspires disbelief, fear, jealousy, and wonder.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Student of the Blade|Alternate Fighter|LLAF|Swordsage|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Battle Trance|Alternate Fighter|LLAF|Swordsage|LLAF:E|3|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Student of the Blade",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"In your study of the sword you have mastered other skills adjacent to swordplay. At 3rd level, you gain proficiency in either Acrobatics, Insight, Intimidation, or Performance.",
-				"In addition, when you adopt this Archetype you learn one additional {@filter Martial Exploit|optionalfeatures|source=LLAF;LLAF:E|feature type=!LLAF:FS;!LLAF:QMR}. This Exploit can be from any list, including Archetype exclusive Exploits, and it doesn't count against your total number of Exploits Known.",
-				"You learn an additional Exploit in this way when you reach 7th level in this class, and again when you reach 18th level."
-			]
-		},
-		{
-			"name": "Battle Trance",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"At 3rd level, you learn to enter a Battle Trance. This Trance grants you improved abilities, provided you are not wearing heavy armor, using a shield, or wielding a heavy weapon.",
-				"As a bonus action, you can expend an Exploit Die to enter a Battle Trance for 1 minute. It ends if you are {@condition incapacitated}, or if you don a shield, heavy armor, or a heavy weapon. While in your Battle Trance you gain the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"Your movement speed increases by 10 feet.",
-						"You gain a bonus to your Armor Class equal to half your proficiency bonus (rounded down).",
-						"You have advantage on Strength ({@skill Athletics}) checks.",
-						"Once per turn, when you roll an Exploit Die for an Exploit you can roll twice and take the higher of the two rolls.",
-						"As a reaction when you are forced to make a saving throw, you can expend an Exploit Die and add it to your roll."
-					]
-				}
-			]
-		},
-		{
-			"name": "Additional Martial Exploit",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"At 7th level, you learn an additional {@filter Martial Exploit|optionalfeatures|source=LLAF;LLAF:E|feature type=!LLAF:FS;!LLAF:QMR} of your choice. This Exploit can be from any list, including Archetype exclusive Exploits, and it doesn't count against your total number of Exploits Known."
-			]
-		},
-		{
-			"name": "Heightened Reflexes",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"You have honed your reflexes in pursuit of martial perfection. At 7th level, you gain proficiency in Dexterity saving throws, and you can add your proficiency bonus to initiative rolls."
-			]
-		},
-		{
-			"name": "Improved Battle Trance",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"You have mastered the Battle Trance of the Swordsage. Starting at 10th level, when you roll initiative, you can enter your Battle Trance without expending an Exploit Die."
-			]
-		},
-		{
-			"name": "Legendary Swordsage (d6)",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"Starting at 15th level, you become a whirlwind of deadly steel while in your Battle Trance. Once per turn, while you are in your Battle Trance, you can use an Exploit you know, rolling a {@dice d6} in place of expending an Exploit Die.",
-				"At 18th level the {@dice d6} from this feature becomes a {@dice d8}."
-			]
-		},
-		{
-			"name": "Legendary Swordsage (d8)",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"At 18th level the {@dice d6} from your Legendary Swordsage feature becomes a {@dice d8}."
-			]
-		},
-		{
-			"name": "Additional Martial Exploit",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Swordsage",
-			"page": 9,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"At 18th level, you learn an additional {@filter Martial Exploit|optionalfeatures|source=LLAF;LLAF:E|feature type=!LLAF:FS;!LLAF:QMR} of your choice. This Exploit can be from any list, including Archetype exclusive Exploits, and it doesn't count against your total number of Exploits Known."
-			]
-		},
-		{
-			"name": "Quartermaster",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 3,
-			"entries": [
-				"Every successful adventurer knows the value of teamwork, but none value it more then those known as Quartermasters. These supportive warriors strive to help their allies reach their full potential. Constantly putting the needs of their companions before their own, Quartermasters keep their team in top condition with a fresh Ration and a helping hand.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Bonus Proficiencies|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Rations|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Bonus Proficiencies",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"At 3rd level you gain proficiency with {@item cook's utensils|PHB}, land vehicles, and in the {@skill Animal Handling} skill. If you are already proficient with any of these skills, you can add double your proficiency bonus to any check that uses that tool or skill."
-			]
-		},
-		{
-			"name": "Rations",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"Beginning at 3rd level, you can prepare Rations, morsels of potent food that keep your allies in peak condition. At the end of each long rest, you can prepare a number of Rations equal to your Constitution modifier (minimum of 1 Ration).",
-				"As an action, you can expend an Exploit Die to prepare additional Rations. You can eat a Ration, or feed the Ration to a creature within 5 feet as part of the same action used to create it. Prepared Rations can be eaten or fed to another creature as a bonus action. Any Rations you create become inert at the end of your next short or long rest. Consuming a Ration ends any current Ration effects on that creature.",
-				"Below are the Rations available to Quartermaster Fighters. If a Ration has a level prerequisite, it refers to your fighter level, and you must meet the prerequisite to prepare it. A creature gains the Ration's benefits immediately upon consuming it.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Fortifying Ration|LLAF:E",
-							"name": "Fortifying Ration (3rd level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Invigorating Ration|LLAF:E",
-							"name": "Invigorating Ration (3rd level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Revitalizing Ration|LLAF:E",
-							"name": "Revitalizing Ration (3rd level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Heightening Ration|LLAF:E",
-							"name": "Heightening Ration (7th level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Tenacious Ration|LLAF:E",
-							"name": "Tenacious Ration (7th level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Warding Ration|LLAF:E",
-							"name": "Warding Ration (7th level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Berserker Ration|LLAF:E",
-							"name": "Berserker Ration (15th level)"
-						},
-						{
-							"type": "refOptionalfeature",
-							"optionalfeature": "Rejuvenating Ration|LLAF:E",
-							"name": "Rejuvenating Ration (15th level)"
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Dependable",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Starting at 7th level, you can use a bonus action on your turn to take the {@action Help} action, targeting a creature within 10 feet."
-			]
-		},
-		{
-			"name": "Improved Rations",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Starting at 10th level, you can use a bonus action to spend an Exploit Die to create a Ration, and any Ration with a duration of 1 minute has its duration increased to 1 hour."
-			]
-		},
-		{
-			"name": "Ever Ready",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"You are always ready to support your companions. Beginning at 15th level, when you roll initiative, you prepare a single Ration of your choice without expending an Exploit Die."
-			]
-		},
-		{
-			"name": "Iron Stomach",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Quartermaster",
-			"page": 8,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Your work taste testing experimenting with new wondrous Ration formulas has toughened your body and hardened your stomach. Upon reaching 18th level your Constitution score, and maximum Constitution score, both increase by 2, and you are immune to the {@condition poisoned} condition.",
-				"In addition, you are always under the effects of one Ration of your choice with a duration longer than instantaneous. It does not need to be a Ration that you prepare, and you can change this effect at the end of each short or long rest."
-			]
-		},
-		{
-			"name": "Pact Warrior",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 6,
-			"level": 3,
-			"entries": [
-				"Those who walk the dark path of the Pact Warrior are driven by an overwhelming desire to destroy the great evils of the world. Those especially dedicated, those willing to give up anything, are often approached by Eldritch Powers, beings of otherworldly might. These benefactors offer power in return for a fraction of the warrior's soul or unquestioning fealty.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Pact Magic|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Sanguine Offering|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Eldritch Power|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Pact Warrior Exploits|Alternate Fighter|LLAF|Pact Warrior|LLAF:E|3|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Pact Magic",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 6,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"At 3rd level, the bargain you have struck with your Patron allows you to cast spells, much like a warlock does.",
-				{
-					"type": "entries",
-					"name": "Cantrips",
-					"page": 6,
-					"entries": [
-						"You learn one cantrip of your choice from the {@filter warlock spell list|spells|class=Warlock}. Upon reaching 10th level in this class you learn one additional warlock cantrip of your choice."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Spell Slots",
-					"page": 6,
-					"entries": [
-						"The Pact Warrior Spellcasting table shows how many spell slots you have, and the level of those spell slots. All of your spell slots from this feature are the same level. To cast one of your warlock spells of 1st-level or higher, you must expend a spell slot. You regain all expended spell slots when you finish a short or long rest."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Spells Known of 1st-Level and Higher",
-					"page": 6,
-					"entries": [
-						"You learn two 1st-level spells of your choice from the warlock spell list. The Spells Known column of the Pact Warrior Spellcasting table shows when you learn more warlock spells of 1st-level or higher. A spell you choose must be of a level no higher than what's shown in the table's Slot Level column for your level.",
-						"When you reach 7th level, for example, you learn a new warlock spell of your choice, which can be 1st or 2nd-level.",
-						"When you gain a level in this class, you can choose one of the warlock spells you know and replace it with another spell of your choice from the warlock spell list, which also must be of a level for which you have spell slots."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Spellcasting Ability",
-					"page": 6,
-					"entries": [
-						"Charisma is your spellcasting ability for your warlock spells. You use your Charisma whenever a spell refers to your spellcasting ability, when setting the saving throw DC, and when making a spell attack roll.",
-						{
-							"type": "abilityDc",
-							"name": "Spell",
-							"attributes": [
-								"cha"
-							]
-						},
-						{
-							"type": "abilityAttackMod",
-							"name": "Spell",
-							"attributes": [
-								"cha"
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Sanguine Offering",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 6,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"You have learned to sacrifice your own vitality to your Patron for increased martial potency. Starting at 3rd level, when you hit a creature with a melee weapon attack, you can expend one of your fighter Hit Die as part of the attack to deal an additional {@dice 2d10} necrotic damage to the target, in addition to the normal damage of your weapon."
-			]
-		},
-		{
-			"name": "Eldritch Power",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 7,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"When you adopt this Archetype at 3rd level, you gain minor eldritch abilities that reflect the source of your power. Work with your GM to determine the source of your power. Is it an Otherworldly Patron available to warlocks? Did you undergo a cataclysmic arcane event that left you with strange power?",
-				"You gain one proficiency of your choice, and you learn {@filter one cantrip of your choice from any class spell list|spells|level=0}. This cantrip doesn't count against your total number of Cantrips Known.",
-				"Often, and at the discretion of your GM, the proficiency and cantrip you gain through this ability should reflect the nature of the Eldritch Power that granted you your arcane abilities."
-			]
-		},
-		{
-			"name": "Otherworldly Step",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 7,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Beginning at 7th level, you can draw upon the dark power gifted to you by your Patron to slip through cracks in reality. As an action, you can expend an Exploit Die to teleport up to 60 feet to an unoccupied space that you can see. If you appear within 5 feet of a creature, you can make one melee weapon attack against them as part of the same action."
-			]
-		},
-		{
-			"name": "Enchanted Strikes",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 7,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"The eldritch magic within your blood seeps into your weapon strikes, undercutting resistance to spells. Starting at 10th level, when you hit a creature with a weapon attack, that creature has disadvantage on the next saving throw it makes against a spell you cast before the end of your next turn."
-			]
-		},
-		{
-			"name": "Improved Sanguine Offering",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 7,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"You can restore your own vitality by inflicting pain on others. Beginning at 15th level, when you empower a weapon attack with your Sanguine Offering, you gain temporary hit points equal to the additional necrotic damage dealt to the creature.",
-				"Temporary hit points from this ability last for one minute, or until you gain temporary hit points from a different source."
-			]
-		},
-		{
-			"name": "Profane Sacrifice",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 7,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Upon reaching 18th level, you can offer the death of your foes to your Eldritch Power in return for enhanced abilities. As a reaction when a creature dies within 30 feet of you, you gain one of the following benefits of your choice:",
-				{
-					"type": "list",
-					"items": [
-						"You have advantage on any weapon attack you make before the end of your next turn.",
-						"You regain {@dice 1d4 + 1} expended Hit Dice.",
-						"You regain one expended Pact Magic spell slot."
-					]
-				},
-				"You can use this ability a number of times equal to your Charisma modifier (minimum of once), and you regain all expended uses when you finish a long rest."
-			]
-		},
-		{
-			"name": "Pact Warrior Exploits",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Pact Warrior",
-			"page": 7,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"The Exploits listed below are exclusive to fighters of the Pact Warrior Archetype. Pact Warrior Exploits allow them to make use of their otherworldly eldritch abilities in combat.",
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Arcane Smite|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Eldritch Insight|LLAF:E"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Spellguard|LLAF"
-				}
-			]
-		},
-		{
-			"name": "Guerilla",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 3,
-			"entries": [
-				"No matter the mission, a Guerrilla will execute it with utmostperfection. Sometimes known as commandos, these warriorsare marked by their determination and adaptability. Whetherharsh terrain, vicious monsters, enemy soldiers, or powerfulspellcasters, nothing short of death will cause the willpowerof a Guerrilla warrior to waver in the pursuit of their goals.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Adaptable Combatant|Alternate Fighter|LLAF|Guerilla|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Survivalist|Alternate Fighter|LLAF|Guerilla|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Guerilla Exploits|Alternate Fighter|LLAF|Guerilla|LLAF:E|3|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Adaptable Combatant",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"Starting at 3rd level, you can adjust your skills to meet the challenge at hand. At the end of a long rest, you can replace one Exploit you know with another Exploit of your choice.",
-				"In addition, you learn an Exploit of your choice from your list of Guerrilla Exploits. This additional Exploit doesn't count against your total number of Exploits Known."
-			]
-		},
-		{
-			"name": "Survivalist",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"At 3rd level, you gain proficiency in two of the following skills of your choice: Athletics, Perception, Stealth, or Survival.",
-				"Starting when you reach 7th level in this class, you can add double your proficiency bonus to any ability check you make that uses either proficiency you gained through this feature."
-			]
-		},
-		{
-			"name": "By Land or Sea",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"You have trained to succeed in any environment, no matter the obstacles. At 7th level, you gain one of the features below. You gain the other feature from this list at 10th level.",
-				{
-					"type": "entries",
-					"name": "Alpine Combatant",
-					"page": 5,
-					"entries": [
-						"You steel yourself for battle at great heights. You gain a climbing speed equal to your movement speed, and as a reaction, you can reduce any falling damage you take by an amount equal to your fighter level."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Marine Combatant",
-					"page": 5,
-					"entries": [
-						"You have prepared for amphibious combat. You gain a swimming speed equal to your movement speed, and you can hold your breath for up to 1 hour."
-					]
-				}
-			]
-		},
-		{
-			"name": "Adaptable Fighting Style",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"You can change your style of fighting to better counter your foes. Starting at 10th level, when you finish a long rest, you can replace your Fighting Style with another Fighting Style of your choice from the list in the fighter class description."
-			]
-		},
-		{
-			"name": "Unwavering",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"You are remarkably resilient. Beginning at 15th level, whenyou use Second Wind you gain the following benefits:",
-				{
-					"type": "list",
-					"items": [
-						"You regain one of your expended Exploit Dice.",
-						"Your level of {@condition exhaustion}, if any, is reduced by 1.",
-						"You can add double your proficiency bonus to your next Strength, Dexterity, or Constitution ability check."
-					]
-				}
-			]
-		},
-		{
-			"name": "Legendary Guerilla",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Starting at 18th level, there is nothing that can stand between you and your goals should you have time to prepare. You can use your Adaptable Combatant and Adaptable Fighting Style features at the end of each short or long rest."
-			]
-		},
-		{
-			"name": "Guerilla Exploits",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guerilla",
-			"page": 5,
-			"level": 3,
-			"header": 2,
-			"entries": [
-				"The Exploits below are exclusive to fighters of the Guerrilla Archetype. Guerrilla Exploits enhance their ability to adapt, and allow them to overcome any obstacle they may face.",
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Adapt|LLAF:E"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Improvise|LLAF:E"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Overcome|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Guardian",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 3,
-			"entries": [
-				"Guardians are elite defensive warriors whose strengths shine while fighting side by side with their allies. Though trained to use weapons of all types, Guardians are especially effective when using a protective style of fighting with a weapon and shield. Alone, a Guardian is a small threat, but when fighting alongside their allies they are impenetrable walls of steel.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Guardian Stance|Alternate Fighter|LLAF|Guardian|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Warrior Smith|Alternate Fighter|LLAF|Guardian|LLAF:E|3|LLAF:E"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Guardian Exploits|Alternate Fighter|LLAF|Guardian|LLAF:E|3|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Guardian Stance",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"Beginning at 3rd level, so long as you are wielding a {@item shield|phb}, you can expend an Exploit Die as a bonus action to enter a Guardian Stance. It lasts for 1 minute, and ends early if you are {@condition incapacitated}, you doff your {@item shield|phb}, or you end it as a free action. While in this Stance, you gain the following features:",
-				{
-					"type": "list",
-					"items": [
-						"Your movement speed is reduced by 10 feet.",
-						"Creatures of your choice within 5 feet that are wielding a shield gain a +1 bonus to their Armor Class.",
-						"As a reaction, when a creature within 5 feet is hit by an attack, you can become the target of the attack, taking the damage of the attack if it would hit you.",
-						"As a bonus action, you can make a special melee attack with your shield. On hit, your shield deals bludgeoning damage equal to 1d4 + your Strength modifier."
-					]
-				}
-			]
-		},
-		{
-			"name": "Warrior Smith",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"You gain the skills to maintain your arms and armor so that you may better defend your allies. At 3rd level you gain proficiency with {@item leatherworker's tools|PHB} and {@item smith's tools|PHB}.",
-				"If you are already proficient with these tools you gain proficiency with another set of artisan's tools of your choice."
-			]
-		},
-		{
-			"name": "Rallying Wind",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"You can rally your allies to hold the line. Starting at 7th level, when you use Second Wind, creatures of your choice within 5 feet gain temporary hit points equal to your fighter level."
-			]
-		},
-		{
-			"name": "Stalwart Defender",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Your defensive tactics grow stronger when amongst your allies. Starting at 10th level, while you are in your Guardian Stance, you gain a +1 bonus to your Armor Class for each friendly creature within 5 feet of you that is wielding a {@item shield|PHB}.",
-				"In addition, so long as your are not surprised when you roll initiative, you can choose to enter your Guardian Stance as a reaction without expending an Exploit Die."
-			]
-		},
-		{
-			"name": "Improved Guardian Stance",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"Starting at 15th level, while you are in your Guardian Stance, creatures of your choice within 5 feet of you gain the benefits of half cover, even if they are not wielding a shield."
-			]
-		},
-		{
-			"name": "Legendary Guardian",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"You have become a master Guardian. Starting at 18th level, any benefits from your Guardian Stance and Guardian Archetype Exploits affect creatures of your choice within 10 feet of you, even if they are not wielding a {@item shield|phb}."
-			]
-		},
-		{
-			"name": "Guardian Exploits",
-			"source": "LLAF:E",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF:E",
-			"subclassShortName": "Guardian",
-			"page": 4,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"The Exploits below are exclusive to fighters of the Guardian Archetype. Guardian Exploits focus on defending their allies and improving their own formidable defensive capabilities.",
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Guardian's Resilience|LLAF:E"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Heart of Steel|LLAF:E"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Immovable|LLAF:E"
-				}
-			]
-		},
-		{
-			"name": "Master at Arms",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 3,
-			"entries": [
-				"While most fighters master one specific martial technique or discipline, a Master at Arms is the rare warrior who is able to truly master multiple styles of combat. Whether through grit, extreme dedication, or extraordinary skill, these elite fighters learn all they can about the theories and armaments of war. They are always on the lookout for a new weapon to master, or a teacher from which to learn a new style of fighting.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Fluid Stances|Alternate Fighter|LLAF|Master at Arms|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Master of Forms|Alternate Fighter|LLAF|Master at Arms|LLAF|3|LLAF"
-				}
-			]
-		},
-		{
-			"name": "Fluid Stances",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"Whether through innate talent or training, you have mastered multiple styles of combat. At 3rd level, you learn an additional {@filter Fighting Style|optionalfeatures|feature type=LLAF:FS} of your choice. However, you can only gain the benefits of one of the Fighting Styles you know at a time.",
-				"As a bonus action, you can change your current Fighting Style to another of your choice Fighting Style that you know."
-			]
-		},
-		{
-			"name": "Master of Forms",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"Your ability to master martial techniques exceeds even that of other fighters. Beginning at 3rd level, whenever you learn a new Exploit, you can choose to learn an Archetype exclusive Exploit, in addition to the Exploits available to all fighters.",
-				"You also learn one additional {@filter Exploit|optionalfeatures|feature type=LLAF:ME;LLAF:ME:AK;LLAF:ME:Ch;LLAF:ME:Co;LLAF:ME:M} of your choice, which doesn't count against your total number of Exploits Known.",
-				"Also at 3rd level, your Exploit Dice all become {@dice d6}s. As yougain levels in this class, your Exploit Dice increase in size again; at 5th level ({@dice d8}), 9th level ({@dice d10}), and 13th level ({@dice d12})."
-			]
-		},
-		{
-			"name": "Consistent Skill",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"You are able to fight at your peak capability for longer than most other warriors. Starting at 7th level, when you use your Second Wind, you regain one of your expended Exploit Dice."
-			]
-		},
-		{
-			"name": "Advanced Technique",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Your study of war has increased your knowledge of marital techniques. At 7th level, you learn another {@filter Fighting Style|optionalfeatures|feature type=LLAF:FS} of your choice (for a total of three), though you can still only gain the benefits of one of your known Fighting Styles at a time.",
-				"You also learn one additional {@filter Exploit|optionalfeatures|feature type=LLAF:ME;LLAF:ME:AK;LLAF:ME:Ch;LLAF:ME:Co;LLAF:ME:M} of your choice, which doesn't count against your total number of Exploits Known."
-			]
-		},
-		{
-			"name": "Masterful Surge",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"You can draw on your techniques as a reflex in times of great need. Starting at 10th level, when you use your Action Surge, you gain one Exploit Die that must be used as part of the additional action granted to you by your Action Surge. If not used, it disappears at the end of your additional action."
-			]
-		},
-		{
-			"name": "Superior Technique",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"In your studies you have mastered an impressive amount of combat styles. At 15th level, you learn another {@filter Fighting Style|optionalfeatures|feature type=LLAF:FS} of your choice (for a total of four), though you can still only gain the benefits of one of your Fighting Styles at a time.",
-				"You also learn one additional {@filter Exploit|optionalfeatures|feature type=LLAF:ME;LLAF:ME:AK;LLAF:ME:Ch;LLAF:ME:Co;LLAF:ME:M} of your choice, which doesn't count against your total number of Exploits Known."
-			]
-		},
-		{
-			"name": "Warrior of Legend",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Master at Arms",
-			"page": 10,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Upon reaching 18th level, your mastery over the armaments of war has become nearly supernatural. Once per turn, when you use an Exploit you know, you can roll a {@dice d6} and use it instead of expending one of your Exploit Dice.",
-				"Also, at the end of each long rest, you can choose either one Exploit or one {@filter Fighting Style|optionalfeatures|feature type=LLAF:FS} you know, and replace it with another Exploit or Fighting Style of your choice."
-			]
-		},
-		{
-			"name": "Marksman",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 3,
-			"entries": [
-				"While every fighter can draw a bow or hurl a javelin, those who train to become Marksmen dedicate themselves to perpetually improving their accuracy and precision with ranged weapons of all types. Most often, this deadly skill is backed up by an unmistakable swagger and un shakable confidence. Relying on their innate talents and signature grit, there are few challenges a true Marksman cannot overcome.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Elite Training|Alternate Fighter|LLAF|Marksman|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Steady Aim|Alternate Fighter|LLAF|Marksman|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Marksman Exploits|Alternate Fighter|LLAF|Marksman|LLAF|3|LLAF"
-				},
-				{
-					"type": "inset",
-					"name": "Gunpowder & Firearms",
-					"entries": [
-						"If your game setting includes firearms and your Marksman has been exposed to their workings, they are considered proficient with all firearms."
-					]
-				}
-			]
-		},
-		{
-			"name": "Elite Training",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"When you adopt this Archetype at 3rd level, your specialized training has enhanced your reaction times. Whenever you make a Dexterity check or saving throw, you can expend an Exploit Die and add it to your roll. You can do so after you roll, but before you know whether you succeed or fail."
-			]
-		},
-		{
-			"name": "Steady Aim",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"You can quiet your body so as to fire with deadly accuracy. Starting at 3rd level, if you haven't moved during your turn, you can use your bonus action to Take Aim, granting you the following benefits until the end of your current turn:",
-				{
-					"type": "list",
-					"items": [
-						"Your movement speed is reduced to 0 feet.",
-						"Until you hit a creature with a ranged weapon attack, you have advantage on all ranged weapon attack rolls.",
-						"When you roll a 1 or 2 on a damage die for an attack you make with a ranged weapon, you can re-roll the die. You must use this new roll, even if the new roll is a 1 or a 2."
-					]
-				}
-			]
-		},
-		{
-			"name": "Marksman Exploits",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"The Exploits listed below are exclusive to fighters who adopt the Marksman Archetype. Marksman Exploits enhance their ranged weapon attacks; striking at their enemies with deadly accuracy or barraging them with ranged attacks.",
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Marksman's Gaze|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Piercing Shot|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Precision Shot|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Volley|LLAF"
-				}
-			]
-		},
-		{
-			"name": "Cunning Shot",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Your experience as a Marksman has trained you to react to danger at a moment's notice. Beginning at 7th level, can you add your proficiency bonus to your Initiative rolls.",
-				"You have also learned to identify and exploit even the smallest weak points in your enemy's defenses. Your attacks with ranged weapons ignore resistance to piercing damage."
-			]
-		},
-		{
-			"name": "Reposition",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Starting at 10th level, when you use Second Wind, your speed increases by 10 feet and opportunity attacks against you are made at disadvantage until the end of your current turn."
-			]
-		},
-		{
-			"name": "Reliable Shot",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"You make even impossible shots with ease. Beginning at 15th level, you ignore disadvantage from your weapon's long range.",
-				"In addition, once per turn, when you have advantage on a ranged weapon attack, you can forgo advantage and make one additional ranged weapon attack against the same target."
-			]
-		},
-		{
-			"name": "Legendary Marksman",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Marksman",
-			"page": 9,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Your marksmanship is supernatural in its precision. Starting at 18th level, when you use Steady Aim the benefits last for 1 minute, and you have advantage on all ranged weapon attacks for the duration. This effect only ends early if you move more then 10 feet in one turn, or you are {@condition incapacitated}."
-			]
-		},
-		{
-			"name": "Commander",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 3,
-			"entries": [
-				"Not all fighters rely solely on themselves in battle, some use their deep knowledge of battlefield tactics to coordinate their allies. Commanders are warriors who lead from the front of the battle, issuing orders and inspiring greatness in others by their own brave deeds. By their presence, a Commander can transform an unorganized militia into a deadly fighting force.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Art of War|Alternate Fighter|LLAF|Commander|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Rallying Cry|Alternate Fighter|LLAF|Commander|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Commander Exploits|Alternate Fighter|LLAF|Commander|LLAF|3|LLAF"
-				}
-			]
-		},
-		{
-			"name": "Art of War",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"In your training you have gained the skill to navigate high society. At 3rd level, you gain proficiency in your choice of either {@skill History}, {@skill Insight}, {@skill Investigation}, or {@skill Persuasion}.",
-				"You also learn the {@optfeature Attack Command|LLAF} Exploit, but it doesn't count against your total number of Exploits Known."
-			]
-		},
-		{
-			"name": "Rallying Cry",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"Beginning at 3rd level, whenever you expend an Exploit Die to use {@optfeature Attack Command|LLAF}, the target gains temporary hit points equal to your proficiency bonus + your Charisma modifier.",
-				"Also, whenever you use Second Wind, you can choose up to three creatures within 30 feet that can see or hear you. Targets immediately regain hit points equal to your Exploit Die + your Charisma modifier. Hit points a creature would gain over their maximum become temporary hit points."
-			]
-		},
-		{
-			"name": "Commander Exploits",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"The Exploits listed below are exclusive to fighters who adopt the Commander Archetype. Commander Exploits focus on bringing out the best in their allies, and defeating their foes through teamwork and carefully planned tactics.",
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Attack Command|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Commander's Insight|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Maneuvering Command|LLAF"
-				}
-			]
-		},
-		{
-			"name": "Strategic Command",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Starting at 7th level, you can organize and command your allies even as you fight. Once per turn, you can use the {@optfeature Attack Command|LLAF} Exploit without expending an Exploit Die."
-			]
-		},
-		{
-			"name": "Heroic Surge",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Your heroic action inspires your allies. Starting at 10th level, when you use Action Surge, you can choose one creature within 30 feet that can see or hear you. That creature can then use their action to move up to their movement speed without provoking opportunity attacks. At the end of this movement, they can make one weapon attack."
-			]
-		},
-		{
-			"name": "Inspiring Commands",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"Beginning at 15th level, when you expend an Exploit Die to use a Marital Exploit that targets a friendly creature, the target creature has advantage on the first attack roll, ability check, or saving throw they make within the next minute."
-			]
-		},
-		{
-			"name": "Legendary Commander",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Commander",
-			"page": 8,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"Your ability to inspire others and lead allies into battle rivals the great conquerers and commanders of legend. Starting at 18th level, your Heroic Surge can affect two creatures of your choice within 30 feet that can see or hear you."
-			]
-		},
-		{
-			"name": "Champion",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 3,
-			"entries": [
-				"While most fighters improve their capabilities by mastering various combat techniques, or augment their skill with magic ,Champions forgo all other routes to improvement and focus on enhancing their raw physical strength. Imposing figures; Champions strive to maintain their peak physical condition through never-ending training. On the battlefield, Champions perform feats of supernatural athleticism and overwhelm their foes with their immense physical might.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Mighty Warrior|Alternate Fighter|LLAF|Champion|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Champion Exploits|Alternate Fighter|LLAF|Champion|LLAF|3|LLAF"
-				},
-				{
-					"type": "inset",
-					"name": "The Alternate Champion",
-					"entries": [
-						"The Champion Archetype presented here is an alternate version of the subclass from the Player's Handbook. The goal of this subclass was to allow the player more meaningful choices in and out of combat, while retaining its signature simplicity. The Alternate Champion presented here is a great choice for both new and experienced players alike!"
-					]
-				}
-			]
-		},
-		{
-			"name": "Mighty Warrior",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"When you adopt this Archetype at 3rd level, the raw physical might that you have cultivated enhances your attacks. Your weapon attacks now score a critical hit on a roll of 19 or 20.",
-				"You also learn the {@optfeature Feat of Strength|LLAF} Exploit, but it doesn't count against your number of Exploits Known. If you already know this Exploit, you learn another Exploit of your choice."
-			]
-		},
-		{
-			"name": "Champion Exploits",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"The Exploits listed below are exclusive to fighters who adopt the Champion Archetype. Champion Exploits make use of their impressive physical power, and ability to overwhelm their opponents with displays of might and athleticism.",
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Champion's Vigor|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Concussive Blow|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Crippling Strike|LLAF"
-				}
-			]
-		},
-		{
-			"name": "Remarkable Athlete",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 7,
-			"header": 2,
-			"entries": [
-				"Your intense training and dedication to physical perfection allows you to perform feats of athleticism that would seem impossible for most mortals. Starting at 7th level, you can add your proficiency bonus to any Strength or Constitution check you make. If you would already add your proficiency bonus to that check you add double your proficiency bonus.",
-				"Also, when you make a standing or running high or long jump, the distance you can jump increases by a number of feet equal to your Strength modifier (minimum of 1 foot)."
-			]
-		},
-		{
-			"name": "Additional Fighting Style",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Your raw skill surpasses that of most other fighters. At 10th level, you learn an additional Fighting Style of your choice. You cannot select a Fighting Style that you already know."
-			]
-		},
-		{
-			"name": "Paragon of Might",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 15,
-			"header": 2,
-			"entries": [
-				"The power of your attacks overwhelms any foe who would dare stand against you. Beginning at 15th level, your weapon attacks score a critical hit on a roll of 18 through 20.",
-				"Also, whenever you make a Strength check or Strength saving throw, you roll a {@dice d6} and add the result to your roll, in addition to any other bonuses to that check or saving throw."
-			]
-		},
-		{
-			"name": "Legendary Champion",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Champion",
-			"page": 7,
-			"level": 18,
-			"header": 2,
-			"entries": [
-				"You are a nearly perfect specimen of physical vigor, and have become exceedingly hard to kill. Starting at 18th level, if you start your turn with half of your hit points or less remaining, you immediately regain hit points equal to 5 + your Constitution modifier (minimum of 5 hit points).",
-				"You do not regain any hit points from this feature if you begin your turn with 0 hit points."
-			]
-		},
 		{
 			"name": "Arcane Knight",
 			"source": "LLAF",
@@ -3983,18 +2835,14 @@
 			"page": 5,
 			"level": 3,
 			"entries": [
-				"Arcane Knights are fighters who supplement their skill with the armaments of war with arcane knowledge. Compared to other mages who study only magic, Arcane Knights can only produce minor spells. However, when combined with their skill in the weapons of warfare, these minor magical spells become deadly enhancements. Proficient in both the arcane arts and the art of war, these spellswords are a deadly force.",
+				"Arcane Knights supplement their skill with the armaments of war with arcane knowledge. Compared to mages who study only magic, Arcane Knights can only produce minor spells, but, when combined with their deadly skill with the weapons of warfare, these minor spells become potent enhancements.",
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Spellcasting|Alternate Fighter|LLAF|Arcane Knight|LLAF|3|LLAF"
+					"subclassFeature": "Weapon Bond|Alternate Fighter|LLAF|Arcane Knight|LLAF|3"
 				},
-				{
+                {
 					"type": "refSubclassFeature",
-					"subclassFeature": "Weapon Bond|Alternate Fighter|LLAF|Arcane Knight|LLAF|3|LLAF"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Arcane Knight Exploits|Alternate Fighter|LLAF|Arcane Knight|LLAF|3|LLAF"
+					"subclassFeature": "Spellcasting|Alternate Fighter|LLAF|Arcane Knight|LLAF|3"
 				}
 			]
 		},
@@ -4007,7 +2855,6 @@
 			"subclassShortName": "Arcane Knight",
 			"page": 5,
 			"level": 3,
-			"header": 1,
 			"entries": [
 				"When you adopt the Arcane Knight Archetype at 3rd level, you learn to cast minor arcane spells, much like a wizard.",
 				{
@@ -4015,7 +2862,7 @@
 					"name": "Cantrips",
 					"page": 5,
 					"entries": [
-						"You learn two cantrips of your choice from the {@filter Arcane Knight spell list|spells|subclass=Alternate Fighter: Arcane Knight (LLAF)|level=0}. You learn one additional Arcane Knight cantrip when you reach 10th level in this class."
+						"You learn two cantrips of your choice from the {@filter Arcane Knight spell list|spells|subclass=Alternate Fighter: Arcane Knight (LLAF)|level=0}. You learn one additional Arcane Knight cantrip at 10th level."
 					]
 				},
 				{
@@ -4031,7 +2878,7 @@
 					"name": "Spells Known of 1st-Level and Higher",
 					"page": 5,
 					"entries": [
-						"You know two 1st-level spells from the {@filter Arcane Knight spell list|spells|subclass=Alternate Fighter: Arcane Knight (LLAF)}. The Spells Known column of the Arcane Knight Spellcasting table shows when you learn more spells of 1st-level or higher. Your spells must be of a level for which you have spell slots.",
+						"You know three 1st-level {@filter Arcane Knight spells|spells|subclass=Alternate Fighter: Arcane Knight (LLAF)}.  The Spells Known column of your Spellcasting table shows when you learn more spells of 1st-level or higher, of a level for which you have spell slots.",
 						"When you gain a level, you can replace one of your Spells Known with another spell from the Arcane Knight spell list. The spell must be of a level for which you have spell slots."
 					]
 				},
@@ -4040,7 +2887,7 @@
 					"name": "Spellcasting Ability",
 					"page": 5,
 					"entries": [
-						"Intelligence is your spellcasting ability for your Arcane Knight spells, as you commit the few potent spells you know to memory. You use your Intelligence whenever a spell refers to your spellcasting ability. You also use your Intelligence modifier when setting the saving throw DC or making a spell attack roll for an Arcane Knight spell.",
+						"Intelligence is your spellcasting ability for your Arcane Knight spells. You use Intelligence whenever a spell refers to your spellcasting ability. You also use your Intelligence modifier when setting the saving throw DC or making a spell attack roll for an Arcane Knight spell.",
 						{
 							"type": "abilityDc",
 							"name": "Spell",
@@ -4056,14 +2903,7 @@
 							]
 						}
 					]
-				},
-				{
-					"type": "inset",
-					"name": "Variant Spellcasting Ability",
-					"entries": [
-						"The subclass presented here is the most common type of Arcane Knight, one who draws on a subset of the magic used by wizards. If your Arcane Knight uses divine magic or druidic magic, consider using Wisdom, instead of Intelligence, as a Spellcasting Ability, and replace the Arcane Knight spell list with either the cleric spell list or the druid spell list."
-					]
-				}
+                }
 			]
 		},
 		{
@@ -4075,36 +2915,16 @@
 			"subclassShortName": "Arcane Knight",
 			"page": 5,
 			"level": 3,
-			"header": 1,
 			"entries": [
-				"At 3rd level, you can ritualistically bond yourself to a weapon of your choice. You perform the ritual over 1 hour, which can be during a short or long rest and you must touch the weapon for the duration. At the conclusion you forge the bond.",
-				"You cannot be disarmed of your bonded weapon unless you are {@condition incapacitated}. If it is on the same plane of existence, you can use a bonus action to summon it, instantly teleporting it to your hand. In addition, your bonded weapon can be used as a spellcasting focus for any Arcane Knight spells you known.",
-				"You can have up to two bonded weapons at any one time, though, they must be summoned one at a time. If you bond a third weapon, you break the bond with one of the other two."
-			]
-		},
-		{
-			"name": "Arcane Knight Exploits",
-			"source": "LLAF",
-			"className": "Alternate Fighter",
-			"classSource": "LLAF",
-			"subclassSource": "LLAF",
-			"subclassShortName": "Arcane Knight",
-			"page": 5,
-			"level": 3,
-			"header": 1,
-			"entries": [
-				"The Exploits below are exclusive to fighters of the Arcane Knight Archetype. They use Exploits to enhance their attacks with magic and defend themselves from arcane assaults.",
+				"At 3rd level, you can magically bond yourself to your weapon. At the end of a short or long rest, you can touch a weapon, forging a magical bond between you and that weapon.",
+				"You cannot be disarmed of a bonded weapon unless you are {@condition incapacitated}. If it is on the same plane of existence, you can use a bonus action to instantly summon it to you. It can be used as a spellcasting focus for your Arcane Knight spells.",
+				"You can have up to two bonded weapons at any one time, though, they must be summoned one at a time. If you bond a third weapon, you break the bond with one of the other two.",
 				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Arcanist's Insight|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Arcane Smite|LLAF"
-				},
-				{
-					"type": "refOptionalfeature",
-					"optionalfeature": "Spellguard|LLAF"
+					"type": "inset",
+					"name": "Master Sword & Spell!",
+					"entries": [
+						"Interested in playing a true master of both sword and spell? Check out the {@link Magus Class|https://www.gmbinder.com/share/-Mslo6ktmq1Yg5WTSjDQ}, the arcane half-caster companion to the paladin and ranger!"
+					]
 				}
 			]
 		},
@@ -4119,7 +2939,7 @@
 			"level": 7,
 			"header": 2,
 			"entries": [
-				"You weave minor spells between your weapon attacks. Starting at 7th level, when you take the {@action Attack} action on your turn, you can cast a cantrip in place of one of your attacks."
+				"You can seamlessly weave minor spells with weapon attacks. Starting at 7th level, when you take the {@action Attack} action on your turn, you can cast a cantrip in place of one of your attacks."
 			]
 		},
 		{
@@ -4133,7 +2953,7 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"Your weapon attacks weaken a creature's resistance to your magic. Starting at 10th level, when you hit a creature with a weapon attack, that creature has disadvantage on the next saving throw it makes against a spell cast by you, before the end of your next turn."
+				"Your weapons weaken a creature's resistance to your magic. Starting at 10th level, when you hit a creature with a weapon attack, it has disadvantage on the next saving throw it makes against a spell cast by you, before the end of your next turn."
 			]
 		},
 		{
@@ -4163,629 +2983,2960 @@
 			"entries": [
 				"You are a master of spell and sword. Starting at 18th level, when you take the {@action Attack} action on your turn, you can cast an Arcane Knight spell in place of one of your weapon attacks."
 			]
+		},
+		{
+			"name": "Champion",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 6,
+			"level": 3,
+			"entries": [
+				"Champions forgo all other forms of improvement to focus on enhancing their raw physical might. These immense figures strive to maintain peak physical condition through relentless training. In battle, Champions perform supernatural feats of athleticism and overwhelm their foes with their raw power.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Champion Exploits|Alternate Fighter|LLAF|Champion|LLAF|3"
+				},
+                {
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mighty Warrior|Alternate Fighter|LLAF|Champion|LLAF|3"
+				}
+			]
+		},
+		{
+			"name": "Champion Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 6,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Champion Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature feat of strength|LLAF}, {@optfeature mighty leap|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature concussive blow|LLAF}, {@optfeature heroic will|LLAF}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature mythic athleticism|LLAF}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Mighty Warrior",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 6,
+			"level": 3,
+			"entries": [
+				"When you adopt this Archetype at 3rd level, the raw physical might that you have cultivated enhances your attacks. Your weapon attacks now score a critical hit on a roll of 19 or 20.",
+				"When you reach 15th level, your critical hit range increase again, you score a critical hit on a roll of 18-20 on the d20."
+			]
+		},
+		{
+			"name": "Remarkable Athlete",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 6,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You can regularly perform feats of athleticism that would be impossible for most mortals. Starting at 7th level, whenever you use either {@optfeature feat of strength|LLAF} or {@optfeature mighty leap|LLAF}, you can roll a d6 and use it instead of expending an Exploit Die.",
+				"When you reach 15th level, this {@dice d6} becomes a {@dice d10}."
+			]
+		},
+		{
+			"name": "Brutal Critical",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 7,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Starting at 10th level, you roll one additional weapon damage die when determining the extra damage for a critical hit.",
+				"This increases to two additional damage dice at 15th level."
+			]
+		},
+		{
+			"name": "Mighty Warrior Improvement",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 6,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"When you reach 15th level, your critical hit range increase again, you score a critical hit on a roll of 18-20 on the d20."
+			]
+		},
+		{
+			"name": "Remarkable Athlete Improvement",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 6,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"When you reach 15th level, the {@dice d6} you can use in place you expending an Exploit Die for {@optfeature feat of strength|LLAF} or {@optfeature mighty leap|LLAF} becomes a {@dice d10}."
+			]
+		},
+		{
+			"name": "Brutal Critical Improvement",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 7,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"When you reach 15th level, you roll two additional weapon damage die when determining the extra damage for a critical hit."
+			]
+		},
+		{
+			"name": "Legendary Champion",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Champion",
+			"page": 7,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"You are a nearly perfect specimen of physical vigor, and have become exceedingly hard to kill. Starting at 18th level, if you start your turn with half of your hit points or less remaining, you regain hit points equal to 5 + your Constitution modifier.",
+				"You do not regain any hit points if you are at 0 hit points."
+			]
+		},
+		{
+			"name": "Commander",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"Not all fighters rely solely on themselves in battle, some use their deep knowledge of battlefield tactics to coordinate their allies. Commanders are warriors who lead from the front of the battle, issuing orders and inspiring greatness in others by their own brave deeds. By their presence, a Commander can transform an unorganized militia into a deadly fighting force.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Commander Exploits|Alternate Fighter|LLAF|Commander|LLAF|3|LLAF"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Student of War|Alternate Fighter|LLAF|Commander|LLAF|3|LLAF"
+				}
+			]
+		},
+		{
+			"name": "Commander Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"You learn certain Tactical Exploits from the {@link warlord class|https://www.gmbinder.com/share/-MrUNf61qoDb0Csw8a9r} at the fighter levels noted in the table below. They don't count against your total number of Exploits Known. Each time you gain a level, you can replace one of the Exploits you learned from this feature with a Tactical Exploit of your choice.",
+				"If a Tactical Exploit has a warlord level prerequisite, you can learn it if your fighter level meets that prerequisite. If a Tactical Exploit requires a Leadership modifier, you can use Intelligence, Wisdom, or Charisma modifier (your choice).",
+				{
+                    "type": "table",
+                    "caption": "Commander Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "attack order, maneuvering order"
+                        ],
+                        [
+                            "5th",
+                            "defensive order, surprise attack"
+                        ],
+                        [
+                            "9th",
+                            "tactical reposition"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Student of War",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"You have studied the strategy of both politics and war. At 3rd level, you learn {@optfeature commander's presence|LLAF}, and whenever you use it, you can roll a {@dice d4} in place of expending an Exploit Die."
+			]
+		},
+		{
+			"name": "Strategic Command",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You can organize your allies even as you fight. Beginning at 7th level, when you use Second Wind, you can choose three creatures within 30 feet that can see or hear you to regain hit points equal to your Exploit Die + your proficiency bonus."
+			]
+		},
+		{
+			"name": "Heroic Surge",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Beginning at 10th level, when you use Action Surge, choose a creature within 30 feet that can see or hear you. The creature can use its reaction to move its speed, without provoking any opportunity attacks, then it can make a single weapon attack."
+			]
+		},
+		{
+			"name": "Inspiring Commands",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"Starting at 15th level, once per turn, when you use a Tactical Exploit that targets allied creatures, one target of your choice gains temporary hit points equal to your proficiency bonus."
+			]
+		},
+		{
+			"name": "Legendary Commander",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Commander",
+			"page": 7,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"Your ability to inspire others and lead allies into battle rivals the great conquerers and commanders of legend. Starting at 18th level, your Heroic Surge can affect up to two creatures of your choice within 30 feet that can see or hear you."
+			]
+		},
+		{
+			"name": "Marksman",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"While all fighters learn to draw a bow or hurl a javelin, those who train as Marksmen dedicate themselves to mastering ranged weapons of all types. Often, their deadly skills are backed up with an unmistakable swagger and unshakable confidence. Relying on their innate talents and signature grit, there are few challenges a true Marksman cannot overcome.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Marksman Exploits|Alternate Fighter|LLAF|Marksman|LLAF|3|LLAF"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Elite Training|Alternate Fighter|LLAF|Marksman|LLAF|3|LLAF"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Marksman's Focus|Alternate Fighter|LLAF|Marksman|LLAF|3|LLAF"
+				},
+				{
+					"type": "inset",
+					"name": "Gunpowder & Firearms",
+					"entries": [
+						"If your game includes firearms and gunpowder, and your Marksman has been exposed to the operation of such weapons, they are proficient with them."
+					]
+				}
+			]
+		},
+		{
+			"name": "Marksman Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Marksman Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature crippling strike|LLAF}, {@optfeature keen observation|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature flaming shot|LLAF}, {@optfeature volley|LLAF}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature thunderous shot|LLAF}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Elite Training",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"Your training has enhanced your reaction times. Starting at 3rd level, when you make a Dexterity check or saving throw, you can expend an Exploit Die and add it to your roll. You can do so after you roll, but before you know if you succeed or fail."
+			]
+		},
+		{
+			"name": "Marksman's Focus",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"You can quiet your body so as to fire with deadly accuracy. Beginning at 3rd level, when you start your turn and are not {@quickref Surprise|PHB|3|0|surprised} or {@condition incapacitated}, you can choose to Focus, granting you the following benefits until the end of your current turn:",
+				{
+					"type": "list",
+					"items": [
+						"Your speed is reduced to 0 feet.",
+						"Until you hit a creature with a ranged weapon attack, you have advantage on all ranged weapon attack rolls.",
+						"When you roll a 1 or 2 on a damage die for an attack you make with a ranged weapon, you can re-roll the die. You must use this new roll, even if the new roll is a 1 or a 2."
+					]
+				}
+			]
+		},
+		{
+			"name": "Cunning Shot",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 8,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You react to danger at a moment's notice. Beginning at 7th level, you add your proficiency bonus to your Initiative rolls.",
+				"Your elite marksmanship allows you to exploit even the smallest weakness in your enemy's defenses. Your ranged weapon attacks ignore any resistance to piercing damage."
+			]
+		},
+		{
+			"name": "Reposition",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 8,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Starting at 10th level, when you use your Second Wind, your speed increases by 10 feet and any opportunity attacks targeting you have disadvantage until the end of your turn."
+			]
+		},
+		{
+			"name": "Reliable Shot",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 8,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You make even impossible shots with ease. Beginning at 15th level, your normal and long range for ranged weapon attacks increases by a number of feet equal to 10 times your level.",
+				"In addition, once per turn, when you have advantage on a ranged weapon attack, you can forgo advantage and make one additional ranged weapon attack against that creature."
+			]
+		},
+		{
+			"name": "Legendary Marksman",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Marksman",
+			"page": 8,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"Your marksmanship is supernatural in precision. Starting at 18th level, when you use Marksman's Focus, the benefits last for 1 minute, and you have advantage on all ranged weapon attacks for the duration. Your Focus only ends early if you move more then 10 feet in a turn, or you are {@condition incapacitated}."
+			]
+		},
+		{
+			"name": "Master at Arms",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"While most fighters master one specific martial discipline, a Master at Arms is the rare warrior who is able to truly master multiple styles of combat. Whether through grit, dedication, or extraordinary skill, these elite fighters learn all they can about the theory of combat. A Master at Arms is always on the lookout for a new weapon or style of fighting to master.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Master at Arms Exploits|Alternate Fighter|LLAF|Master at Arms|LLAF|3|LLAF"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Advanced Technique|Alternate Fighter|LLAF|Master at Arms|LLAF|3|LLAF"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Fluid Stances|Alternate Fighter|LLAF|Master at Arms|LLAF|3|LLAF"
+				}
+			]
+		},
+		{
+			"name": "Master at Arms Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Master at Arms Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature lightstep|LLAF}, {@optfeature riposte|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature defensive stance|LLAF}, {@optfeature warrior's challenge|LLAF}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature heroic focus|LLAF}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Advanced Technique",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"Your ability to learn and utilize martial techniques exceeds most other warriors. When you adopt this Archetype at 3rd level, your total number of Exploit Dice increases by 2.",
+				"Your training has also made your Exploits more potent than the average fighter. Your Exploit Dice become {@dice d8}s. At certain fighter levels they increase again; at 5th level they become {@dice d10}s, and finally at 11th level they become {@dice d12}s."
+			]
+		},
+		{
+			"name": "Fluid Stances",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"Whether by talent or training, you are a master of multiple combat styles. At 3rd level, you learn an additional {@filter Fighting Style|optionalfeatures|feature type=fs:af} of your choice. However, you can only benefit from one Fighting Style at a time. You can use a bonus action to switch your Fighting Style to another Fighting Style you know.",
+				"You learn an additional Fighting Style of your choice at 7th level, and again when you reach 15th level in this class. You can still only benefit from one Fighting Style at a time."
+			]
+		},
+		{
+			"name": "Consistent Skill",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You are able to fight at your peak capability for longer than most other warriors. Starting at 7th level, when you use your Second Wind, you regain one of your expended Exploit Dice."
+			]
+		},
+		{
+			"name": "Master of Forms",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 9,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"By 7th level, your technical skill with the weapons of war has grown, allowing you to learn exotic techniques from a variety of disciplines. Choose two {@filter Exploits|optionalfeatures|feature type=LL:1DE;LL:2DE;LL:3DE;LL:4DE;LL:5DE} from any class, including this one. If the Exploit has a prerequisite level, you can learn it as long as your fighter level meets that prerequisite.",
+				"These Exploits count as Martial Exploits for you, but they don't count against your total number of Exploits Known.",
+				"You learn one additional Exploit of your choice from any class at 15th level, and one final Exploit at 18th level.",
+				{
+					"type": "inset",
+					"name": "Advanced Martial Classes",
+					"entries": [
+						"{@i Master of Forms} references learning Exploits from any class. Other than the Alternate Fighter, there are currently two other classes that use Exploits:",
+						{
+							"type": "list",
+							"items": [
+								"The Alternate Fighter: Expanded - {@book Found Here|LLAF:E|0|Alternate Fighter:Expanded}",
+								"The Alternate Barbarian - {@link Found here|https://www.gmbinder.com/share/-N2gn3QXALCVqwAFJe5v}",
+								"The Warlord - {@link Found here|https://www.gmbinder.com/share/-MrUNf61qoDb0Csw8a9r}"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Fluid Stances (2)",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 7,
+			"entries": [
+				"At 7th level, you learn an additional {@filter Fighting Style|optionalfeatures|feature type=fs:af} of your choice. You can still only benefit from one Fighting Style at a time."
+			]
+		},
+		{
+			"name": "Masterful Surge",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 9,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You can draw on your techniques as a reflex in times of great need. Starting at 10th level, when you use your Action Surge, you gain a single Exploit Die that must be used as part of the additional action granted to you by your Action Surge. If not used, it disappears at the end of your additional action.",
+				"Also, you can benefit from two of Fighting Styles you know at once. Though, you can only switch one per bonus action."
+			]
+		},
+		{
+			"name": "Fluid Stances (3)",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 15,
+			"entries": [
+				"At 15th level, you learn an additional {@filter Fighting Style|optionalfeatures|feature type=fs:af} of your choice. You can still only benefit from one Fighting Style at a time."
+			]
+		},
+		{
+			"name": "Master of Forms (2)",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 15,
+			"entries": [
+				"At 15th level, you learn one additional {@filter Exploit|optionalfeatures|feature type=LL:1DE;LL:2DE;LL:3DE;LL:4DE;LL:5DE} of your choice from any class.",
+				"This Exploit counts as a Martial Exploit for you, but doesn't count against your total number of Exploits Known."
+			]
+		},
+		{
+			"name": "Master of Forms (3)",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 8,
+			"level": 18,
+			"entries": [
+				"At 18th level, you learn one additional {@filter Exploit|optionalfeatures|feature type=LL:1DE;LL:2DE;LL:3DE;LL:4DE;LL:5DE} of your choice from any class.",
+				"This Exploit counts as a Martial Exploit for you, but doesn't count against your total number of Exploits Known."
+			]
+		},
+		{
+			"name": "Warrior of Legend",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF",
+			"subclassShortName": "Master at Arms",
+			"page": 9,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"By 18th level, your mastery with the weapons of war is near-supernatural. Once per turn when you use an Exploit, you can roll a {@dice d6} in place of expending an Exploit Die.",
+				"Also, at the end of a long rest, you can replace an Exploit or Fighting Style you know with another Exploit or Fighting Style of your choice."
+			]
+		},
+		{
+			"name": "Arcane Archer",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Arcane Archer",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"An Arcane Archer studies a unique elven method of archery that weaves magic into attacks to produce supernatural effects. Arcane Archers are some of the most elite warriors among the elves. They stand watch over the fringes of elven domains, keeping a keen eye out for trespassers and using magic-infused arrows to defeat monsters and invaders before they can reach elven settlements. Over the centuries, the methods of these elf archers have been learned by members of other races who can also balance arcane aptitude with archery.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Arcane Archer Exploits|Alternate Fighter|LLAF|Arcane Archer|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Arcane Archer Lore|Fighter|PHB|Arcane Archer|XGE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Arcane Shot|Alternate Fighter|LLAF|Arcane Archer|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Arcane Shot Options|Alternate Fighter|LLAF|Arcane Archer|LLAF|3"
+				},
+				{
+					"type": "inset",
+					"name": "Order of Arcane Archers",
+					"entries": [
+						"Want to play a true master of both bow and spell that can imbue arrows with any spell they know?",
+						"Check out the Order of Arcane Archers for the {@link Magus|https://www.gmbinder.com/share/-Mslo6ktmq1Yg5WTSjDQ}, an Intelligence-based arcane half-caster companion class to the paladin and ranger!"
+					]
+				}
+			]
+		},
+		{
+			"name": "Arcane Archer Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Arcane Archer",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+					"type": "table",
+					"caption": "Arcane Archer Exploits",
+					"colLabels": [
+						"Fighter Level",
+						"Exploits"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@optfeature precision strike|LLAF}, {@optfeature scholar's insight|LLAF}"
+						],
+						[
+							"5th",
+							"{@optfeature flaming shot|LLAF}, {@optfeature volley|LLAF}"
+						],
+						[
+							"9th",
+							"{@optfeature thunderous shot|LLAF}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Arcane Shot",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Arcane Archer",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"You learn to imbue your ammunition with magic. At 3rd level, you learn two Arcane Shots from the list of Arcane Shots (see \"Arcane Shot Options\" below).",
+				"Once per turn, when you hit a target with a ranged attack from a longbow, shortbow, light crossbow, or heavy crossbow, you can apply one of the Arcane Shots you know to that hit.",
+				"You can use this ability a number of times equal to your Intelligence modifier (minimum of once), and you regain all expended uses when you finish a short or long rest.",
+				"You learn an additional Arcane Shot of your choice at certain levels in this class: 7th, 10th, 15th, and 18th level."
+			]
+		},
+		{
+			"name": "Arcane Shot Options",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Arcane Archer",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"The Arcane Shot feature lets you choose options for it at certain levels. The options are presented here in alphabetical order. They are all magical effects, and each one is associated with one of the schools of magic.",
+				"If an option requires a saving throw, your Arcane Shot save DC is calculated as follows:",
+				{
+					"type": "abilityDc",
+					"name": "Arcane Shot",
+					"attributes": [
+						"int"
+					]
+				},
+				{
+					"type": "options",
+					"count": 2,
+					"entries": [
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Banishing Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Beguiling Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Bursting Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Enfeebling Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Grasping Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Piercing Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Seeking Arrow|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Shadow Arrow|LLAF"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Magic Ammunition",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Arcane Archer",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"header": 2,
+			"level": 7,
+			"entries": [
+				"At 7th level, you gain the ability to infuse ammunition with magic. Whenever you fire a nonmagical piece of ammunition from a shortbow, longbow, light crossbow, or heavy crossbow, it counts as magical for the purpose of overcoming resistance and immunity to nonmagical attacks. The magic fades from the ammunition immediately after it hits or misses its target."
+			]
+		},
+		{
+			"name": "Curving Shot",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Arcane Archer",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"header": 2,
+			"level": 7,
+			"entries": [
+				"At 7th level, you can direct an errant shot at a new target. When you make an attack with a magic piece of ammunition and miss, you can use a bonus action to reroll the attack roll against a different target within 60 feet of the original target."
+			]
+		},
+		{
+			"name": "Cavalier",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Cavalier",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"The archetypal Cavalier excels at mounted combat. Usually born among the nobility and raised at court, a Cavalier is equally at home leading a cavalry charge or exchanging repartee at a state dinner. Cavaliers also learn how to guard those in their charge from harm, often serving as the protectors of their superiors and of the weak. Compelled to right wrongs or earn prestige, many of these fighters leave their lives of comfort to embark on glorious adventure.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Bonus Proficiency|Fighter|PHB|Cavalier|XGE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Born to the Saddle|Fighter|PHB|Cavalier|XGE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Cavalier Exploits|Alternate Fighter|LLAF|Cavalier|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Unwavering Mark|Alternate Fighter|LLAF|Cavalier|LLAF|3"
+				}
+			]
+		},
+		{
+			"name": "Cavalier Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Cavalier",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+					"type": "table",
+					"caption": "Cavalier Exploits",
+					"colLabels": [
+						"Fighter Level",
+						"Exploits"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@optfeature brace up|LLAF}, {@optfeature skilled rider|LLAF}"
+						],
+						[
+							"5th",
+							"{@optfeature defensive stance|LLAF}, {@optfeature take cover|LLAF}"
+						],
+						[
+							"9th",
+							"{@optfeature resilient body|LLAF}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Unwavering Mark",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Cavalier",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"Beginning at 3rd level, you menace your foes, foiling attacks and punishing them for harming your allies. When you hit a creature with a melee weapon attack, you can Mark it as your foe until the end of your next turn. While it can see you, it has disadvantage on any attack roll not against you.",
+				"If the Marked creature deals damage to a creature other than you, you can use your reaction to make a melee weapon attack against it. You have advantage on this attack roll, and on hit, you deal additional damage equal to your Exploit Die.",
+				"If you have already used your reaction, you can expend an Exploit Die to make this special reaction attack again."
+			]
+		},
+		{
+			"name": "Warding Maneuver",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Cavalier",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"header": 2,
+			"level": 7,
+			"entries": [
+				"At 7th level, you learn to fend off strikes directed at you, your mount, or other creatures nearby. As a reaction when you or another creature within 5 feet of you is hit by an attack, you can expend an Exploit Die and add it to the creature's Armor Class against the triggering attack. If the attack still hits, the target has resistance against the attack's damage. You must be wielding a melee weapon or shield to use this reaction."
+			]
+		},
+		{
+			"name": "Ferocious Charger",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Cavalier",
+			"subclassSource": "LLAF",
+			"page": 14,
+			"header": 2,
+			"level": 15,
+			"entries": [
+				"Starting at 15th level, you run down your foes, mounted or not. Once per turn, when you move 10 feet in a straight line then hit a creature with a melee weapon attack, it must succeed on a Strength saving throw or be knocked {@condition prone}."
+			]
+		},
+		{
+			"name": "Samurai",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Samurai",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"The Samurai is a fighter who draws on an implacable fighting spirit to overcome enemies. A Samurai's resolve is nearly unbreakable, and the enemies in a Samurai's path have two choices: yield or die fighting.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Bonus Proficiency|Fighter|PHB|Samurai|XGE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Samurai Exploits|Alternate Fighter|LLAF|Samurai|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Fighting Spirit|Alternate Fighter|LLAF|Samurai|LLAF|3"
+				}
+			]
+		},
+		{
+			"name": "Samurai Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Samurai",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+					"type": "table",
+					"caption": "Samurai Exploits",
+					"colLabels": [
+						"Fighter Level",
+						"Exploits"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@optfeature commander's presence|LLAF}, {@optfeature martial focus|LLAF}"
+						],
+						[
+							"5th",
+							"{@optfeature aggressive strike|LLAF}, {@optfeature heroic will|LLAF}"
+						],
+						[
+							"9th",
+							"{@optfeature heroic focus|LLAF}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Fighting Spirit",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Samurai",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"Starting at 3rd level, you can use a bonus action on your turn, to give yourself advantage on all weapon attack rolls until the end of your current turn. When you use this bonus action, you also gain temporary hit points equal to your Fighter level.",
+				"Once you use this feature you must finish a short or long rest before you can use it again."
+			]
+		},
+		{
+			"name": "Echo Knight",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Echo Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"A mysterious and feared frontline warrior of the Kryn Dynasty, the Echo Knight has mastered the art of using dunamis to summon the fading shades of unrealized timelines to aid them in battle. Surrounded by echoes of their own might, they charge into the fray as a cycling swarm of shadows and strikes.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Echo Knight Exploits|Alternate Fighter|LLAF|Echo Knight|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Manifest Echo|Alternate Fighter|LLAF|Echo Knight|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Unleash Incarnation|Alternate Fighter|LLAF|Echo Knight|LLAF|3"
+				}
+			]
+		},
+		{
+			"name": "Echo Knight Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Echo Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+					"type": "table",
+					"caption": "Echo Knight Exploits",
+					"colLabels": [
+						"Fighter Level",
+						"Exploits"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@optfeature martial focus|LLAF}, {@optfeature scholar's insight|LLAF}"
+						],
+						[
+							"5th",
+							"{@optfeature heroic will|LLAF}, {@optfeature whirlwind strike|LLAF}"
+						],
+						[
+							"9th",
+							"{@optfeature heroic focus|LLAF}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Manifest Echo",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Echo Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"You can use a bonus action to magically manifest an echo of yourself in an unoccupied space you can see within 15 feet of you. This echo is a magical, translucent, gray image of you that lasts until it is destroyed, until you dismiss it as a bonus action, until you manifest another echo, or until you're {@condition incapacitated}.",
+				"Your echo has AC 14 + your Charisma modifier, 1 hit point, and immunity to all conditions. If it has to make a saving throw, it uses your saving throw bonus for the roll. It is the same size as you, and it occupies its space. On your turn, you can mentally command the echo to move up to 30 feet in any direction (no action required). If your echo is ever more than 30 feet from you at the end of your turn, it is destroyed.",
+				"You can use the echo in the following ways:",
+				{
+					"type": "list",
+					"items": [
+						"As a bonus action, you can teleport, magically swapping places with your echo at a cost of 15 feet of your movement, regardless of the distance between the two of you.",
+						"When you take the {@action Attack} action on your turn, any attack you make with that action can originate from your space or the echo's space. You make this choice for each attack.",
+						"Your Exploits can originate from yourself or your echo.",
+						"When a creature that you can see within 5 feet of your echo moves at least 5 feet away from it, you can use your reaction to make an opportunity attack against that creature as if you were in the echo's space."
+					]
+				}
+			]
+		},
+		{
+			"name": "Unleash Incarnation",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Echo Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"Also at 3rd level, whenever you take the {@action Attack} action, you can make one additional melee attack from your Echo.",
+				"You can use this feature a number of times equal to your Charisma modifier (a minimum of once), and you regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"name": "Reclaim Potential",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Echo Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"header": 2,
+			"level": 15,
+			"entries": [
+				"Starting at 15th level, whenever your Echo is destroyed by taking damage, you can choose to gain temporary hit points equal to your Exploit Die + your Charisma modifier.",
+				"You can use this feature a number of times equal to your Charisma modifier (a minimum of once), and you regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"name": "Rune Knight",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Rune Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"Rune Knights enhance their martial prowess using the supernatural power of runes, an ancient practice that originated with giants. Rune cutters can be found among any family of giants, and you likely learned your methods first or second hand from such a mystical artisan. Whether you found the giant's work carved into a hill or cave, learned of the runes from a sage, or met the giant in person, you studied the giant's craft and learned how to apply magic runes to empower your equipment.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Bonus Proficiencies|Fighter||Rune Knight|TCE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Runic Exploits|Alternate Fighter|LLAF|Rune Knight|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Rune Carver|Alternate Fighter|LLAF|Rune Knight|LLAF|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Giant's Might|Alternate Fighter|LLAF|Rune Knight|LLAF|3"
+				}
+			]
+		},
+		{
+			"name": "Runic Exploits",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Rune Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+					"type": "table",
+					"caption": "Echo Knight Exploits",
+					"colLabels": [
+						"Fighter Level",
+						"Exploits"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@optfeature hurl|LLAF}, {@optfeature scholar's insight|LLAF}"
+						],
+						[
+							"5th",
+							"{@optfeature crushing strike|LLAF}, {@optfeature heroic will|LLAF}"
+						],
+						[
+							"9th",
+							"{@optfeature resilient body|LLAF}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Rune Carver",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Rune Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"You can use magic runes to enhance your gear. You learn two runes of your choice, from among the runes described below, and each time you gain a level in this class, you can replace one rune you know with a different one from this feature. When you reach certain levels in this class, you learn additional runes, as shown in the Runes Known table.",
+				"Whenever you finish a long rest, you can touch a number of objects equal to the number of runes you know, and you inscribe a different rune onto each of the objects. To be eligible, an object must be a weapon, a suit of armor, a shield, a piece of jewelry, or something else you can wear or hold in a hand. Your rune remains on an object until you finish a long rest, and an object can bear only one of your runes at a time.",
+				{
+					"type": "table",
+					"caption": "Runes Known",
+					"colLabels": [
+						"Fighter Level",
+						"Number of Runes"
+					],
+					"colStyles": [
+						"col-6 text-center",
+						"col-6 text-center"
+					],
+					"rows": [
+						[
+							"3rd",
+							"2"
+						],
+						[
+							"7th",
+							"3"
+						],
+						[
+							"10th",
+							"4"
+						],
+						[
+							"15th",
+							"5"
+						]
+					]
+				},
+				"The following runes are available to you when you learn a rune. If a rune has a level requirement, you must be at least that level in this class to learn the rune. If a rune requires a saving throw, your Rune Magic save DC equals 8 + your proficiency bonus + your Constitution modifier.",
+				{
+					"type": "options",
+					"count": 2,
+					"entries": [
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Cloud Rune|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Fire Rune|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Frost Rune|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Stone Rune|LLAF"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Hill Rune|LLAF",
+							"name": "Hill Rune (7th Level or Higher)"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Storm Rune|LLAF",
+							"name": "Storm Rune (7th Level or Higher)"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Giant's Might",
+			"source": "LLAF",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassShortName": "Rune Knight",
+			"subclassSource": "LLAF",
+			"page": 15,
+			"level": 3,
+			"entries": [
+				"At 3rd level, you can use a bonus action on your turn to transform and gain the following benefits for 1 minute:",
+				{
+					"type": "list",
+					"items": [
+						"If you are smaller than Large, you become Large, along with anything you are wearing. If you lack the room to become Large in size, your size doesn't change.",
+						"You gain a bonus to both your Strength checks and Strength saving throws equal to your Exploit Die.",
+						"Once per turn, when you hit a target with a melee or thrown weapon attack, you can deal additional damage of the weapon's type equal to your Exploit Die on hit."
+					]
+				},
+				"You can use this feature a number of times equal to your Constitution modifier (minimum of once), and you regain all expended uses of it when you finish a long rest."
+			]
+		},
+		{
+			"name": "Crusader",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"Many warriors swear Oaths to gods of battle and war, but not all are blessed with the divine power of paladins or clerics. Those who fight for the gods without their explicit blessing are known as Crusaders. These zealots stand as champions of divine causes, their fervent belief fueling their battle fury.",
+				"Crusaders serve many gods and causes, but they all have one thing in common; their fanatical devotion to what they believe is right. Their belief is forged in the fires of devotion, and a dedicated Crusader will often snap rather than bend.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Crusader Exploits|Alternate Fighter|LLAF|Crusader|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Crusader's Ire|Alternate Fighter|LLAF|Crusader|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Fanatical Disciple|Alternate Fighter|LLAF|Crusader|LLAF:E|3"
+				},
+				{
+					"type": "inset",
+					"name": "Optional Rule: Oathbreaker Paladin",
+					"entries": [
+						"Should a Paladin break or forsake their Oath in your game, the Crusader Archetype here can be used to represent a Paladin who has lost their divine power."
+					]
+				}
+			]
+		},
+		{
+			"name": "Crusader Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Crusader Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature commander's presence|LLAF}, {@optfeature wild strike|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature execute|LLAF}, {@optfeature intimidating command|LLAF:E}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature inspirational speech|LLAF:E}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Crusader's Ire",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"You mark your foes for divine judgment. As a bonus action, you can Mark a creature within 60 feet as the target of your Crusader's Ire, granting you the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Once per turn when you miss the creature with a weapon attack, you can immediately make another weapon attack against that creature using the same weapon.",
+						"When the creature is within your reach and casts a spell or makes an attack against a creature other then you, you can use your reaction to make an opportunity attack.",
+						"When the creature forces you to make a saving throw, you gain a bonus to your roll equal to your Exploit Die."
+					]
+				},
+				"Your Mark lasts for 1 minute, or until the creature is slain. Once you use this feature you must finish a long rest before you can use it again. When you have no uses remaining, you can expend an Exploit Die to use this feature again."
+			]
+		},
+		{
+			"name": "Fanatical Disciple",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"level": 3,
+			"entries": [
+				"You gain proficiency in {@skill Religion}, and whenever you make an Intelligence ({@skill Religion}) check related to the god or cause you serve you gain a bonus to your roll equal to your Exploit Die."
+			]
+		},
+		{
+			"name": "Renewed Fervor",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"header": 2,
+			"level": 7,
+			"entries": [
+				"Your fanaticism grants you bursts of fervor in battle. When you use Second Wind you regain the use of Crusader's Ire.",
+				"In addition, when you Mark a creature as the target of your Crusader's Ire, you can move up to 30 feet toward it as part of the same bonus action without expending your movement."
+			]
+		},
+		{
+			"name": "Zealous Fury",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"header": 2,
+			"level": 10,
+			"entries": [
+				"Your conviction allows you to survive blows that would slay those of lesser faith. When you are reduced to 0 Hit Points but not killed outright, you can drop to 1 hit point instead, and immediately make one weapon attack against your attacker.",
+				"Once you use this feature you must finish a short or long rest before you can use it again. If you have no uses left, you can use it again, but you instantly gain a level of {@condition exhaustion}."
+			]
+		},
+		{
+			"name": "Righteous Judgment",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"header": 2,
+			"level": 15,
+			"entries": [
+				"You are the arbiter of divine wrath. When you hit the target of Crusader's Ire with a weapon attack, you can end the Mark to have your attack to deal maximum damage instead of rolling.",
+				"If the attack reduces the target to 0 hit points you instantly regain the use of Crusader's Ire."
+			]
+		},
+		{
+			"name": "Legendary Crusader",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Crusader",
+			"page": 7,
+			"header": 2,
+			"level": 18,
+			"entries": [
+				"When the target of Crusader's Ire target's you with an attack, you can use your reaction to make a single weapon attack against that creature. If you use this reaction after the attack hits you, your weapon attack is made with advantage."
+			]
+		},
+		{
+			"name": "Guardian",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"Guardians are elite defensive warriors whose strengths shine while fighting side by side with their allies. Though trained to use weapons of all types, Guardians are especially effective when using a protective style of fighting with a weapon and shield. Alone, a Guardian is a small threat, but when fighting alongside their allies they are impenetrable walls of steel.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Guardian Exploits|Alternate Fighter|LLAF|Guardian|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Warrior Smith|Alternate Fighter|LLAF|Guardian|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Guardian Stance|Alternate Fighter|LLAF|Guardian|LLAF:E|3|LLAF:E"
+				}
+			]
+		},
+		{
+			"name": "Guardian Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Guardian Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature reposition|LLAF:E}, {@optfeature warding strike|LLAF:E}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature immovable stance|LLAF:E}, {@optfeature shield impact|LLAF}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature resilient body|LLAF}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Warrior Smith",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"You gain the skills to maintain your arms and armor so that you may defend your allies to the best of your ability. You gain proficiency with {@item leatherworker's tools|PHB} and {@item smith's tools|PHB}.",
+				"During a long rest, you can spend 1 hour using either set of tools to reinforce a shield or a set of armor you touch. The object grants its wearer an additional +1 bonus to their Armor Class that lasts until the end of your next long rest."
+			]
+		},
+		{
+			"name": "Guardian Stance",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"While you are wielding a {@item shield|phb}, you can use a bonus action to enter a Guardian Stance which lasts indefinitely. It ends if you are incapacitated, you doff your shield, or you end it as a free action. Your Stance grants you the following features:",
+				{
+					"type": "list",
+					"items": [
+						"Your speed is reduced by 10 feet.",
+						"Creatures of your choice within 5 feet that are also wielding a shield gain a +1 bonus to their Armor Class.",
+						"As a reaction, when a creature within 5 feet of you is hit by an attack, you can become the target of the attack, taking the damage of the attack if it would hit you.",
+						"You can make a {@action Shove} attack as a bonus action."
+					]
+				}
+			]
+		},
+		{
+			"name": "Rallying Wind",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You inspire your allies to hold their position against all odds. When you use Second Wind while in your Guardian Stance, creatures of your choice within 5 feet of you that can see or hear you gain temporary hit points equal to your fighter level."
+			]
+		},
+		{
+			"name": "Stalwart Defender",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You are strongest when standing side by side, and shield by shield, with your allies. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You gain a +1 bonus to your Armor Class for each friendly creature within 5 feet of you that is wielding a {@item shield|PHB}.",
+						"You cannot be moved against your will while conscious.",
+						"Both you, and friendly creatures within 5 feet of you, have advantage on Strength and Constitution saving throws.",
+						"When you roll initiative you can immediately enter your Guardian Stance as long as you are not surprised."
+					]
+				}
+			]
+		},
+		{
+			"name": "Improved Guardian Stance",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"At 15th level, you improve your defensive technique to better defend those who stand beside you. While in your Guardian Stance, you grant friendly creatures within 5 feet of you the benefits of {@quickref Cover|PHB|3|0|half cover}, in place of the +1 Armor Class bonus."
+			]
+		},
+		{
+			"name": "Legendary Guardian",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guardian",
+			"page": 8,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"You are a master Guardian and serve as a supernatural shield to defend the weak. The range of all your Guardian features increase to include any creature of your choice within 15 feet."
+			]
+		},
+		{
+			"name": "Guerrilla",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"No matter the mission, a Guerrilla will execute it with utmost perfection. Sometimes known as commandos, these warriors are marked by their determination and adaptability. Whether harsh terrain, vicious monsters, enemy soldiers, or powerful spellcasters, nothing short of death will cause the willpower of a Guerrilla warrior to waver in the pursuit of their goals.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Adaptable Exploits|Alternate Fighter|LLAF|Guerrilla|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Guerrilla Exploits|Alternate Fighter|LLAF|Guerrilla|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Survivalist|Alternate Fighter|LLAF|Guerrilla|LLAF:E|3"
+				}
+			]
+		},
+		{
+			"name": "Adaptable Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 8,
+			"level": 3,
+			"entries": [
+				"You can adjust your skills to meet any challenge. At the end of each long rest, you can replace one Exploit you know with another Exploit for which you meet the prerequisites.",
+				"When you reach 10th level in this class, you can use this feature at the end of a short rest. Once you do so, you must finish a long rest before you can use it in that way again."
+			]
+		},
+		{
+			"name": "Guerrilla Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 9,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and they cannot be switched upon gaining a level, or by using your Adaptable Exploits feature.",
+				{
+                    "type": "table",
+                    "caption": "Guerrilla Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature mighty leap|LLAF}, {@optfeature navigator's know-how|LLAF:E}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature improvised skill|LLAF:E}, {@optfeature take cover|LLAF}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature survey wilderness|LLAF:E}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Survivalist",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 9,
+			"level": 3,
+			"entries": [
+				"You are an expert at overcoming natural obstacles. Choose two of the following skills: {@skill Athletics}, {@skill Perception}, {@skill Stealth}, or {@skill Survival}. Whenever you make an ability check with that skill you gain a bonus to your roll equal to your Exploit Die.",
+				"Upon reaching 7th level in this class, you can choose two additional skills from the list above to gain the same benefit."
+			]
+		},
+		{
+			"name": "By Land or Sea",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 9,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You have trained to succeed in any environment. At 7th level, and again at 15th level you gain one of the following features:",
+				{
+					"type": "entries",
+					"name": "Alpine Combatant",
+					"page": 9,
+					"entries": [
+						"You have trained for battle at great heights. You gain a climbing speed equal to your walking speed, and when you fall, you can use your reaction to reduce any falling damage by an amount equal to your fighter level."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Marine Combatant",
+					"page": 9,
+					"entries": [
+						"You prepare for amphibious combat. You gain a swimming speed equal to your walking speed, and you can hold your breath for up to 1 hour underwater."
+					]
+				}
+			]
+		},
+		{
+			"name": "Adaptable Fighting Style",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 9,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You can adapt your style of fighting to better counter your enemies. When you finish a long rest, you can replace one {@filter Fighting Style|optionalfeatures|feature type=fs:af} you know with another Style of your choice."
+			]
+		},
+		{
+			"name": "Unwavering",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 9,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You are remarkably hardy, even compared to other fighters. When you use Second Wind you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You regain one of your expended Exploit Dice.",
+						"Your level of {@condition exhaustion}, if any, is reduced by 1.",
+						"You gain a bonus to the next Strength, Dexterity, or Constitution ability check or saving throw you make within the next minute equal to your Exploit Die."
+					]
+				}
+			]
+		},
+		{
+			"name": "Legendary Guerrilla",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Guerrilla",
+			"page": 9,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"There is nothing that can stand between you and your goals should you have time to prepare. You can use your Adaptable Fighting Style feature at the end of each short or long rest.",
+				"Moreover, when you roll initiative and are not {@quickref Surprise|PHB|3|0|surprised}, you gain one of the following benefits of your choice:",
+				{
+					"type": "list",
+					"items": [
+						"You gain temporary hit points equal to your fighter level.",
+						"You can immediately move up to your full speed."
+					]
+				}
+			]
+		},
+		{
+			"name": "Master of Hounds",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 9,
+			"level": 3,
+			"entries": [
+				"Since the dawn of civilization, beasts have worked alongside mortals. Most notable of these domesticated animals is the dog. The earliest hunters worked in tandem with these loyal beasts, sharing food and fire. Some fighters still take up this mantle and train {@creature Loyal Hound|LLAF:E|Loyal Hounds} to adventure by their side.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hound Master Exploits|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Loyal Hound|Alternate Fighter|LLAF|Master of Hounds|LLAF:E|3"
+				},
+				{
+					"type": "inset",
+					"name": "Loyal Hounds & Other Canines",
+					"entries": [
+						"Depending on your table and game setting, there are many creatures that could be a Loyal Hound.",
+						"In a more mundane or low-magic setting, your Hound is most likely going to be a dog or wolf.",
+						"In other more fantastical games, any four legged beast or monstrosity could serve as a Loyal Hound."
+					]
+				}
+			]
+		},
+		{
+			"name": "Hound Master Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 9,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Master of Hounds Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature reposition|LLAF:E}, {@optfeature survivalist's craft|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature intimidating command|LLAF:E}, {@optfeature weakening blow|LLAF:E}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature survey wilderness|LLAF:E}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Loyal Hound",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 10,
+			"level": 3,
+			"entries": [
+				"When you adopt this Archetype at 3rd level, you complete the training of a {@creature Loyal Hound|LLAF:E}. Your Hound is friendly to you and obeys your commands. It uses the {@creature Loyal Hound|LLAF:E} stat block, which uses your proficiency bonus (PB) in several places.",
+				"In combat, your Hound acts during your turn. It can move and use its reaction on its own, but it only takes the {@action Dodge} action unless you use a bonus action to command it to take an action from its stat block, or another action. Whenever you take the {@action Attack} action, you can command the Hound to take the {@action Attack} action in place of one of your attacks. If you are {@condition incapacitated}, your Hound acts on its own.",
+				"If your Hound is reduced to 0 hit points, it makes death saving throws like a player character would. If your Hound dies, your special skills allow you to find a canine-like creature and train it as a {@creature Loyal Hound|LLAF:E} over the course of a long rest, at which point, that creature uses the {@creature Loyal Hound|LLAF:E} stat block."
+			]
+		},
+		{
+			"name": "Iron Jaws",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 10,
+			"header": 2,
+			"level": 7,
+			"entries": [
+				"Your Hound has been infused with a portion of your own heroic fighting spirit. Your Loyal Hound's Bite and Maul attacks ignore resistance to nonmagical piercing and slashing damage.",
+				"In addition, any creature that is at least one size smaller than your Hound has disadvantage on its Strength saving throw to resist the Hound's {@action grapple}."
+			]
+		},
+		{
+			"name": "Steadfast Companion",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 10,
+			"header": 2,
+			"level": 10,
+			"entries": [
+				"You can face any foe so long as your Hound is by your side. Your Hound has advantage on any saving throw it is forced to make so long as it is within 30 feet and can see or hear you.",
+				"Also, whenever you use Second Wind, your Loyal Hound also regains hit points equal to 1d10 + your Fighter level."
+			]
+		},
+		{
+			"name": "Canine Fury",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 10,
+			"header": 2,
+			"level": 15,
+			"entries": [
+				"Your commands inspire wild fury. Whenever you command your Loyal Hound to take the {@action Attack} action, it can make two Maul attacks, or one Maul attack and one Bite attack."
+			]
+		},
+		{
+			"name": "Hound of Legend",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Master of Hounds",
+			"page": 10,
+			"header": 2,
+			"level": 18,
+			"entries": [
+				"Thanks to your training, your Hound has come to rival the great beasts of legend. When you use Action Surge, your Hound also gains one extra action on that turn.",
+				"Moreover, your Loyal Hound's Strength and Dexterity scores each become 18, thereby increasing the bonus to hit and damage of both its Bite and Maul attacks by +2 each."
+			]
+		},
+		{
+			"name": "Mystic Warrior",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 11,
+			"level": 3,
+			"entries": [
+				"Where most fighters look to maximize their physical abilities, those known as Mystic Warriors work to unlock the psionic potential of their minds. Drawing upon this wondrous power ability, these ascetic warriors can perform feats that would be impossible through strength alone. Where others strive for strength in battle, a Mystic Warrior strives for enlightenment.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Psionics|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Minor Telekinesis|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mystic Exploits|Alternate Fighter|LLAF|Mystic Warrior|LLAF:E|3"
+				},
+				{
+					"type": "inset",
+					"name": "Unleash your Psionic Potential",
+					"entries": [
+						"The Mystic Warrior Archetype presented here is a replacement for the Psi Knight publshed in Tasha's Cauldron of Everything. As the Eldritch Knight is to the wizard, so the Mystic Knight it to the {@link Psion|https://www.gmbinder.com/share/-MPkCSxSj0OETiEd3Pyf}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Psionics",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 11,
+			"level": 3,
+			"entries": [
+				"You have unlocked the true potential of your mind, and have learned to manifest spells, much like a true {@link psion|https://www.gmbinder.com/share/-MPkCSxSj0OETiEd3Pyf} does.",
+				{
+					"type": "entries",
+					"name": "Psi Points",
+					"page": 11,
+					"entries": [
+						"The potential of your mind is represented by a pool of psi points. The Mystic Warrior table shows how many psi points you have to manifest your spells of 1st-level and higher. To manifest one of these spells, you must expend psi points equal to the spell's level (0 for cantrips). You regain all of your psi points each time you finish a short or long rest."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Mental Limit",
+					"page": 11,
+					"entries": [
+						"Your fighter level limits the potency of spells you can manifest with your psionics. This limit is reflected in the Mental Limit column of the Mystic Warrior Table."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells Known of 1st-Level and Higher",
+					"page": 11,
+					"entries": [
+						"You learn two 1st-level spells of your choice from the {@link psion spell list|https://www.gmbinder.com/share/-MPkCSxSj0OETiEd3Pyf}. The Spells Known column of the Mystic Warrior table shows when you learn more psion spells of 1st-level or higher. Any spell you learn must be of a level equal to your Mental Limit or lower.",
+						"When you gain a level in this class, you can choose one of the psion spells you know and replace it with a psion spell of your choice, of a level equal to your Mental Limit or lower."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Focus",
+					"page": 11,
+					"entries": [
+						"Your mind itself is your spellcasting focus. You must have at least one free hand to cast spells that require somatic or material components, and you also must provide material components that are consumed by the spell or have a required gold cost. When you manifest a spell with your psionics, you exhibit noticeable changes."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Ability",
+					"page": 11,
+					"entries": [
+						"Intelligence is your spellcasting ability for your Psion spells. You use Intelligence whenever a spell refers to your spellcasting ability. You also use your Intelligence modifier when setting the saving throw DC or making a spell attack roll for a psion spell you know.",
+						{
+							"type": "abilityDc",
+							"name": "Spell",
+							"attributes": [
+								"int"
+							]
+						},
+						{
+							"type": "abilityAttackMod",
+							"name": "Spell",
+							"attributes": [
+								"int"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Minor Telekinesis",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 11,
+			"level": 3,
+			"entries": [
+				"You have learned to move objects with nothing but your mind. You learn the {@spell mage hand} cantrip, and when you manifest it you do not need to provide the verbal or the somatic components. Your {@spell mage hand} is invisible, and it can lift a total number of pounds equal to 10 times your Intelligence modifier (minimum of 10)."
+			]
+		},
+		{
+			"name": "Mystic Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 11,
+			"level": 3,
+			"entries": [
+				"You learn the {@optfeature mighty leap|LLAF} and {@optfeature mighty thrust|LLAF} Exploits, but they don't count against your total number of Exploits known, and you cannot replace them when you gain a level in this class.",
+				"Moreover, whenever you use either of these Exploits you gain a bonus to yoru roll equal to your Intelligence modifier."
+			]
+		},
+		{
+			"name": "Phase Step",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 11,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"When you use Second Wind, you also gain the benefits of the {@action Dash} action and partially discorporate. Until the end of your current turn, you can move through solid nonmagical objects and creatures as if they were difficult terrain.",
+				"If you end your movement inside an object or creature, you are instantly shunted to the nearest unoccupied space, taking {@dice 1d10} force damage for every 5 feet you are forced to move."
+			]
+		},
+		{
+			"name": "Inscrutable Mind",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 11,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"The raw power of your mind makes you difficult for others to dominate. You have advantage on any saving throw to resist being {@condition charmed}, {@condition frightened}, or to have your thoughts read.",
+				"Also, whenever you succeed on an Intelligence, Wisdom, or Charisma saving throw, you can spend 1 psi point to force the attacker to make an Intelligence saving throw. On a failed save, it takes psychic damage equal to your fighter level."
+			]
+		},
+		{
+			"name": "Greater Telekinesis",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 12,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You have unlocked even more of your psionic potential. You learn the {@spell telekinesis} spell, but it doesn't count against your total number of Spells Known. You can manifest this spell once, without expending any psi points.",
+				"Once you manifest {@spell telekinesis} in this way, you must finish a long rest before you can manifest it again, unless you expend 5 psi points to manifest the spell an additional time."
+			]
+		},
+		{
+			"name": "Legendary Mystic",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Mystic Warrior",
+			"page": 12,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"You can briefly tap into the full psionic potential of your mind and take on an ascended luminous form. As a bonus action, you can transform into a being of pure psionic energy. While in this ascended form, you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You become translucent and emit otherworldly bright light, in a 5-foot radius, and dim light 5 feet beyond that.",
+						"You gain a flying speed equal to your walking speed, and while flying in this way you can hover in place.",
+						"You can move through other creatures and objects as if they were {@quickref Difficult Terrain|PHB|3|0|difficult terrain}. If you end your movement inside another object or creature, you are immediately shunted to the nearest unoccupied space, taking {@dice 1d10} force damage for every 5 feet you were forced to travel.",
+						"Whenever you deal damage with an Exploit, you can choose for its additional damage to by psychic damage."
+					]
+				},
+				"You can remain in this form for up to 1 minute. It ends early if you are {@condition incapacitated} or you end it as a bonus action. Once you use this feature, you cannot use it again until you finish a long rest, unless you expend 7 psi points to do so."
+			]
+		},
+		{
+			"name": "Quartermaster",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page":  12,
+			"level": 3,
+			"entries": [
+				"Every successful adventurer knows the value of teamwork, but none value it more then those known as Quartermasters. These supportive warriors strive to help their allies reach their full potential. Constantly putting the needs of their companions before their own, Quartermasters keep their team in top condition with a fresh Ration and a helping hand.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Down to Earth|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Quartermaster Exploits|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Rations|Alternate Fighter|LLAF|Quartermaster|LLAF:E|3|LLAF:E"
+				}
+			]
+		},
+		{
+			"name": "Down to Earth",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 12,
+			"level": 3,
+			"entries": [
+				"You gain proficiency with {@item cook's utensils|PHB}, {@filter land vehicles|items|type=!treasure;!renaissance;vehicle (land);!modern;!futuristic}, and in {@skill Animal Handling}. Whenever you make an ability check that uses one of the proficiencies you gained through this feature, you a bonus to your roll equal to your Exploit Die."
+			]
+		},
+		{
+			"name": "Quartermaster Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 12,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Quartermaster Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature first aid|LLAF}, {@optfeature skilled rider|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature immovable stance|LLAF:E}, {@optfeature take cover|LLAF}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature daring rescue|LLAF:E}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Rations",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 12,
+			"level": 3,
+			"entries": [
+				"You are able to prepare potent morsels of food that keep your allies in peak condition. At the end of each long rest, you can prepare a number of these {@filter Rations|optionalfeatures|feature type=ll:qmr} equal to your Constitution modifier (minimum of 1) from the list at end of this subclass.",
+				"As a bonus action, you can eat a prepared Ration, or feed a Ration to a creature within 5 feet. Consuming a Ration ends any current Ration effects on that creature. Any Rations you have prepared become inert at the end of your next long rest.",
+				"As an action, you can expend an Exploit Die to prepare an additional Ration of your choice. You can eat a Ration or feed it to a creature as part of the same action used to create it."
+			]
+		},
+		{
+			"name": "Dependable",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 12,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You are always there to lend a helping hand to your allies.",
+				"You can take the following special actions as a bonus action:",
+				{
+					"type": "entries",
+					"name": "Administer",
+					"entries": [
+						"You feed a potion, Ration, or consumable item to a willing or unconscious creature within 5 feet of you."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Arm",
+					"entries": [
+						"You give a weapon, item, or any ammunition you are carrying to a creature within 5 feet. The creature can then equip the given item, and stow one item as a free action."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Encourage",
+					"entries": [
+						"You take the {@action Help} action, targeting a creature of your choice within 10 feet that can see or hear you."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Wrangle",
+					"entries": [
+						"You make a Wisdom ({@skill Animal Handling}) or a {@filter land vehicles|items|type=!treasure;!renaissance;vehicle (land);!modern;!futuristic} check to control a mount or cart you are riding."
+					]
+				}
+			]
+		},
+		{
+			"name": "Improved Rations",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 12,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You have greatly improved the speed at which you prepare Rations. You can use a bonus action on your turn to create a Ration of your choice, eating it or feeding it to a creature within 5 feet of you as part of that same bonus action."
+			]
+		},
+		{
+			"name": "Ever Ready",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 13,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You are always ready to support your companions. When you roll initiative, so long as you are not {@quickref Surprise|PHB|3|0|surprised}, you prepare one Ration of your choice without expending an Exploit Die."
+			]
+		},
+		{
+			"name": "Iron Stomach",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Quartermaster",
+			"page": 13,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"Your experiments with new Ration formulas have toughened your body and hardened your stomach. Your Constitution score, and maximum Constitution score, increase by 2, and you are immune to the {@condition poisoned} condition.",
+				"In addition, you are always under the effects of one Ration of your choice with a duration of at least 1 minute. It does not need to be a Ration that you prepared, and you can change the Ration effect at the end of each short or long rest."
+			]
+		},
+		{
+			"name": "Swordsage",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"Swordsage, blade master, sword saints; expert warriors who dedicate their lives to the art of battle have had many names throughout history. Only drawing their weapon when they are prepared to kill, a Swordsage will only slay another creature when necessary. A master Swordsage will only take a single apprentice, teaching everything they know to a single warrior.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Student of the Blade|Alternate Fighter|LLAF|Swordsage|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Swordsage Exploits|Alternate Fighter|LLAF|Swordsage|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Battle Trance|Alternate Fighter|LLAF|Swordsage|LLAF:E|3|LLAF:E"
+				}
+			]
+		},
+		{
+			"name": "Student of the Blade",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"In your studies you have mastered other skills adjacent to swordplay. You gain proficiency in one of the following skills: {@skill Athletics}, {@skill Acrobatics}, {@skill Insight}, {@skill Intimidation}, or {@skill Performance}.",
+				"Whenever you make an ability check with the chosen skill you gain a bonus to your roll equal to your Exploit Die."
+			]
+		},
+		{
+			"name": "Swordsage Exploits",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"You learn certain Exploits at the fighter levels noted in the table below. They don't count against your total number of Exploits Known and can't be switched upon gaining a level.",
+				{
+                    "type": "table",
+                    "caption": "Swordsage Exploits",
+                    "colLabels": [
+                        "Fighter Level",
+                        "Exploits"
+                    ],
+                    "colStyles": [
+                        "col-2 text-center",
+                        "col-10"
+                    ],
+                    "rows": [
+                        [
+                            "3rd",
+                            "{@optfeature lightstep|LLAF}, {@optfeature martial focus|LLAF}"
+                        ],
+                        [
+                            "5th",
+                            "{@optfeature whirlwind strike|LLAF}, {@optfeature zephyr slash|LLAF:E}"
+                        ],
+                        [
+                            "9th",
+                            "{@optfeature gale force slash|LLAF:E}"
+                        ]
+                    ]
+                }
+			]
+		},
+		{
+			"name": "Battle Trance",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"So long as you are not wearing heavy armor or a shield, you can use a bonus action to enter a Battle Trance. Your Battle Trance grants you the following benefits for 1 minute:",
+				{
+					"type": "list",
+					"items": [
+						"You can take the {@action Dash} action as a bonus action.",
+						"You gain a +1 bonus to your Armor Class.",
+						"You have advantage on Dexterity ({@skill Acrobatic}) checks.",
+						"Once per turn when you use a Swordsage Exploit, you can roll a {@dice d4} instead of expending one of your Exploit Dice.",
+						"As a reaction when you are forced to make a saving throw, you can expend an Exploit Die and add it to your roll."
+					]
+				}
+			]
+		},
+		{
+			"name": "Heightened Reflexes",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You have honed your reflexes in pursuit of martial perfection. At 7th level, you gain proficiency in Dexterity saving throws, and you can add your proficiency bonus to initiative rolls."
+			]
+		},
+		{
+			"name": "Improved Battle Trance",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You have mastered the Battle Trance of the Swordsage. Starting at 10th level, when you roll initiative, you can enter your Battle Trance without expending an Exploit Die."
+			]
+		},
+		{
+			"name": "Legendary Swordsage (d6)",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You become a whirlwind of deadly steel while in your Battle Trance. Once per turn while you are in a Battle Trance, you can use any Exploit that you know, rolling a {@dice d6} in place of expending one of your Exploit Dice.",
+				"At 18th level the {@dice d6} from this feature becomes a {@dice d8}."
+			]
+		},
+		{
+			"name": "Legendary Swordsage (d8)",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Swordsage",
+			"page": 14,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"At 18th level the {@dice d6} from your Legendary Swordsage feature becomes a {@dice d8}."
+			]
+		},
+		{
+			"name": "Tinker Knight",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"The fighters known as Tinker Knights seek an unorthodox form of martial skill. Rather than master martial techniques they look to augment their physical ability with mechanical inventions and innovative weaponry. Though they spend most of their time theorizing, tinkering, and experimenting with new Schematics, Tinker Knights and their inventive arsenals are a force to be reckoned with on the field of battle.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Analytical Mind|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Inventive Arsenal|Alternate Fighter|LLAF|Tinker Knight|LLAF:E|3|LLAF:E"
+				},
+				{
+					"type": "inset",
+					"name": "Tinker's Knight in Your Setting",
+					"entries": [
+						"Tinker Knights value brains over brawn. While the descriptive text here describes gears and springs, they can just as easily create their inventions with wood, rocks, crystals, bones, sticks, and scales."
+					]
+				}
+			]
+		},
+		{
+			"name": "Analytical Mind",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"You gain proficiency with {@item tinker's tools|phb|tinker's} and {@item smith's tools|phb}. If you already proficient with these tools, you gain proficiency with another set of tools of your choice.",
+				"You also learn the {@optfeature tinker's intuition|LLAF:E} Exploit, but it doesn't count against your total number of Exploits Known."
+			]
+		},
+		{
+			"name": "Inventive Arsenal",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 3,
+			"entries": [
+				"You have come up with a cacophony of strange modifications for weapons and armor, known as {@filter Schematics|optionalfeatures|feature type=ll:tks}. You know two Schematics from the list at the end of this subclass. When you gain a level in this class, you can replace one Schematic you know with another Schematic of your choice.",
+				"As you gain levels in this class, your number of Schematics known grows; at 7th level (3), 10th level (4), and 15th level (5).",
+				"At the end of each a long rest, you can touch a number of objects equal to your number of Schematics Known and you modify each object with the features of one Schematic. These features last until the end of your next long rest. Each object can only be modified by one Schematic at a time, and it must meet the requirements in the Schematic description.",
+				{
+					"type": "entries",
+					"name": "Saving Throws",
+					"page": 14,
+					"entries": [
+						"If a Schematic requires a saving throw, your Schematic save DC is calculated as follows:",
+						{
+							"type": "abilityDc",
+							"name": "Schematic",
+							"attributes": [
+								"int"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Tinker's Expertise",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"Your proficiency bonus is doubled for any ability check that uses your proficiency with {@item tinker's tools|phb|tinker's} or {@item smith's tools|phb}.",
+				"In addition, items modified by your Schematics count as magical for overcoming resistances and immunities, and you can apply Schematics to magic weapons and armor."
+			]
+		},
+		{
+			"name": "Mechanical Synergy",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Your modifications can work in tandem with each other. You can apply two Schematics to one object, so long as the object meets the prerequisites for both Schematics."
+			]
+		},
+		{
+			"name": "Flexible Innovation",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"Your inventive arsenal can adjust to meet the challenges at hand. At the end of a short rest, you can transfer a Schematic from one object to another, so long as the new object meets the prerequisites. If a Schematic has a limited amount of charges, the number of expended charges remains the same.",
+				"In addition, you can apply up to three Schematics to one object, so long as it meets all the Schematic prerequisites."
+			]
+		},
+		{
+			"name": "Masterwork Inventions",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Tinker Knight",
+			"page": 14,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"Weapons modified by your Schematics gain a +1 bonus to its attack and damage rolls for each Schematic applied to it, and any set of armor modified by a Schematic gains a +1 bonus to its Armor Class for each of your Schematics applied to it.",
+				"Weapons and armor modified by your Schematics cannot gain a bonus greater then +3, regardless of any bonuses the item may have had before applying your Schematics."
+			]
+		},
+		{
+			"name": "Witch Knight",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 16,
+			"level": 3,
+			"entries": [
+				"Those who walk the dark path of the Witch Knight are driven by an overwhelming desire to destroy the great evils of the world. Those especially dedicated, those willing to give up anything, are often approached by Eldritch Powers, beings of otherworldly might. These benefactors offer power in return for a fraction of the warrior's soul or unquestioning fealty.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Pact Magic|Alternate Fighter|LLAF|Witch Knight|LLAF:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Sanguine Offering|Alternate Fighter|LLAF|Witch Knight|LLAF:E|3"
+				}
+			]
+		},
+		{
+			"name": "Pact Magic",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 16,
+			"level": 3,
+			"entries": [
+				"The bargain you have struck with your Patron has granted you the ability to cast spells, much like a warlock does.",
+				{
+					"type": "entries",
+					"name": "Cantrips",
+					"page": 16,
+					"entries": [
+						"You learn one cantrip of your choice from the {@filter warlock spell list|spells|class=Warlock}. Upon reaching 10th level in this class you learn one additional warlock cantrip of your choice."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spell Slots",
+					"page": 16,
+					"entries": [
+						"The Witch Knight Spellcasting table shows how many spell slots you have, and the level of those spell slots. All of your spell slots from this feature are the same level. To cast one of your warlock spells of 1st-level or higher, you must expend a spell slot. You regain all expended spell slots when you finish a short or long rest."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells Known of 1st-Level and Higher",
+					"page": 16,
+					"entries": [
+						"You learn two 1st-level spells of your choice from the {@filter warlock spell list|spells|class=Warlock}. The Spells Known column of the Witch Knight Spellcasting table shows when you learn more warlock spells of 1st-level or higher. A spell you choose must be of a level no higher than what's shown in the table's Slot Level column for your level.",
+						"When you gain a level, you can choose a warlock spell you know and replace it with another spell from the warlock spell list, which must be of a level for which you have spell slots."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Ability",
+					"page": 16,
+					"entries": [
+						"Charisma is your spellcasting ability for your warlock spells. You use your Charisma whenever a spell refers to your spellcasting ability, when setting the saving throw DC, and when making a spell attack roll.",
+						{
+							"type": "abilityDc",
+							"name": "Spell",
+							"attributes": [
+								"cha"
+							]
+						},
+						{
+							"type": "abilityAttackMod",
+							"name": "Spell",
+							"attributes": [
+								"cha"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Sanguine Offering",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 17,
+			"level": 3,
+			"entries": [
+				"Once per turn, when you hit a creature with a melee weapon attack, you can expend one of your fighter Hit Dice as part of the attack to deal an additional {@damage 2d6} necrotic damage to the target, in addition to the normal damage of your weapon."
+			]
+		},
+		{
+			"name": "Otherworldly Step",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 17,
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"You can use Eldritch power to slip through cracks in reality. When you use Second Wind, you can teleport up to 60 feet to an unoccupied space you can see. If you appear within 5 feet of a creature, you can make one weapon attack against it."
+			]
+		},
+		{
+			"name": "Enchanted Strikes",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 17,
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"The Eldritch magic within your blood seeps into your weapon strikes. When you hit a creature with a weapon attack, that creature has disadvantage on the next saving throw it makes against a spell you cast before the end of your next turn."
+			]
+		},
+		{
+			"name": "Improved Sanguine Offering",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 17,
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"You can restore your own vitality by inflicting pain on others. When you use Sanguine Offering, you gain temporary hit points equal to the necrotic damage dealt to the creature.",
+				"Temporary hit points from this ability last for one minute, or until you gain temporary hit points from a different source."
+			]
+		},
+		{
+			"name": "Profane Sacrifice",
+			"source": "LLAF:E",
+			"className": "Alternate Fighter",
+			"classSource": "LLAF",
+			"subclassSource": "LLAF:E",
+			"subclassShortName": "Witch Knight",
+			"page": 7,
+			"level": 18,
+			"header": 2,
+			"entries": [
+				"You can offer the death of your foes to your Eldritch Power for enhanced abilities. As a reaction when a creature dies within 30 feet of you, you can regain one of your expended Pact Magic spell slots, or {@dice 1d4} of your expended Hit Dice.",
+				"Once you use this feature you must finish a short or long rest before you can use it again."
+			]
 		}
 	],
 	"optionalfeature": [
 		{
-			"name": "Cavalier's Training",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Archery",
+			"source": "LLAF",
+			"page": 2,
 			"entries": [
-				"When you make a Charisma ({@skill Persuasion}), Wisdom ({@skill Insight}) or Wisdom ({@skill Animal Handling}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"You gain a +2 bonus to attack rolls with ranged weapons."
 			],
 			"featureType": [
-				"LLAF:MK:Ca"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Mounted Strike",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Classical Swordplay",
+			"source": "LLAF",
+			"page": 2,
 			"entries": [
-				"When you hit a creature with an attack from atop a mount, you can expend an Exploit Die, adding it to the damage of your attack and forcing it to make a Strength saving throw. On a failed save, it is knocked {@condition prone}."
+				"While wielding a finesse weapon and no other weapons, you gain a +1 bonus to your attack rolls and a +1 to your Armor Class so long as you are not using heavy armor or a shield."
 			],
 			"featureType": [
-				"LLAF:MK:Ca"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Skilled Rider",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Defensive Fighting",
+			"source": "LLAF",
+			"page": 2,
 			"entries": [
-				"Whenever a mount you are riding makes an ability check or saving throw, you can expend an Exploit Die and add it to the result of the roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"While wearing armor or wielding a shield, you gain a +1 bonus to your Armor Class."
 			],
 			"featureType": [
-				"LLAF:MK:Ca"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Critical Strike",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Dual Wielding",
+			"source": "LLAF",
+			"page": 2,
 			"entries": [
-				"When you score a critical hit with a weapon attack, you can expend an Exploit Die to re-roll any amount of the damage dice for that attack. You must use the result of the new rolls."
+				"When you take the {@action Attack} action while two-weapon fighting, you can make a single additional attack with your off-hand weapon as part of your action instead of your bonus action, adding your ability modifier to the damage of this attack"
 			],
 			"featureType": [
-				"LLAF:MK:S"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Regal Spirit",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Dueling",
+			"source": "LLAF",
+			"page": 2,
 			"entries": [
-				"Whenever you are forced to make a saving throw to resist being {@condition charmed}, {@condition frightened}, or {@condition stunned}, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with it."
 			],
 			"featureType": [
-				"LLAF:MK:S"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Samurai's Nobility",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Featherweight Fighting",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you make an Intelligence ({@skill History}), Wisdom ({@skill Insight}), or Charisma ({@skill Persuasion}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"While you are wielding only light weapons, and nothing else your speed increases by 10 feet. You also gain a +1 bonus to damage rolls with light weapons, so long as you are not wearing medium or heavy armor, or wielding a shield."
 			],
 			"featureType": [
-				"LLAF:MK:S"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Echo Knight's Esoterica",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Great Weapon Fighting",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you make a Intelligence ({@skill Arcana}), Dexterity ({@skill Stealth}) or Wisdom ({@skill Insight}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"When you roll a 1 or 2 on the damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the damage, though you must use the new roll, even if the new roll is a 1 or a 2.",
+				"The weapon must have the heavy, versatile, or two-handed property to gain this benefit."
 			],
 			"featureType": [
-				"LLAF:MK:EK"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Enhanced Echo",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Improvised Fighting",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you create an Echo, you can expend an Exploit Die as part of that bonus action and add it to the Echo's hit points."
+				"You gain proficiency with improvised weapons. Once per turn, when you hit with a improvised weapon attack, you can roll the damage die twice and take the higher roll. When you do this, the improvised weapon is destroyed and cannot be used for further attacks. You can't use this feature to destroy magical objects."
 			],
 			"featureType": [
-				"LLAF:MK:EK"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Shadow Transposition",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Melee Marksman",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"As a bonus action, you can expend an Exploit Die to switch places with your Echo. You and your Echo instantly teleportto the other's location without provoking opportunity attacks."
+				"Having a hostile creature within 5 feet of you does not impose disadvantage on your ranged weapon attacks, so long as you are attacking a creature within 5 feet.",
+				"When you make a ranged weapon attack against a creature within 5 feet, you can use your bonus action to make a melee attack against it with your ranged weapon. On hit, you deal bludgeoning damage equal to {@dice 1d4} + your Strength modifier."
 			],
 			"featureType": [
-				"LLAF:MK:EK"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Awakened Mind",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Protection",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you are forced to make a Intelligence, Wisdom, or Charisma save to resist the effects of a spell, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a melee weapon or a shield to use this reaction."
 			],
 			"featureType": [
-				"LLAF:MK:PsiW"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Psi Warrior's Aura",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Strongbow",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you make a Wisdom ({@skill Insight}), Charisma ({@skill Intimidation}), or Charisma ({@skill Persuasion}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"You can use your Strength modifier, in place of Dexterity, for your attack and damage rolls with {@item longbow|phb|longbows} and {@item shortbow|phb|shortbows}."
 			],
 			"featureType": [
-				"LLAF:MK:PsiW"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Psionic Strength",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Thrown Weapon Fighting",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you make a Strength ({@skill Athletics}) check, you can expend an Exploit Die, and you gain a bonus to that roll equal to your Exploit Die + your Intelligence modifier (minimum of +1)."
+				"You can draw a weapon that has the thrown property as part of the attack you make with the weapon. Moreover, when you hit with a ranged weapon attack using a thrown weapon, you gain a +2 bonus to the damage roll of that attack."
 			],
 			"featureType": [
-				"LLAF:MK:PsiW"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Rune Knight's Knowledge",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Unarmed Fighting",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you make a Intelligence ({@skill Arcana}), Intelligence ({@skill History}) or {@item smith's tools|PHB} check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"Your unarmed strikes can deal bludgeoning damage equal to {@dice 1d6} + your Strength modifier on a hit. If you have two free hands when you make the attack roll, the {@dice d6} becomes a {@dice d8}.",
+                "At the beginning of each of your turns, you can deal {@dice 1d4} bludgeoning damage to one creature you are grappling."
 			],
 			"featureType": [
-				"LLAF:MK:RK"
+				"FS:AF"
 			]
 		},
 		{
-			"name": "Runic Endurance",
-			"source": "LLAF:E",
-			"page": 12,
+			"name": "Versatile Fighting",
+			"source": "LLAF",
+			"page": 3,
 			"entries": [
-				"When you take bludgeoning, piercing, or slashing damage, you can expend an Exploit Die to reduce the damage by an amount equal to twice your Exploit Die."
+				"While wielding a single versatile weapon and no shield, you can choose to wield your weapon one or two-handed until the start of your next turn. When wielding it one-handed you gain a +1 bonus to attack rolls and to your Armor Class. Wielding it two-handed you gain a +2 bonus to your damage rolls."
 			],
 			"featureType": [
-				"LLAF:MK:RK"
-			]
-		},
-		{
-			"name": "Runic Lore",
-			"source": "LLAF:E",
-			"page": 12,
-			"entries": [
-				"When you make a Charisma check related to Giants, you can expend a Exploit Die and add it to the result of your roll."
-			],
-			"featureType": [
-				"LLAF:MK:RK"
-			]
-		},
-		{
-			"name": "Featherweight Schematic",
-			"source": "LLAF:E",
-			"page": 11,
-			"entries": [
-				"You modify the metallurgical makeup of an item, making it lighter. The wearer or wielder of an object modified by this Schematic has their movement speed increased by 10 feet.",
-				{
-					"type": "entries",
-					"name": "Heavy Armor",
-					"page": 11,
-					"entries": [
-						"When applied, the wearer ignores any Strength requirements the armor may have, or any penalty itmay impose upon their Dexterity ({@skill Stealth}) checks."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Light Armor",
-					"page": 11,
-					"entries": [
-						"When applied, the wearer can subtract up to 100 feet from their fall distance when calculating fall damage and can move horizontally 2 feet for every 1 foot they fall."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Weapon",
-					"page": 11,
-					"entries": [
-						"When applied, a Heavy weapon becomes normal weight, and a normal weapon becomes a Light weapon."
-					]
-				}
-			],
-			"featureType": [
-				"LLAF:TKSCH"
-			]
-		},
-		{
-			"name": "Intuitive Schematic",
-			"source": "LLAF:E",
-			"page": 11,
-			"entries": [
-				"You modify an item to take advantage of your martial and investigative instincts. The wearer or wielder of an object modified by this Schematic gains proficiency in {@skill Investigation} and they can add double their proficiency bonus to any Intelligence ({@skill Investigation}) checks they make.",
-				{
-					"type": "entries",
-					"name": "Armor",
-					"page": 11,
-					"entries": [
-						"When applied, the wearer can use their Intelligence in place of Dexterity, when calculating their Armor Class."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Weapon",
-					"page": 11,
-					"entries": [
-						"When applied, the wielder can use their Intelligence modifier, in place of Strength or Dexterity, for attack and damage rolls with this weapon."
-					]
-				}
-			],
-			"featureType": [
-				"LLAF:TKSCH"
-			]
-		},
-		{
-			"name": "Radiant Schematic",
-			"source": "LLAF:E",
-			"page": 11,
-			"entries": [
-				"You imbue an item with a source of radiant energy. The wearer or wielder of an object modified by this Schematic can use a bonus action to cause the object to emit bright light in a 15-foot radius, and dim light 15 feet beyond that. They can extinguish the light as a bonus action on their turn.",
-				{
-					"type": "entries",
-					"name": "Armor or Weapon",
-					"page": 11,
-					"entries": [
-						"As a reaction when you are hit by an attack (armor), or hit a creature with an attack (weapon), you can force the creature to make a Constitution saving throw. On a failure, it is {@skill blinded} for 1 minute. It can repeat the save at the end of each turn, ending the effect on a success.",
-						"Once you use this reaction, you must finish a short or long rest before you can use it again."
-					]
-				}
-			],
-			"featureType": [
-				"LLAF:TKSCH"
-			]
-		},
-		{
-			"name": "Rebounding Schematic",
-			"source": "LLAF:E",
-			"page": 11,
-			"entries": [
-				"You modify an item so that it has elastic properties. The wearer or wielder of an object modified by this Schematic can use their reaction to add your Intelligence modifier (minimum of +1) to their Armor Class against one attack.",
-				{
-					"type": "entries",
-					"name": "Armor",
-					"page": 11,
-					"entries": [
-						"As a reaction when the wearer of this armor is hit by an attack, they can reduce the damage by an amount equal to {@dice 1d12} + your Intelligence modifier. If the damage is reduced to 0, the attacker takes the full damage of the attack as if they had been the original target.",
-						"Once you use this feature, you must finish a short or long rest before you can use it again."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Non-Heavy Weapon",
-					"page": 11,
-					"entries": [
-						"When applied, the weapon gains the Thrown property with a range of 20 feet. After making an attack with this weapon, it immediately returns to the wielder."
-					]
-				}
-			],
-			"featureType": [
-				"LLAF:TKSCH"
-			]
-		},
-		{
-			"name": "Empowered Schematic",
-			"source": "LLAF:E",
-			"page": 11,
-			"prerequisite": [
-				{
-					"level": {
-						"class": {
-							"name": "Alternate Figther",
-							"source": "LLAF"
-						},
-						"subclass": {
-							"name": "Tinker Knight",
-							"source": "LLAF:E",
-							"visible": true
-						},
-						"level": 7
-					}
-				}
-			],
-			"entries": [
-				"You modify an object with clockwork mechanics that improve physical ability and sharpens reflexes. The wearer or wielder of an object modified by this Schematic gains a bonus to their initiative equal to your Intelligence modifier (minimum of +1).",
-				{
-					"type": "entries",
-					"name": "Heavy Armor",
-					"page": 11,
-					"entries": [
-						"When applied, the wearer can use your Intelligence score, in place of Strength, for any Strength ability checks or saving throws they make."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Light Armor",
-					"page": 11,
-					"entries": [
-						"When applied, the wearer can use your Intelligence score, in place of Dexterity, for any Dexterity ability checks or saving throws they make."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Weapon",
-					"page": 11,
-					"entries": [
-						"When applied, anytime the wielder rolls a 1 or 2for a damage roll with this weapon, they can choose to re-rollthe die, but you must use the new result even if it is a 1 or 2."
-					]
-				}
-			],
-			"featureType": [
-				"LLAF:TKSCH"
-			]
-		},
-		{
-			"name": "Resilient Schematic",
-			"source": "LLAF:E",
-			"page": 11,
-			"prerequisite": [
-				{
-					"level": {
-						"class": {
-							"name": "Alternate Figther",
-							"source": "LLAF"
-						},
-						"subclass": {
-							"name": "Tinker Knight",
-							"source": "LLAF:E",
-							"visible": true
-						},
-						"level": 7
-					}
-				}
-			],
-			"entries": [
-				"You modify the metallurgical makeup of this item to make it far more resilient. The wearer or wielder of an object modified by this Schematic has advantage on saving throws to resist being {@condition grappled} or moved against their will.",
-				{
-					"type": "entries",
-					"name": "Armor",
-					"page": 11,
-					"entries": [
-						"When applied, this armor grants resistance to nonmagical bludgeoning, piercing, and slashing damage."
-					]
-				},
-				{
-					"type": "entries",
-					"name": "Weapon",
-					"page": 11,
-					"entries": [
-						"When applied, this weapon deals bonus damage equal to your Intelligence modifier (minimum of 1) + your fighter level when you score a critical hit."
-					]
-				}
-			],
-			"featureType": [
-				"LLAF:TKSCH"
-			]
-		},
-		{
-			"name": "Fortifying Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 3,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"Choose either Strength, Dexterity, or Constitution. For 1 minute, the creature can add your Constitution modifier (minimum of +1) to any ability check or saving throw for the chosen ability score."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Invigorating Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 3,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"The creature regains hit points equal to your Constitution modifier + your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Revitalizing Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 3,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"The creature ends one of the following conditions currently effecting it: {@condition blinded}, {@condition deafened}, {@condition poisoned}, or they reduce their {@condition exhaustion} level by 1."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Heightening Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 7,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"Choose either Charisma, Intelligence, or Wisdom. For 1 minute, the creature can addyour Constitution modifier (minimum of +1) to any ability check or saving throw for the chosen ability score."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Tenacious Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 7,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"Choose {@condition blinded}, {@condition charmed}, {@condition deafened}, {@condition frightened}, {@condition poisoned}, {@condition paralyzed}, or {@condition stunned}. For 1 minute, the creature gains immunity to that condition."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Warding Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 7,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"You gain resistance to one ofthe following damage types for 1 minute: acid, bludgeoning, cold, fire, piercing, poison, lighting, slashing, or thunder."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Berserker Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 15,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"For 1 hour, you do not fall unconscious when reduced to 0 hit points. You still make death saving throws as normal, and die upon three failures. A creature that consumes this Ration cannot gain the benefits of another Ration until they finish a long rest."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Rejuvenating Ration",
-			"source": "LLAF:E",
-			"page": 8,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 15,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF"
-						}
-					}
-				}
-			],
-			"entries": [
-				"You instantly gain all the benefits of a short rest, including the ability to spend Hit Dice, as part of consuming this Ration. In addition to the short rest, you immediately gain 1 level of {@condition exhaustion}. A creature that consumes this Ration cannot gain the benefits of another Ration until they finish a long rest."
-			],
-			"featureType": [
-				"LLAF:QMR"
-			]
-		},
-		{
-			"name": "Eldritch Insight",
-			"source": "LLAF:E",
-			"page": 7,
-			"entries": [
-				"When you make an Intelligence ({@skill Arcana}) or a check using the proficiency gained from your Eldritch Power, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME:PactW"
-			]
-		},
-		{
-			"name": "Adapt",
-			"source": "LLAF:E",
-			"page": 5,
-			"entries": [
-				"When you make a saving throw to resist the effects of a hostile environment, or you make Strength ({@skill Athletics}) or a Dexterity ({@skill Acrobatics}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME:Gue"
-			]
-		},
-		{
-			"name": "Improvise",
-			"source": "LLAF:E",
-			"page": 5,
-			"entries": [
-				"When you make an ability check that does not include your proficiency bonus, you can expend an Exploit Die and add it to your roll. You must use this Exploit before you roll."
-			],
-			"featureType": [
-				"LLAF:ME:Gue"
-			]
-		},
-		{
-			"name": "Overcome",
-			"source": "LLAF:E",
-			"page": 5,
-			"entries": [
-				"When you are reduced to 0 hit points but not killed outright, you can use your reaction to expend an Exploit Die and make a Constitution saving throw. The save DC equals 10 or half the damage you take, whichever number is higher. On asuccessful save, you drop to 1 hit point instead of 0."
-			],
-			"featureType": [
-				"LLAF:ME:Gue"
-			]
-		},
-		{
-			"name": "Guardian's Resilience",
-			"source": "LLAF:E",
-			"page": 4,
-			"entries": [
-				"When you are forced to make a Strength saving throw, a saving throw to resist the effects of {@condition exhaustion}, or a {@item smith's tools|PHB} check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME:Gua"
-			]
-		},
-		{
-			"name": "Heart of Steel",
-			"source": "LLAF:E",
-			"page": 4,
-			"entries": [
-				"As a reaction when you are hit by a melee attack, you can expend an Exploit Die and reduce the damage you would take by an amount equal to twice your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME:Gua"
-			]
-		},
-		{
-			"name": "Immovable",
-			"source": "LLAF:E",
-			"page": 4,
-			"entries": [
-				"As an action, you can expend an Exploit Die and plant your feet in an immovable stance. Until the end of your next turn, a creature that would move you, or move through your space, must succeed on a Strength saving throw in order to do so."
-			],
-			"featureType": [
-				"LLAF:ME:Gua"
+				"FS:AF"
 			]
 		},
 		{
@@ -4793,10 +5944,10 @@
 			"source": "LLAF:E",
 			"page": 1,
 			"entries": [
-				"You fight with reckless abandon in battle. Once per turn, you can grant yourself advantage on a single attack roll. Once you take this advantaged attack, your Armor Class is reduced by 2 until the beginning of your next turn."
+				"You fight with reckless abandon in battle. Once per turn, you can grant yourself advantage on a single melee wepaon attack roll. Once you take this advantaged attack, your Armor Class is reduced by 2 until the beginning of your next turn."
 			],
 			"featureType": [
-				"LLAF:FS"
+				"FS:AF"
 			]
 		},
 		{
@@ -4804,10 +5955,32 @@
 			"source": "LLAF:E",
 			"page": 1,
 			"entries": [
-				"You use your weight, and the weight of your weapon, to land devastating blows. While you are wielding a heavy weapon, you gain a +2 bonus to damage rolls with that weapon, and you have advantage on Strength ({@skill Athletics}) checks to {@action Shove|phb|shove}."
+				"You use the weight of your weapon, to land devastating blows. While you are wielding a heavy weapon, you gain a +2 bonus to damage rolls and you have advantage on Strength ({@skill Athletics}) checks made to {@action Shove|phb|shove}."
 			],
 			"featureType": [
-				"LLAF:FS"
+				"FS:AF"
+			]
+		},
+		{
+			"name": "Mariner",
+			"source": "LLAF:E",
+			"page": 1,
+			"entries": [
+				"When you are not wearing medium or heavy armor, or using a shield, you have a swimming speed equal to your walking speed, and you gain a +1 bonus to your Armor Class."
+			],
+			"featureType": [
+				"FS:AF"
+			]
+		},
+		{
+			"name": "Mountaineer",
+			"source": "LLAF:E",
+			"page": 1,
+			"entries": [
+				"When you are not wearing medium or heavy armor, or using a shield, you have a climbing speed equal to your movement speed, and you gain a +1 bonus to your Armor Class."
+			],
+			"featureType": [
+				"FS:AF"
 			]
 		},
 		{
@@ -4818,7 +5991,7 @@
 				"Once per turn, when you hit a creature with a melee attack while riding a mount, you can force the target to make a Strength saving throw against your Exploit save DC. On a failed save, a Large or smaller target is knocked {@condition prone}."
 			],
 			"featureType": [
-				"LLAF:FS"
+				"FS:AF"
 			]
 		},
 		{
@@ -4837,7 +6010,7 @@
 				}
 			],
 			"featureType": [
-				"LLAF:FS"
+				"FS:AF"
 			]
 		},
 		{
@@ -4845,21 +6018,1760 @@
 			"source": "LLAF:E",
 			"page": 1,
 			"entries": [
-				"You fight using your shield for both offense and defense. For you, {@item shield|phb|shields} count as martial melee weapons, and deal {@dice 2d4} bludgeoning damage on hit. If you are wielding a shield and no other weapons, you gain a +1 bonus to both your Armor Class and to your damage rolls for attacks with your shield."
+				"You gain proficiency with {@item shield|phb|shields} as a martial melee weapon, and on hit, your shield deals {@dice 2d4} bludgeoning damage. If you are wielding a shield and nothing else, you gain a +1 bonus to your shield attack damage rolls and to your Armor Class."
 			],
 			"featureType": [
-				"LLAF:FS"
+				"FS:AF"
+			]
+		},
+		{
+			"name": "Standard Bearer",
+			"source": "LLAF:E",
+			"page": 1,
+			"entries": [
+				"When a creature within 5 feet of you makes an attack against a creature that you can see, you can grant them advantage on their attack roll as a reaction. You must be carrying a banner, flag, or standard in your hand to use this reaction."
+			],
+			"featureType": [
+				"FS:AF"
+			]
+		},
+		{
+			"name": "Wrestler",
+			"source": "LLAF:E",
+			"page": 1,
+			"entries": [
+				"When you hit a creature with a melee attack, you can attempt to {@action grapple} that creature as a bonus action on that turn, so long as you have a free hand to do so. Also, you can drag {@condition grappled} creatures up to your full speed."
+			],
+			"featureType": [
+				"FS:AF"
+			]
+		},
+		{
+			"name": "Banishing Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"You use abjuration magic to try to temporarily banish your target to a harmless location in the Feywild. The creature hit by the arrow takes extra force damage equal to one roll of your Exploit Die, and must also succeed on a Charisma saving throw or be banished. While banished in this way, the target's speed is 0, and it is {@condition incapacitated}. At the end of its next turn, the target reappears in the space it vacated or in the nearest unoccupied space if that space is occupied."
+			]
+		},
+		{
+			"name": "Beguiling Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"Your enchantment magic causes this arrow to temporarily beguile its target. The creature hit by the arrow takes extra psychic damage equal to two rolls of your Exploit Die, and choose one of your allies within 30 feet of the target. The target must succeed on a Wisdom saving throw, or it is {@condition charmed} by the chosen ally until the start of your next turn. This effect ends early if the chosen ally attacks the {@condition charmed} target, deals damage to it, or forces it to make a saving throw."
+			]
+		},
+		{
+			"name": "Bursting Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"You imbue your arrow with force energy drawn from the school of evocation. The energy detonates after your attack. Immediately after the arrow hits the creature, the target and all other creatures within 10 feet of it each take force damage equal to two rolls of your Exploit Die."
+			]
+		},
+		{
+			"name": "Enfeebling Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"You weave necromantic magic into your arrow. The creature hit by the arrow takes extra necrotic damage equal to two rolls of your Exploit Die. The target must also succeed on a Constitution saving throw, or the damage dealt by its weapon attacks is halved until the start of your next turn."
+			]
+		},
+		{
+			"name": "Grasping Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"When this arrow strikes its target, conjuration magic creates grasping, poisonous brambles, which wrap around the target. The creature hit by the arrow takes extra poison damage equal to two rolls of your Exploit Die, its speed is reduced by 10 feet, and it takes slashing damage equal to two rolls of your Exploit Die the first time on each turn it moves 1 foot or more without teleporting. The target or any creature that can reach it can use its action to remove the brambles with a successful Strength ({@skill Athletics}) check against your Arcane Shot save DC. Otherwise, the brambles last for 1 minute or until you use this option again."
+			]
+		},
+		{
+			"name": "Piercing Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"You use transmutation magic to give your arrow an ethereal quality. When you use this option, you don't make an attack roll for the attack. Instead, the arrow shoots forward in a line, which is 1 foot wide and 30 feet long, before disappearing. The arrow passes harmlessly through objects, ignoring cover. Each creature in that line must make a Dexterity saving throw. On a failed save, a creature takes damage as if it were hit by the arrow, plus extra piercing damage equal to one roll of your Exploit Die. On a successful save, a target takes half as much damage."
+			]
+		},
+		{
+			"name": "Seeking Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"Using divination magic, you grant your arrow the ability to seek out a target. When you use this option, you don't make an attack roll for the attack. Instead, choose one creature you have seen in the past minute. The arrow flies toward that creature, moving around corners if necessary and ignoring three-quarters cover and half cover. If the target is within the weapon's range and there is a path large enough for the arrow to travel to the target, the target must make a Dexterity saving throw. Otherwise, the arrow disappears after traveling as far as it can. On a failed save, the target takes damage as if it were hit by the arrow, plus extra force damage equal to one roll of your Exploit Die, and you learn the target's current location. On a successful save, the target takes half as much damage, and you don't learn its location."
+			]
+		},
+		{
+			"name": "Shadow Arrow",
+			"source": "LLAF",
+			"page": 14,
+			"featureType": [
+				"LL:ASA"
+			],
+			"entries": [
+				"You weave illusion magic into your arrow, causing it to occlude your foe's vision with shadows. The creature hit by the arrow takes extra psychic damage equal to two rolls of your Exploit Die, and it must succeed on a Wisdom saving throw or be unable to see anything farther than 5 feet away until the start of your next turn."
+			]
+		},
+		{
+			"name": "Cloud Rune",
+			"source": "LLAF",
+			"page": 15,
+			"featureType": [
+				"LL:RNA"
+			],
+			"entries": [
+				"This rune emulates the deceptive magic used by some cloud giants. While you wear or carry an object with this Rune, you gain a bonus to Dexterity ({@skill Sleight of Hand}) and Charisma ({@skill Deception}) checks equal to your Exploit Die.",
+				"In addition, when you or a creature you can see within 30 feet of you is hit by an attack roll, you can use your reaction to invoke the rune and choose a different creature within 30 feet of you, other than the attacker. The chosen creature becomes the target of the attack, using the same roll. This magic can transfer the attack's effects regardless of the attack's range. Once you invoke this rune, you can't do so again until you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Fire Rune",
+			"source": "LLAF",
+			"page": 15,
+			"featureType": [
+				"LL:RNA"
+			],
+			"entries": [
+				"This rune's magic channels the masterful craftsmanship of great smiths. While you wear or carry an object with this Rune, you gain a bonus to any tool proficiency checks you make equal to your Exploit Die.",
+				"In addition, when you hit a creature with an attack using a weapon, you can invoke the rune to summon fiery shackles: the target takes extra fire damage equal to two rolls of your Exploit Die, and it must succeed on a Strength saving throw or be {@condition restrained} for 1 minute. While {@condition restrained} by the shackles, the target takes fire damage equal to two rolls of your Exploit Die at the start of each of its turns. The target can repeat the saving throw at the end of each of its turns, banishing the shackles on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Frost Rune",
+			"source": "LLAF",
+			"page": 15,
+			"featureType": [
+				"LL:RNA"
+			],
+			"entries": [
+				"This rune's magic evokes the might of those who survive in the wintry wilderness, such as frost giants. While you wear or carry an object with this Rune, you gain a bonus to Wisdom ({@skill Animal Handling}) and Charisma ({@skill Intimidation}) checks equal to your Exploit Die.",
+				"In addition, you can invoke the rune as a bonus action to increase your sturdiness. For 10 minutes, you gain a +2 bonus to all ability checks and saving throws that use Strength or Constitution. Once you invoke this rune, you can't do so again until you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Hill Rune",
+			"source": "LLAF",
+			"page": 15,
+			"featureType": [
+				"LL:RNA"
+			],
+			"entries": [
+				"This rune's magic bestows a resilience reminiscent of a hill giant. While wearing or carrying an object that bears this rune, you have advantage on saving throws against being {@condition poisoned}, and you have resistance against poison damage.",
+				"In addition, you can invoke the rune as a bonus action, gaining resistance to bludgeoning, piercing, and slashing damage for 1 minute. Once you invoke this rune, you can't do so again until you finish a short or long rest."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 7,
+						"class": {
+							"name": "Alternate Fighter"
+						},
+						"subclass": {
+							"name": "Rune Knight"
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Stone Rune",
+			"source": "LLAF",
+			"page": 15,
+			"featureType": [
+				"LL:RNA"
+			],
+			"entries": [
+				"This rune's magic channels the judiciousness associated with stone giants. While you wear or carry an object with this Rune, you gain a bonus to Wisdom ({@skill Insight}) checks equal to your Exploit Die, and you have 120-foot radius {@sense darkvision}.",
+				"In addition, when a creature you can see ends its turn within 30 feet of you, you can use your reaction to invoke the rune and force the creature to make a Wisdom saving throw. Unless the save succeeds, the creature is {@condition charmed} by you for 1 minute. While {@condition charmed} in this way, the creature has a speed of 0 and is {@condition incapacitated}, descending into a dreamy stupor. The creature repeats the saving throw at the end of each of its turns, ending the effect on a success. Once you invoke this rune, you can't do so again until you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Storm Rune",
+			"source": "LLAF",
+			"page": 15,
+			"featureType": [
+				"LL:RNA"
+			],
+			"entries": [
+				"Using this rune, you can glimpse the future like a storm giant seer. While you wear or carry an object with this Rune, you gain a bonus to Intelligence ({@skill Arcana}) checks equal to your Exploit Die, and you can't be surprised as long as you aren't {@condition incapacitated}.",
+				"In addition, you can invoke the rune as a bonus action to enter a prophetic state for 1 minute or until you're {@condition incapacitated}. Until the state ends, when you or another creature you can see within 60 feet of you makes an attack roll, a saving throw, or an ability check, you can use your reaction to cause the roll to have advantage or disadvantage. Once you invoke this rune, you can't do so again until you finish a short or long rest."
+			],
+            "prerequisite": [
+                {
+					"level": {
+						"level": 7,
+						"class": {
+							"name": "Alternate Fighter"
+						},
+						"subclass": {
+							"name": "Rune Knight"
+						}
+					}
+				}
+            ]
+		},
+		{
+			"name": "Blinding Strike",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and force a creature within 10 feet to make a Constitution saving throw. On a failure, it takes piercing damage equal to your Exploit Die and is {@condition blinded} until the start of your next turn."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Brace Up",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"You steel yourself for combat, preparing to take incoming blows. As a bonus action, you can expend an Exploit Die to gain temporary hit points equal to 1 + your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "con": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Charlatan's Guile",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"When you make a Dexterity ({@skill Sleight of Hand}), Charisma ({@skill Deception}), or a  Charisma ({@skill Performance}) check, you can expend an Exploit Die and add it to result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "dex": 11
+                        },
+                        {
+                            "cha": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Commander's Presence",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"When you make a Charisma ({@skill Intimidation}), Charisma ({@skill Persuasion}), or a Intelligence ({@skill History}) check, you can expend an Exploit Die and add it to result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "int": 11
+                        },
+                        {
+                            "cha": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Crippling Strike",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"When you hit a creature with a weapon attack, you can expend an Exploit Die and force it to make a Dexterity saving throw. On a failure, it takes additional damage equal to your Exploit Die and its speed is 0 until the start of your next turn."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Disarm",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"When you hit a creature with a weapon attack, you can expend an Exploit Die to force it to make a Strength saving throw. On a failure, it takes additional damage equal to your Exploit Die, and it drops an item of your choice at its feet."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Feat of Strength",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"Whenever you make a Strength or Constitution-based ability check or saving throw, you can expend an Exploit Die and add it to the result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "str": 11
+                        },
+                        {
+                            "con": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Feint",
+			"source": "LLAF",
+			"page": 9,
+			"entries": [
+				"When you make a melee weapon attack, you can expend an Exploit Die to attempt a feint. One creature of your choice that can see you within range of your weapon must make a Wisdom saving throw. On a failed save, you add your Exploit Die to both your attack roll and damage roll for that attack."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "First Aid",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"As an action, you can touch a conscious and willing creature and expend an Exploit Die to heal them. As a reaction, the creature can expend one of their Hit Dice to immediately regain hit points equal to their Hit Die + your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Heroic Fortitude",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"Whenever you are forced to make a Strength, Dexterity, or Constitution saving throw, you can expend an Exploit Die and add it to the result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
 			]
 		},
 		{
 			"name": "Hurl",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die to throw an object you are holding at a target you can see within 60 feet, forcing it to make a Dexterity saving throw. On a failed save, both the object and target take bludgeoning damage equal to your Exploit Die + your Strength modifier."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "str": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Keen Observation",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a Intelligence ({@skill Investigation}), Wisdom ({@skill Insight}), or a Wisdom ({@skill Perception}) check, you can expend an Exploit Die and add it to result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "int": 11
+                        },
+                        {
+                            "wis": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Lightstep",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"Whenever you make a Dexterity ({@skill Acrobatics}) or a Dexterity ({@skill Stealth}) check, or roll initiative, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "dex": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Martial Focus",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a weapon attack, you can expend an Exploit Die as part of the attack to grant yourself advantage on your attack roll. You can use this Exploit after you roll, but before you know whether your attack hits or misses your target."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Menacing Shout",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and force a creature within 30 feet that can see or hear you to make a Wisdom saving throw. On a failed save, it is {@condition frightened} of you for one minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on a success.",
+                "The fear effect ends early for the target if the frightened creature sees you take damage of any kind."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Mighty Leap",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a running or standing jump, you can expend an Exploit Die to increase your jump distance by a number of feet equal to your Exploit Die roll + your Strength modifier, even if the distance exceeds your remaining movement speed."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "str": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Mighty Thrust",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die to force a creature within reach to make a Strength saving throw. On a failure, it is pushed away from you a number of feet equal to 5 times your Strength modifier. Creatures more than one size larger than you have advantage on the saving throw."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "str": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Precision Strike",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a weapon attack, you can expend an Exploit Die and add it to the attack roll. You can use this Exploit after you roll, but before you know if the attack hits or misses."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "dex": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Riposte",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"As a reaction when a creature you can see targets you with a melee attack, you can expend an Exploit Die and add it to your Armor Class against the attack. If the attack misses, you can immediately make a weapon attack against your attacker."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "dex": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Ruthless Strike",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die and add it to the damage of the attack. You can use this Exploit after you know if your attack hits."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "str": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Scholar's Insight",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a Intelligence ({@skill Arcana}), Intelligence ({@skill Nature}), or a Intelligence ({@skill Religion}) check, you can expend an Exploit Die and add it to result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "int": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Skilled Rider",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you are riding a trained mount and the mount makes an ability check, attack roll, or saving throw, or you make a Wisdom ({@skill Animal Handling}) check to control it, you can expend an Exploit Die and add it to the roll. You can use this Exploit after roll, but before you know if it succeed or failed."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "wis": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Survivalist's Craft",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a Wisdom ({@skill Animal Handling}), Wisdom ({@skill Medicine}), or a Wisdom ({@skill Survival}) check, you can expend an Exploit Die and add it to result of your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "int": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Sweeping Strike",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to force it to make a Dexterity saving throw. On a failed save, it falls {@condition prone} and takes bludgeoning damage equal to your Exploit Die. Creatures more than one size larger than you have advantage on their saving throw."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Wild Strike",
+			"source": "LLAF",
+			"page": 10,
+			"entries": [
+				"When you make a melee weapon attack, you can expend an Exploit Die as part of the attack to strike with wild abandon. You have advantage on your attack roll, but you must subtract your Exploit Die from your attack roll. However, on hit, you deal additional damage equal to two rolls of your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+            "prerequisite": [
+                {
+                    "ability": [
+                        {
+                            "str": 11
+                        },
+                        {
+                            "dex": 11
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Aggressive Strike",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and move up to your speed toward a hostile creature you can see and make one melee weapon attack against the hostile creature."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+            "prerequisite": [
+                {
+                    "level": {
+						"level": 5,
+						"class":{
+							"name": "Alternate Fighter",
+							"source":"LLAF",
+							"visible": true
+						}
+					}
+                }
+            ]
+		},
+		{
+			"name": "Concussive Blow",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"When you hit a creature with a melee attack, you can expend an Exploit Die to empower your attack, and force it to make a Constitution saving throw. On a failed save, the target suffers the following effects until the beginning of your next turn:",
+				{
+					"type": "list",
+					"items": [
+						"Its speed is reduced to 0.",
+						"It can speak only falteringly.",
+						"It cannot take actions, bonus actions, or reactions.",
+						"It has disadvantage on Dexterity saving throws."
+					]
+				}
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+            "prerequisite": [
+                {
+                    "level": {
+						"level": 5,
+						"class":{
+							"name": "Alternate Fighter",
+							"source":"LLAF",
+							"visible": true
+						}
+					}
+				},
+				{
+                    "ability": [
+                        {
+                            "str": 13
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Crushing Strike",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die and force it to make a Constitution saving throw. On a failed save, it takes extra damage equal to your Exploit Die, and its Armor Class is reduced by 1 until its defenses are repaired, or it finishes a short or long rest."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+            "prerequisite": [
+                {
+                    "level": {
+						"level": 5,
+						"class":{
+							"name": "Alternate Fighter",
+							"source":"LLAF",
+							"visible": true
+						}
+					}
+				},
+				{
+                    "ability": [
+                        {
+                            "str": 13
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Defensive Stance",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to enter a defensive stance which lasts until the start of your next turn. Each time a creature that you can see hits you with an attack while you are in your defensive stance, you roll your Exploit Die and add it to your Armor Class against the attack."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+            "prerequisite": [
+                {
+                    "level": {
+						"level": 5,
+						"class":{
+							"name": "Alternate Fighter",
+							"source":"LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Dirty Hit",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"When you hit a creature with a weapon attack, you can expend an Exploit Die and force it to make a Constitution saving throw. On a failed save, it takes additional damage equal to your Exploit Die, and until the start of your next turn it cannot take reactions and its speed is halved."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+            "prerequisite": [
+                {
+                    "level": {
+						"level": 5,
+						"class":{
+							"name": "Alternate Fighter",
+							"source":"LLAF",
+							"visible": true
+						}
+					}
+				},
+				{
+                    "ability": [
+                        {
+                            "dex": 13
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Execute",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die to try to execute an {@condition incapacitated} or {@condition prone} creature within 5 feet of you. Make an attack roll with a melee weapon and add your Exploit die to the attack roll. If your attack roll exceeds the target's remaining hit points, its hit points are reduced to 0."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+            "prerequisite": [
+                {
+                    "level": {
+						"level": 5,
+						"class":{
+							"name": "Alternate Fighter",
+							"source":"LLAF",
+							"visible": true
+						}
+					}
+				},
+				{
+                    "ability": [
+                        {
+                            "str": 13
+                        }
+                    ]
+                }
+            ]
+		},
+		{
+			"name": "Flaming Shot",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"When you make a ranged weapon attack, you can expend an Exploit Die to light the ammunition aflame. On hit, the target takes additional fire damage equal to your Exploit Die.",
+				"If your target is a flammable object that is not being worn or carried, you can ignite it in place of dealing damage."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Heroic Will",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"Whenever you are forced to make an Intelligence, Wisdom, or Charisma saving throw, you can expend an Exploit Die and add it to the result of your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Redirect",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As a reaction when a creature you can see misses you with a melee attack, you can expend an Exploit Die and force it to repeat its attack against a target of your choice within reach. On hit, it deals additional damage equal to your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Shield Impact",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As a reaction when a creature you can see hits you with an attack, you can expend an Exploit Die to reduce the damage by an amount equal to your Exploit Die + your Constitution modifier. You must be wielding a {@item shield|phb} to use this Exploit."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Suppressing Strike",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"When you hit a creature with a weapon attack, you can expend an Exploit Die and force it to make a Constitution saving throw. On a failed save, it takes additional damage equal to your Exploit Die, and it is {@condition blinded}, {@condition deafened}, or muted (your choice) until the start of your next turn."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Take Cover",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As a reaction when a creature you can see targets you with a ranged attack or forces you to make a Dexterity saving throw, you can expend an Exploit Die to immediately fall {@condition prone} and gain temporary hit points equal to your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Volley",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As an action, you can expend an Exploit Die to fire a volley of ammunition at a point you can see within the normal range of your weapon. Creatures of your choice within 5 feet of that point must make a Dexterity Saving throw. On a failed save, they take piercing damage equal to your Exploit Die + your Dexterity modifier, and half as much damage on a success.",
+				"You must have enough ammunition to hit each target."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 13
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Warrior's Challenge",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and force a creature within 30 feet that can see or hear you to make a Wisdom saving throw. On a failed save, it has disadvantage on any attack roll it makes against targets other than you for one minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on a success. This effect ends early if you attack a creature other than the target."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Whirlwind Strike",
+			"source": "LLAF",
+			"page": 11,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die and force each creature within range of melee weapon you are wielding to make a Dexterity saving throw. They take damage equal to your Exploit Die + either your Strength or Dexterity modifier on a failure, and half as much on a successful save."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 13
+						},
+						{
+							"dex": 13
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Disorienting Blow",
+			"source": "LLAF",
+			"page": 12,
+			"entries": [
+				"When you hit with a melee weapon attack, you can expend an Exploit Die to strike with overwhelming force. The creature takes additional damage equal to twice your Exploit Die and it suffers the following effects for 1 minute:",
+				{
+					"type": "list",
+					"items": [
+						"Its speed is halved.",
+						"It cannot take reactions.",
+						"Its Armor Class is reduced by 2.",
+						"Its Dexterity saving throw bonus is reduced by 2.",
+						"On its turn it can only take an action or a bonus action.",
+						"It cannot make more then one attack during its turn."
+					]
+				},
+				"The creature can make a Wisdom saving throw at the end of each of its turns, ending the effects of this Exploit on a successful save.",
+				"This Exploit's effects do not stack with {@spell slow|phb}."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Heroic Focus",
+			"source": "LLAF",
+			"page": 12,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to enter a heightened state of combat focus which you must concentrate on as if you were concentrating on a spell. For the next minute, or until you lose your concentration, you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Your speed is doubled.",
+						"You gain a +2 bonus to your Armor Class.",
+						"You have advantage on Dexterity saving throws.",
+						"You gain an additional action on each of your turns. It can only be used to take the {@action Attack} (one weapon attack only), {@action Dash}, {@action Disengage}, {@action Hide}, {@action Search}, or {@action Use an Object} action."
+					]
+				},
+				"When the effect ends, you can’t move or take actions until after your next turn, as a wave of lethargy sweeps over you.",
+				"This Exploit's effects do not stack with the  {@spell haste|phb} spell."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Mythic Athleticism",
+			"source": "LLAF",
+			"page": 12,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to enter a heightened state of physical performance which you must concentrate on as if you were concentrating on a spell. For the next 10 minutes, you gain the benefits listed below:",
+				{
+					"type": "list",
+					"items": [
+						"Whenever you make a Strength or Constitution check, you can treat a roll of 9 or lower on the d20 as a 10.",
+						"Your speed increases by a number of feet equal to 5 times your Strength modifier (minimum of 5 feet).",
+						"You count as one size larger for the purposes of carrying capacity and the size of creatures that you can grapple.",
+						"Both your long and high jump distances double, even if that distance would exceed your remaining movement."
+					]
+				},
+				"When the effects of this Exploit would end you can expend one of your Hit Dice to increase the duration by 10 minutes."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 15
+						},
+						{
+							"con": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Resilient Body",
+			"source": "LLAF",
+			"page": 12,
+			"entries": [
+				"When you take damage from a source you can see, you can expend an Exploit Die to reduce the damage by twice your Exploit Die + your Constitution modifier. Any hit points not consumed by the attack become temporary hit points."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"con": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Thunderous Shot",
+			"source": "LLAF",
+			"page": 12,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die and fire a piece of ammunition in a straight line, forcing creatures in that line out to the normal range of the weapon to make a Dexterity saving throw. Creatures take your weapon's normal damage plus piercing damage equal to twice your Exploit Die on a failed save, and half as much damage on a success."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "War Cry",
+			"source": "LLAF",
+			"page": 12,
+			"entries": [
+				"As an action, you can expend an Exploit Die and issue a mighty war cry, forcing any creatures in an adjacent 30 foot cone that can hear you to make a Wisdom saving throw. On a failed save, creatures drop whatever they are holding and are {@condition frightened} of you for one minute. If a creature ends its turn in a location where it doesn’t have line of sight to you, it can repeat the saving throw, ending the effect on a success."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Quick Draw",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and enter into a heightened state of focus which you must concentrate on as if concentrating on a spell. For the next minute, or until you lose concentration, you can use a bonus action to make two ranged weapon attacks so long as you have ammunition.",
+				"This Exploit's effects don't stack with the {@spell swift quiver|phb} spell."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 17
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Expert Determination",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"As an action, you can expend an Exploit Die to focus your mind and temporarily sharpen one of your skills. Choose a skill or tool that you are proficient in. For the next hour, you can add your Exploit Die to any check you make that uses the chosen skill, without expending one of your Exploit Dice."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Fluid Movements",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to enter a heightened state of movement which you must concentrate on as if you were concentrating on a spell. For 1 minute, or until you lose concentration, you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Your movement is unaffected by {@quickref Difficult Terrain|PHB|3|0|difficult terrain}.",
+						"You can use a bonus action on your turn to gain the benefits of both the {@action Dash} and {@action Disengage} action.",
+						"Spells and other magical effects can neither reduce the your speed nor cause you to be {@condition paralyzed} or {@condition restrained}.",
+						"You can spend 5 feet of movement to instantly escape from nonmagical restraints like manacles or a grapple.",
+						"Swimming or being underwater imposes no penalties on your movements or your attack rolls."
+					]
+				}
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 17
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Staggering Blow",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to strike with near-supernatural force. The creature takes additional bludgeoning damage equal to three times your Exploit Die, and it has disadvantage attack rolls and ability checks, and can't take reactions for 1 minute.",
+				"The creature can make a Wisdom saving throw at the end of each of its turns, ending these effects on a success."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 17
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Unbreakable",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"When you take damage that would reduce you to 0 hit points, even if that damage would kill you outright, you can use your reaction to expend an Exploit Die to fall to 1 hit point."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"con": 17
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Storm of Arrows",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die to fire a volley of ammunition at a point you can see within the range of your weapon. Creatures of your choice within 30 feet of that point must make a Dexterity saving throw. Targets take piercing damage equal to four rolls of your Exploit Die + your Dexterity modifier on a failed save, and half on a success.",
+				"You must have enough ammunition to hit each target."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:5DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 17,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 19
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Steel Wind Slash",
+			"source": "LLAF",
+			"page": 13,
+			"entries": [
+				"In place of an attack, you expend an Exploit Die and flourish your melee weapon then vanish. Choose up to five creatures you can see within 30 feet of, making a melee weapon attack against each one. On a hit, each target takes damage of your weapon's type equal to four rolls of your Exploit Die + either your Strength or Dexterity modifier (your choice).",
+				"You then appear in an unoccupied space of your choice that you can see within 5 feet of one of the targets of this Exploit."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:5DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 17,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 19
+						},
+						{
+							"dex": 19
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Aristocratic Education",
 			"source": "LLAF:E",
 			"page": 2,
 			"entries": [
-				"As an action, you can expend an Exploit Die and throw an object that you can hold in one hand, that isn't being worn or carried, at a creature within 60 feet. The target must succeed on a Dexterity saving throw or take bludgeoning damage equal to your Exploit Die + your Strength modifier. The object takes the damage regardless if it hits or misses."
+				"When you make an Intelligence ({@skill History}), Wisdom ({@skill Animal Handling}), or Charisma ({@skill Persuasion}) check, you can expend an Exploit Die and add it to the roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
 			],
 			"featureType": [
-				"LLAF:ME"
+				"LL:ME",
+                "LL:1DE"
+			],
+			"prerequisite": [
+				{
+					"ability": [
+						{
+							"int": 11
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Lunge",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"When you make a melee weapon attack, you can expend an Exploit Die to increase the range of that attack by 5 feet. On hit, you add your Exploit Die to the damage roll of the attack."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Navigator's Know-how",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"When you make an ability check with {@item cartographer's tools|phb}, {@item navigator's tools}, or {@filter land or water vehicles|items|source=|type=vehicle (land);vehicle}, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+			"prerequisite": [
+				{
+					"ability": [
+						{
+							"int": 11
+						},
+						{
+							"wis": 11
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Reposition",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to switch places with a conscious and willing creature within 5 feet of you, without either of you provoking opportunity attacks.",
+				"Moreover, the first one of you that gets hit with an attack before the beginning or your next turn gains a bonus to their Armor Class against that attack equal to your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Street Smarts",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"Whenever you make a Charisma ({@skill Investigation}), Charisma ({@skill Persuasion}), or Charisma ({@skill History}) check, you can expend an Exploit Die and add it to the roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+			"prerequisite": [
+				{
+					"ability": [
+						{
+							"cha": 11
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Take Down",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to make a {@action Shove} or {@action Grapple} attack against a creature in your reach, adding your Exploit Die to your Strength ({@skill Athletics}) check."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+			"prerequisite": [
+				{
+					"ability": [
+						{
+							"str": 11
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Tinker's Intuition",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"Whenever you make an ability check with a set of {@filter artisan's tools|items|source=|type=artisan's tools}, {@item thieves' tools|phb}, or {@item tinker's tools|phb}, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			],
+			"prerequisite": [
+				{
+					"ability": [
+						{
+							"int": 11
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Warding Strike",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"When a creature moves into the reach of a melee weapon you are wielding, you can use your reaction to expend an Exploit Die and make a melee weapon attack against that creature. On hit, you add your Exploit Die to the damage of the attack."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:1DE"
+			]
+		},
+		{
+			"name": "Glancing Blow",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"When you make a melee weapon attack and miss, you can expend an Exploit Die to immediately repeat your attack against another target within the reach of your weapon."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Immovable Stance",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and plant your feet in an immovable stance. Until you move from that space, a creature that would move you, or move through your space, must succeed on a Strength saving throw to do so."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 13
+						},
+						{
+							"con": 13
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Improvised Skill",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"When you make an ability check that doesn't include your proficiency bonus, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Intimidating Command",
+			"source": "LLAF:E",
+			"page": 2,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die and shout a one-word command at a creature that can hear you within 30 feet, and force it to make a Wisdom saving throw. On a failure, it obeys your command on its next turn, unless the command is directly harmful to itself or impossible to follow."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"cha": 13
+						}
+					]
+				}
 			]
 		},
 		{
@@ -4867,28 +7779,104 @@
 			"source": "LLAF:E",
 			"page": 2,
 			"entries": [
-				"As an action, you can expend an Exploit Die and strike the ground at your feet. Creatures within 5 feet of you must succeed on a Dexterity saving throw or take bludgeoning damage equal to your Exploit Die and fall {@condition prone}. If the ground in the area you strike is loose earth or stone, it becomes difficult terrain until cleared."
+				"In place of an attack, you can expend an Exploit Die to strike the ground at your feet, forcing creatures within 5 feet of you to make a Dexterity saving throw. On a failed save, creatures take bludgeoning damage equal to your Exploit Die + your Strength modifier and are knocked {@condition prone}. On a successful save, creatures take half damage and do not fall {@condition prone}.",
+				"If the area you strike is loose earth or stone, it becomes {@quickref Difficult Terrain|PHB|3|0|difficult terrain} until a creature uses its action to clear it."
 			],
 			"featureType": [
-				"LLAF:ME"
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 13
+						}
+					]
+				}
 			]
 		},
 		{
-			"name": "Zephyr Focus",
+			"name": "Thunderous Blow",
 			"source": "LLAF:E",
 			"page": 2,
 			"entries": [
-				"As a bonus action, you can expend an Exploit Die to move with the speed of the wind. Until the end of your current turn, your movement speed increased by 30 feet, and your movement doesn't provoke opportunity attacks.",
-				"Once before the end of your turn when you hit a creature with a melee weapon attack, you can deal additional damage of the weapon's type equal to your Exploit Die."
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die and force it to make a Strength saving throw. On a failure, it takes additional bludgeoning damage equal to your Exploit Die and is pushed away from you a number of feet equal to 5 times your Strength modifier. A creature larger than you has advantage on its saving throw."
 			],
 			"featureType": [
-				"LLAF:ME"
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 13
+						}
+					]
+				}
 			]
 		},
 		{
-			"name": "Flaming Shot",
+			"name": "Trick Shot",
 			"source": "LLAF:E",
 			"page": 2,
+			"entries": [
+				"As a bonus action, you can make a ranged weapon attack with a weapon that has the finesse and thrown properties.",
+				"This ranged attack ignores the benefits of cover, so long as it can ricochet off one surface and hit a target within range. If this attack would normally have disadvantage, it does not. On hit, you add your Exploit Die to the damage roll of the attack."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 13
+						},
+						{
+							"int": 13
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Weakening Blow",
+			"source": "LLAF:E",
+			"page": 3,
+			"entries": [
+				"When you hit a creature with a weapon attack, you can expend an Exploit Die to temporarily weaken it. The first attack made against it before the start of your next turn has advantage and deals extra damage equal to your Exploit Die."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
 			"prerequisite": [
 				{
 					"level": {
@@ -4900,19 +7888,20 @@
 						}
 					}
 				}
-			],
-			"entries": [
-				"When you make a ranged weapon attack, you can expend an Exploit Die to light the ammunition aflame. On hit, the target takes additional fire damage equal to twice your Exploit Die.",
-				"If the target is flammable, and it is not being worn or carried, you can choose to ignite it rather than deal damage."
-			],
-			"featureType": [
-				"LLAF:ME"
 			]
 		},
 		{
-			"name": "Shattering Wave",
+			"name": "Zephyr Slash",
 			"source": "LLAF:E",
-			"page": 2,
+			"page": 3,
+			"entries": [
+				"As an action, you can expend an Exploit Die and flourish your melee weapon then instantly move up to 30 feet in a straight line. Creatures you pass through must succeed on a Dexterity saving throw or take damage equal to twice your Exploit Die + your Strength or Dexterity modifier (your choice).",
+				"This movement does not provoke opportunity attacks."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:2DE"
+			],
 			"prerequisite": [
 				{
 					"level": {
@@ -4922,21 +7911,30 @@
 							"source": "LLAF",
 							"visible": true
 						}
-					}
+					},
+					"ability": [
+						{
+							"str": 13
+						},
+						{
+							"dex": 13
+						}
+					]
 				}
-			],
-			"entries": [
-				"As an action, you can expend an Exploit Die and strike the ground at your feet, forcing creatures in an adjacent 15-foot cone to make a Dexterity saving throw. On a failed save, they take bludgeoning damage equal to your Exploit Die + your Strength modifier and are knocked {@condition prone}.",
-				"Objects affected by this Exploit take maximum damage."
-			],
-			"featureType": [
-				"LLAF:ME"
 			]
 		},
 		{
-			"name": "Erupting Slam",
+			"name": "Daring Rescue",
 			"source": "LLAF:E",
-			"page": 2,
+			"page": 3,
+			"entries": [
+				"As a reaction when a creature within 30 feet is reduced to 0 hit points, you can expend an Exploit Die and attempt to save it. You can immediately move up to twice your speed, so long as you end your movement within 5 feet of the downed ally.",
+				"Your ally can then expend one of its Hit Dice to instantly regain hit points equal to its Hit Die roll + its Constitution modifier + temporary hit points equal to one roll of your Exploit Die for each opportunity attack you provoked."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
 			"prerequisite": [
 				{
 					"level": {
@@ -4948,19 +7946,20 @@
 						}
 					}
 				}
-			],
-			"entries": [
-				"As an action, you can expend an Exploit Die and strike the ground at your feet. The earth in an adjacent 20-foot cube erupts, and creatures within that area must make a Dexterity saving throw. Creatures take bludgeoning damage equal to your Exploit Die + your Strength modifier on a failed save, and half as much on a success. The area becomes difficult terrain until a creature takes 1 minute to clear it away.",
-				"Objects affected by this Exploit take maximum damage."
-			],
-			"featureType": [
-				"LLAF:ME"
 			]
 		},
 		{
-			"name": "Rain of Arrows",
+			"name": "Destructive Slam",
 			"source": "LLAF:E",
-			"page": 2,
+			"page": 3,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die to strike the ground at your feet, forcing creatures in an adjacent 20-foot cube to make a Dexterity saving throw. On a failed save, creatures take bludgeoning damage equal to two rolls of your Exploit Die + your Strength modifier and fall prone. On a success, they take half damage and don't fall prone. Objects within this area take the maximum amount of damage.",
+				"The area of the 20-foot cube becomes {@quickref Difficult Terrain|PHB|3|0|difficult terrain} until a creature takes 1 minute to clear it."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
 			"prerequisite": [
 				{
 					"level": {
@@ -4970,92 +7969,344 @@
 							"source": "LLAF",
 							"visible": true
 						}
-					}
+					},
+					"ability": [
+						{
+							"str": 15
+						}
+					]
 				}
-			],
+			]
+		},
+		{
+			"name": "Gale Force Slash",
+			"source": "LLAF:E",
+			"page": 3,
 			"entries": [
-				"As an action while you are wielding a ranged weapon, you can expend an Exploit Die and force creatures in an adjacent 30-foot cone to make a Dexterity saving throw. On a failed save, creatures take piercing damage equal to your Exploit Die + your Dexterity modifier. You must have a piece of ammunition to hit each creature."
+				"In place of an attack, you can expend an Exploit Die to rend the air in front of you with a melee weapon. Creatures in an adjacent 20-foot cone to must make a Constitution saving throw. Targets take slashing damage equal to twice your Exploit Die + either your Strength or your Dexterity modifier (your choice), on a failure, and half as much on a success."
 			],
 			"featureType": [
-				"LLAF:ME"
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 15
+						},
+						{
+							"dex": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Inspirational Speech",
+			"source": "LLAF:E",
+			"page": 3,
+			"entries": [
+				"You can expend an Exploit Die and spend 1 minute giving an inspirational speech to a number of creatures that can hear you equal to 1 + your Charisma modifier. At the end of this speech, targets gain temporary hit points equal to your level.",
+				"While the temporary hit points from this Exploit last, the creatures have advantage on Wisdom saving throws."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"cha": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Recruit Mercenary",
+			"source": "LLAF:E",
+			"page": 3,
+			"entries": [
+				"You can expend an Exploit Die and spend 1 hour to recruit a humanoid Mercenary from a settlement you currently occupy. For this Exploit to work, there must be a willing humanoid in a settlement of significant size, as determined by the DM.",
+				"When you use this Exploit, you choose to recruit a {@creature Brute|LLAF:E|Mercenary (Brute)} or a {@creature Scout|LLAF:E|Mercenary (Scout)}, which determines certain traits in its stat block.",
+				"The Mercenary uses the stat block below, and rolls its own initiative in combat. On its turn, it does its best to follow any orders you have given it. Other then that, it will defend itself to the best of its ability. If you fall to 0 hit points or die, they abandon you and do everything in their power to flee home.",
+				"Once you use this Exploit in a settlement, you cannot use it there again for 7 days. You can only have one Mercenary following you at a time. Recruiting another causes any other Mercenaries to immediately abandon you and return home."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"int": 15
+						},
+						{
+							"cha": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Survey Settlement",
+			"source": "LLAF:E",
+			"page": 4,
+			"entries": [
+				"You can expend an Exploit Die and spend 1 hour gathering information on up to 1 square mile of a settlement that you currently occupy. At the end of the hour, you gain knowledge about three of the following as they relate to the area:",
+				{
+					"type": "list",
+					"items": [
+						"Any active factions and faction outposts within the area.",
+						"Prominent buildings, gathering places, and cultural sites.",
+						"Powerful (CR 1 or higher) politicians or military leaders.",
+						"Loyalties, beliefs, and fears of the local populace.",
+						"Secret alleyways, doors, hideouts, or storefronts."
+					]
+				},
+				"Once you use this Exploit to survey a settlement you must finish a long rest before you can use it in that location again."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"dex": 15 
+						},
+						{
+							"cha": 15 
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Survey Wilderness",
+			"source": "LLAF:E",
+			"page": 4,
+			"entries": [
+				"You can expend an Exploit Die and spend 1 hour gathering information on up to 1 square mile of a wilderness that you currently occupy. At the end of the hour, you gain knowledge about three of the following as they relate to the area:",
+				{
+					"type": "list",
+					"items": [
+						"Any settlements or camps with five or more occupants.",
+						"Prominent natural formations, bodies of water, and ruins.",
+						"Native plants, animals, weather, and ecosystems.",
+						"Powerful (CR 1 or higher) creatures that reside within, or have passed through the area within the last 24 hours."
+					]
+				},
+				"Once you use this Exploit to survey an area of wilderness you must finish a long rest before you can use it there again."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:3DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 15
+						},
+						{
+							"wis": 15
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Equip Militia",
+			"source": "LLAF:E",
+			"page": 4,
+			"entries": [
+				"You can expend an Exploit Die and spend 1 hour training a number of humanoid creatures equal to your level to fight. Creatures that spend the full hour listening and training with you gain two of the following benefits of your choice:",
+				{
+					"type": "list",
+					"items": [
+						"They gain proficiency with one {@filter martial weapon|items|type=!futuristic;martial weapon;!modern;!renaissance;!treasure|miscellaneous=mundane}.",
+						"They gain proficiency with {@filter light armor|items|type=!futuristic;light armor;!modern;!renaissance;!treasure|miscellaneous=mundane} and {@item shield|phb|shields}.",
+						"They gain temporary hit points equal to your Exploit Die.",
+						"They gain proficiency in one of the following skills: {@skill Animal Handling}, {@skill Athletics}, {@skill Medicine}, {@skill Survival}, or {@skill Stealth}.",
+						"They have advantage on saving throws to resist being {@condition charmed} or {@condition frightened}."
+					]
+				},
+				"The benefits you choose for these creatures last until they are {@condition incapacitated}, or until the end of their next long rest."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Sundering Strike",
+			"source": "LLAF:E",
+			"page": 4,
+			"entries": [
+				"In place of an attack, you can expend an Exploit Die to strike a creation of magical force, such as a {@spell prismatic wall}, {@spell otiluke's resilient sphere}, or {@spell forcecage}. Any magic creation of 3rd-level or lower is instantly destroyed. If the target was created with a spell of 4th-level or higher, make a Strength check. The DC equals 10 + the spell's level. On a successful check, it is dispelled."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:4DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 13,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 17
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Banishing Strike",
+			"source": "LLAF:E",
+			"page": 4,
+			"entries": [
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to empower your blow with legendary force, and force the target to make a Charisma saving throw. It takes additional force damage equal to three rolls of your Exploit Die on a failure, and half as much on a success.",
+				"If this attack reduces the target to 50 hit points of fewer, it shunted to a harmless demiplane where it is {@condition incapacitated}. The creature reappears in the unoccupied space nearest to the last space it occupied at the end of your next turn."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:5DE"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 17,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 19
+						}
+					]
+				}
 			]
 		},
 		{
 			"name": "Cataclysmic Slam",
 			"source": "LLAF:E",
-			"page": 2,
+			"page": 4,
+			"entries": [
+				"In place of an attack, you can expend an Exploit De and strike the ground at your feet with legendary power. A shockwave of earth and thunderous force erupts from you, forcing any creatures within 30 feet to make a Constitution saving throw. On a failed save, creatures take bludgeoning damage equal to three rolls of your Exploit Die + your Strength modifier and are knocked {@condition prone}. On a successful save, creatures take half as much damage and don't fall {@condition prone}. Any objects within this area take the maximum amount of damage.",
+				"The area becomes {@quickref Difficult Terrain|PHB|3|0|difficult terrain} until a creature uses its action to clear one 5 foot square of this difficult terrain."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:5DE"
+			],
 			"prerequisite": [
 				{
 					"level": {
-						"level": 13,
+						"level": 17,
 						"class": {
 							"name": "Alternate Fighter",
 							"source": "LLAF",
 							"visible": true
 						}
-					}
-				}
-			],
-			"entries": [
-				"As an action, you can expend an Exploit Die and strike the ground at your feet with overwhelming force. A shockwave of earth and thunderous sound erupts from you, and creatures within 30 feet must make a Constitution saving throw. Creatures take bludgeoning damage equal to your Exploit Die + your Strength modifier on a failed save, and half as much on a success. The area becomes difficult terrain until a creature takes 1 minute to clear it away.",
-				"Objects affected by this Exploit take maximum damage."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Gale Force Strike",
-			"source": "LLAF:E",
-			"page": 2,
-			"prerequisite": [
-				{
-					"level": {
-						"level": 13,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF",
-							"visible": true
+					},
+					"ability": [
+						{
+							"str": 19
 						}
-					}
+					]
 				}
-			],
-			"entries": [
-				"As an action while wielding a melee weapon, you can expend an Exploit Die and move at blinding speed. Make a melee attack against up to five creatures you can see within 30 feet. On a hit, a target takes damage equal to your Exploit Die + your Strength or Dexterity modifier (your choice).",
-				"You then appear to an unoccupied space you can see within 5 feet of one of the targets you hit or missed."
-			],
-			"featureType": [
-				"LLAF:ME"
 			]
 		},
 		{
-			"name": "Storm of Arrows",
+			"name": "Mythic Focus",
 			"source": "LLAF:E",
-			"page": 2,
-			"prerequisite": [
+			"page": 4,
+			"entries": [
+				"As a bonus action, you can expend an Exploit Die to enter a legendary state of focus which you must concentrate on as if you were concentrating on a spell. For 1 minute, or until you lose concentration, you gain the following benefits:",
 				{
-					"level": {
-						"level": 13,
-						"class": {
-							"name": "Alternate Fighter",
-							"source": "LLAF",
-							"visible": true
-						}
-					}
-				}
-			],
-			"entries": [
-				"As an action while you are wielding a ranged weapon, you can expend an Exploit Die and choose a point within the range of your weapon. Creatures within 30 feet of that point must make a Dexterity saving throw. Targets take piercing damage equal to your Exploit Die + your Dexterity modifier on a failed save, and half as much on a success. You must have a piece of ammunition to hit each creature.",
-				"You then appear to an unoccupied space you can see within 5 feet of one of the targets you hit or missed."
+					"type": "list",
+					"items": [
+						"You gain 50 temporary hit points. If any of these remain when the effects of this Exploit end, they are lost.",
+						"You have advantage on any weapon attacks you make.",
+						"Once per turn when you hit a target with a weapon attack, you can deal additional damage equal to your Exploit Die.",
+						"You gain a bonus to Strength, Dexterity, and Constitution saving throws equal to your Exploit Die.",
+						"When you take the {@action Attack} action on your turn, you can make an additional weapon attack as part of that action."
+					]
+				},
+				"When the effect ends, you can’t move or take actions until after your next turn, as a wave of lethargy sweeps over you.",
+				"This Exploit doesn't stack with {@spell tenser's transformation|xge}."
 			],
 			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Legendary Exploit",
-			"source": "LLAF:E",
-			"page": 2,
+				"LL:ME",
+                "LL:5DE"
+			],
 			"prerequisite": [
 				{
 					"level": {
@@ -5067,675 +8318,848 @@
 						}
 					}
 				}
-			],
+			]
+		},
+		{
+			"name": "Vorpal Strike",
+			"source": "LLAF:E",
+			"page": 4,
 			"entries": [
-				"Epic level fighters should be capable of legendary feats onpar with powerful spellcasters. Should your table allow it,consult your GM to design a custom Legendary Exploit thatreflects the pinnacle of your training and martial skill.",
-				"When designing a Legendary Exploit for your fighter,consider the following guidelines for creation:",
+				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die and attempt to behead it. If the target's remaining hit points after your attack are equal to your level + your Strength or Dexterity score (your choice) + three rolls of your Exploit Die, or lower, you cut off one of its heads.",
+				"The creature instantly dies if it cannot survive without the lost head. A creature is immune to this Exploit if it is immune to slashing damage, or if it doesn't have or need a head."
+			],
+			"featureType": [
+				"LL:ME",
+                "LL:5DE"
+			],
+			"prerequisite": [
 				{
-					"type": "list",
-					"items": [
-						"You should expend an Exploit Die as an action to use it.",
-						"If it targets a single creature, it should deal at maximum three times your Exploit Die + your Strength (or Dexterity) modifier in bludgeoning, piercing, or slashing damage.",
-						"If it targets an area, reduce the damage of the Exploit accordingly. The larger the area, the less damage.",
-						"If it targets an area, it should force creatures in that area to make a Strength, Dexterity, or Constitution saving throw to resist its effects.",
-						"If it causes a condition in addition to damage (such as {@condition prone}, {@condition blinded}, {@condition stunned}, etc) the damage should also be reduced according to the strength of the condition."
+					"level": {
+						"level": 17,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					},
+					"ability": [
+						{
+							"str": 19
+						},
+						{
+							"dex": 19
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Fortifying Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature chooses either Strength, Dexterity, or Constitution. For 1 minute, the creature can add your Constitution modifier (minimum of +1) to any ability check or saving throw for the chosen ability score.",
+				"At 10th level the duration of the effect increases to 1 hour."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Invigorating Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature regains hit points equal to {@dice 1d10} + your Constitution modifier (minimum of +1).",
+				"Starting at 10th level, this Ration restores an additional {@dice 1d10} hit points, and any hit points they regain that exceed their hit point maximum become temporary hit points."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Revitalizing Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature ends one of the following conditions currently affecting it: {@condition blinded|phb|blindness}, {@condition deafened|phb|deafness}, {@condtion poisoned|phb|poison}, or they reduce their {@condition exhaustion} level by 1.",
+				"Starting at 10th level, this Ration can also cure the {@condition charmed}, {@condition frightened}, {@condition paralyzed}, and {@condition stunned} conditions."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Stimulating Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"This Ration must be consumed as part of a short rest. Upon consumption, the creature gains advantage on the roll for any Hit Dice they choose to expend during that short rest.",
+				"Starting at 10th level, consuming this Ration allows the creature to treat any Hit Dice they expend during the short rest as their maximum possible result instead of rolling."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Limbering Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature's speed increases by 10 feet for 1 minute.",
+				"At 10th level the creature's speed increases by 20 feet."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Thickening Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature gains resistance to either bludgeoning, piercing, or slashing damage (their choice) for 1 minute.",
+				"Starting at 10th level consuming this Ration grants resistance to bludgeoning, piercing, and slashing damage."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 5,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Heightening Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature chooses either Intelligence, Wisdom, or Charisma. For the duration, the creature can add your Constitution modifier (minimum of +1) to any ability check or saving throw for the chosen ability score.",
+				"At 10th level the duration of the effect increases to 1 hour."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 7,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Warding Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature gains resistance to acid, cold, fire, poison, lightning, or thunder damage (their choice) for 1 minute.",
+				"At 10th level the duration of the effect increases to 1 hour, and the creature can choose from force, necrotic, psychic, or radiant damage in addition to the other damage types."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 7,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Tenacious Ration",
+			"source": "LLAF:E",
+			"page": 13,
+			"entries": [
+				"Upon consumption, the creature gains immunity to one of the following conditions (their choice): {@condition blinded}, {@condition charmed}, {@condition deafened}, {@condition frightened}, {@condition poisoned}, {@condition paralyzed}, or {@condition stunned} for 1 hour."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 10,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Berserker Ration",
+			"source": "LLAF:E",
+			"page": 14,
+			"entries": [
+				"Upon consumption, for the next hour the creature does not fall {@condition unconscious} when it is reduced to 0 hit points. However, it still makes death saving throws as normal, dying upon failing three."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 15,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Rejuvenating Ration",
+			"source": "LLAF:E",
+			"page": 14,
+			"entries": [
+				"Upon consumption, the creature gains all the benefits of a short rest, including the ability to expend its Hit Dice as part of consuming the Ration. At the end of its current turn, the creature gains 1 level of {@condition exhaustion}. After a creature eats this Ration, it must finish a long rest before it can gain the benefits of any other Ration you prepare."
+			],
+			"featureType": [
+				"LL:QMR"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 15,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Featherweight Schematic",
+			"source": "LLAF:E",
+			"page": 15,
+			"entries": [
+				"You modify the metallurgic makeup of an item, making it significantly lighter. The bearer of an object modified by this Schematic has their base speed increased by 10 feet.",
+				{
+					"type": "entries",
+					"name": "Heavy Armor",
+					"entries": [
+						"The wearer ignores penalties to Dexterity ({@skill Stealth}) checks or Strength requirements of this armor."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Light Armor",
+					"entries": [
+						"The wearer can subtract up to 100 feet from their fall distance when calculating fall damage and can move horizontally 2 feet for every 1 foot they fall."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Weapon",
+					"entries": [
+						"A Heavy weapon looses the Heavy property, and a non-heavy weapon gains the Light and Finesse properties."
 					]
 				}
 			],
 			"featureType": [
-				"LLAF:ME"
+				"LL:TKS"
 			]
 		},
 		{
-			"name": "Marksman's Gaze",
-			"source": "LLAF",
-			"page": 9,
+			"name": "Intuitive Schematic",
+			"source": "LLAF:E",
+			"page": 15,
 			"entries": [
-				"When you make a Wisdom ({@skill Insight}), Wisdom ({@skill Perception}), or Intelligence ({@skill Investigation}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"You modify an item to enhance your investigative instincts. The bearer of an object modified by this Schematic gains proficiency in Investigation and adds double their proficiency bonus to any Intelligence ({@skill Investigation}) checks they make.",
+				{
+					"type": "entries",
+					"name": "Armor",
+					"entries": [
+						"The wearer can use their Intelligence in place of Dexterity when calculating their Armor Class in this armor."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Weapon",
+					"entries": [
+						"The wielder uses their Intelligence modifier, in place of the normal Strength or Dexterity, for their attack and damage rolls with this weapon."
+					]
+				}
 			],
 			"featureType": [
-				"LLAF:ME:M"
+				"LL:TKS"
 			]
 		},
 		{
-			"name": "Piercing Shot",
-			"source": "LLAF",
-			"page": 9,
+			"name": "Radiant Schematic",
+			"source": "LLAF:E",
+			"page": 16,
 			"entries": [
-				"When you hit a creature with a ranged weapon attack, you can expend an Exploit Die to deal additional damage equal to the creature equal to two rolls of your Exploit Die."
+				"You imbue an item with radiant energy. The bearer of an object modified by this Schematic can use a bonus action to cause the object to emit (or extinguish) bright light in a 15-foot radius, and dim light 15 feet beyond that.",
+				{
+					"type": "entries",
+					"name": "Armor",
+					"entries": [
+						"As a reaction when you are hit by an attack, you can force the attacker to make a Constitution saving throw. On a failed save, it is {@condition blinded} for 1 minute. It can repeat the save at the end of each turn, ending the effect on a success.",
+						"Once you use this reaction, you must finish a short or long rest before you can use it again."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Weapon",
+					"entries": [
+						"When you hit a creature with this weapon, you can force it to make a Constitution saving throw. On a failure, it is {@condition blinded} for 1 minute. It can repeat its save at the end of each turn, ending the effect on a success.",
+						"Once you use this reaction, you must finish a short or long rest before you can use it again."
+					]
+				}
 			],
 			"featureType": [
-				"LLAF:ME:M"
+				"LL:TKS"
 			]
 		},
 		{
-			"name": "Precision Shot",
-			"source": "LLAF",
-			"page": 9,
+			"name": "Rebounding Schematic",
+			"source": "LLAF:E",
+			"page": 16,
 			"entries": [
-				"When you make a ranged weapon attack against a creature, you can expend on Exploit Die to add it to your attack roll. You can use this Exploit after you roll, but before you know whether your attack hits or misses the target."
+				"You imbue and item with elastic properties. As a reaction when the bearer of an object modified by this Schematic is hit by an attack, it can to add your Intelligence modifier (minimum of +1) to their Armor Class against that attack.",
+				{
+					"type": "entries",
+					"name": "Armor",
+					"entries": [
+						"As a reaction when the wearer is hit by an attack, it can reduce the incoming damage by an amount equal to your Exploit Die + your Intelligence modifier. If this reaction reduces the incoming damage to 0, the attacker takes the full damage of the attack as if they had been the original target.",
+						"Once you use this feature you must finish a short or long rest before you can use it again."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Non-Heavy Weapon",
+					"entries": [
+						"When applied, the weapon gains the Thrown property with a range of 20 feet. After making an attack with this weapon, it instantly returns to the wielder."
+					]
+				}
 			],
 			"featureType": [
-				"LLAF:ME:M"
+				"LL:TKS"
 			]
 		},
 		{
-			"name": "Volley",
-			"source": "LLAF",
-			"page": 9,
+			"name": "Empowered Schematic",
+			"source": "LLAF:E",
+			"page": 16,
 			"entries": [
-				"As an action, you can expend an Exploit Die to fire a volley of projectiles at a point you can see within the normal range of your weapon. Creature within 5 feet of that point must make a Dexterity Saving throw. They take piercing damage equal to two rolls of your Exploit Die on a failure, and half damage on a success. You must have enough ammunition to hit each target in the area in order to use this Exploit."
+				"You modify an object with clockwork mechanics that improve both power and reflexes. The bearer of an object modified by this Schematic gains a bonus to its initiative rolls equal to your Intelligence modifier (minimum of +1).",
+				{
+					"type": "entries",
+					"name": "Heavy Armor",
+					"entries": [
+						"The wearer of this armor can use your Intelligence score, in place of Strength, for any Strength-based ability checks or Strength saving throws it makes."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Light Armor",
+					"entries": [
+						"The wearer of this armor can use your Intelligence score, in place of Dexterity, for any Dexterity-based ability checks or Dexterity saving throws they make."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Weapon",
+					"entries": [
+						"When applied, anytime the wielder rolls a 1 or 2 for a damage roll with this weapon, they can choose to re-roll the die, but you must use the new result even if it is a 1 or 2."
+					]
+				}
 			],
 			"featureType": [
-				"LLAF:ME:M"
+				"LL:TKS"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 7,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
 			]
 		},
 		{
-			"name": "Attack Command",
-			"source": "LLAF",
-			"page": 8,
+			"name": "Resilient Schematic",
+			"source": "LLAF:E",
+			"page": 16,
 			"entries": [
-				"When you take the {@action Attack} action, you can expend an Exploit Die in place of one of your attacks to issue a command to a creature within 30 feet that can see or hear you. The target creature can use their reaction to make one weapon attack, adding your Exploit Die to the damage roll of the attack."
+				"You modify the metallurgic makeup of this item to greatly increase its resilience. The bearer of an object modified by this Schematic has advantage on saving throws to resist being {@condition grappled} or moved against their will.",
+				{
+					"type": "entries",
+					"name": "Armor",
+					"entries": [
+						"The wearer of this armor gains resistance to nonmagical bludgeoning, piercing, and slashing damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Weapon",
+					"entries": [
+						"When the wielder scores a critical hit with this weapon, it deals bonus damage equal to your Intelligence modifier (minimum of 1) + your fighter level."
+					]
+				}
 			],
 			"featureType": [
-				"LLAF:ME:Co"
+				"LL:TKS"
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 7,
+						"class": {
+							"name": "Alternate Fighter",
+							"source": "LLAF",
+							"visible": true
+						}
+					}
+				}
+			]
+		}
+	],
+	"monster": [
+        {
+            "name": "Mercenary (Brute)",
+            "source": "LLAF:E",
+            "page": 3,
+            "summonedByClass": "Alternate Fighter|LLAF",
+            "size": [
+                "M"
+            ],
+            "type": "humanoid",
+            "alignment": [
+                "A"
+            ],
+            "ac": [
+                {
+                    "special": "18 (scale mail, shield)"
+                }
+            ],
+            "hp": {
+                "special": "6 + five times your fighter level"
+            },
+            "speed": {
+                "walk": 30
+            },
+            "str": 16,
+            "dex": 16,
+            "con": 13,
+            "int": 10,
+            "wis": 12,
+            "cha": 8,
+			"save": {
+				"str": "+6",
+				"dex": "+6"
+			},
+			"skill": {
+				"athletics": "+6"
+			},
+            "passive": 12,
+            "languages": [
+                "Common",
+				"and one other language"
+            ],
+            "trait": [
+                {
+                    "name": "Hit Dice",
+                    "entries": [
+                        "The Mercenary has a number of {@dice d10} Hit Dice equal to your level. It also gains all the normal benefits of both short and long rests."
+                    ]
+                },
+                {
+                    "name": "Morale",
+                    "entries": [
+                        "If you fall to 0 hit points the Mercenary does everything in its power to flee and return home."
+                    ]
+                },
+                {
+                    "name": "Rough & Tumble",
+                    "entries": [
+                        "The Mercenary can use a bonus action to attempt a {@action Shove} or {@action Grapple}."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Battleaxe",
+                    "entries": [
+                        "{@atk mw} +6 to hit, reach 5 ft., one target. {@h}{@damage 1d8 + 3} slashing damage."
+                    ]
+                }
+            ]
+        },
+		{
+            "name": "Mercenary (Scout)",
+			"source": "LLAF:E",
+            "page": 3,
+            "summonedByClass": "Alternate Fighter|LLAF",
+            "size": [
+                "M"
+            ],
+            "type": "humanoid",
+            "alignment": [
+                "A"
+            ],
+            "ac": [
+                {
+                    "special": "15 (studded leather)"
+                }
+            ],
+            "hp": {
+                "special": "6 + five times your fighter level"
+            },
+            "speed": {
+                "walk": 30
+            },
+            "str": 16,
+            "dex": 16,
+            "con": 13,
+            "int": 10,
+            "wis": 12,
+            "cha": 8,
+			"save": {
+				"str": "+6",
+				"dex": "+6"
+			},
+			"skill": {
+				"stealth": "+6"
+			},
+            "passive": 12,
+            "languages": [
+                "Common",
+				"and one other language"
+            ],
+            "trait": [
+                {
+                    "name": "Hit Dice",
+                    "entries": [
+                        "The Mercenary has a number of {@dice d10} Hit Dice equal to your level. It also gains all the normal benefits of both short and long rests."
+                    ]
+                },
+                {
+                    "name": "Morale",
+                    "entries": [
+                        "If you fall to 0 hit points the Mercenary does everything in its power to flee and return home."
+                    ]
+                },
+                {
+                    "name": "Cunning Strike",
+                    "entries": [
+                        "If the Mercenary makes an attack with advantage, it deals {@dice 2d6} bonus damage."
+                    ]
+                },
+                {
+                    "name": "Slippery",
+                    "entries": [
+                        "The Mercenary can use a bonus action to take the {@action Disengage} or {@action Hide} action."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Shortsword",
+                    "entries": [
+                        "{@atk mw} +6 to hit, reach 5 ft., one target. {@h}{@damage 1d6 + 3} slashing damage."
+                    ]
+                },
+                {
+                    "name": "Shortbow",
+                    "entries": [
+                        "{@atk mw} +6 to hit, range 80/320 ft., one target. {@h}{@damage 1d6 + 3} piercing damage."
+                    ]
+                }
+            ]
+        },
+		{
+            "name": "Loyal Hound",
+            "source": "LLAF:E",
+            "page": 10,
+            "summonedByClass": "Alternate Fighter|LLAF",
+            "size": [
+                "M"
+            ],
+            "type": "beast",
+            "alignment": [
+                "N"
+            ],
+            "ac": [
+                {
+                    "special": "13 + PB (natural armor)"
+                }
+            ],
+            "hp": {
+                "special": "5 + five times your fighter level"
+            },
+            "speed": {
+                "walk": 40,
+				"swim": 20
+            },
+            "str": 14,
+            "dex": 14,
+            "con": 15,
+            "int": 8,
+            "wis": 14,
+            "cha": 11,
+            "passive": 12,
+            "languages": [
+                "understands the languages you speak"
+            ],
+			"pbNote": "equals your bonus",
+            "trait": [
+                {
+                    "name": "Hit Dice",
+                    "entries": [
+                        "Your Hound has a total number of {@dice d8} Hit Dice equal to your fighter level. It also gains all the normal benefits of both short and long rests."
+                    ]
+                },
+                {
+                    "name": "Loyal Companion",
+                    "entries": [
+                        "You add your PB to any ability check or saving throw that your Hound makes."
+                    ]
+                },
+                {
+                    "name": "Keen Senses",
+                    "entries": [
+                        "Your Hound has advantage on any ability check that relies on their hearing or smell."
+                    ]
+                }
+            ],
+            "action": [
+                {
+                    "name": "Bite",
+                    "entries": [
+                        "{@atk mw} +2 + PB to hit, reach 5 ft., one target. {@h}{@damage 1d6 + 2 + PB} piercing damage. On hit, the target must succeed on a Strength saving throw (DC equals 10 + PB) or be {@condition grappled}. The Hound can only grapple one creature at a time."
+                    ]
+                },
+				{
+                    "name": "Maul",
+                    "entries": [
+                        "{@atk mw} +2 + PB to hit, reach 5 ft., one target. {@h}{@damage 1d8 + 2 + PB} slashing damage."
+                    ]
+                }
+            ]
+        }
+    ],
+	"feat": [
+		{
+			"name": "Masterful Technique",
+			"source": "LLAF:E",
+			"page": 5,
+			"entries": [
+				"You have learned to change your fighting stance to best meet the challenges you face. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You increase your Strength, Dexterity, or Constitution score by 1, to a maximum of 20.",
+						"You learn another {@filter Fighting Style from those available to the Alternate Fighter|optionalfeatures|feature type=fs:af}. However, you can only be under the effect of one Fighting Style you know.",
+						"As a bonus action on your turn, you can switch your Fighting Style to another Fighting Style you know."
+					]
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con"
+						],
+						"amount": 1
+					}
+				}
+			],
+			"prerequisite": [
+				{
+					"other": "At least one Fighting Style Known"
+				}
 			]
 		},
 		{
-			"name": "Commander's Insight",
-			"source": "LLAF",
-			"page": 8,
+			"name": "Martial Training",
+			"source": "LLAF:E",
+			"page": 5,
 			"entries": [
-				"When you make an Intelligence ({@skill History}), Wisdom ({@skill Insight}), or Intelligence ({@skill Investigation}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME:Co"
+				"You have studied combat techniques which allow you to perform {@filter Martial Exploits|optionalfeatures|feature type=ll:1de;ll:me=sand}. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You learn two 1st-degree {@filter Martial Exploits|optionalfeatures|feature type=ll:1de;ll:me=sand} of your choice from those available to the Alternate Fighter. If an Exploit you use requires the target to make a saving throw to resist the effects, the DC is equal to 8 + your proficiency bonus + your Strength or Dexterity modifier (your choice).",
+						"Each time you gain a level, you can replace one Exploit you know with another 1st-degree Exploit of your choice.",
+						"You gain two {@dice d4} Exploit Dice to fuel your Exploits. An Exploit Die is expended when you use it. You regain all of your Exploit Dice when you finish a short or long rest.",
+						"If you have Exploit Dice from another source, these are added to your pool and are the size of your other Dice."
+					]
+				}
 			]
 		},
 		{
-			"name": "Maneuvering Command",
-			"source": "LLAF",
-			"page": 8,
+			"name": "Signature Technique",
+			"source": "LLAF:E",
+			"page": 5,
 			"entries": [
-				"When you take the {@action Attack} action, you can expend an Exploit Die in place of one of your attacks to issue a command to a creature within 30 feet that can see or hear you. The target creature can then use their reaction to move up to its full movement speed without provoking opportunity attacks."
+				"You have practiced and mastered a single technique so that you can utilize it at a whim. Choose one {@filter 1st-degree Exploit|optionalfeatures|feature type=ll:1de} that you know to be your Signature Exploit.",
+				"Once per turn when you use your Signature Exploit, you can roll a {@dice d4} in place of expending an Exploit Die."
 			],
-			"featureType": [
-				"LLAF:ME:Co"
+			"prerequisite": [
+				{
+					"other": "At least one Exploit Known"
+				}
 			]
 		},
 		{
-			"name": "Champion's Vigor",
-			"source": "LLAF",
-			"page": 7,
+			"name": "Signature Weapon",
+			"source": "LLAF:E",
+			"page": 5,
 			"entries": [
-				"Whenever you make a saving throw to resist the effects of {@condition exhaustion}, or you make Strength ({@skill Athletics}) or a Dexterity ({@skill Acrobatics}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
+				"Rather then master many weapons you have chosen to hone your skills with one. You gain the benefits below:",
+				{
+					"type": "list",
+					"items": [
+						"You increase your Strength, Dexterity, or Constitution score by 1, to a maximum of 20.",
+						"Choose a weapon that you are proficient with to be your Signature Weapon. When you attack with that weapon, its damage die increases by one, as shown in the table below.",
+						"When you roll a 1 on the damage die for that weapon you can reroll that die. You must use the new damage roll.",
+						"You can spend 7 consecutive long rests to change your Signature Weapon to another weapon of your choice."
+					]
+				},
+				{
+					"type": "table",
+					"name": "Signature Weapon Damage Increase",
+					"colLabels": [
+						"Original",
+						"Signature"
+					],
+					"colStyles": [
+						"col-6 text-center",
+						"col-6 text-center"
+					],
+					"rows": [
+						[
+							"1",
+							"{@dice 1d4}"
+						],
+						[
+							"{@dice 1d4}",
+							"{@dice 1d6}"
+						],
+						[
+							"{@dice 1d6}",
+							"{@dice 1d8}"
+						],
+						[
+							"{@dice 1d8}",
+							"{@dice 1d10}"
+						],
+						[
+							"{@dice 1d10}",
+							"{@dice 1d12}"
+						],
+						[
+							"{@dice 2d6}/{@dice 1d12}",
+							"{@dice 2d8}"
+						]
+					]
+				}
 			],
-			"featureType": [
-				"LLAF:ME:Ch"
-			]
-		},
-		{
-			"name": "Concussive Blow",
-			"source": "LLAF",
-			"page": 7,
-			"entries": [
-				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to force them to make a Constitution saving throw. On a failed save, the target takes additional damage equal to your Exploit Die and is {@condition stunned} until the beginning of your next turn."
-			],
-			"featureType": [
-				"LLAF:ME:Ch"
-			]
-		},
-		{
-			"name": "Crippling Strike",
-			"source": "LLAF",
-			"page": 7,
-			"entries": [
-				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die and force it to make a Dexterity saving throw. On a failed save, the creature takes additional damage equal to your Exploit Die and its movement speed is reduced to 0 until the beginning of your next turn."
-			],
-			"featureType": [
-				"LLAF:ME:Ch"
-			]
-		},
-		{
-			"name": "Arcanist's Insight",
-			"source": "LLAF",
-			"page": 6,
-			"entries": [
-				"Whenever you make an Intelligence ({@skill Arcana}), Intelligence ({@skill History}), or Intelligence ({@skill Religion}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME:AK"
-			]
-		},
-		{
-			"name": "Arcane Smite",
-			"source": "LLAF",
-			"page": 6,
-			"entries": [
-				"When you hit a creature with a weapon attack, you can expend an Exploit Die to deal additional force damage to the target, equal to your Exploit Die + your Intelligence modifier."
-			],
-			"featureType": [
-				"LLAF:ME:AK"
-			]
-		},
-		{
-			"name": "Spellguard",
-			"source": "LLAF",
-			"page": 6,
-			"entries": [
-				"As a reaction when you make an Intelligence, Wisdom, or Charisma saving throw to resist a spell, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know if you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME:AK"
-			]
-		},
-		{
-			"name": "Archery",
-			"source": "LLAF",
-			"page": 2,
-			"entries": [
-				"You gain a +2 bonus to attack rolls with ranged weapons."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Classical Swordplay",
-			"source": "LLAF",
-			"page": 2,
-			"entries": [
-				"While you are wielding a finesse weapon and nothing in your other hand, you gain a +2 bonus to attack rolls and to your Armor Class so long as you are not wearing heavy armor."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Defensive Fighting",
-			"source": "LLAF",
-			"page": 2,
-			"entries": [
-				"While wearing armor or wielding a shield, you gain a +1 bonus to your Armor Class."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Dual Wielding",
-			"source": "LLAF",
-			"page": 2,
-			"entries": [
-				"When you take the {@action Attack} action while two-weapon fighting, you can make a single additional attack with your off-hand weapon as part of your action instead of your bonus action, adding your ability modifier to the damage of this attack."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Dueling",
-			"source": "LLAF",
-			"page": 2,
-			"entries": [
-				"When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with it."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Featherweight Fighting",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"While you are wielding only light weapons, your movement speed increases by 10 feet and you gain a +2 bonus to your damage rolls, so long as you are not wearing medium armor, heavy armor, or wielding a shield."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Great Weapon Fighting",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"When you roll a 1 or 2 on the damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the damage, though you must use the new roll, even if the new roll is a 1 or a 2.",
-				"The weapon must have the heavy, versatile, or two-handed property to gain this benefit."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Improvised Fighting",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"You gain proficiency with improvised weapons. Once per turn, when you hit with a improvised weapon attack, you can roll the damage die twice and take the higher roll. When you do this, the improvised weapon is destroyed and cannot be used for further attacks. You can't use this feature to destroy magical objects."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Protection",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll. You must be wielding a melee weapon or a shield to use this reaction."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Marine Fighting",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"When you are not wearing medium or heavy armor, or using a shield, you have a swimming speed equal to your movement speed, and you gain a +1 bonus to your Armor Class."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Melee Marksman",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"When you make a ranged attack targeting a creature within 5 feet of you, you do not have disadvantage on the attack roll.",
-				"If you make a ranged attack against a creature within 5 feet, you can use a bonus action to strike the creature with your ranged weapon, dealing {@dice 1d4} bludgeoning damage on hit."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Versatile Fighting",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"When wielding a versatile weapon with two hands you gain a +2 bonus to damage rolls. When wielding a versatile weapon with one hand, and nothing in your other hand, you gain a +1 bonus to both your attack rolls and your Armor Class.",
-				"You can also make a {@action Shove|phb|shove} attack or an unarmed strike as a bonus action so long as you have a free hand to do so."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Wrestler",
-			"source": "LLAF",
-			"page": 3,
-			"entries": [
-				"When you hit a creature with a melee attack, you can attempt to grapple that creature as a bonus action on that turn, so long as your have a free hand to do so. Also, you can drag {@condition grappled} creatures up to your full movement speed."
-			],
-			"featureType": [
-				"LLAF:FS"
-			]
-		},
-		{
-			"name": "Blinding Shot",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"As a bonus action, you can expend an Exploit Die and force a creature within 10 feet, to make a Constitution saving throw. On a failed save, it takes piercing damage equal to your Exploit Die and is {@condition blinded} until the start of your next turn."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Brace Up",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"As a bonus action on your turn, you can expend an Exploit Die to grant yourself temporary hit points equal to your Exploit Die + your Constitution modifier (minimum of 1)."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Charlatan's Guile",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you make a Dexterity ({@skill Sleight of Hand}) or Charisma ({@skill Deception}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Defensive Stance",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"As a bonus action, you can expend an Exploit Die to enter a defensive stance. Each time a creature that you can see hits you with an attack before the start of your next turn you gain a bonus to your Armor Class equal to your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Dirty Hit",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you hit a creature with a weapon attack, you can expend an Exploit Die and force it to make a Constitution saving throw. On a failed save, it takes additional damage equal to your Exploit Die, and until the start of your next turn, it cannot take reactions and its movement speed is halved."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Disarm",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you hit a creature with a weapon attack, you can expend an Exploit Die to force them to make a Strength saving throw. On a failed save, the creature takes additional damage equal to your Exploit Die, and it drops one item that it is currently holding (your choice) at its feet."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Disorienting Blow",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to force them to make a Constitution saving throw. On a failed save, the creature takes additional damage equal to your Exploit Die, and on its next turn, its speed is halved, and it can use either an action or a bonus action. It can't make more than one attack during that turn."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Disciple's Conviction",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you make a Wisdom ({@skill Insight}) or Intelligence ({@skill Religion}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Feat of Strength",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you make a Strength-based ability check or saving throw, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "First Aid",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"As an action, you can expend an Exploit Die and touch a creature. As a reaction, the target can expend a Hit Die to regain hit points equal to the Hit Die + your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Glancing Blow",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you miss your target with a melee weapon attack, you can expend an Exploit Die to repeat your attack against another target within the reach of your weapon."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Investigator's Intuition",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you make an Intelligence ({@skill Investigation}) or Wisdom ({@skill Perception}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Lightstep",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you roll for initiative or make a Dexterity ({@skill Stealth}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Martial Focus",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"Once per turn, when you make a weapon attack roll, you can expend an Exploit Die to grant yourself advantage on the roll. You must use this Exploit before you make your attack roll."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Menacing Cry",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"As a bonus action, you can expend an Exploit Die to force a creature within 30 feet that can see or hear you to make a Wisdom saving throw. On a failed save, the target is {@condition frightened} of you until the start of your next turn."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Mighty Leap",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you make a running or standing jump, you can expend an Exploit Die to increase your jump distance by a number of feet equal to your Exploit Die + your Strength modifier, even if the distance of the jump would exceed your remaining movement speed for that turn."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Naturalist's Intuition",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you make a Wisdom ({@skill Animal Handling}) or Intelligence ({@skill Nature}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Reckless Strike",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"As part of a weapon attack, you can expend an Exploit Die to attack recklessly. You have advantage on your attack roll, but you subtract your Exploit Die from both attack rolls. On hit, you deal additional damage equal to twice your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Redirect",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When a creature misses you with a melee attack, you can expend an Exploit Die as a reaction to force them to make an attack against a target of their choice within their reach."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Riposte",
-			"source": "LLAF",
-			"page": 11,
-			"entries": [
-				"When you are hit by a melee attack, you can use your reaction to expend an Exploit Die, adding it to your Armor Class against that attack. If the attack misses, you can immediately make one weapon attack against the attacker."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Ruthless Strike",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to deal additional damage to the target equal to two rolls of your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Suppressing Strike",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"When you hit a creature with a weapon attack, you canexpend an Exploit Die to force them to make a Constitutionsaving throw. On a failed save, the creature takes bludgeoningdamage equal to your Exploit Die, and it is either deafened orcannot speak (your choice) until the start of your next turn."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Survivalist's Cunning",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"When you make a Wisdom ({@skill Medicine}) or Wisdom ({@skill Survival}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Sweeping Strike",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"When you hit a creature with a melee weapon attack, you can expend an Exploit Die to force it to make a Dexterity saving throw. On a failed save, the creature falls {@condition prone} and takes bludgeoning damage equal to your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Swordsman's Grace",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"Whenever you make a Dexterity ({@skill Acrobatics}) or Charisma ({@skill Performance}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Take Down",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"As a bonus action, you can expend an Exploit Die to make a {@action Shove} or {@action Grapple} attack against a creature within your reach, adding your Exploit Die to your Strength ({@skill Athletics}) roll."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Taunt",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"As a bonus action, you can expend an Exploit Die to force a creature within 30 feet that can see or hear you to make a Wisdom saving throw. On a failed save, the target has disadvantage on any attack roll it makes against a target other than you until the start of your next turn."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Warlord's Presence",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"Whenever you make a Charisma ({@skill Intimidation}) or Charisma ({@skill Persuasion}) check, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Warrior's Fortitude",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"Whenever you are forced to make a Strength or Constitution saving throw, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Warrior's Reflexes",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"Whenever you are forced to make a Dexterity or Intelligence saving throw, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Warrior's Willpower",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"Whenever you are forced to make a Wisdom or Charisma saving throw, you can expend an Exploit Die and add it to your roll. You can use this Exploit after you roll, but before you know whether you succeed or fail."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Whirlwind Attack",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"As an action, you can expend an Exploit Die to make a melee weapon attack against any number of creatures within the reach of your weapon, with a separate attack roll for each target. On hit, the creatures take damage equal to your Exploit Die + your Strength modifier."
-			],
-			"featureType": [
-				"LLAF:ME"
-			]
-		},
-		{
-			"name": "Weakening Blow",
-			"source": "LLAF",
-			"page": 12,
-			"entries": [
-				"When you hit a create with a weapon attack, you can expend an Exploit Die to temporarily weaken their defenses. The first attack made against the target before the start of your next turn is made with advantage, and on hit, the attack deals additional damage equal to your Exploit Die."
-			],
-			"featureType": [
-				"LLAF:ME"
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex",
+							"con"
+						],
+						"amount": 1
+					}
+				}
 			]
 		}
 	]


### PR DESCRIPTION
-Exploits were revamped, from per subclass to subclass agnostic
-Updated books with new/moved sections between Standard and Expanded docs
-Added new subclasses/exploits/fighting styles
-Created optional types for 1st, 2nd, 3rd, 4th, 5th degree exploits
-Added monster stat blocks for new subclass/exploits
-Added feats
-Added links to other classes from the brewer where needed
-Generally updated text and ability descriptions