### PR TITLE
Update BeardedJB; Cosmic Cleric Domain.json

### DIFF
--- a/subclass/BeardedJB; Cosmic Cleric Domain.json
+++ b/subclass/BeardedJB; Cosmic Cleric Domain.json
@@ -5,12 +5,8 @@
 				"json": "CosmicDomain",
 				"abbreviation": "CD",
 				"full": "Cleric: Cosmic Domain",
-				"authors": [
-					"WotC"
-				],
-				"convertedBy": [
-					"BeardedJB"
-				],
+				"authors": ["WotC"],
+				"convertedBy": ["BeardedJB"],
 				"version": "1.0"
 			}
 		],
@@ -53,7 +49,7 @@
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 1,
 			"entries": [
 				"Clerics of the cosmic domain (somtimes called Clerics of Spacetime) are a new addition to the varied pantheon of clerics that came about with the discovery of Arcana thousands of years ago. With that came understanding of the flow of time and the matter of cosmic space. Clerics of this domain the study of the rules of the cosmos, which by extension is the rule of the gods, as they created the cosmos we live in. This order of clerics attracts those drawn to knowledge and wonder, they may be the most travelled of the clerics, looking to document some of the worlds most weird and wonderful godly and arcane artefacts. The magic they have found with their deities is new, and some consider dangerous.",
@@ -64,11 +60,11 @@
 				},
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Implement of the cosmos|Cleric||Cosmic|TCE|1"
+					"subclassFeature": "Implement of the cosmos|Cleric||Cosmic|CosmicDomain|1"
 				},
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Cosmic Influence|Cleric||Cosmic|TCE|1"
+					"subclassFeature": "Cosmic Influence|Cleric||Cosmic|CosmicDomain|1"
 				}
 			]
 		},
@@ -87,47 +83,32 @@
 				{
 					"type": "table",
 					"caption": "Cosmic Domain Spells",
-					"colLabels": [
-						"Cleric Level",
-						"Spells"
-					],
-					"colStyles": [
-						"col-2 text-center",
-						"col-10"
-					],
+					"colLabels": ["Cleric Level", "Spells"],
+					"colStyles": ["col-2 text-center", "col-10"],
 					"rows": [
-						[
-							"1st",
-							"{@spell heroism}, {@spell sanctuary}"
-						],
+						["1st", "{@spell heroism}, {@spell sanctuary}"],
 						[
 							"3rd",
 							"{@spell fortune's favor|egw}, {@spell warding bond}"
 						],
-						[
-							"5th",
-							"{@spell pulse wave|egw}, {@spell sending}"
-						],
+						["5th", "{@spell pulse wave|egw}, {@spell sending}"],
 						[
 							"7th",
 							"{@spell gravity sinkhole|egw}, {@spell Otiluke's resilient sphere}"
 						],
-						[
-							"9th",
-							"{@spell passwall}, {@spell wall of force}"
-						]
+						["9th", "{@spell passwall}, {@spell wall of force}"]
 					]
 				}
 			]
 		},
 		{
 			"name": "Cosmic Influence",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 1,
 			"header": 1,
 			"entries": [
@@ -138,12 +119,12 @@
 		},
 		{
 			"name": "Implement of the cosmos",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 1,
 			"header": 1,
 			"entries": [
@@ -153,12 +134,12 @@
 		},
 		{
 			"name": "Channel Divinity: Flow of Time",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 2,
 			"header": 2,
 			"consumes": {
@@ -171,12 +152,12 @@
 		},
 		{
 			"name": "Fractal Bond",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -186,28 +167,28 @@
 		},
 		{
 			"name": "Blessed Strikes",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 8,
 			"isClassFeatureVariant": true,
 			"header": 2,
 			"entries": [
-				"{@i 8th-level cleric {@variantrule optional class features|tce|optional feature}, which replaces the Potent Spellcasting feature}",
+				"{@i 8th-level cleric {@variantrule optional class features|CosmicDomain|optional feature}, which replaces the Potent Spellcasting feature}",
 				"You are blessed with the might of the whole cosmos, channeled through your god. When a creature takes damage from one of your cantrips or weapon attacks, you can also deal {@damage 1d8} radiant damage to that creature. Once you deal this damage, you can't use this feature again until the start of your next turn."
 			]
 		},
 		{
 			"name": "Potent Spellcasting",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 8,
 			"header": 2,
 			"entries": [
@@ -217,12 +198,12 @@
 		},
 		{
 			"name": "Expansive Influence",
-			"source": "TCE",
+			"source": "CosmicDomain",
 			"page": 32,
 			"className": "Cleric",
 			"classSource": "PHB",
 			"subclassShortName": "Cosmic",
-			"subclassSource": "TCE",
+			"subclassSource": "CosmicDomain",
 			"level": 17,
 			"header": 2,
 			"entries": [


### PR DESCRIPTION
Attempting to fix an undefined error `TypeError: Cannot read properties of undefined (reading 'subclassShortName')` by fixing the `"subclassSource"` which was still defaulted to `"source": "TCE"` instead of the new `"source": "CosmicDomain"` in most cases. 