### PR TITLE
Add the Demi-Dragon 4.5

### DIFF
--- a/class/Aron; Demi-Dragon.json
+++ b/class/Aron; Demi-Dragon.json
@@ -1,0 +1,6833 @@
+{
+	"$schema": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_schema-fast/homebrew.json",
+	"_meta": {
+		"sources": [
+			{
+				"json": "TheDemiDragon",
+				"abbreviation": "TDD",
+				"full": "The Demi-Dragon",
+				"authors": [
+					"Aron"
+				],
+				"convertedBy": [
+					"Aron",
+					"Zar Shef"
+				],
+				"version": "4.5",
+				"url": "https://www.gmbinder.com/share/-LpZX_fRKhLCn-mr_64B",
+				"targetSchema": "1.0.0",
+				"color": "e34234"
+			}
+		],
+		"dateAdded": 15062022,
+		"dateLastModified": 26082022,
+		"optionalFeatureTypes": {
+			"MV:J": "Maneuver, Juggernaut",
+			"Morph": "Morph Category, Metamorph"
+		}
+	},
+	"race": [
+		{
+			"name": "Demi-Dragon",
+			"source": "TheDemiDragon",
+			"size": [
+				"M"
+			],
+			"speed": {
+				"walk": 30
+			},
+			"darkvision": 60,
+			"ability": [
+				{
+					"str": 2,
+					"choose": {
+						"from": [
+							"dex",
+							"con",
+							"int",
+							"wis",
+							"cha"
+						],
+						"count": 1,
+						"amount": 1
+					}
+				}
+			],
+			"languageProficiencies": [
+				{
+					"common": true,
+					"draconic": true
+				}
+			],
+			"traitTags": [
+				"Monstrous Race",
+				"Natural Armor",
+				"Natural Weapon",
+				"Powerful Build",
+				"Skill Proficiency"
+			],
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"arcana",
+							"acrobatics",
+							"deception",
+							"persuasion",
+							"history"
+						],
+						"count": 1
+					}
+				}
+			],
+			"entries": [
+				{
+					"name": "Ability Score Increase",
+					"entries": [
+						"Your Strength score increases by 2, and one other ability score of your choice increases by 1."
+					]
+				},
+				{
+					"name": "Age",
+					"entries": [
+						"A demi-dragon can live for roughly four hundred years, starting from when they were first transformed."
+					]
+				},
+				{
+					"name": "Creature Type",
+					"entries": [
+						"You are a Dragon."
+					]
+				},
+				{
+					"name": "Size",
+					"entries": [
+						"Demi-dragons have a body mass that is identical to that of their previous form. At most, a demi-dragon stands 4 feet tall from shoulder to the ground, and measures no longer than 16 feet from snout to tail tip, of which their body accounts for a maximum of 5 feet. Your size is Medium."
+					]
+				},
+				{
+					"name": "Aided Jump",
+					"entries": [
+						"Your wings provide you with lift. Your maximum jump distance for high and long jumps is doubled, and you do not need to take a running start. This extra distance costs movement as normal."
+					]
+				},
+				{
+					"name": "Darkvision",
+					"entries": [
+						"You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
+					]
+				},
+				{
+					"name": "Mythic Build",
+					"entries": [
+						"You count as one size category larger when determining your carrying capacity and the weight you can push, drag, or lift.",
+						"Your claws have enough manual dexterity to manipulate objects as normal, but you have disadvantage on attack rolls made with weapons that have the ammunition or two-handed properties, and receive no benefit from wielding shields. In order to wear armor, you must have it specially constructed, costing two times the normal rate."
+					]
+				},
+				{
+					"name": "Dragon Scales",
+					"entries": [
+						"Your magical essence enhances your protective scales. While you aren't wearing armor, your Armor Class equals 10 + your Constitution modifier + your Charisma modifier."
+					]
+				},
+				{
+					"name": "Natural Weapons",
+					"entries": [
+						"You have access to an arsenal of natural weapons. These natural weapons count as martial melee weapons for you, and you are proficient with them. You can use them to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with them. Your fanged maw deals {@damage 1d12} piercing damage on a hit. Your lashing tail has a reach of 10 feet and deals {@damage 1d10} bludgeoning damage. Your rending claws deal {@damage 1d6} slashing damage. When you take the {@action Attack} action and attack with your claw, you can use your bonus action to make an additional claw attack."
+					]
+				},
+				{
+					"name": "Class Restriction",
+					"entries": [
+						"You can't use the demi-dragon racial traits if you don't have at least one level of the demi-dragon class.",
+						"If your race is later changed by another effect, you lose access to all demi-dragon class features. Your race and class are invariably tied together."
+					]
+				},
+				{
+					"name": "Inheritance",
+					"entries": [
+						"Your connection to a particular type of true dragon manifests as a related skill. You gain proficiency with one of the following skills of your choice: Arcana, Acrobatics, Deception, History, and Persuasion."
+					]
+				},
+				{
+					"name": "Languages",
+					"entries": [
+						"You can speak, read, and write Common and Draconic."
+					]
+				}
+			]
+		}
+	],
+	"class": [
+		{
+			"name": "Demi-Dragon",
+			"source": "TheDemiDragon",
+			"hd": {
+				"number": 1,
+				"faces": 10
+			},
+			"proficiency": [
+				"str",
+				"con"
+			],
+			"startingProficiencies": {
+				"skills": [
+					{
+						"choose": {
+							"from": [
+								"athletics",
+								"insight",
+								"intimidation",
+								"investigation",
+								"persuasion",
+								"stealth",
+								"survival"
+							],
+							"count": 2
+						}
+					}
+				]
+			},
+			"startingEquipment": {
+				"additionalFromBackground": true,
+				"default": [
+					"{@item Claws|TheDemiDragon}, {@item Bite|TheDemiDragon}, and {@item Tail|TheDemiDragon}",
+					"assorted shiny valuables worth 2d4 x 5 gp",
+					"(a) a {@item scholar's pack|phb}, (b) a {@item priest's pack|phb}, or (c) an {@item explorer's pack|phb}. Packs take the form of modified saddlebags",
+					"a personal item from before your transformation."
+				],
+				"defaultData": [
+					{
+						"_": [
+							"Claws|TheDemiDragon",
+							"Bite|TheDemiDragon",
+							"Tail|TheDemiDragon"
+						]
+					},
+					{
+						"a": [
+							"dungeoneer's pack|phb"
+						],
+						"b": [
+							"priest's pack|phb"
+						],
+						"c": [
+							"explorer's pack|phb"
+						]
+					}
+				]
+			},
+			"classTableGroups": [
+				{
+					"colLabels": [
+						"Breath Damage",
+						"Breath Line/Cone",
+						"Glide/Fly Speed"
+					],
+					"rows": [
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 2,
+										"faces": 8
+									}
+								]
+							},
+							"30/15 ft.",
+							"-"
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 2,
+										"faces": 8
+									}
+								]
+							},
+							"35/15 ft.",
+							"40 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 3,
+										"faces": 8
+									}
+								]
+							},
+							"40/15 ft.",
+							"40 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 3,
+										"faces": 8
+									}
+								]
+							},
+							"45/20 ft.",
+							"40 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 4,
+										"faces": 8
+									}
+								]
+							},
+							"50/20 ft.",
+							"50 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 4,
+										"faces": 8
+									}
+								]
+							},
+							"55/20 ft.",
+							"50 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 5,
+										"faces": 8
+									}
+								]
+							},
+							"60/20 ft.",
+							"50 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 5,
+										"faces": 8
+									}
+								]
+							},
+							"65/25 ft.",
+							"50 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 6,
+										"faces": 8
+									}
+								]
+							},
+							"70/25 ft.",
+							"55 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 6,
+										"faces": 8
+									}
+								]
+							},
+							"75/25 ft.",
+							"55 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 7,
+										"faces": 8
+									}
+								]
+							},
+							"80/25 ft.",
+							"60 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 7,
+										"faces": 8
+									}
+								]
+							},
+							"85/30 ft.",
+							"60 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 8,
+										"faces": 8
+									}
+								]
+							},
+							"90/30 ft.",
+							"65 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 8,
+										"faces": 8
+									}
+								]
+							},
+							"95/30 ft.",
+							"65 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 9,
+										"faces": 8
+									}
+								]
+							},
+							"100/30 ft.",
+							"70 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 9,
+										"faces": 8
+									}
+								]
+							},
+							"105/35 ft.",
+							"70 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 10,
+										"faces": 8
+									}
+								]
+							},
+							"110/35 ft.",
+							"75 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 10,
+										"faces": 8
+									}
+								]
+							},
+							"115/35 ft.",
+							"75 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 11,
+										"faces": 8
+									}
+								]
+							},
+							"120/35 ft.",
+							"80 ft."
+						],
+						[
+							{
+								"type": "dice",
+								"toRoll": [
+									{
+										"number": 11,
+										"faces": 8
+									}
+								]
+							},
+							"125/40 ft.",
+							"80 ft."
+						]
+					]
+				}
+			],
+			"classFeatures": [
+				"Dragon Spark|Demi-Dragon|TheDemiDragon|1",
+				"Dragon's Breath|Demi-Dragon|TheDemiDragon|1",
+				"Devour Magic|Demi-Dragon|TheDemiDragon|1",
+				"Breath Recharge|Demi-Dragon|TheDemiDragon|1",
+				"Resolution|Demi-Dragon|TheDemiDragon|1",
+				"Elemental Adaptation|Demi-Dragon|TheDemiDragon|2",
+				"Glide|Demi-Dragon|TheDemiDragon|2",
+				"Absorb Magic|Demi-Dragon|TheDemiDragon|3",
+				{
+					"classFeature": "Draconic Embodiment|Demi-Dragon|TheDemiDragon|3",
+					"gainSubclassFeature": true
+				},
+				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|4",
+				"Extra Attack|Demi-Dragon|TheDemiDragon|5",
+				"Stride|Demi-Dragon|TheDemiDragon|5",
+				"Devour Magic 60 ft.|Demi-Dragon|TheDemiDragon|5",
+				"Leeching Strikes|Demi-Dragon|TheDemiDragon|6",
+				{
+					"classFeature": "Embodiment feature|Demi-Dragon|TheDemiDragon|6",
+					"gainSubclassFeature": true
+				},
+				"Flight|Demi-Dragon|TheDemiDragon|7",
+				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|8",
+				"Eye of the Dragon|Demi-Dragon|TheDemiDragon|9",
+				{
+					"classFeature": "Embodiment feature|Demi-Dragon|TheDemiDragon|10",
+					"gainSubclassFeature": true
+				},
+				"Size Increase|Demi-Dragon|TheDemiDragon|10",
+				"Dragon's Might|Demi-Dragon|TheDemiDragon|11",
+				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|12",
+				"Dragon's Breath (three uses)|Demi-Dragon|TheDemiDragon|13",
+				"Fabled Resistance|Demi-Dragon|TheDemiDragon|14",
+				"Force of Self|Demi-Dragon|TheDemiDragon|15",
+				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|16",
+				{
+					"classFeature": "Embodiment feature|Demi-Dragon|TheDemiDragon|17",
+					"gainSubclassFeature": true
+				},
+				"Rend and Ruin|Demi-Dragon|TheDemiDragon|17",
+				"Devour Magic (two uses)|Demi-Dragon|TheDemiDragon|18",
+				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|19",
+				"Fabled Resistance (three uses)|Demi-Dragon|TheDemiDragon|20"
+			],
+			"multiclassing": {
+				"requirements": {
+					"str": 13
+				}
+			},
+			"subclassTitle": "Draconic Embodiment",
+			"fluff": [
+				{
+					"name": "Demi-Dragon",
+					"source": "TheDemiDragon",
+					"type": "section",
+					"page": 1,
+					"entries": [
+						"A single crimson-scaled runt of a dragon stands defiant amidst an orcish warband, waving their axes in anticipation of an easy kill. With a roar, fire lights up the forest clearing as she charges fearlessly, driving the startled orcs back with a ferocity that belies her modest size.",
+						"The azure dragon studies the wizard's arcane runes, his companions waiting close by. Jotting a note down in his beloved journal, he inhales deeply, leeching the magical energy right out of the protective ward. With a satisfied smirk, he leads his companions deeper into the wizard's sanctum.",
+						"Within a stone temple upon an icy mountaintop, a dragon sage sits in meditation. He was content to weather the blizzard that would soon leave him stranded and isolated, warmed only by the soft glow of the smoldering sphere of fire which he held aloft in supplication. He relished the chance to reflect upon the events of his journey.",
+						"Though each of these demi-dragons tell a different story, they share a similar background - they were once humanoids who underwent a metamorphic transformation that changed their body. Those that are so afflicted are rare, but each must learn to live with the consequences in their own way. Each demi-dragon is different, with some drawing heavily upon the essence of true dragons, while others defy such comparisons. Many demi-dragons are ostracized by those around them. Some relish their new form, while others loathe what has been done to them, but all are linked by the transformation they have undergone.",
+						{
+							"type": "entries",
+							"name": "Imitation of Form",
+							"entries": [
+								"To most, dragons are monsters to be feared and hated. But to a few, they are symbols of power and potential - and those few would sacrifice anything if it would let them have the strength of dragons to use for their own ends.",
+								"Whether driven by fanatical beliefs, a hunger for personal power, or a genuine wish to help others by whatever means are available, some choose to undergo a ritual transformation that changes their body into an imitation of a true dragon. Other individuals concoct detailed magical experiments on unwilling subjects, exploring the limitations of the blood of dragons. Regardless of origin, the resulting creature is known as a demi-dragon - a being that was created rather than born."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Ritual Transformation",
+							"entries": [
+								"The exact details of the demi-dragon transformation are unclear, but the nature of innate dragon magic hints at multiple paths to the same result. Whether accomplished through magical prowess, alchemy, zealous devotion, or by bathing in dragon's blood, the transformation draws upon the essence of a true dragon to instill a spark of magic within the subject, forcing them to take on the physical characteristics of a dragon. Though adopting the shape of a dragon during the transformation, the subject is often brought only halfway there, and can be left temporarily scaleless or wingless. Such deficiencies tend to correct themselves over time - but once transformed, there is no known way to reverse the metamorphosis."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Spark of Magic",
+							"entries": [
+								"As part of their transformation, a spark of magic forms in the heart of a demi-dragon - this is what allows them to mimic a dragon's power and imitate their elemental breath weapons.",
+								"As a result of their unusual nature, demi-dragons develop the ability to siphon magic out of their surroundings, requiring an external source of magical energy to feed this spark as a way to bring themselves closer to the inherent nature of true dragons. The relative power of this spark is a measure of the magical essence a demi-dragon has accumulated.",
+								"Where true dragons are born into their natural splendor, demi-dragons must toil, steal, and sacrifice for but a fraction of that power.",
+								{
+									"type": "table",
+									"caption": "Cause of Transformation",
+									"colLabels": [
+										"{@dice d6}",
+										"Cause of Transformation"
+									],
+									"colStyles": [
+										"col-1 text-center",
+										"col-11"
+									],
+									"rows": [
+										[
+											{
+												"type": "cell",
+												"roll": {
+													"exact": 1
+												}
+											},
+											"You studied for years as a dragon disciple, surpassing the other students by achieving a true transformation."
+										],
+										[
+											{
+												"type": "cell",
+												"roll": {
+													"exact": 2
+												}
+											},
+											"You participated in slaying a dragon, then used its magical blood to imbue yourself with its essence."
+										],
+										[
+											{
+												"type": "cell",
+												"roll": {
+													"exact": 3
+												}
+											},
+											"A crazed wizard captured and transformed you against your will as part of a magical experiment."
+										],
+										[
+											{
+												"type": "cell",
+												"roll": {
+													"exact": 4
+												}
+											},
+											"As a promising young warrior of a barbarian clan, you were chosen to become the clan's draconic champion."
+										],
+										[
+											{
+												"type": "cell",
+												"roll": {
+													"exact": 5
+												}
+											},
+											"You found and wore a cursed artifact, which transformed you. You now seek a way to remove the artifact and its curse."
+										],
+										[
+											{
+												"type": "cell",
+												"roll": {
+													"exact": 6
+												}
+											},
+											"Actually, you are a true dragon, searching for your very own adventure."
+										]
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Creating a Demi-Dragon",
+							"entries": [
+								"When creating your demi-dragon, you should carefully consider two questions: who were you before you became a demi-dragon, and what series of events led you to become one? Consider what your character was like before, how others see them, and how they see themselves now.",
+								{
+									"type": "entries",
+									"name": "Quick Build",
+									"entries": [
+										"You can make a demi-dragon quickly by following these suggestions. First, make Strength your highest ability score, followed by Constitution and Charisma. Second, choose the Victim of Thaumaturgy background. Last, choose a cone of fire for your Dragon's Breath feature."
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	],
+	"classFeature": [
+		{
+			"name": "Dragon Spark",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"entries": [
+				"When you become a demi-dragon, you internalize a spark of inherent magical power that fuels your new form and allows you to mimic the extraordinary abilities of a true dragon. The power of this spark is a measure of the magical essence you have accumulated.",
+				{
+					"type": "entries",
+					"entries": [
+						"Charisma is your ability for specific class features. You use Charisma whenever a feature gained through this class refers to your Dragon Spark. In addition, you use Charisma when setting the saving throw DC for such an effect and when making an attack roll with one.",
+						{
+							"type": "abilityDc",
+							"name": "Dragon Spark",
+							"attributes": [
+								"cha"
+							]
+						},
+						{
+							"type": "abilityAttackMod",
+							"name": "Dragon Spark",
+							"attributes": [
+								"cha"
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Devour Magic",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"entries": [
+				"To sustain your new form, you have developed an innate ability that lets you consume magic. Starting from 1st level, as an action, choose one creature, object, or magical effect within a range of 10 feet of you. Any spell of a level lower than or equal to one third your demi-dragon level (minimum 1) on the target is dispelled. For each spell of a level higher than that, make a Charisma check. The DC equals 10 + the spell's level. On a success, the spell ends. Regardless of success, you then regain hit points equal to your demi-dragon level + your Constitution modifier (minimum 1). Effects that refer to {@spell dispel magic} also apply to this feature, such as {@spell wall of force}.",
+				"You can use this feature once, and must finish a long rest before you can use it again."
+			]
+		},
+		{
+			"name": "Dragon's Breath",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"entries": [
+				"Destructive energy simmers within you, ready to be released. When you gain this feature at 1st level, choose between a 30-foot line that is 5 feet wide or a 15-foot cone. Additionally, choose a damage type from among the following: acid, cold, fire, force, lightning, necrotic, poison, psychic, radiant, or thunder.",
+				"As an action, you exhale destructive energy. Each creature in the area you chose must make a saving throw against your Dragon Spark save DC. A creature takes {@damage 2d8} damage of the chosen type on a failed save, or half as much damage on a sucessful one. The type of saving throw depends on the damage type you chose, as shown in the table below.",
+				"The damage and range of this feature increase as you gain demi-dragon levels, as shown in the Breath Damage and Breath Line/Cone columns of the Demi-Dragon table. You can use this feature twice, and regain all uses of it after finishing a short or long rest. Starting at 13th level, you can use it three times before a rest.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Damage Type",
+						"Saving Throw"
+					],
+					"colStyles": [
+						"col-6",
+						"col-6"
+					],
+					"rows": [
+						[
+							"Acid, Fire, Lightning",
+							"Dexterity"
+						],
+						[
+							"Cold, Necrotic, Poison, Radiant, Thunder",
+							"Constitution"
+						],
+						[
+							"Force",
+							"Strength"
+						],
+						[
+							"Psychic",
+							"Intelligence"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Transformed Power",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"isClassFeatureVariant": true,
+			"entries": [
+				"{@i 1st-level demi-dragon {@variantrule optional class features|TheDemiDragon|optional feature}}",
+				"When you first take a level in demi-dragon while already having levels in another class, you may optionally convert those levels to an equivalent amount of demi-dragon levels."
+			]
+		},
+		{
+			"name": "Indefinite Mind",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"isClassFeatureVariant": true,
+			"entries": [
+				"{@i 1st-level demi-dragon {@variantrule optional class features|TheDemiDragon|optional feature}}",
+				"The path of the demi-dragon need not be a confining one. A wizard may strive to turn themselves into a dragon, and some monks follow the way of the dragon disciple. As an option, choose Intelligence or Wisdom. The chosen ability score is used in place of Charisma for Dragon Spark and Dragon Scales, as well as every demi-dragon feature that refers to Charisma (except for Force of Self)."
+			]
+		},
+		{
+			"name": "Breath Recharge",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"isClassFeatureVariant": true,
+			"entries": [
+				"{@i 1st-level demi-dragon {@variantrule optional class features|TheDemiDragon|optional feature} which changes the Dragon's Breath feature}",
+				"{@classFeature Dragon's Breath|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Dragon's Breath} no longer stores multiple charges. When you use your Dragon's Breath, roll a d6 at the start of each of your turns. On a 6, you regain use of the feature. Starting at 13th level, you regain use of the feature if you roll a 5 or 6."
+			]
+		},
+		{
+			"name": "Resolution",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"isClassFeatureVariant": true,
+			"entries": [
+				"{@i 1st- and 18th-level demi-dragon {@variantrule optional class features|TheDemiDragon|optional feature} which replaces the Devour Magic feature}",
+				"You act with purpose and celebrate your triumphs. As a bonus action, you set your attention upon the accomplishment of a task—be it slaying a particular foe, obtaining an item not in your possession, or helping an ally in some manner. The task must be non-trivial in nature. While the task remains undone, you have advantage on your next Wisdom saving throw. When the task is accomplished, you regain hit points equal to 1d10 + your demi-dragon level. If you abandon the task or fail to complete it before 10 minutes have passed, these benefits are lost.",
+				"Once you use this feature, you must finish a short or long rest before you can use it again. Starting at 18th level, you gain advantage on all Wisdom saving throws until the task is accomplished."
+			]
+		},
+		{
+			"name": "Glide",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 2,
+			"entries": [
+				"Your wings can slow your fall. Starting from 2nd level, as a reaction you can take when falling while you aren't {@condition prone}, you can spread your wings and glide, slowing your rate of descent to 20 feet per round. While gliding, you can as part of your movement move up to 40 feet in any horizontal direction, or dive straight down. When you land, you take no falling damage and can land on your feet. You can also start gliding by expending at least 10 feet of movement as part of a high jump.",
+				"The speed at which you can glide increases as you gain demi-dragon levels, as shown in the Glide/Fly Speed column of the Demi-Dragon table."
+			]
+		},
+		{
+			"name": "Elemental Adaptation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 2,
+			"entries": [
+				"At 2nd level, your form continues to change as you adapt to your newly-attained elemental nature. You gain resistance to the damage type you chose for Dragon's Breath."
+			]
+		},
+		{
+			"name": "Absorb Magic",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"At 3rd level, you gain the ability to absorb the magical enchantment of a weapon or piece of equipment. This grants you access to the magical powers provided by that item, and removes it from the item. The stolen magic harmlessly flows through your veins. You can absorb an enchantment from a magical item as part of a long rest, during which the item must be in your possession. Once absorbed, you can use the item's magical properties as if you were wearing or wielding the item. The stolen magical power follows all rules that would normally apply to it.",
+				"You can return the enchantment to the original item as part of a short or long rest. When returning an enchantment, you do not need to have the item in your possession.",
+				"You can have a maximum of 5 such enchantments active at any one time. If the item requires attunement to use, it follows normal attunement rules, and you count as being attuned while the enchantment remains absorbed by you. You can't absorb an item's magic if doing so would cause you to be attuned to more than your maximum attunements.",
+				"You can't absorb the power of shields or artifacts Additionally, the Dungeon Master may rule that a specific item's enchantment can't be absorbed. Only enchantments on items that are designed to be equipment (worn or wielded) can be absorbed. You can't combine these enchantments in any way that would not normally be possible - you can't, for instance, benefit from more than one weapon enchantment when making an attack, but if multiple such enchantments are available to you, you can decide which one to use each time you make an attack.",
+				"Should you absorb a cursed item, the curse functions as normal. You can rid yourself of the curse after fulfilling its requirements, such as by using the remove curse spell. Doing so temporarily allows you to return the cursed enchantment to its item as part of a short or long rest."
+			]
+		},
+		{
+			"name": "Draconic Embodiment",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"At 3rd level, you choose an aspect of draconic might to dedicate yourself to. Your choice grants you features at 3rd, 6th, 10th, and 17th level."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 4,
+			"entries": [
+				"When you reach 4th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Extra Attack",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 5,
+			"entries": [
+				"Beginning at 5th level, you can attack twice, instead of once, whenever you take the {@action Attack} action on your turn."
+			]
+		},
+		{
+			"name": "Stride",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 5,
+			"entries": [
+				"At 5th level, you've become better used to your body. Your walking speed increases by 10 feet while you aren't wearing heavy armor.",
+				"Additionally, a creature that is the same size category as you or smaller can ride on your back if you allow it. In such a situation, you continue to act independently, not as a controlled mount."
+			]
+		},
+		{
+			"name": "Devour Magic 60 ft.",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 5,
+			"entries": [
+				"Starting at 5th level, the range of your {@classFeature Devour Magic|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Devour Magic} increases to 60 feet."
+			]
+		},
+		{
+			"name": "Leeching Strikes",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 6,
+			"entries": [
+				"From 6th level, your stolen magic empowers your attacks. All of your natural weapons count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage."
+			]
+		},
+		{
+			"name": "Embodiment feature",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 6,
+			"entries": [
+				"At 6th level, you gain a feature determined by your Draconic Embodiment."
+			]
+		},
+		{
+			"name": "Flight",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 7,
+			"entries": [
+				"At 7th level, you gain a flying speed of 50 feet. You can only use this flying speed if you aren't wearing heavy armor and aren't encumbered. Your flying speed increases as you gain demi-dragon levels, as shown in the Glide/Fly Speed column of the Demi-Dragon table."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 8,
+			"entries": [
+				"When you reach 8th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Eye of the Dragon",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 9,
+			"entries": [
+				"At 9th level, your senses become supernaturally honed. You gain proficiency in your choice of the Perception or the Investigation skill. If you already have proficiency in the chosen skill, your proficiency bonus is doubled for that skill.",
+				"Additionally, you gain blindsight out to a range of 10 feet. You faintly sense the location of any magical effect that is within the range of your blindsight, and innately know if such a magical effect can be dispelled."
+			]
+		},
+		{
+			"name": "Embodiment feature",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 10,
+			"entries": [
+				"At 10th level, you gain a feature determined by your Draconic Embodiment."
+			]
+		},
+		{
+			"name": "Size Increase",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 10,
+			"isClassFeatureVariant": true,
+			"entries": [
+				"{@i 10th- and 20th-level demi-dragon {@variantrule optional class features|TheDemiDragon|optional feature}}",
+				"Your size increases to Large. At 20th level, your size increases to Huge."
+			]
+		},
+		{
+			"name": "Dragon's Might",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 11,
+			"entries": [
+				"At 11th level, raw draconic vitality empowers you. Your Strength, Constitution, and Charisma scores each increase by 2. Your maximum for those scores is now 22."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 12,
+			"entries": [
+				"When you reach 12th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Dragon's Breath (three uses)",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 13,
+			"entries": [
+				"Starting at 13th level, you can use your {@classFeature Dragon's Breath|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Dragon's Breath} feature three times before a short or long rest."
+			]
+		},
+		{
+			"name": "Fabled Resistance",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 14,
+			"entries": [
+				"The tenacity of dragons is legendary. Starting 14th level, you gain two resistance dice, which are d6s. When you fail a saving throw, you can choose to roll one or more of your resistance dice, adding the result to your saving throw total. You can roll each die one by one. Once a resistance die has turned a failure into a success, the die is expended and cannot be used again until you have finished a long rest."
+			]
+		},
+		{
+			"name": "Force of Self",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 15,
+			"entries": [
+				"At 15th level, you have developed a unique connection to the material plane and a stubborn persistence in the face of adversity. You gain proficiency in Charisma saving throws. If you already have this proficiency, you instead gain proficiency in Intelligence or Strength saving throws (your choice)."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 16,
+			"entries": [
+				"When you reach 16th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Rend and Ruin",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 17,
+			"entries": [
+				"At 17th level, your savage strikes leave your foes broken and bleeding. Once on each of your turns if you deal damage to a target with at least two natural weapon attacks, the target takes an additional 3d6 damage of the same type, and has its speed reduced by 10 feet until the start of your next turn."
+			]
+		},
+		{
+			"name": "Embodiment feature",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 17,
+			"entries": [
+				"At 17th level, you gain a feature determined by your Draconic Embodiment."
+			]
+		},
+		{
+			"name": "Devour Magic (two uses)",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 18,
+			"entries": [
+				"At 18th level, you can use your {@classFeature Devour Magic|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Devour Magic} feature twice before a long rest."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 19,
+			"entries": [
+				"When you reach 19th level, you can increase one ability score of your choice by 2, or you can increase two ability scores of your choice by 1. As normal, you can't increase an ability score above 20 using this feature."
+			]
+		},
+		{
+			"name": "Fabled Resistance (three uses)",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 20,
+			"entries": [
+				"At 20th level, you gain another die for your {@classFeature Fabled Resistance|Demi-Dragon|TheDemiDragon|14|TheDemiDragon|Fabled Resistance} for a total of three, and they each turn into d10s."
+			]
+		}
+	],
+	"subclass": [
+		{
+			"name": "Embodiment of the Juggernaut",
+			"optionalfeatureProgression": [
+				{
+					"name": "Maneuvers",
+					"featureType": [
+						"MV:J"
+					],
+					"progression": {
+						"3": 3,
+						"6": 5,
+						"10": 7,
+						"17": 9
+					}
+				}
+			],
+			"subclassFeatures": [
+				"Embodiment of the Juggernaut|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|3",
+				"Tenacious Assault|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|6",
+				"Unwavering Combatant|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|10",
+				"Anvil of Will|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Juggernaut",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Sibilant",
+			"subclassFeatures": [
+				"Embodiment of the Sibilant|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|3",
+				"Clarity of Thought|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|6",
+				"Obfuscate Consciousness|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|6",
+				"Overwhelming Desolation|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|10",
+				"Dominion of Perception|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Sibilant",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Shadestalker",
+			"subclassFeatures": [
+				"Embodiment of the Shadestalker|Demi-Dragon|TheDemiDragon|Shadestalker|TheDemiDragon|3",
+				"Shade Veil|Demi-Dragon|TheDemiDragon|Shadestalker|TheDemiDragon|6",
+				"Fade and Ambush|Demi-Dragon|TheDemiDragon|Shadestalker|TheDemiDragon|10",
+				"Blood and Shade|Demi-Dragon|TheDemiDragon|Shadestalker|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Shadestalker",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Scion",
+			"subclassFeatures": [
+				"Embodiment of the Scion|Demi-Dragon|TheDemiDragon|Scion|TheDemiDragon|3",
+				"Ardent Focus|Demi-Dragon|TheDemiDragon|Scion|TheDemiDragon|6",
+				"Elemental Suffusion|Demi-Dragon|TheDemiDragon|Scion|TheDemiDragon|10",
+				"Frightful Roar|Demi-Dragon|TheDemiDragon|Scion|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Scion",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Ascetic",
+			"subclassFeatures": [
+				"Embodiment of the Ascetic|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|3",
+				"Anointed Blessings|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|6",
+				"Bestow Grace|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|10",
+				"Sage Wisdom|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|10",
+				"Ineffable Paragon|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Ascetic",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Arbiter",
+			"shortName": "Arbiter",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"spellcastingAbility": "cha",
+			"casterProgression": "1/3",
+			"cantripProgression": [
+				0,
+				0,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3
+			],
+			"spellsKnownProgression": [
+				0,
+				0,
+				3,
+				4,
+				4,
+				4,
+				5,
+				6,
+				6,
+				7,
+				8,
+				8,
+				9,
+				10,
+				10,
+				11,
+				11,
+				11,
+				12,
+				13
+			],
+			"subclassTableGroups": [
+				{
+					"subclasses": [
+						{
+							"name": "Arbiter",
+							"source": "TheDemiDragon"
+						}
+					],
+					"colLabels": [
+						"{@filter Cantrips Known|spells|level=0|class=sorcerer}",
+						"{@filter Spells Known|spells|class=sorcerer}"
+					],
+					"rows": [
+						[
+							0,
+							0
+						],
+						[
+							0,
+							0
+						],
+						[
+							2,
+							3
+						],
+						[
+							2,
+							4
+						],
+						[
+							2,
+							4
+						],
+						[
+							2,
+							4
+						],
+						[
+							2,
+							5
+						],
+						[
+							2,
+							6
+						],
+						[
+							2,
+							6
+						],
+						[
+							3,
+							7
+						],
+						[
+							3,
+							8
+						],
+						[
+							3,
+							8
+						],
+						[
+							3,
+							9
+						],
+						[
+							3,
+							10
+						],
+						[
+							3,
+							10
+						],
+						[
+							3,
+							11
+						],
+						[
+							3,
+							11
+						],
+						[
+							3,
+							11
+						],
+						[
+							3,
+							12
+						],
+						[
+							3,
+							13
+						]
+					]
+				},
+				{
+					"title": "Spell Slots per Spell Level",
+					"subclasses": [
+						{
+							"name": "Arbiter",
+							"source": "TheDemiDragon"
+						}
+					],
+					"colLabels": [
+						"{@filter 1st|spells|level=1|class=sorcerer}",
+						"{@filter 2nd|spells|level=2|class=sorcerer}",
+						"{@filter 3rd|spells|level=3|class=sorcerer}",
+						"{@filter 4th|spells|level=4|class=sorcerer}"
+					],
+					"rowsSpellProgression": [
+						[
+							0,
+							0,
+							0,
+							0
+						],
+						[
+							0,
+							0,
+							0,
+							0
+						],
+						[
+							2,
+							0,
+							0,
+							0
+						],
+						[
+							3,
+							0,
+							0,
+							0
+						],
+						[
+							3,
+							0,
+							0,
+							0
+						],
+						[
+							3,
+							0,
+							0,
+							0
+						],
+						[
+							4,
+							2,
+							0,
+							0
+						],
+						[
+							4,
+							2,
+							0,
+							0
+						],
+						[
+							4,
+							2,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							2,
+							0
+						],
+						[
+							4,
+							3,
+							2,
+							0
+						],
+						[
+							4,
+							3,
+							2,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							1
+						],
+						[
+							4,
+							3,
+							3,
+							1
+						]
+					]
+				}
+			],
+			"subclassFeatures": [
+				"Embodiment of the Arbiter|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|3",
+				"Dragonweave|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|6",
+				"Focal Point|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|6",
+				"Unmakers Sight|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|10",
+				"Weave and Unweave|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|17"
+			]
+		},
+		{
+			"name": "Embodiment of the Fervent Hoarder",
+			"subclassFeatures": [
+				"Embodiment of the Fervent Hoarder|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|3",
+				"Manifest Lair|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|6",
+				"Claim Item|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|10",
+				"Homely Lair|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|10",
+				"Splendor|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Fervent Hoarder",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Metamorph",
+			"optionalfeatureProgression": [
+				{
+					"name": "Morph Category",
+					"featureType": [
+						"Morph"
+					],
+					"progression": {
+						"3": 3,
+						"6": 5,
+						"10": 6,
+						"17": 7
+					}
+				}
+			],
+			"subclassFeatures": [
+				"Embodiment of the Metamorph|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|3",
+				"Twinned Adaptation|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|6",
+				"Fueling the Transformation|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|6",
+				"Remake Self|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|10",
+				"Essence of Change|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|10",
+				"Flawless Metamorphosis|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Metamorph",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		}
+	],
+	"subclassFeature": [
+		{
+			"name": "Embodiment of the Juggernaut",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Juggernauts face their foes head on and break them under a barrage of fury. Juggernauts rely on raw might and tenacity to wade into battle, using their multiple limbs to tear their enemies down with their powerful natural weapons.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Fury|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Maneuvers|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "By Any Means|Demi-Dragon|TheDemiDragon|Juggernaut|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Fury",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Your body is a weapon of war. Starting from 3rd level, you learn special maneuvers which are fueled by a resource called fury.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Maneuvers",
+							"entries": [
+								"You learn three {@filter maneuvers|optionalfeatures|source=TheDemiDragon|feature type=MV:J} of your choice, which are detailed under \"Maneuvers\" below. Many maneuvers require you to make an attack. Resolve the attack as you normally would while accounting for the additional effect of the maneuver.",
+								"You learn two additional maneuvers of your choice at 6th, 10th, and 17th level. Each time you learn new maneuvers, you can also replace one maneuver you know with a different one."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fury",
+							"entries": [
+								"You have four fury points. You regain all of your expended fury points when you finish a short or long rest.",
+								"You can spend fury to perform a maneuver. Each maneuver costs fury points to use, noted in parentheses. You must be able to pay the fury cost to use the maneuver.",
+								"You gain two more fury points at levels 6th, 10th, and 17th."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Saving Throws",
+							"entries": [
+								"Some of your maneuvers require your target to make a saving throw to resist the maneuver's effects. The saving throw DC is calculated as follows:",
+								{
+									"type": "abilityDc",
+									"name": "Maneuver",
+									"attributes": [
+										"str"
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "By Any Means",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"By 3rd level, your horns and wings are alternative means of attack that are used as part of many of your maneuvers. These natural weapons count as martial melee weapons for you, and you are proficient with them. You can use them to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with them. Your {@item horns|TheDemiDragon} deal 2d4 piercing damage. Your {@item wings|TheDemiDragon} deal 1d4 bludgeoning damage. When you take the {@action Attack} action to attack with your claw or wing, you can use your bonus action to make an additional claw or wing attack."
+			]
+		},
+		{
+			"name": "Maneuvers",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"The maneuvers are presented in alphabetical order.",
+				{
+					"type": "options",
+					"count": 3,
+					"entries": [
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Bolstering Roar (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Hammering Lunge (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Launch Ally (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Lockjaw (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Skylaunch (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Suppressing Gale (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Thieving Talons (1)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Brutal Dive (2)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Defiance (2)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Fearsome Wound (2)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Reprisal (2)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Rising Wing (2)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Battering Ram (3)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Tail Sweep (3)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Wrath (3)|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Wrest Magic (3)|TheDemiDragon"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Tenacious Assault",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"By 6th level, a fervor burns within you to enact your fury upon your enemies. When you make an attack as a part of a maneuver, you have advantage on the attack roll."
+			]
+		},
+		{
+			"name": "Unwavering Combatant",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, you embrace challenge. You gain the following benefits:",
+				{
+					"type": "options",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fearless",
+							"entries": [
+								"You have advantage on saving throws you make to avoid or end the {@condition frightened} condition on yourself."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Heat of Battle",
+							"entries": [
+								"Whenever you roll initiative, you gain temporary hit points equal to your demi-dragon level. These temporary hit points last for 1 minute."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Anvil of Will",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"Combat is the anvil of will, and you are its hammer. Starting from 17th level, when a creature succeeds on a saving throw against one of your demi-dragon class features, you can force it to reroll. It must use the new roll. Once you use this feature, you can't do so again until you finish a long rest."
+			]
+		},
+		{
+			"name": "Embodiment of the Sibilant",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Sibilants are psionic manipulators who prefer to quietly and selectively influence those around them in their own favor, whispering unassuming suggestions that play into their plans. A sibilant will compel their foes to step right into the path of their elemental breath without them even realizing.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Sibilant Mind|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Telepathic|Demi-Dragon|TheDemiDragon|Sibilant|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Sibilant Mind",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting from 3rd level, your psionic mind lets you manipulate those who surround you, or protect yourself from attackers. As a bonus action, you gain one of the following benefits which lasts until you choose the other option:",
+				{
+					"type": "options",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Beckoning Influence",
+							"entries": [
+								"When you spend your action to take the {@action Attack}, {@action Dodge}, or {@classFeature Dragon's Breath|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Dragon's Breath} actions, you can nudge the mind of another creature that you can see within 60 feet of you as part of that action. The creature must succeed on a Wisdom saving throw against your Dragon Spark save DC or immediately move up to 10 feet in a direction of your choosing. This movement doesn't provoke opportunity attacks, and occurs before your action. A creature can willingly fail this save. At 10th level, you can influence up to two different targets."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Bolstering Backlash",
+							"entries": [
+								"As a reaction when a creature forces you to make a saving throw, you can choose to lash out at the offender with your mind. The creature takes {@damage 1d4} psychic damage. You gain a bonus to your saving throw equal to the damage dealt. At 10th level, the damage increases to {@damage 1d8}."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Telepathic",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting from 3rd level, you can speak telepathically to any creature you can see within 60 feet of you. Your telepathic utterances are in a language you know, and the creature understands you only if it knows that language. Your communication doesn't give the creature the ability to respond to you telepathically."
+			]
+		},
+		{
+			"name": "Clarity of Thought",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, your careful planning and disciplined thoughts leave no room for error. You cannot be {@condition charmed}. Additionally, whenever you start your turn with no hostile creature within 5 feet of you, you can add your Charisma modifier to one damage roll you make before the end of your turn."
+			]
+		},
+		{
+			"name": "Obfuscate Consciousness",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Starting from 6th level, you can infiltrate the minds of others to change how they see you. As a bonus action, choose a creature within 120 feet of you that you are aware of. The creature must succeed on a Wisdom saving throw or become {@condition charmed} by you for 10 minutes. Additionally, you alter the creature's perception of you, choosing from the following secondary effects:",
+				{
+					"type": "list",
+					"items": [
+						"You appear to the target as a completely different creature of your choice, looking and sounding as you determine.",
+						"You erase yourself from the target's vision. The target treats you as if you were {@condition invisible}.",
+						"You appear to the target as a haunting vision. The target is {@condition frightened} of you and {@condition deafened} to all around it save you."
+					]
+				},
+				"If the charmed target takes any damage, the charm ends, but the secondary effect persists for the remaining duration. You can use this feature once, and must then finish a short or long rest to use it again."
+			]
+		},
+		{
+			"name": "Overwhelming Desolation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Amidst the destruction of your elemental breath reigns confusion. Starting from 10th level, when you use your {@classFeature Dragon's Breath|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Dragon's Breath} feature, you can use your bonus action to psionically overwhelm one target that failed its save against your Dragon's Breath. That creature must make a Wisdom saving throw against your Dragon Spark save DC or be {@condition incapacitated} until the end of their next turn."
+			]
+		},
+		{
+			"name": "Dominion of Perception",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, you leave a web of altered perception in your wake. When you use Obfuscate Consciousness, you can choose to concentrate (as if on a spell) for up to 1 hour afterwards. While concentrating in this manner, you can use Obfuscate Consciousness at will, but cannot target the same creature more than once."
+			]
+		},
+		{
+			"name": "Embodiment of the Shadestalker",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Some demi-dragons are rejected or feared by those around them, and learn to rely on tricks and subterfuge. Shadestalkers outmaneuver their enemies with predatory ambushes before vanishing into the night, striking only when they have the advantage.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Umbral Lunge|Demi-Dragon|TheDemiDragon|Shadestalker|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Keen Predator|Demi-Dragon|TheDemiDragon|Shadestalker|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Umbral Lunge",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting from 3rd level, you can become a shade and dart forward. Once on each of your turns while you aren't {@condition grappled}, {@condition incapacitated}, or {@condition prone}, you can choose an unoccupied space which you can see within 15 feet of you. You can act as if you occupy that space, instead of your own. Shadows pull you back and end the effect when you move, at the end of your turn, or if you choose to end it early (no action required). If an effect reduces your speed to 0 during the lunge, you instead move to the space."
+			]
+		},
+		{
+			"name": "Keen Predator",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"At 3rd level, predatory instincts awaken in you. You can use your Charisma modifier in place of your Dexterity modifier when making Dexterity checks and Dexterity saving throws. Additionally, you gain blindsight out to 10 feet. When you gain {@classFeature Eye of the Dragon|Demi-Dragon|TheDemiDragon|9|TheDemiDragon|Eye of the Dragon}, this range increases to 20 feet."
+			]
+		},
+		{
+			"name": "Shade Veil",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, you can create an area of sheltering shadows. As a bonus action, you choose a point within your Cone Range from which spreads a 15-foot cube of magical darkness. The darkness spreads around corners, a creature with darkvision can't see through the darkness, and nonmagical light can't illuminate it. The darkness lasts for 1 minute, or until you choose to dismiss it early as a bonus action. You can use this feature three times, and must then complete a short or long rest before you can use it again."
+			]
+		},
+		{
+			"name": "Fade and Ambush",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Starting from 10th level, you vanish and reappear abruptly. Immediately after ending your turn, you can take the {@action Hide} action as a reaction.",
+				"Additionally, whenever you hit with a melee weapon attack which you had advantage on, the target of your attack must make a Wisdom save against your Dragon Spark save DC. On a failure, the target becomes {@condition frightened} of you for 1 minute. The target can repeat the saving throw at the end of each of its turns. A target that succeeds on this save is immune to this effect for the next 8 hours."
+			]
+		},
+		{
+			"name": "Blood and Shade",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, shadows cling to you as you burst from concealment, and when you strike, you leave your enemies bleeding and crippled. If you start your turn while heavily obscured or hidden, you become invisible until the end of your turn.",
+				"Additionally, the speed reduction of your Rend and Ruin lasts for 1 minute."
+			]
+		},
+		{
+			"name": "Embodiment of the Scion",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Scions are demi-dragons who commit themselves fully to dragonkind. The purity of their elemental spark makes them nearly indistinguishable from true dragons, inheriting their most iconic traits. Scions dedicate themselves to a specific draconic bloodline from which they draw their power.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Bloodline Heritage|Demi-Dragon|TheDemiDragon|Scion|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Ardent Gift|Demi-Dragon|TheDemiDragon|Scion|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Bloodline Heritage",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"At 3rd level, you grow closer to one of the fifteen draconic bloodlines, taking on the physical appearance of a dragon of that type. Choose a dragon type from the table below. The type chosen must match the damage type you chose for Dragon's Breath. You gain a climbing, swimming, or burrowing speed depending on your choice. If you choose Silver, you instead gain the Silver Mist morph, detailed under the Embodiment of the Metamorph.",
+				"If you gain a climbing speed, it is equal to your walking speed and you suffer no ill effects from high altitudes. If you gain a swimming speed, it is equal to your walking speed and you can breathe both air and water. If you gain a burrowing speed, it is equal to half your walking speed and you can tunnel through loose dirt, gravel, and similar materials, but not through solid materials. If you burrow at half speed, you can reinforce your tunnel as you move, letting others safely pass through - otherwise it slowly collapses behind you.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Dragon",
+						"Damage Type",
+						"Speed",
+						"Ardent Gift"
+					],
+					"colStyles": [
+						"col-3",
+						"col-3",
+						"col-3",
+						"col-3"
+					],
+					"rows": [
+						[
+							"Black",
+							"Acid",
+							"Swim",
+							"Acid Barrage"
+						],
+						[
+							"Blue",
+							"Lightning",
+							"Burrow",
+							"Lightning Lance"
+						],
+						[
+							"Green",
+							"Poison",
+							"Swim",
+							"Beguiling Miasma"
+						],
+						[
+							"Red",
+							"Fire",
+							"Climb",
+							"Fiery Eruption"
+						],
+						[
+							"White",
+							"Cold",
+							"Burrow or Swim",
+							"Freezing Mist"
+						],
+						[
+							"Brass",
+							"Fire",
+							"Burrow",
+							"Fiery Eruption"
+						],
+						[
+							"Bronze",
+							"Lightning",
+							"Swim",
+							"Lightning Lance"
+						],
+						[
+							"Copper",
+							"Acid",
+							"Climb",
+							"Acid Barrage"
+						],
+						[
+							"Gold",
+							"Fire",
+							"Swim",
+							"Fiery Eruption"
+						],
+						[
+							"Silver",
+							"Cold",
+							"Silver Mist",
+							"Freezing Mist"
+						],
+						[
+							"Amethyst",
+							"Force",
+							"Swim",
+							"Spatial Echo"
+						],
+						[
+							"Crystal",
+							"Radiant",
+							"Burrow or Climb",
+							"Scintillating Radiance"
+						],
+						[
+							"Emerald",
+							"Psychic",
+							"Burrow",
+							"Delusion Zone"
+						],
+						[
+							"Sapphire",
+							"Thunder",
+							"Burrow or Climb",
+							"Thunderous Disruption"
+						],
+						[
+							"Topaz",
+							"Necrotic",
+							"Swim",
+							"Desiccating Aura"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Ardent Gift",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting from 3rd level, you inherit the unique properties of your bloodline's fabled powers. Depending on your Bloodline Heritage, you gain a unique draconic ability. You can use this feature once, and regain the ability to do so once you finish a short or long rest. At 6th level, you can use this feature twice.",
+				"Each Ardent Gift uses the numbers listed in the Breath Line/Cone column of the Demi-Dragon class table, and increases in range as you gain levels. It uses the specified line or cone regardless of what you chose for Dragon's Breath.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Acid Barrage",
+							"entries": [
+								"As an action, you launch bursts of acid at up to 3 nearby targets that you can see and which are within a number of feet equal to your Line Range. Make a ranged Dragon Spark attack against each target. On a hit, the target takes acid damage equal to your Dragon's Breath Damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Beguiling Miasma",
+							"entries": [
+								"As a bonus action, you breathe forth a vaporous poison, which billows around one creature you can see that is within the range of your Line Range. The creature must succeed on a Wisdom saving throw against your Dragon Spark save DC or become {@condition charmed} by you for 1 minute. If the charmed target takes any damage, it can repeat the saving throw, ending the effect on a success. While charmed in this way, the target is {@condition poisoned}. At the end of the charmed creature's turn, every creature of your choice within 5 feet of the charmed creature must succeed on a Constitution saving throw against your Dragon Spark save DC or become poisoned until the start of the charmed creature's next turn."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Delusion Zone",
+							"entries": [
+								"As an action, you craft a shared delusion in the mind of each creature in a radius equal to your Cone Range, at a location you choose within your Line Range. When a creature moves into the area of the delusion or starts its turn there, that creature must succeed on a Wisdom saving throw against your Dragon Spark save DC or be affected by the delusion until the start of their next turn. While caught in the delusion, a creature is convinced that it is surrounded by illusory shapes. Each time the creature makes an attack while the effect lasts, you roll a d20 to determine whether the attack instead targets one of your illusory shapes. If you roll an 11 or higher, you force the creature to instead attack and destroy one of your illusory shapes. You have a number of illusory shapes equal to your proficiency bonus, and your delusion lasts for 1 minute or until you have no illusory shapes left. While the effect lasts, you can move the delusion up to 30 feet as a bonus action."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Desiccating Aura",
+							"entries": [
+								"As an action, you fill yourself with negative energy for 1 minute. You gain an aura equal in radius to your Cone Range. Each creature of your choice that moves into the aura's area for the first time on a turn or starts its turn there is afflicted by your baleful presence until the start of their next turn. Whenever an afflicted creature makes an attack roll or a saving throw, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Fiery Eruption",
+							"entries": [
+								"As an action, you lob a ball of fire at a square that you can see within the range of your Line Range, which explodes into a 5-foot-wide, 20-foot-tall cylinder of flames. Each creature in the eruption's area must make a Dexterity saving throw against your Dragon Spark save DC or take fire damage equal to twice the damage dice of your Dragon's Breath Damage on a failed save, or half as much of the total damage on a successful one."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Freezing Mist",
+							"entries": [
+								"As an action, you breathe a freezing mist forth, which fills a cylinder equal in height and radius to your Cone Range, centered on a point within range of your Line Range. The mist spreads around corners, and its area is lightly obscured. Each creature other than you in the mist when it appears or which ends its turn in the mist must make a Constitution saving throw against your Dragon Spark save DC or take cold damage on a failed save or half as much damage on a successful one. The damage follows the progression of your Dragon's Breath Damage, but using d4s in place of d8s. The mist lasts until the start of your next turn."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Lightning Lance",
+							"entries": [
+								"As a bonus action, your breath forms a beam of crackling energy between yourself and a target within the range of your Line Range, creating a sustained arc of lightning. Make a Dragon Spark attack against that creature. On a hit, the target takes lightning damage, and on each of your subsequent turns for up to 1 minute thereafter, you can use your bonus action to automatically deal further lightning damage to the target. The damage follows the progression of your Dragon's Breath Damage, but using d4s in place of d8s. The effect ends if you use your bonus action to do anything else. The effect also ends if the target is ever outside the range of your Line Range or if it has total cover from you. While the effect lasts, your bite attacks deal lightning damage instead of the piercing damage normal for a {@item bite|TheDemiDragon} attack."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Scintillating Radiance",
+							"entries": [
+								"As a bonus action, you grant yourself and each creature of your choice within a diameter of yourself equal to your Cone Range a number of temporary hit points equal to your demi-dragon level + your Constitution modifier. These temporary hit points last for 1 minute."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Spatial Echo",
+							"entries": [
+								"As a bonus action, you manifest a dimensional projection of yourself in an unoccupied space that you can see within your *Line Range*. The echo looks like a magical shimmering purple image of you. The echo lasts until it is destroyed or until one minute has passed. Your echo shares your AC and saving throws, has hit points equal to twice your demi-dragon level, and immunity to all conditions. It is the same size as you, and occupies its space. Whenever you move during your turn, you can choose to move yourself or the echo, expending 5 feet of your movement for each 5 feet you move the echo. The echo shares your senses, and you experience what it sees and hears (no action required). You can use the echo in the following ways:",
+								{
+									"type": "list",
+									"items": [
+										"When you take the {@action Attack} or Dragon's Breath actions on your turn, you can choose to treat any attack or breath exhalation you make with that action as originating from your space or the echo's space. You make this choice for each attack.",
+										"When a creature that you can see moves away from your echo, you can treat the reach of your natural weapons as if you were in the echo's space, and you can use your reaction to make an opportunity attack against that creature."
+									]
+								}
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Thunderous Disruption",
+							"entries": [
+								"As a bonus action, you launch a thunderous detonation of sound that can be heard up to 100 feet away at one creature you can see within your Line Range. The creature must succeed on a Constitution saving throw against your Dragon Spark save DC or take thunder damage and be {@condition incapacitated} until the end of its next turn. On a successful saving throw, a creature takes half the damage and isn't incapacitated. The damage follows the progression of your Dragon's Breath Damage, but using d4s in place of d8s."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Ardent Focus",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, you've learned how to get the most out of your Ardent Gift. Depending on your Bloodline Heritage, you gain the following benefit:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Corrosion",
+							"entries": [
+								"Before the end of your next turn, the next attack roll made against each target hit by your *Acid Barrage* has advantage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Induce Torpor",
+							"entries": [
+								"As an action while a target {@condition poisoned} by your Beguiling Miasma is within 10 feet of you, you can force the target to make a Constitution saving throw against your Dragon Spark save DC or be rendered {@condition unconscious} for up to 1d4 hours. If the unconscious creature takes any damage, it wakes up."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Mirage Synthesis",
+							"entries": [
+								"When you create your Delusion Zone, you can choose to include additional illusory effects. At an area of your choice within the delusion, you create a silent image that does not require your concentration and which lasts until the delusion ends. Each time you move your delusion, you can choose to change the appearance and position of the silent image, but it must always be within the area of the delusion."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Withering Presence",
+							"entries": [
+								"You can now choose to activate your Desiccating Aura as a bonus action. Additionally, any creature that is afflicted by your aura can't regain hit points."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Explosive Departure",
+							"entries": [
+								"When you use Fiery Eruption, you can use your bonus action to take flight and launch yourself 15 feet into the air. This movement doesn't provoke opportunity attacks."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Glacial Chill",
+							"entries": [
+								"Creatures that fail their saving throw against your Freezing Mist have their speed halved until the end of their next turn."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Sweeping Lightning",
+							"entries": [
+								"As a reaction when Lightning Lance misses its initial target or would end, you can redirect the beam of lightning to another target. Make a Dragon Spark attack against a different target that is within range. On a hit, the target takes no damage, but becomes the new target of your Lightning Lance. Once you use your reaction in this way, you can't do so again until you initiate Lightning Lance again."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Light Burst",
+							"entries": [
+								"When you activate your Scintillating Radiance, each creature of your choice within its range must succeed on a Dexterity saving throw or be {@condition blinded} until the end of their next turn."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Dimensional Reversal",
+							"entries": [
+								"At the end of your turn while your Spatial Echo lasts or immediately when it is destroyed or expires, you can choose to instantaneously swap position with the echo (no action required)."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Awesome Shockwave",
+							"entries": [
+								"When a creature fails its saving throw against your Thunderous Disruption, it is additionally {@condition stunned} until the end of its next turn, and you can choose to push it up to 10 feet away from you."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Elemental Suffusion",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"By 10th level, you've grown fully attuned to your bloodline. You are immune to the damage type you chose for {@classFeature Dragon's Breath|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Dragon's Breath}."
+			]
+		},
+		{
+			"name": "Frightful Roar",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, your heritage lets you inspire fear in those around you. As an action, each creature of your choice that is aware of you and within 60 feet of you is forced to make a Wisdom saving throw against your *Dragon Spark* save DC. On a failed save, a target becomes frightened of you for 1 minute. You can use this feature once, and regain the ability to do so after finishing a long rest."
+			]
+		},
+		{
+			"name": "Embodiment of the Ascetic",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Ascetics devote themselves to contemplation and worship. By seeking to better themselves through spiritual and physical training, Ascetics harness the magical nature of their Dragon Spark, developing it into an ember of ineffable power which they use to aid and protect their allies.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Imbue Breath|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Disciple's Meditation|Demi-Dragon|TheDemiDragon|Ascetic|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Imbue Breath",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting at 3rd level, you can invest allies with the blessing of your breath. As a bonus action when you use {@classFeature Dragon's Breath|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Dragon's Breath}, you can anoint yourself or one creature in your breath's area with your elemental might. The target takes no damage from your Dragon's Breath as your elemental energy harmlessly swirls around it. Once per turn when the creature deals damage, they can choose to deal an additional {@damage 2d4} damage. The extra damage is of the same type as your Dragon's Breath, and while imbued with your breath, the target has resistance to that damage type. These effects last for 1 minute.",
+				"You can use this feature twice, after which you must finish a short or long rest to use it again. At 13th level, you can use it three times before a rest."
+			]
+		},
+		{
+			"name": "Disciple's Meditation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"At 3rd level, you can focus your Dragon Spark to mend wounds. If you or one other creature of your choice regains hit points by spending Hit Dice at the end of a short rest, the target regains an extra {@dice 2d6} hit points. The extra hit points increase to 3d6 at 6th level, 4d6 at 10th level, and 5d6 at 17th level."
+			]
+		},
+		{
+			"name": "Anointed Blessings",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, the gift of your breath imbues greater boons. When you use Imbue Breath, you can additionally grant the target one of the following additional effects:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Bravery of the Venerated",
+							"entries": [
+								"Your gifted breath takes the form of a symbol of protection. While the benefit lasts, the target of your Imbue Breath is immune to being {@condition frightened} and gains temporary hit points equal to your Charisma modifier (minimum 1) + your Proficiency bonus at the start of each of its turns."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Might of Dominion",
+							"entries": [
+								"Your gifted breath flows and shapes with the gesture of its wielder. Once per turn while the benefit lasts, when the target of your Imbue Breath deals damage to a creature, they can choose to deal additional elemental damage equal to your Charisma modifier (minimum 1) to every creature of their choice within 5 feet of the initial target. The damage type is the same as your Dragon's Breath."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Bestow Grace",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, your Dragon Spark can bond your breath to a creature. When you use Imbue Breath, you can additionally grant the target one of the following additional effects:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Gift of Flight",
+							"entries": [
+								"Your gifted breath forms a pair of wings shaped by elemental power. While the benefit lasts, the target of your Imbue Breath gains a flying speed of 40 feet. If you target a creature that already has a flying speed, it instead increases by 20 feet."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Crown of the Irrepressible",
+							"entries": [
+								"Your gifted breath forms a set of horns shaped by elemental power upon the target's brow. While the benefit lasts, the target of your Imbue Breath gains a bonus to their saving throws equal to your Charisma modifier (minimum 1)."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Sage Wisdom",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, you become a conduit for the teachings of dragon sages. At the end of a short rest, the target of your Disciple's Meditation can ask one question that can be answered with a yes or no. The sages speak through you, and give a correct answer for the question. The DM provides the answer.",
+				"The sages aren't omniscient, so you might receive \"unclear\" as an answer if a question pertains to information that lies beyond their knowledge. In a case where a one-word answer could be misleading or contrary to the sages' teachings, the DM might offer a short phrase as an answer instead."
+			]
+		},
+		{
+			"name": "Ineffable Paragon",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Ascetic",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"By 17th level, your selfless dedication has exalted your being. Choose one of the effects from Anointed Blessings or Bestow Grace. You gain the chosen effect permanently. You can change your choice each time you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Embodiment of the Arbiter",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Arbiters tap into their inner strength through magic by binding spells to their very form. Arbiters learn esoteric magical secrets that aid them in enhancing their own natural abilities with spells, using core principles of magic known only to dragonkind.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellcasting|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Scale Bind|Demi-Dragon|TheDemiDragon|Arbiter|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Spellcasting",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"At 3rd level, you begin to tap into your innate dragon magic and gain the ability to cast spells. See {@book chapter 10|PHB|10} for the general rules of spellcasting and {@book chapter 11|PHB|11} for the {@filter sorcerer spell list|spells|class=sorcerer}.",
+				{
+					"type": "entries",
+					"name": "Cantrips",
+					"entries": [
+						"You learn two cantrips of your choice from the {@filter sorcerer spell list|spells|class=sorcerer}. You learn an additional sorcerer cantrip of your choice at 10th level."
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Spell Slots",
+							"entries": [
+								"The Arbiter Spellcasting table shows how many spell slots you have to cast your {@filter sorcerer spells|spells|class=sorcerer} of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",
+								"For example, if you know the 1st-level spell {@spell burning hands} and have a 1st-level and a 2nd-level spell slot available, you can cast {@spell burning hands} using either slot."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Spells Known of 1st-Level and Higher",
+							"entries": [
+								"You know three 1st-level sorcerer spells of your choice, two of which you must choose from the abjuration, evocation, and transmutation spells on the sorcerer spell list.",
+								"The Spells Known column of the Arbiter Spellcasting table shows when you learn more sorcerer spells of 1st level or higher. Each of these spells must be an abjuration, evocation, or transmutation spell of your choice, and must be of a level for which you have spell slots. For instance, when you reach 7th level in this class, you can learn one new spell of 1st or 2nd level. The spells you learn at 8th, 14th, and 20th level can come from any school of magic.",
+								"The spells you learn at 8th, 14th, and 20th level can come from any school of magic.",
+								"Whenever you gain a level in this class, you can replace one of the sorcerer spells you know with another spell of your choice from the sorcerer spell list. The new spell must be of a level for which you have spell slots, and it must be an abjuration, transmutation, or evocation spell, unless you're replacing the spell you gained at 3rd, 8th, 14th, or 20th level from any school of magic."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Spellcasting Ability",
+							"entries": [
+								"Charisma is your spellcasting ability for your sorcerer spells. You use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a sorcerer spell you cast and when making an attack roll with one.",
+								{
+									"type": "abilityDc",
+									"name": "Spell",
+									"attributes": [
+										"cha"
+									]
+								},
+								{
+									"type": "abilityAttackMod",
+									"name": "Spell",
+									"attributes": [
+										"cha"
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Scale Bind",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting at 3rd level, you gain the ability to mystically bind spells to your scales. Doing so takes 1 minute, during which you expend a spell slot to imbue the desired spell. While the spell remains bound, you can cast the spell as a reaction at any time.",
+				"If the spell requires concentration, it lasts for the full duration and doesn't take up your concentration. Once cast with a reaction, Scale Bind ends.",
+				"As an action, you can rip loose the scale upon which the spell is bound and throw it up to 30 feet. The binding remains intact unless the scale is destroyed, and can be triggered with a reaction as normal, given a valid target for the bound spell which you are aware of.",
+				"While the spell remains bound, the scale bears a glowing runic sigil and appears as obviously magical. The spell remains bound for up to 8 hours if not triggered, after which the effect dissipates. You can only bind spells that normally take an action, reaction, or bonus action to cast, and which are of a spell level which your Arbiter level allows you to cast.",
+				"You can use this feature once, and you must finish a long rest before you can use it again."
+			]
+		},
+		{
+			"name": "Dragonweave",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"The melding of body and the Weave of magic lies in your heritage. As a bonus action, you can call on your innate magic to grant yourself Dragonweave until the end of your turn. If you take the {@action Attack} action while you have Dragonweave, you can cast one of your cantrips in place of one of your attacks. The cantrip must have a casting time of 1 action."
+			]
+		},
+		{
+			"name": "Focal Point",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, you now regain use of your Scale Bind feature when you finish a short rest.",
+				"Additionally, while the scale is detached from you and the spell remains bound, you can see and hear from the scale's location (no action required), using your own senses."
+			]
+		},
+		{
+			"name": "Unmakers Sight",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"When you reach 10th level, you've studied both the creation and destruction of magic, and have developed an unerring sight for the mystical. You gain the ability to cast {@spell detect magic} and {@spell identify} at will. Additionally, you add {@spell dispel magic} and {@spell counterspell} to your spells known, and you can cast them each once per long rest without expending a spell slot."
+			]
+		},
+		{
+			"name": "Weave and Unweave",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, you've learned how to fuel your spells with the sundered power of your enemies. Whenever you use {@classFeature Devour Magic|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Devour Magic} or cast {@spell dispel magic}, you can immediately use your bonus action to cast a spell of 2nd level or lower. The spell must have a casting time of 1 action or bonus action."
+			]
+		},
+		{
+			"name": "Embodiment of the Fervent Hoarder",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Fervent Hoarders hold a singular desire in their heart, and take up adventuring to sate it. Hoarders form a special bond with an object that they covet, binding it tightly to the Weave of magic as a focus for their own extraordinary power. Though many Hoarders desire glittering gold, their magical bond can take the form of any beloved object.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Heart of the Hoard|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "True Treasure|Demi-Dragon|TheDemiDragon|Fervent Hoarder|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Heart of the Hoard",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting at 3rd level, the pride and joy of your hoard takes the form of a special centerpiece item, which is imbued with your draconic magic as a nascent focal point of your lair. During a short or long rest, you can designate one item in your possession as your hoard centerpiece. The item can benefit from any enchantments that you have available via Absorb Magic as if it were a part of you, but is also subject to the same restrictions. When you designate an item, choose from the following benefits to apply to it:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Reach of the Hoard",
+							"entries": [
+								"Your {@item hoard centerpiece|TheDemiDragon} takes the form of a melee weapon, a rod, a large gemstone, a piece of furniture, a collection of coins, or some other perilous object. You can magically float the centerpiece item while it remains within 20 feet of you, and you can use it to make melee weapon attacks. It counts as a natural melee weapon for you, and you add your Charisma modifier to the attack and damage rolls when you attack with it. The centerpiece item deals 2d6 damage of a type determined by the DM and has a reach of 20 feet, but cannot be used to make opportunity attacks. When you attack with the centerpiece item, you can optionally choose to conjure a spectral copy of it as part of the attack."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Fortification of the Hoard",
+							"entries": [
+								"The centerpiece item takes the form of a piece of armor, a series of gemstones embedded in your hide, a lucky talisman, or some other protective object. The centerpiece item has a number of charges equal to your Charisma modifier. While the centerpiece item is in your possession, when you are hit by an attack or fail a saving throw, you can choose to expend 1 charge and roll a {@dice d6}. You add the result both to your AC and to each of your saving throws that you make until the start of your next turn. You regain all charges when you finish a short or long rest."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Ingenuity of the Hoard",
+							"entries": [
+								"The centerpiece item takes the form of an amulet, a piece of clothing or jewelry, a beloved plushie, a coin or other currency, a book, or some other precious object. When you first select this option for Heart of the Hoard, you can choose one cantrip and a number of spells from the {@filter sorcerer spell list|spells|class=sorcerer}. See the table below to determine how many spells you know and the highest spell level that is available to you. When you gain a level in this class, you can choose new sorcerer spells and cantrips.",
+								"The centerpiece item acts as an arcane focus for you. While the centerpiece item is in your possession, you can cast the spells at the highest spell level available to you, using your Dragon Spark as your spellcasting ability.",
+								"Once you cast a spell in this way, you can't do so again until you finish a short or long rest. At 11th level, you can cast two spells before a rest.",
+								{
+									"type": "table",
+									"colLabels": [
+										"Demi-Dragon Level",
+										"Spell Slots & Known",
+										"Spell Level"
+									],
+									"colStyles": [
+										"col-4",
+										"col-4",
+										"col-4"
+									],
+									"rows": [
+										[
+											"3rd",
+											"1",
+											"2nd"
+										],
+										[
+											"5th",
+											"1",
+											"3rd"
+										],
+										[
+											"7th",
+											"1",
+											"4th"
+										],
+										[
+											"9th",
+											"1",
+											"5th"
+										],
+										[
+											"11th",
+											"2",
+											"5th"
+										]
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "True Treasure",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"From 3rd level, your fascination with a particular type of treasure manifests as a keen knowledge in a related field of artisanry, and a unique magical talent for handling your property. You gain proficiency in one set of {@filter artisan's tools|items|itemType=artisan's tools} of your choice.",
+				"Additionally, as an action you can magically float up to 50 pounds of items which you own, which remain in place as you designate for 1 minute or until you are ever more than 20 feet away from the items, after which the items gently descend to the ground. As an action while floating the items, you can manipulate one item as if you were holding it, and can use any of your proficiencies with it."
+			]
+		},
+		{
+			"name": "Manifest Lair",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"A hoard serves as the magical anchor for a lair, and as an adventuring dragon, you've learned to rapidly form and sever the magical connections that signify a lair. Starting from 6th level, as an action you establish a connection to all nearby terrain within a 60 feet radius of your centerpiece item. Your lair lasts until the centerpiece item is moved from within the range of the established lair, until you manifest a new lair, or until you die.",
+				"While you are within your lair, you can take one of the following reactions of your choice at the end of any other creature's turn.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Whisk Away",
+							"entries": [
+								"A tapestry, carpet, gust of wind, or magic wand instantaneously transports a willing creature within your lair up to 30 feet in a direction of your choosing."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Hoard Barrage",
+							"entries": [
+								"Your hoard magically launches one object that you own at a target that you can see within 120 feet. Make a ranged spell attack using your Dragon Spark. On a hit, the target takes damage equal to {@damage 1d4} + your Charisma modifier. The type of damage dealt is determined by the DM."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Shelter of the Lair",
+							"entries": [
+								"Your lair conceals those within. One willing creature of your choice becomes {@condition invisible} until the start of their next turn. The creature can choose to take the {@action Hide} action as a reaction."
+							]
+						}
+					]
+				},
+				"Once you manifest your lair, you can't do so again until you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Claim Item",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"From 10th level, all that you survey is yours to wield. As an action, you immediately attune to a magical item that is in your possession and is not attuned to another creature. If doing so would cause you to be attuned to more than your maximum attuned items, you can immediately unattune from one other item as part of the action.",
+				"When you attune or unattune to an item in this way, you can additionally choose to use Absorb Magic to absorb or return the item's enchantment. If you do, the item must remain in your possession for 1 hour, else the enchantment returns to the item at the end of the hour.",
+				"You can use this feature a number of times equal to your proficiency bonus, after which you must finish a long rest to use it again."
+			]
+		},
+		{
+			"name": "Homely Lair",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Given a little time to settle in, you can make improvements to your new home. From 10th level, when you finish a long rest while resting in the area of your Manifest Lair, you can choose a spell from the following list which takes effect: {@spell druid grove|XGE}, {@spell guards and wards}, {@spell programmed illusion}, and {@spell project image}. You determine the effects of the spell as if you had cast it, but all effects must be within the radius of your lair and cannot leave it. Only one of these spells can be active at any one time, and the spell immediately ends if Manifest Lair ends. The spell does not require you to concentrate on it."
+			]
+		},
+		{
+			"name": "Splendor",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, the crowning glory of your hoard is a true marvel. When you designate an item as your centerpiece item during a short or long rest, you can choose two of the features detailed in Heart of the Hoard. You gain the benefits of both."
+			]
+		},
+		{
+			"name": "Embodiment of the Metamorph",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Metamorphs learn to master and manipulate the secrets that drove their initial transformation. They can reshape their own bodies, adapting themselves to overcome the challenges that are brought on by their surroundings, solve practical problems, enhance their draconic nature, or to express themselves freely by taking on fantastical traits of their choosing - such as by imitating the brightly-colored feathered wings of the coatl, or the flowing mane of a ki-rin.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Adaptive Morph|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Swift Adaptation|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Morphs|Demi-Dragon|TheDemiDragon|Metamorph|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Adaptive Morph",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting at 3rd level, your form is an ever-shifting canvas, constantly changing to reflect your circumstances.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Morphs",
+							"entries": [
+								"You learn three {@filter morphs|optionalfeatures|source=TheDemiDragon|feature type=morph} of your choice, which are detailed under \"Morphs\" below.",
+								"You learn two additional morph categories of your choice at 6th level, and one additional category at 10th and 17th level. Each time you complete a long rest, you can choose to replace one morph category you know with a different one."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Active Category",
+							"entries": [
+								"As part of a short or long rest, you undergo a metamorphosis which grants you new benefits. Choose one morph category that you know. The morph category you choose becomes your Active category, granting you one of its two listed features (your choice). This morph lasts indefinitely, or until you choose to change it again."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Waning Morph",
+							"entries": [
+								"When you change your Active Category to a different one, the morph you chose as part of that category becomes \"Waning\". You keep the benefits of the morph, but you are one step closer to forfeiting it. When you change your Active category again, the effect of the previously Waning morph is lost, and the morph of your previously Active category becomes Waning. In this manner, you are always gaining and discarding new effects."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Swift Adaptation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting from 3rd level, you can rapidly adjust to new surroundings. If you spend 1 minute in deep focus, you can assume a new morph from among those you have learned. Choose a new Active Category and one of its morphs, and discard old morphs as if you had changed morphs during a rest. Once you use this feature, you can't do so again until you finish a short or long rest."
+			]
+		},
+		{
+			"name": "Morphs",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"The morph categories are presented in alphabetical order.",
+				{
+					"type": "options",
+					"count": 3,
+					"entries": [
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Aid|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Courage|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Cooperation|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Creation|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Disruption|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Freedom|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Heritage|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Instinct|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Might|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Navigation|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Pain|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Salvation|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Sanctuary|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Subtlety|TheDemiDragon"
+						},
+						{
+							"type": "refOptionalfeature",
+							"optionalfeature": "Vantage|TheDemiDragon"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Twinned Adaptation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Starting from 6th level, your morphs carry side effects with them. Whenever you choose an Active Category, you gain both the benefits listed in that category. When you choose a new Active Category, you choose one morph from the previously Active Category to keep as a Waning morph and one to discard."
+			]
+		},
+		{
+			"name": "Fueling the Transformation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, your form is so malleable that it only needs a spark of energy to change entirely. When you use {@classFeature Devour Magic|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Devour Magic}, or upon completing the goal of your {@classFeature Resolution|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Resolution}, you can additionally choose to immediately change your form. If you do, choose a new Active Category that you know and one of its morphs, and discard old morphs as if you had changed morphs during a rest."
+			]
+		},
+		{
+			"name": "Remake Self",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, you can remake yourself from the ground up. As part of a long rest, you can choose to undergo a metamorphic ritual, during which you cocoon yourself as you rework the nature of your being. This allows you to change your past choices. Change each of the following to your liking. Upon completing the ritual, any ability score damage, scars suffered, or limbs lost are restored. Once initiated, the ritual can't be interrupted. You are helpless and unconscious for the full duration, and can only be stopped by an untimely death.",
+				{
+					"type": "list",
+					"items": [
+						"Dragon's Breath Damage Type: acid, cold, fire, force, lightning, necrotic, poison, psychic, radiant, or thunder.",
+						"Dragon's Breath Area Effect: line or cone",
+						"Elemental Adaptation Damage Type: acid, cold, fire, force, lightning, necrotic, poison, psychic, radiant, or thunder.",
+						"Eye of the Dragon Proficiency: perception or investigation."
+					]
+				}
+			]
+		},
+		{
+			"name": "Essence of Change",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, you understand change like few others. Unless you choose to be affected, your form can't be changed against your will, such as by the {@spell polymorph} spell or a Medusa's Petrifying Gaze."
+			]
+		},
+		{
+			"name": "Flawless Metamorphosis",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"Starting from 17th level, you have nigh-total control over your transformation. You can retain one additional Waning morph, and when you change morphs, you can choose to change each of your previously Waning morphs to any morph from any category you know."
+			]
+		}
+	],
+	"optionalfeature": [
+		{
+			"name": "Bolstering Roar (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, you bolster the conviction of your companions. Each creature of your choice other than yourself that is within 20 feet of you and which can see or hear you gain a Bolster die, a d4. Once within the next 10 minutes, the creature can roll the die and add the number rolled to one saving throw it makes. The creature can wait until after it rolls the d20, but must decide before the DM says whether the roll succeeds or fails. Once the Bolster die is rolled, it is lost. A creature can only have one Bolster die at a time."
+			]
+		},
+		{
+			"name": "Hammering Lunge (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, make an attack with your {@item horns|TheDemiDragon} against a target. You can choose to move up to 10 feet without provoking opportunity attacks before you make this attack."
+			]
+		},
+		{
+			"name": "Launch Ally (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, choose a friendly creature within 5 feet of you that is the same size category as you or smaller. That creature can use its reaction to let you launch it to an unoccupied space you can see within a number of feet of it equal to twice your Strength score."
+			]
+		},
+		{
+			"name": "Lockjaw (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As part of the {@action Attack} action, you can replace one attack you make with a special {@item bite|TheDemiDragon} attack against a target. On a hit, the target must make a Strength saving throw if it's a creature that is up to one size category larger than you. On a failure, it is {@condition grappled}."
+			]
+		},
+		{
+			"name": "Skylaunch (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, you spread your wings and launch 15 feet into the air. This maneuver doesn't expend your movement and doesn't provoke opportunity attacks. Creatures up to one size category larger than you that are within 5 feet of you must succeed on a Strength saving throw or be knocked prone by a powerful gust of wind as you launch. You remain airborne until the start of your next turn or until you are incapacitated."
+			]
+		},
+		{
+			"name": "Suppressing Gale (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, you blast gusts of wind at your surroundings. Creatures up to one size category larger than you within 30 feet of you must spend 2 feet of movement for every 1 foot when moving closer to you. The gale disperses gas or vapor, and extinguishes candles, torches, and smaller unprotected flames in the area. This effect lasts until the start of your next turn, until you become {@condition incapacitated}, or until you choose to end it early (no action required)."
+			]
+		},
+		{
+			"name": "Thieving Talons (1)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, make an attack with your {@item wings|TheDemiDragon}. On a hit, the target must succeed on a Strength saving throw or drop one item of your choice that it's holding. The object lands at its feet."
+			]
+		},
+		{
+			"name": "Brutal Dive (2)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action that you can take while gliding or flying, you dive up to your Glide/Fly speed directly downwards. If you move at least 30 feet during your dive, choose one creature up to one size category larger than you that is within melee range. The creature must make a Strength saving throw. On a failed save, the target is knocked {@condition Prone}. As part of the same bonus action, you can then immediately make a {@item bite|TheDemiDragon} attack against the creature."
+			]
+		},
+		{
+			"name": "Defiance (2)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, you steel yourself against all attackers. Until the start of your next turn, you gain resistance to all damage."
+			]
+		},
+		{
+			"name": "Fearsome Wound (2)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, make a {@item claws|TheDemiDragon} attack against a target. On a hit, the target is wounded, causing it to bleed for an additional {@damage 1d6} damage at the end of its next turn. Additionally, it must make a Wisdom saving throw. On a failed save, it is {@condition frightened} of you until the end of its next turn."
+			]
+		},
+		{
+			"name": "Reprisal (2)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"When a creature misses you with a melee attack, you can use your reaction to make a {@item horns|TheDemiDragon} attack against the creature. On a hit, the creature must succeed on a Constitution saving throw or be unable to take reactions until the start of its next turn."
+			]
+		},
+		{
+			"name": "Rising Wing (2)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As part of the Attack action, you can replace one attack you make with a special {@item wings|TheDemiDragon} attack against a target. On a hit, the target must make a Strength saving throw if it's a creature that is up to one size category larger than you. On a failure, you knock the target 20 feet upwards. At your option, you can choose to prevent the target from falling until the end of your turn."
+			]
+		},
+		{
+			"name": "Battering Ram (3)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As an action, you can move up to your speed as you charge in a straight line, during which you can enter other creatures' spaces and creatures have disadvantage on opportunity attacks against you. While charging, you can make a number of {@item horns|TheDemiDragon} attacks against creatures within 5 feet of you as if you had taken the {@action Attack} action. One creature that is up to one size category larger than you and which you hit must succeed on a Strength saving throw or be pushed forward to the end of your charge. If the target ends its movement adjacent to another creature or a solid object, both the pushed target and the creature or object take bludgeoning damage equal to {@damage 2d6} + your Strength modifier. This maneuver deals double damage to objects and structures."
+			]
+		},
+		{
+			"name": "Tail Sweep (3)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, make a {@item tail|TheDemiDragon} attack against up to two targets, both of which must be within your reach. Roll separately for each. If the attack hits, a target must make a Strength saving throw if it's a creature that is up to one size category larger than you. On a failed save, a target is pushed 15 feet away from you."
+			]
+		},
+		{
+			"name": "Wrath (3)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"As a bonus action, make a {@item claws|TheDemiDragon} attack against each creature of your choice within 5 feet of you."
+			]
+		},
+		{
+			"name": "Wrest Magic (3)",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"MV:J"
+			],
+			"entries": [
+				"When a spell effect passes within 60 feet of you, you can use your reaction to redirect it to yourself. You become the target of the effect. If the effect creates an area, it is centered on you. If the spell requires you to make a saving throw, you have advantage on it. After the effects of the spell are resolved, you regain hit points equal to twice the level of the spell + your Constitution modifier. You can't target spells with a range of touch or self."
+			]
+		},
+		{
+			"name": "Aid",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Gold Luck",
+							"entries": [
+								"You harness the mystic fortuity of the gold dragon. Whenever you or an ally makes an attack roll, an ability check, or a saving throw, you can choose to roll an additional d20. You can take this action after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw. You can use this feature once, and regain the ability to do so after finishing a short or long rest."
+							]
+						},
+						{
+							"name": "Sheltering Wings",
+							"entries": [
+								"Flexible armor plating grows across your wings, allowing you to use them as shelter for your allies. When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Courage",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Ivory Charge",
+							"entries": [
+								"Your horns split into a branching crown of antlers, capable of punching holes through hide and armor alike. You gain an {@item antlers|TheDemiDragon} natural weapon, which counts as a martial melee weapon for you. You can use it to make melee weapon attacks, with which you are proficient. Your antlers deal piercing damage equal to {@damage 3d4} + your Strength modifier. If you move at least 10 feet in a straight line during your turn, you gain advantage on the first attack you make with your antlers."
+							]
+						},
+						{
+							"name": "Warrior's Will",
+							"entries": [
+								"You adorn your form with a symbol of bravery and prepare yourself to face opposition. You gain advantage on Wisdom saving throws."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Cooperation",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Draining Scales",
+							"entries": [
+								"You alter your scales to siphon magical energy. Whenever you are a target of any spell of 1st level or higher, you gain temporary hit points equal to your Constitution modifier (minimum 1) before the spell's effects are resolved."
+							]
+						},
+						{
+							"name": "Silver Mist",
+							"entries": [
+								"You take on the aspect of the silver dragon, and can walk on clouds. As a reaction that you can take when you or another creature that is Large or smaller within 60 feet of you falls, you can create a cloud beneath the target as a reaction. The cloud supports the creature's weight and can harmlessly break their fall as if it were a physical object. As part of creating the cloud, you can choose to have it immediately move up to 10 feet up or down, where it will then float in place for up to 1 hour, or until you create a new one."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Creation",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Stone Scales",
+							"entries": [
+								"You assimilate available minerals in order to create a thick layer of defensive stone scales. Your Armor Class becomes equal to 16 + your Constitution modifier. You count as wearing heavy armor, but don't suffer any penalty to your Dexterity (Stealth) or as a result of not having heavy armor proficiency."
+							]
+						},
+						{
+							"name": "Capable Form",
+							"entries": [
+								"Your body grows better suited to grasping and manipulating objects. You can ignore the disadvantage imposed on attack rolls by Mythic Build. Additionally, you gain proficiency with simple and martial weapons as well as with two tools of your choice. You can change your tool choices every time you finish a short or long rest."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Disruption",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Tunnel Wyrm",
+							"entries": [
+								"You gain a burrowing speed equal to half your walking speed. You can tunnel through loose dirt, gravel, and similar materials, but not through solid materials. If you burrow at half speed, you can reinforce your tunnel as you move, allowing others to pass through - otherwise your tunnel slowly collapses behind you. Additionally, as an action while burrowing, you can hollow out a portion of space in the terrain into a 15-feet wide and deep sinkhole. If the sinkhole connects to the surface, it immediately collapses. Creatures caught in the area must succeed on a Dexterity saving throw against your Dragon Spark DC or fall into the sinkhole and drop prone. On a successful save, a creature can instead choose to move to the nearest available space without provoking opportunity attacks. If you spend 1 minute creating the sinkhole, it will instead collapse when the first creature that is Small or larger moves into its space. You can use this property twice, after which you must finish a short or long rest before you can use it again."
+							]
+						},
+						{
+							"name": "Reverberating Roar",
+							"entries": [
+								"Your voice commands the attention of your foes. As a bonus action, you can roar, inciting fear and hesitation. Each creature of your choice within 20 feet of you are forced to make a Wisdom saving throw against your Dragon Spark save DC. A target is unaffected if it can't hear or see you. On a failed save, a target can't take reactions until the start of your next turn. A creature that succeeds on this saving throw is immune to your roar until the end of your next turn."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Freedom",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Esoteric Ward",
+							"entries": [
+								"Runic glyphs carved across your body guard you against a variety of magics. You gain advantage on all Intelligence, Charisma, and Strength saving throws against magical effects."
+							]
+						},
+						{
+							"name": "Veiled Wings",
+							"entries": [
+								"Your wings take on a new aspect. Your Glide/Fly speed increases by 10 feet, and you can take the {@action Disengage} action as a bonus action."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Heritage",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Blasting Breath",
+							"entries": [
+								"Your elemental spark is always at the ready. You can use your action to exhale a bolt of elemental energy and spit it at a creature you can see within a range of 120. Make a ranged Dragon Spark attack. On a hit, the target takes {@damage 1d10} + your Charisma modifier damage. The damage is the same damage type as your Dragon's Breath. The number of damage dice increases by one at levels 5, 11, and 17."
+							]
+						},
+						{
+							"name": "Wyrm Tongue",
+							"entries": [
+								"Your suave voice is confident and convincing. You have advantage on your choice of Charisma (Deception) or Charisma (Persuasion) checks. Additionally, you learn two languages of your choice. You can change your choices every time you finish a short or long rest."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Instinct",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "White Cunning",
+							"entries": [
+								"You instill yourself with the primal awareness of the white dragon. You have advantage on initiative checks and you ignore non-magical difficult terrain."
+							]
+						},
+						{
+							"name": "Rending Jaws",
+							"entries": [
+								"Your jaw grows more powerful, and your fangs become serrated and cruel, capable of puncturing armor and rending flesh. When you hit with a {@item bite|TheDemiDragon} attack, the target suffers a -1 to AC for 1 minute. This effect can only be applied once per creature."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Might",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Driving Strikes",
+							"entries": [
+								"The tip of your tail develops a tough, bony club, and the force of your blows leaves your enemies reeling. When you make a tail attack on your turn, your reach for it is 5 feet greater than normal. Additionally, when you hit a target twice on the same turn with any combination of natural weapons, the target must succeed on a Strength saving throw or be pushed 10 feet away from you.",
+								{
+									"type": "abilityDc",
+									"name": "Morph",
+									"attributes": [
+										"str"
+									]
+								}
+							]
+						},
+						{
+							"name": "Elemental Maw",
+							"entries": [
+								"Volatile energy fills your gullet. Once on each of your turns when you hit with a {@item bite|TheDemiDragon} attack, you deal an additional {@damage 1d6} damage of your Dragon's Breath damage type."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Navigation",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Darting Predator",
+							"entries": [
+								"You adapt to better surprise your foes with short bursts of speed. You can take the {@action Dash} action as a bonus action."
+							]
+						},
+						{
+							"name": "Drowning Terror",
+							"entries": [
+								"You gain a swimming speed equal to your walking speed, and you can breathe both air and water. Whenever you grapple a target that is unable to breathe freely - such as an aquatic creature on land or vice versa - at the start of each of its turns, the target of your grapple must succeed on a Wisdom save against your Dragon Spark DC or become {@condition frightened} of drowning until it can again breathe freely. Additionally, when you are dragging or carrying a {@condition grappled} creature with you, your speed is no longer halved."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Pain",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Thorny Spines",
+							"entries": [
+								"You grow a series of sharp, slender spikes across your body. Any enemy that deals damage to you in melee suffers {@damage 1d4} piercing damage. At the start of each of your turns you deal 1d4 piercing damage to any creature grappling you or any creature {@condition grappled} by you."
+							]
+						},
+						{
+							"name": "Skewering Quills",
+							"entries": [
+								"You develop clusters of sharp quills along your limbs which you can fire in an arc at your foes. You gain a {@item quills|TheDemiDragon} natural weapon, which counts as a martial ranged weapon for you and which you are proficient with. You can use them to make ranged weapon attacks with a range of 60/120, and you add your Strength modifier to the attack and damage rolls when you attack with them. On a hit, they deal 1d10 piercing damage. Hit or miss, one square occupied by the targeted creature is then filled with quills, and you can additionally choose two squares within 5 feet of that square to also fill with quills as your inaccurate bombardment harmlessly scatters across the area. Any creature that subsequently enters a square filled with quills must succeed on a Dexterity saving throw against your Dragon Spark save DC or stop moving this turn and take 1 piercing damage. A creature moving through the area at half speed doesn't need to make the save. You can use this attack a number of times equal to 1 + your Constitution modifier (minimum 1), after which you must finish a short or long rest to use it again."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Salvation",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Breath of Bolstering Essence",
+							"entries": [
+								"Your magical essence is a wellspring of vitality waiting to be shared. As an action, you exhale revitalizing power unto a creature of your choice within 10 feet of you, restoring a number of hit points equal to your demi-dragon level. At your option, you can expend one or more of your Hit Dice, up to half your demi-dragon level. For each Hit Die spent in this way, roll the die then add your Constitution modifier, and add the result to the total amount of hit points you restore to the target. Once you use this feature, you cannot use it again until you finish a short or long rest."
+							]
+						},
+						{
+							"name": "Enthralling Dragonsong",
+							"entries": [
+								"You can sing a wordless aria that pacifies your audience. As a bonus action and on each subsequent turn while your song lasts, every creature of your choice within 20 feet of you must succeed on a Wisdom saving throw against your Dragon Spark or become {@condition charmed} by you until your song ends. A creature that cannot hear you or which has successfully saved against your song is immune to this use of your song. The song ends after 1 minute, if you are {@condition incapacitated}, or if you do not maintain it with a bonus action each turn. Once you use this feature, you cannot use it again until you finish a short or long rest."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Sanctuary",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Numinous Dragonsong",
+							"entries": [
+								"As a bonus action, you can sing a wordless hymn that bolsters your allies. Your song lasts until the start of your next turn, and while it lasts you and creatures of your choice within 20 feet of you gain a bonus to death saving throws and Constitution saving throws equal to your Charisma modifier (with a minimum bonus of +1). The song ends if you are {@condition incapacitated} or if you do not maintain it with a bonus action each turn."
+							]
+						},
+						{
+							"name": "Shape Breath",
+							"entries": [
+								"When you breathe destructive energy, you can shape pockets of relative safety within the area of your breath. When you use your Dragon's Breath feature, you can choose a number of creatures that are within the area of the breath weapon and which you can see equal to 1 + your Charisma modifier (minimum 1). The chosen creatures need not make a saving throw, and take no damage from your Dragon's Breath."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Subtlety",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Chameleon Scales",
+							"entries": [
+								"Your scales gain the ability to change color, letting you blend in with your surroundings. You can take the {@action Hide} action as a bonus action on your turn. You have advantage on Stealth checks made to hide in dim light and in natural terrain, such as rocks, plants, or sand."
+							]
+						},
+						{
+							"name": "Venomous Sting",
+							"entries": [
+								"Your tail develops a stinger, loaded with poison. Your {@item tail|TheDemiDragon} attack deals your choice of piercing or bludgeoning damage. Once on each of your turns when you deal damage with a tail attack, the target must succeed on a Constitution saving throw against your Dragon Spark save DC. On a failure, the target takes an additional {@damage 2d6} poison damage and is {@condition poisoned} until the end of its next turn."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Vantage",
+			"source": "TheDemiDragon",
+			"featureType": [
+				"Morph"
+			],
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						{
+							"name": "Skittering Crawl",
+							"entries": [
+								"You gain a climbing speed equal to your walking speed. If you move at least 20 feet on the ground or as part of a climb, you can choose to take the {@action Dodge} action as a bonus action."
+							]
+						},
+						{
+							"name": "Snatching Tail",
+							"entries": [
+								"Your tail becomes flexible, letting you unexpectedly catch your foes and yank them around. When you deal damage to a creature that is up to one size category larger than you with your {@item tail|TheDemiDragon}, you can choose to force them to roll a Strength saving throw. On a failure, they are pulled to a space of your choosing within 10 feet of you. The space must be unoccupied.",
+								{
+									"type": "abilityDc",
+									"name": "Morph",
+									"attributes": [
+										"str"
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		}
+	],
+	"foundryRaceFeature": [
+		{
+			"name": "Dragon Scales",
+			"source": "TheDemiDragon",
+			"raceName": "Demi-Dragon",
+			"raceSource": "TheDemiDragon",
+			"effects": [
+				{
+					"name": "Dragon Scales",
+					"changes": [
+						{
+							"key": "data.attributes.ac.calc",
+							"mode": "OVERRIDE",
+							"value": "custom"
+						},
+						{
+							"key": "data.attributes.ac.formula",
+							"mode": "OVERRIDE",
+							"value": "10 + @abilities.con.mod + @abilities.cha.mod"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Natural Weapons",
+			"source": "TheDemiDragon",
+			"raceName": "Demi-Dragon",
+			"raceSource": "TheDemiDragon",
+			"data": {
+				"activation.type": "action"
+			}
+		}
+	],
+	"foundryClassFeature": [
+		{
+			"name": "Dragon's Breath",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"data": {
+				"activation.type": "action",
+				"activation.cost": 1,
+				"actionType": "save",
+				"save": {
+					"ability": "Breath Save",
+					"scaling": "cha"
+				},
+				"uses": {
+					"value": 2,
+					"max": "(@classes.demi-dragon.levels >= 13 ? 3 : 2)",
+					"per": "sr"
+				},
+				"damage": {
+					"parts": [
+						[
+							"(1 + ceil(@classes.demi-dragon.levels / 2))d8",
+							"element"
+						]
+					]
+				},
+				"formula": ""
+			}
+		},
+		{
+			"name": "Devour Magic",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 1,
+			"data": {
+				"activation.type": "action",
+				"activation.cost": 1,
+				"actionType": "heal",
+				"heal": {
+					"ability": "cha"
+				},
+				"uses": {
+					"value": 1,
+					"max": "(@classes.demi-dragon.levels >= 18 ? 2 : 1)",
+					"per": "lr"
+				},
+				"damage": {
+					"parts": [
+						[
+							"@classes.demi-dragon.levels + @abilities.con.mod",
+							"healing"
+						]
+					]
+				},
+				"formula": "max(1,max(floor(@classes.demi-dragon.levels / 3),1d20 + @mod - 10))"
+			}
+		},
+		{
+			"name": "Glide",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 2,
+			"effects": [
+				{
+					"name": "Glide",
+					"changes": [
+						{
+							"key": "data.attributes.movement.fly",
+							"mode": "ADD",
+							"value": "@attributes.movement.walk + 10"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Stride",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 5,
+			"effects": [
+				{
+					"name": "Stride",
+					"changes": [
+						{
+							"key": "data.attributes.movement.fly",
+							"mode": "ADD",
+							"value": "10"
+						},
+						{
+							"key": "data.attributes.movement.walk",
+							"mode": "ADD",
+							"value": "10"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Flight",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 7,
+			"effects": [
+				{
+					"name": "Flight",
+					"changes": [
+						{
+							"key": "data.attributes.movement.fly",
+							"mode": "ADD",
+							"value": "max(0,ceil((@classes.demi-dragon.levels - 8) / 2)) * 5"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Eye of the Dragon",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 9,
+			"actorDataMod": {
+				"skills.prc.value": [
+					{
+						"mode": "setMax",
+						"value": 2
+					}
+				]
+			}
+		},
+		{
+			"name": "Dragon's Might",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 11,
+			"effects": [
+				{
+					"name": "Dragon's Might",
+					"changes": [
+						{
+							"key": "data.abilities.str.value",
+							"mode": "ADD",
+							"value": "2"
+						},
+						{
+							"key": "data.abilities.con.value",
+							"mode": "ADD",
+							"value": "2"
+						},
+						{
+							"key": "data.abilities.cha.value",
+							"mode": "ADD",
+							"value": "2"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Fabled Resistance",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 14,
+			"entryData": {
+				"resources": [
+					{
+						"name": "Fabled Resistance",
+						"type": "dicePool",
+						"recharge": "restLong",
+						"count": "floor((@classes.demi-dragon.levels) / 20) + 2",
+						"number": 1,
+						"faces": "(6 + (floor(@classes.demi-dragon.levels / 20) * 4))"
+					}
+				]
+			}
+		},
+		{
+			"name": "Force of Self",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 15,
+			"effects": [
+				{
+					"name": "Force of Self",
+					"changes": [
+						{
+							"key": "data.abilities.cha.proficient",
+							"mode": "UPGRADE",
+							"value": "1"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Rend and Ruin",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 17,
+			"data": {
+				"activation.type": "special",
+				"damage": {
+					"parts": [
+						[
+							"3d6",
+							""
+						]
+					]
+				},
+				"formula": ""
+			}
+		}
+	],
+	"foundrySubclassFeature": [
+		{
+			"name": "Fury",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"data": {
+				"activation.type": "special",
+				"uses": {
+					"value": 4,
+					"max": "(@classes.demi-dragon.levels >= 17 ? 10 : @classes.demi-dragon.levels >= 10 ? 8 : @classes.demi-dragon.levels >= 6 ? 6 : 4)",
+					"per": "sr"
+				}
+			}
+		},
+		{
+			"name": "By Any Means",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"isIgnored": true,
+			"data": {
+				"activation.type": "action"
+			}
+		},
+		{
+			"name": "Unwavering Combatant",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"data": {
+				"actionType": "heal",
+				"damage.parts": [
+					[
+						"@classes.demi-dragon.levels + @abilities.con.mod",
+						"temphp"
+					]
+				]
+			}
+		},
+		{
+			"name": "Anvil of Will",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"data": {
+				"activation.type": "special",
+				"uses": {
+					"value": 1,
+					"max": "1",
+					"per": "lr"
+				}
+			}
+		},
+		{
+			"name": "Sibilant Mind",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"data": {
+				"activation.type": "reaction",
+				"actionType": "save",
+				"save": {
+					"ability": "wis",
+					"scaling": "cha"
+				},
+				"damage": {
+					"parts": [
+						[
+							"(@classes.demi-dragon.levels >= 10 ? 1d8 : 1d4)",
+							"psychic"
+						]
+					]
+				},
+				"formula": ""
+			}
+		},
+		{
+			"name": "Obfuscate Consciousness",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Sibilant",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"data": {
+				"activation.type": "bonus action",
+				"activation.cost": 1,
+				"actionType": "save",
+				"save": {
+					"ability": "wis",
+					"scaling": "cha"
+				},
+				"uses": {
+					"value": 1,
+					"max": "1",
+					"per": "sr"
+				}
+			}
+		},
+		{
+			"name": "Shade Veil",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Shadestalker",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"data": {
+				"activation.type": "bonus action",
+				"activation.cost": 1,
+				"uses": {
+					"value": 3,
+					"max": "3",
+					"per": "sr"
+				}
+			}
+		},
+		{
+			"name": "Ardent Gift",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"data": {
+				"activation.type": "special",
+				"activation.cost": 1,
+				"uses": {
+					"value": 1,
+					"max": "(@classes.demi-dragon.levels >= 6 ? 2 : 1)",
+					"per": "sr"
+				}
+			}
+		},
+		{
+			"name": "Frightful Roar",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"data": {
+				"activation.type": "action",
+				"activation.cost": 1,
+				"uses": {
+					"value": 1,
+					"max": "1",
+					"per": "lr"
+				}
+			}
+		},
+		{
+			"name": "Imbue Breath",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Scion",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"data": {
+				"activation.type": "bonus action",
+				"activation.cost": 1,
+				"uses": {
+					"value": 2,
+					"max": "(@classes.demi-dragon.levels >= 13 ? 3 : 2)",
+					"per": "sr"
+				}
+			}
+		},
+		{
+			"name": "Scale Bind",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Arbiter",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"data": {
+				"activation.type": "reaction",
+				"activation.cost": 1,
+				"uses": {
+					"value": 1,
+					"max": "1",
+					"per": "lr"
+				}
+			}
+		},
+		{
+			"name": "Manifest Lair",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"data": {
+				"activation.type": "action",
+				"activation.cost": 1,
+				"uses": {
+					"value": 1,
+					"max": "1",
+					"per": "sr"
+				}
+			}
+		},
+		{
+			"name": "Claim Item",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Fervent Hoarder",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"data": {
+				"activation.type": "action",
+				"activation.cost": 1,
+				"uses": {
+					"value": 4,
+					"max": "@prof",
+					"per": "lr"
+				}
+			}
+		},
+		{
+			"name": "Swift Adaptation",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"data": {
+				"activation.type": "1 minute",
+				"activation.cost": 1,
+				"uses": {
+					"value": 1,
+					"max": "1",
+					"per": "sr"
+				}
+			}
+		}
+	],
+	"feat": [
+		{
+			"name": "Broadened Breath",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon",
+							"subrace": "line breath"
+						},
+						{
+							"name": "dragonborn",
+							"subrace": "black, blue, brass, bronze, or copper"
+						}
+					]
+				}
+			],
+			"entries": [
+				"The width of your elemental breath broadens. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Increase your Constitution or Charisma score by 1, to a maximum of 20.",
+						"When you use your Dragon's Breath or Breath Weapon, you can choose to increase the width of your breath from 5 feet to 10 feet."
+					]
+				}
+			]
+		},
+		{
+			"name": "Dragon's Hoard",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon"
+						}
+					],
+					"level": 8
+				}
+			],
+			"entries": [
+				"A deep-seated greed takes hold of you. During a long rest, you can magically link yourself to a location, claiming an area with a 60-foot radius as the location of your hoard. Coins, gems, art, and other nonmagical wealth located inside the area contributes to your hoard, calculated in gold pieces. You can only be linked to one hoard area at a time, and can only link yourself to a new hoard once every 7 days. If any treasure is removed from the hoard, you immediately know what is being taken. You gain the following benefits based on how much wealth is stored in the hoard area. If enough wealth is lost to put you below a wealth threshold, you lose all benefits associated with that threshold until you again have enough wealth to qualify.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Wealth",
+						"Absorb Magic Enchantments",
+						"Features"
+					],
+					"colStyles": [
+						"col-4",
+						"col-4",
+						"col-4"
+					],
+					"rows": [
+						[
+							"3000 gp",
+							"+3",
+							"Siphon Treasure"
+						],
+						[
+							"10000 gp",
+							"+1",
+							"Auric Slumber"
+						],
+						[
+							"30000 gp",
+							"+1",
+							"Unbound Attunement"
+						]
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Absorb Magic Enchantments",
+							"entries": [
+								"The maximum limit of magic items that you can have absorbed with Absorb Magic increases by the listed amount for that threshold."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Siphon Treasure",
+							"entries": [
+								"Your magical hunger extends across any distance to the extraordinary items stored in your hoard. You can use any piece of non-equipment treasure, such as a potion or some wondrous items, that is stored within your hoard as if you were holding it. The item functions as normal, and is consumed on use or expends charges if it normally would. If the item requires itself to function, such as an {@item immovable rod|DMG} or a figurine of wondrous power, you conjure a spectral projection of it. Such a spectral projection represents the magical essence of the item being pulled forth by you, and any damage taken by such a projection carries over to the real item. An unattended projection fades after 1d4 hours, after which you can call it forth again provided that all other rules are met."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Auric Slumber",
+							"entries": [
+								"Whenever you finish a long rest while resting within 30 feet of your hoard, you gain temporary hit points equal to twice your level. These temporary hit points are not lost at the end of a long rest, and last up to 7 days. In addition, your exhaustion level, if any, is decreased by 1."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Unbound Attunement",
+							"entries": [
+								"You can attune to up to four magic items at once. Additionally, you ignore all class, race, and level requirements on the use of magic items."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Misfit's Adaptation",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon"
+						}
+					]
+				}
+			],
+			"entries": [
+				"The width of your elemental breath broadens. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Increase your Strength, Constitution or Charisma score by 1, to a maximum of 20.",
+						"Choose one individual feature from a {@filter morph category|optionalfeatures|source=TheDemiDragon|feature type=morph} available to the {@class demi-dragon|TheDemiDragon|Embodiment of the Metamorph|Metamorph|TheDemiDragon|2-0}. You gain the chosen effect, which is permanent. If you already had access to morphs and have learned the associated morph category, you can choose whether to change this or your other Waning morph whenever you change morphs."
+					]
+				}
+			]
+		},
+		{
+			"name": "Natural Ferocity",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon"
+						}
+					]
+				}
+			],
+			"entries": [
+				"You've grown used to using your body as the weapon it was meant to be. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You learn two {@filter maneuvers|optionalfeatures|source=TheDemiDragon|feature type=MV:J} of your choice from among those available to the {@class demi-dragon|TheDemiDragon|Embodiment of the Juggernaut|Juggernaut|TheDemiDragon|2-0} archetype. If a maneuver you use requires your target to make a saving throw to resist the maneuver’s effects, the saving throw DC equals 8 + your proficiency bonus + your Strength modifier. If the maneuver makes use of a {@item horns|TheDemiDragon} or {@item wings|TheDemiDragon} natural weapon, you add it to your list of natural weapons.",
+						"You gain 3 points of fury, as described under the Embodiment of the Juggernaut. You can spend them on any Juggernaut maneuver you know and which you can pay the fury cost for. If you already had fury, your total increases by 3. You regain your expended fury when you finish a short or long rest."
+					]
+				}
+			]
+		},
+		{
+			"name": "Skyterror",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon"
+						}
+					]
+				}
+			],
+			"entries": [
+				"The weight of your body is a terrifying weapon in its own right, and you've learned to master it by brutally diving onto your enemies. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"On your turn, when you score a critical hit with a natural weapon or reduce a creature to 0 hit points with one, you can use your bonus action to launch yourself up to 15 feet into the air without provoking opportunity attacks.",
+						"Your Glide & Fly Speed is doubled when moving directly toward the ground.",
+						"If you move at least 30 feet directly toward a target on a turn, you can choose to take a -5 penalty to any attack roll made with a natural weapon. If the attack hits, you add +10 to the attack's damage."
+					]
+				}
+			]
+		},
+		{
+			"name": "War Plating",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon"
+						}
+					]
+				}
+			],
+			"entries": [
+				"You've trained in wearing heavy armor into combat. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Increase your Strength score by 1, to a maximum of 20.",
+						"You gain proficiency with heavy armor.",
+						"When you don a heavy armor, you can choose to forgo using its AC calculation. If you do, bludgeoning, piercing, and slashing damage that you take from nonmagical attacks is reduced by 3.",
+						"Wearing heavy armor no longer restricts the Flight or Stride features."
+					]
+				}
+			]
+		}
+	],
+	"itemProperty": [
+		{
+			"abbreviation": "NAT",
+			"source": "TheDemiDragon",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Natural Weapon"
+				}
+			]
+		},
+		{
+			"abbreviation": "FevR",
+			"source": "TheDemiDragon",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Fervent Reach",
+					"entries": [
+						"The weapon has a reach of 20 feet, but cannot be used to make opportunity attacks."
+					]
+				}
+			]
+		}
+	],
+	"item": [
+		{
+			"name": "Claws",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "1d6",
+			"dmgType": "S",
+			"property": [
+				"NAT"
+			],
+			"entries": [
+				"Your rending claws deal 1d6 slashing damage. When you take the {@action Attack} action and attack with your claw, you can use your bonus action to make an additional claw attack."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Bite",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "1d12",
+			"dmgType": "P",
+			"property": [
+				"NAT"
+			],
+			"entries": [
+				"Your fanged maw deals 1d12 piercing damage on a hit."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Tail",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "1d10",
+			"dmgType": "B",
+			"property": [
+				"NAT",
+				"R"
+			],
+			"entries": [
+				"Your lashing tail deals 1d10 bludgeoning damage on a hit."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Horns",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "2d4",
+			"dmgType": "P",
+			"property": [
+				"NAT"
+			],
+			"entries": [
+				"Your horns deal 2d4 piercing damage."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Wings",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "1d4",
+			"dmgType": "B",
+			"property": [
+				"NAT"
+			],
+			"entries": [
+				"Your wings deal 1d4 bludgeoning damage. When you take the {@action Attack} action to attack with your claw or wing, you can use your bonus action to make an additional claw or wing attack."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Antlers",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "3d4",
+			"dmgType": "P",
+			"property": [
+				"NAT"
+			],
+			"entries": [
+				"Your antlers deal piercing damage equal to 3d4 + your Strength modifier. If you move at least 10 feet in a straight line during your turn, you gain advantage on the first attack you make with your antlers."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Quills",
+			"type": "R",
+			"weapon": true,
+			"rarity": "none",
+			"range": "60/120",
+			"dmg1": "1d10",
+			"dmgType": "P",
+			"property": [
+				"NAT"
+			],
+			"entries": [
+				"Your quills deal 1d10 piercing damage. Hit or miss, one square occupied by the targeted creature is then filled with quills, and you can additionally choose two squares within 5 feet of that square to also fill with quills as your inaccurate bombardment harmlessly scatters across the area. Any creature that subsequently enters a square filled with quills must succeed on a Dexterity saving throw against your Dragon Spark save DC or stop moving this turn and take 1 piercing damage. A creature moving through the area at half speed doesn't need to make the save. You can use this attack a number of times equal to 1 + your Constitution modifier (minimum 1), after which you must finish a short or long rest to use it again."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Hoard Centerpiece",
+			"type": "M",
+			"weapon": true,
+			"rarity": "none",
+			"dmg1": "2d6",
+			"property": [
+				"NAT",
+				"FevR"
+			],
+			"entries": [
+				"The centerpiece item deals 2d6 damage + your Charisma modifier."
+			],
+			"source": "TheDemiDragon"
+		},
+		{
+			"name": "Clawguards",
+			"source": "TheDemiDragon",
+			"type": "M",
+			"rarity": "none",
+			"weight": 10,
+			"value": 2000,
+			"property": [
+				"NAT"
+			],
+			"dmg1": "1d6",
+			"dmgType": "P",
+			"weapon": true,
+			"entries": [
+				"These sturdy kite-shaped steel spades are made to fit over a creature's claws, serving as gauntlets. They are intended to reduce the strain of manual labor, and you can use them to perform the functions of a {@item shovel|PHB}, {@item crowbar|PHB}, or {@item hammer|PHB}. While wearing them, your claw attacks deal piercing damage."
+			]
+		},
+		{
+			"name": "Crown of the Platinum Savior",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"bonusAc": "+1",
+			"bonusSavingThrow": "+1",
+			"reqAttune": "by a creature that has a breath weapon and is of neutral or good alignment",
+			"entries": [
+				"This platinum filigree ornament clasps a softly glowing sapphire spindle. It signifies one who is favored by Bahamut.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Protection",
+							"entries": [
+								"You gain a +1 bonus to AC and saving throws while you wear this crown."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Radiant Blessing",
+							"entries": [
+								"When you use a breath weapon while wearing the crown, you can choose to change your elemental exhalation into a burst of radiant energy. If you do, your breath deals radiant damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Breath of Life",
+							"entries": [
+								"When you use a breath weapon while wearing the crown, you can choose to change your destructive breath into a burst of healing energy. If you do, you and each creature in the area of your breath's exhalation instead regain a number of hit points equal to the damage normally dealt by your breath. Once you use this property of the crown, you can't use it again until the next dawn."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Dragongilded Armring",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"reqAttune": true,
+			"entries": [
+				"This ornate armring was forged from gold mixed with dragon's blood. It is made up of looping segments that can be adjusted to fit onto practically any limb, and bears a subtle magical enchantment that protects its wearer. While wearing the armring, you can choose to calculate your Armor Class as 13 + your Constitution modifier."
+			]
+		},
+		{
+			"name": "Formshifter's Armring",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"reqAttune": true,
+			"curse": true,
+			"entries": [
+				"This gleaming gold armring appears to be a {@item dragongilded armring|TheDemiDragon} to anyone who tries to identify it, and it confers that item's property when attuned to.",
+				{
+					"type": "entries",
+					"name": "Curse",
+					"entries": [
+						"This item is cursed. When attuned to, you fall unconscious for 2d4 hours, during which you are transformed into a demi-dragon using {@classFeature Transformed Power|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Transformed Power} and {@classFeature Indefinite Mind|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Indefinite Mind}. The DM determines the shape and damage type of your Dragon's Breath, but you otherwise make your own class choices. The armring can be removed with the remove curse spell or similar magic, but doing so doesn't return you to your old form. Only a remove curse spell cast at 6th level or higher, the wish spell, or obtaining the blessing of a true dragon can restore you to your old form. This curse has no effect on a character that is already a demi-dragon, and it can't curse more than one target at a time."
+					]
+				}
+			]
+		},
+		{
+			"name": "Dragonrider's Saddle",
+			"source": "TheDemiDragon",
+			"rarity": "none",
+			"type": "TAH",
+			"weight": 30,
+			"value": 7500,
+			"entries": [
+				"Each of these heavily-cushioned saddles are constructed to individual specifications. A dragonrider's saddle braces the rider and comes with straps and handholds to hold the rider in place during flight or battle, providing advantage on any check to remain mounted.",
+				"The saddle also has space for pouches and saddlebags, positioned within the reach of the dragon wearing it."
+			]
+		},
+		{
+			"name": "Green Dragon Gizzard Stone",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"reqAttune": "by a creature with a poison breath weapon",
+			"entries": [
+				"This noxious green jewel writhes with vile smoke. Exposed to centuries of magical corruption, the hazardous vapor it emits would kill a lesser creature. As part of attuning to it, you must swallow it in order to gain its benefits.",
+				"While attuned to the gizzard stone, you are immune to the {@condition poisoned} condition. Additionally, any creature that fails their saving throw against your breath weapon is {@condition poisoned} for 1 minute. A creature can repeat the same saving throw they made against your breath weapon at the end of each of their turns, ending the effect on themselves on a success."
+			]
+		},
+		{
+			"name": "Inkbound Jewel",
+			"source": "TheDemiDragon",
+			"rarity": "common",
+			"wondrous": true,
+			"entries": [
+				"This small gem bears a simple enchantment. By focusing on the jewel and passing it across a surface, you can sketch a simple picture or write a short message in a language you know as an action. The image or message appears on a suitable surface that is within 5 feet of you, and is written in ink."
+			]
+		},
+		{
+			"name": "Medallion of Change Shape",
+			"source": "TheDemiDragon",
+			"rarity": "rare",
+			"wondrous": true,
+			"entries": [
+				"This rune-inscribed medallion, with a core of willow wood inset in a steel frame, grants the ability to change one's physical shape. As an action while wearing the medallion, you magically polymorph into a humanoid that has a challenge rating no higher than 1. You revert to your true form if you die, if you lose the medallion, or if you use a bonus action to do so. Any equipment you are wearing or carrying is absorbed or borne by the new form (your choice). Once you have used the medallion to polymorph into a new form, you cannot use the medallion to assume the form of a different humanoid until you next finish a short rest, but can still use the medallion to change between the chosen humanoid form and your true form.",
+				"In a new form, you retain your personality, alignment, hit points, Hit Dice, ability to speak, proficiencies, and Intelligence, Wisdom, and Charisma scores. Your statistics and capabilities are otherwise replaced by those of the new form, except any class features (including spell casting) or legendary actions of that form, and you additionally gain proficiency with simple weapons, light armor, and medium armor if you don't already have those proficiencies."
+			]
+		},
+		{
+			"name": "Myrielle's Razors",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"reqAttune": "by a winged creature",
+			"entries": [
+				"These elegant fan-shaped razors come as a pair, and are decorated with artistic patterns of seafoam. They are intended to be worn on the wing limb and used as a slicing weapon. While wearing the razors, you gain a wing attack, which is a natural weapon and which counts as a martial melee weapon for you, and you are proficient with it. You can use it to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with it. Your wing attack deals 1d6 slashing damage.",
+				"While you wear the razors and are attuned to them, you additionally gain 2 Fury points, and learn the {@optfeature Suppressing Gale|TheDemiDragon} and {@optfeature Thieving Talons|TheDemiDragon} maneuvers, as described under the Embodiment of the Juggernaut."
+			]
+		},
+		{
+			"name": "Obsidian Blast-Sphere",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"entries": [
+				"This spherical chunk of shaped obsidian is hollow on the inside, and its dark surface is inscribed with runes of protection. A gilded lid on one side gives access to the interior. If you have a breath weapon, you can breathe into the inert Blast-Sphere, sealing one use of your breath weapon within the sphere for up to 1 hour.",
+				"As an action, you can unseal a charged Blast-Sphere, causing the stored breath to burst forth in a direction of your choosing. Alternatively, the Blast-Sphere can be thrown up to 30 feet as an action. When thrown, roll a d8 to determine which direction the breath bursts forth in. After being used, a charged Blast-Sphere becomes inert."
+			]
+		},
+		{
+			"name": "Potion of Change Shape",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"type": "P",
+			"entries": [
+				"This grayish, murky potion swirls and shifts when shaken. When you drink it, you magically polymorph into a humanoid that has a challenge rating no higher than 1 for 2d4 hours. This form is determined when the potion is initially created. You revert to your true form if you die or at the end of the duration. Any equipment you are wearing or carrying is absorbed or borne by the new form (your choice).",
+				"In a new form, you retain your personality, alignment, hit points, Hit Dice, ability to speak, proficiencies, and Intelligence, Wisdom, and Charisma scores. Your statistics and capabilities are otherwise replaced by those of the new form, except any class features (including spell casting) or legendary actions of that form, and you additionally gain proficiency with simple weapons, light armor, and medium armor if you don't already have those proficiencies."
+			]
+		},
+		{
+			"name": "Ring of Draconic Deception",
+			"source": "TheDemiDragon",
+			"rarity": "rare",
+			"wondrous": true,
+			"reqAttune": "by a creature with the dragon type",
+			"entries": [
+				"This ornate silver jewelry is inlaid with jade and takes the form of a bracelet, hornring, tailring, or other suitable ornament. While wearing it, as an action you can alter your appearance to mimic the form of any creature with the dragon type which has the same basic arrangement of limbs as yourself. This change holds up to physical and sensory inspection, but magic may reveal your true nature.",
+				"The ring has 3 charges. Whenever you use a breath weapon, you can expend 1 charge to change the damage type of your breath to one of the following of your choice: acid, cold, fire, force, lightning, necrotic, poison, psychic, radiant, or thunder. The ring regains all charges daily at dawn."
+			]
+		},
+		{
+			"name": "Sapping Lattice",
+			"source": "TheDemiDragon",
+			"rarity": "rare",
+			"wondrous": true,
+			"bonusSpellAttack": "+1",
+			"bonusSpellSaveDc": "+1",
+			"reqAttune": "by a creature with a Constitution saving throw breath weapon",
+			"entries": [
+				"This net of white-gold filigree jewelry is made to wrap around the neck, and is shaped in arcane patterns that resonate with draining energy when in use. Your breath save DC or your Dragon Spark save DC and attack bonus increases by 1. When a creature fails their saving throw against your breath weapon, its speed is reduced by 15 feet until the start of your next turn."
+			]
+		},
+		{
+			"name": "Skybreaker's Wing Spurs",
+			"source": "TheDemiDragon",
+			"rarity": "rare",
+			"wondrous": true,
+			"reqAttune": "by a winged creature",
+			"entries": [
+				"This set of elaborate mithral plates are of a distinctly elven design, and end in talon-like spurs inset with sapphires. They are worn on a creature's wings, protecting the main limb. While wearing them during flight, you have advantage on checks made to resist being knocked prone.",
+				"The spurs have 5 charges, which are used to fuel the spells within them. While wearing the spurs, you can use your action and expend 1 charge to cast one of the following spells (save DC 15) from the spurs: {@spell gust of wind}, {@spell thunderwave} (2nd level), or {@spell warding wind|XGE}. The spurs regain 1d4 + 1 expended charges each day at dawn. If you expend the spurs' last charge, roll a d20. On a 1, the sapphires set into the spurs crack, and they can no longer be used to cast spells."
+			]
+		},
+		{
+			"name": "Spell Slinger's Chains",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": true,
+			"entries": [
+				"This set of thick iron chains connects to a ruby pendant, intended to be worn on the limbs and chest, respectively. The set was created by a gallant spell duelist who preferred to defeat his adversaries by turning the power of their own magic against them.",
+				"As a reaction when you see a creature within 60 feet of you casting a spell, you can attempt to interrupt the creature's spellcasting. Make an ability check using your highest mental ability score. The DC equals 10 + the spell’s level. On a success, the creature’s spell fails and has no effect, and you store the spell that was being cast for up to 8 hours. You can cast the spell stored in the chains, even if you can't usually cast spells. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster, but is otherwise treated as if you cast the spell. Once the spell has been cast from the chains, it is no longer stored in them.",
+				"Once you attempt to disrupt a creature's spell, it can't be used to do so again until the next dawn."
+			]
+		},
+		{
+			"name": "Stone of Avarice",
+			"source": "TheDemiDragon",
+			"rarity": "uncommon",
+			"wondrous": true,
+			"reqAttune": true,
+			"curse": true,
+			"entries": [
+				"This lustrous gemstone appears to be a {@item stone of good luck|DMG} to anyone who tries to identify it, and it confers that item's property while on your person.",
+				{
+					"type": "entries",
+					"name": "Curse",
+					"entries": [
+						"This item is cursed. While it is on your person, you are seized by boundless greed. Whenever you are presented with a clear chance to add to your fortune, you must make a DC 10 Wisdom saving throw. On a failure, you must act on your desire, even if doing so would put you in danger. You are unwilling to part with the stone until the curse is broken with *remove curse* or similar magic."
+					]
+				}
+			]
+		},
+		{
+			"name": "Talrion's Gatecrasher",
+			"source": "TheDemiDragon",
+			"rarity": "rare",
+			"wondrous": true,
+			"reqAttune": true,
+			"entries": [
+				"This sturdy adamantine-plated helmet conforms to the shape of a dragon's skull, and is padded on the inside. Forward-facing adamantine horns are designed to splinter wood and puncture armor. While wearing the helm, you gain a {@item horns|TheDemiDragon} attack, which is a natural weapon and which counts as a martial melee weapon for you, and you are proficient with it. You can use it to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with it. Your horn attack deals 2d4 piercing damage, and whenever you hit an object with it, the hit is a critical hit.",
+				"While you wear the helm and are attuned to it, you additionally gain 3 Fury points, and learn the {@optfeature Hammering Lunge|TheDemiDragon}, {@optfeature Reprisal|TheDemiDragon}, and {@optfeature Battering Ram|TheDemiDragon} maneuvers, as described under the Embodiment of the Juggernaut."
+			]
+		},
+		{
+			"name": "Warmask of the Brass Dragon",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": "by a demi-Dragon, dragonborn, or half-dragon",
+			"entries": [
+				"This ornamental mask of burnished brass is stylized with the back-swept crest of a brass dragon. While you are wearing the mask you gain the following properties.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Damage Protection",
+							"entries": [
+								"You have resistance against fire damage. If you already have resistance to fire damage from another source, you instead have immunity to fire damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Sleep Breath",
+							"entries": [
+								"As an action, you can use a charge of your breath weapon to exhale sleep gas in an area. The affected area is determined by your breath weapon. Each creature in that area must succeed on a Constitution saving throw with a DC equal to your breath weapon or fall unconscious for 10 minutes. This effect ends for a creature if the creature takes damage or someone uses an action to wake it.",
+								"You can use this property without expending a charge of your breath, but must then wait until the next dawn to do so again."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Warmask of the Bronze Dragon",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": "by a demi-Dragon, dragonborn, or half-dragon",
+			"entries": [
+				"This ornamental mask of polished bronze is stylized with the ribbed crest of a bronze dragon. While you are wearing the mask you gain the following properties.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Damage Protection",
+							"entries": [
+								"You have resistance against lightning damage. If you already have resistance to lightning damage from another source, you instead have immunity to lightning damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Repulsion Breath",
+							"entries": [
+								"As an action, you can use a charge of your breath weapon to exhale repulsion energy in an area. The affected area is determined by your breath weapon. Each creature in that area must succeed on a Strength saving throw with a DC equal to your breath weapon or be pushed 60 feet away from you.",
+								"You can use this property without expending a charge of your breath, but must then wait until the next dawn to do so again."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Warmask of the Copper Dragon",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": "by a demi-Dragon, dragonborn, or half-dragon",
+			"entries": [
+				"This ornamental mask of ruddy copper is stylized with the prominent brow plates of a copper dragon. While you are wearing the mask you gain the following properties.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Damage Protection",
+							"entries": [
+								"You have resistance against acid damage. If you already have resistance to acid damage from another source, you instead have immunity to acid damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Slowing Breath",
+							"entries": [
+								"As an action, you can use a charge of your breath weapon to exhale slowing gas in an area. The affected area is determined by your breath weapon. Each creature in that area must succeed on a Constitution saving throw with a DC equal to your breath weapon. On a failed save, the creature can't use reactions, its speed is halved, and it can't make more than one attack on its turn. In addition, the creature can use either an action or a bonus action on its turn, but not both. These effects last for 1 minute. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself with a successful save.",
+								"You can use this property without expending a charge of your breath, but must then wait until the next dawn to do so again."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Warmask of the Gold Dragon",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": "by a demi-Dragon, dragonborn, or half-dragon",
+			"entries": [
+				"This ornamental mask of gleaming gold is stylized with the sagely whiskers of a gold dragon. While you are wearing the mask you gain the following properties.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Damage Protection",
+							"entries": [
+								"You have resistance against fire damage. If you already have resistance to fire damage from another source, you instead have immunity to fire damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Weakening Breath",
+							"entries": [
+								"As an action, you can use a charge of your breath weapon to exhale weakening gas in an area. The affected area is determined by your breath weapon. Each creature in that area must succeed on a Strength saving throw with a DC equal to your breath weapon or have disadvantage on Strength-based attack rolls, Strength checks, and Strength saving throws for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+								"You can use this property without expending a charge of your breath, but must then wait until the next dawn to do so again."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Warmask of the Silver Dragon",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": "by a demi-Dragon, dragonborn, or half-dragon",
+			"entries": [
+				"This ornamental mask of shimmering silver is stylized with the spiny frill of a silver dragon. While you are wearing the mask you gain the following properties.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Damage Protection",
+							"entries": [
+								"You have resistance against cold damage. If you already have resistance to cold damage from another source, you instead have immunity to cold damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Paralyizing Breath",
+							"entries": [
+								"As an action, you can use a charge of your breath weapon to exhale paralyzing gas in an area. The affected area is determined by your breath weapon. Each creature in that area must succeed on a Constitution saving throw with a DC equal to your breath weapon or be paralyzed until the end of their next turn.",
+								"You can use this property without expending a charge of your breath, but must then wait until the next dawn to do so again."
+							]
+						}
+					]
+				}
+			]
+		}
+	],
+	"spell": [
+		{
+			"name": "Férend's Tempestuous Tail-Lash",
+			"source": "TheDemiDragon",
+			"level": 0,
+			"school": "T",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "radius",
+				"distance": {
+					"type": "feet",
+					"amount": 10
+				}
+			},
+			"components": {
+				"s": true,
+				"m": {
+					"text": "a tail natural weapon"
+				}
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"You call forth a tempest and direct it at an enemy with a tail natural weapon that you have. Make a melee weapon attack with your tail against one creature within 10 feet of you. On a hit, the target suffers the tail weapon's normal effects and is pushed 10 feet away from you.",
+				"This spell's damage increases when you reach certain levels. At 5th level, the melee attack deals an extra {@damage 1d8} slashing damage to the target on a hit. It increases again at 11th level ({@damage 2d8}) and 17th level ({@damage 3d8})."
+			],
+			"scalingLevelDice": [
+				{
+					"label": "slashing damage",
+					"scaling": {
+						"5": "1d8",
+						"11": "2d8",
+						"17": "3d8"
+					}
+				}
+			],
+			"damageInflict": [
+				"slashing"
+			],
+			"miscTags": [
+				"SCL",
+				"FMV"
+			],
+			"areaTags": [
+				"ST"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Malygris' Cadaverous Tail-Sting",
+			"source": "TheDemiDragon",
+			"level": 0,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "radius",
+				"distance": {
+					"type": "feet",
+					"amount": 10
+				}
+			},
+			"components": {
+				"s": true,
+				"m": {
+					"text": "a tail natural weapon"
+				}
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"You warp your own body with bone spurs and lash out with a tail natural weapon that you have. Make a melee weapon attack with your tail natural weapon against one creature within 10 feet of you. On a hit, the target suffers the attack's normal effects and a bone spur is left in them. If the target is hit again before the beginning of your next turn, it takes an additional {@damage 1d4} piercing damage, ending the spell.",
+				"This spell's damage increases by 2d4 when you reach 5th level ({@damage 3d4}), 11th level ({@damage 5d4}), and 17th level ({@damage 7d4})."
+			],
+			"scalingLevelDice": [
+				{
+					"label": "bone spur",
+					"scaling": {
+						"1": "1d4",
+						"5": "3d4",
+						"11": "5d4",
+						"17": "7d4"
+					}
+				}
+			],
+			"damageInflict": [
+				"piercing"
+			],
+			"miscTags": [
+				"SCL"
+			],
+			"areaTags": [
+				"ST"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Rogoth's Caustic Tail-Swipe",
+			"source": "TheDemiDragon",
+			"level": 0,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "radius",
+				"distance": {
+					"type": "feet",
+					"amount": 10
+				}
+			},
+			"components": {
+				"s": true,
+				"m": {
+					"text": "a tail natural weapon"
+				}
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"You coat a tail natural weapon that you have with seeping acid. Make a melee weapon attack with your tail natural weapon against one creature within 10 feet of you. On a hit, the target suffers the weapon attack's normal effects. On a miss, acid splashes the target, and you instead deal {@damage 1d4} acid damage.",
+				"This spell's damage increases when you reach certain levels. At 5th level, the melee attack deals an additional {@damage 1d8} acid damage to the target on a hit, and the acid damage dealt on a miss increases to {@damage 2d4}. Both damage rolls increase by one die at 11th level ({@damage 2d8} and {@damage 3d4}) and 17th level ({@damage 3d8} and {@damage 4d4})."
+			],
+			"scalingLevelDice": [
+				{
+					"label": "acid damage on a miss",
+					"scaling": {
+						"1": "1d4",
+						"5": "2d4",
+						"11": "3d4",
+						"17": "4d4"
+					}
+				},
+				{
+					"label": "acid damage on a hit",
+					"scaling": {
+						"5": "1d8",
+						"11": "2d8",
+						"17": "3d8"
+					}
+				}
+			],
+			"damageInflict": [
+				"acid"
+			],
+			"miscTags": [
+				"SCL"
+			],
+			"areaTags": [
+				"ST"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Talon's Freezing Tail-Strike",
+			"source": "TheDemiDragon",
+			"level": 0,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "self"
+				}
+			},
+			"components": {
+				"s": true,
+				"m": {
+					"text": "a tail natural weapon"
+				}
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "hour",
+						"amount": 1
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"You imbue a tail natural weapon that you have with numbing icicles. The next time you hit a creature with a tail attack during this spell's duration, the icicles are released in a crippling spray, the attack deals an extra 1d8 cold damage, and the target's speed is reduced by 15 feet until the start of your next turn. The spell then ends.",
+				"When you cast this spell at higher levels, you can make additional tail attacks before the spell ends, for a total of two attacks at 5th level, three at 11th level, and four at 17th level."
+			],
+			"scalingLevelDice": [
+				{
+					"label": "slashing damage",
+					"scaling": {
+						"5": "1d8",
+						"11": "2d8",
+						"17": "3d8"
+					}
+				}
+			],
+			"damageInflict": [
+				"slashing"
+			],
+			"miscTags": [
+				"SCL",
+				"FMV"
+			],
+			"areaTags": [
+				"ST"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Elemental Javelin",
+			"source": "TheDemiDragon",
+			"level": 2,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "self"
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "minute",
+						"amount": 10
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"You form a mote of elemental power in your palm. Choose acid, cold, fire, lightning, or poison. When you cast the spell—and as a bonus action on each of your turns thereafter—you can evoke a javelin of the chosen elemental energy from the mote and hurl it at a creature within 60 feet of you. Make a ranged spell attack. On a hit, the target takes damage equal to {@damage 2d6} of the elemental type you chose.",
+				"The spell ends when you have made six javelin spell attacks."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for every two slot levels above 2nd."
+					]
+				}
+			],
+			"damageInflict": [
+				"acid",
+				"cold",
+				"fire",
+				"lightning",
+				"poison"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "PHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Spurious Glide",
+			"source": "TheDemiDragon",
+			"level": 2,
+			"school": "C",
+			"time": [
+				{
+					"number": 1,
+					"unit": "reaction",
+					"condition": "which you take when you or a creature within 120 feet of you falls"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "feet",
+					"amount": 120
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "minute",
+						"amount": 1
+					}
+				}
+			],
+			"entries": [
+				"You call forth a phantasmal winged spirit. One falling creature of your choice that you can see within range halts in midair and remains suspended for the duration as their rate of descent is reduced to 0. While gliding in this way, the creature's speed increases by 10, and it can as part of its movement move in any horizontal direction, or dive straight down. If the creature lands before the spell ends, it takes no falling damage and can land on its feet, and the spell ends."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell using a spell slot of 3rd level or higher, you can target one additional creature for each slot level above 2nd."
+					]
+				}
+			],
+			"areaTags": [
+				"ST"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Elemental Stake",
+			"source": "TheDemiDragon",
+			"level": 3,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "feet",
+					"amount": 120
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"You summon a lance of elemental energy and hurl it at a target within range. Choose between acid, cold, fire, lightning, or poison. Make a ranged spell attack against the target. On a hit, the target takes {@damage 6d8} damage of the type you chose, and must then succeed on a Strength saving throw or pushed 30 feet away from you. If the target collides with terrain as part of this push, it is pinned by the lance and {@condition restrained} until the end of your next turn."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell using a spell slot of 4th level or higher, the damage increases by {@scaledamage 6d8|3-9|1d8} for each slot level above 4th."
+					]
+				}
+			],
+			"damageInflict": [
+				"acid",
+				"cold",
+				"fire",
+				"lightning",
+				"poison"
+			],
+			"miscTags": [
+				"FMV"
+			],
+			"conditionInflict": [
+				"restrained"
+			],
+			"savingThrow": [
+				"strength"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "PHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Caesar's Faded Imprint",
+			"source": "TheDemiDragon",
+			"level": 4,
+			"school": "D",
+			"time": [
+				{
+					"number": 1,
+					"unit": "minute"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "touch"
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true,
+				"m": "a fried pastry"
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "hour",
+						"amount": 1
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"You touch a point on the ground from which you call forth the memories of all that transpired within a radius of 20 feet within a breadth of 4d4 hours before the spell was cast. While the spell lasts, you can take an action to focus upon a particular point in time within that duration. The events that took place at that time replay as an illusory imprint that acts out everything that happened within the radius of the spell exactly as it transpired. The projection is obviously illusory to anyone who observes it, and can't be interacted with."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell using a spell slot of 5th level or higher, the breadth of duration increases by roll 4d4 for each slot level above 4th."
+					]
+				}
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "PHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					}
+				]
+			}
+		}
+	],
+	"reward": [
+		{
+			"name": "Boon of Draconic Magic",
+			"source": "TheDemiDragon",
+			"type": "Boon",
+			"entries": [
+				"When you gain this boon, choose a dragon type. You gain the spells associated with that dragon type listed in the Boon of Draconic Magic table at the indicated level, and can cast each of them once per long rest. Charisma is your ability for Draconic Magic spells. You use your Charisma whenever a spell refers to your spellcasting ability. In addition, you use your Charisma modifier when setting the saving throw DC for a spell you cast and when making an attack roll with one.",
+				{
+					"type": "abilityDc",
+					"name": "Spell",
+					"attributes": [
+						"cha"
+					]
+				},
+				{
+					"type": "abilityAttackMod",
+					"name": "Spell",
+					"attributes": [
+						"cha"
+					]
+				},
+				{
+					"type": "table",
+					"colLabels": [
+						"Type",
+						"1st",
+						"3rd",
+						"5th",
+						"7th",
+						"9th",
+						"11th"
+					],
+					"colStyles": [
+						"col-2",
+						"col-2",
+						"col-2",
+						"col-2",
+						"col-2",
+						"col-2",
+						"col-2"
+					],
+					"rows": [
+						[
+							"Black",
+							"-",
+							"blindness/deafness, darkness",
+							"-",
+							"greater invisibility",
+							"-",
+							"-"
+						],
+						[
+							"Blue",
+							"create or destroy water",
+							"-",
+							"major image",
+							"hallucinatory terrain",
+							"-",
+							"-"
+						],
+						[
+							"Green",
+							"-",
+							"suggestion",
+							"fast friends, plant growth",
+							"-",
+							"-",
+							"-"
+						],
+						[
+							"Red",
+							"cause fear",
+							"locate object",
+							"-",
+							"-",
+							"-",
+							"find the path"
+						],
+						[
+							"White",
+							"-",
+							"gust of wind, pass without trace",
+							"-",
+							"freedom of movement",
+							"-",
+							"-"
+						],
+						[
+							"Brass",
+							"speak with animals",
+							"-",
+							"tongues",
+							"locate creature",
+							"-",
+							"-"
+						],
+						[
+							"Bronze",
+							"-",
+							"detect thoughts, zone of truth",
+							"-",
+							"control water",
+							"-",
+							"-"
+						],
+						[
+							"Copper",
+							"earth tremor",
+							"-",
+							"-",
+							"stone shape",
+							"-",
+							"move earth"
+						],
+						[
+							"Gold",
+							"bless",
+							"fortune's favor",
+							"-",
+							"-",
+							"geas",
+							"-"
+						],
+						[
+							"Silver",
+							"fog cloud",
+							"-",
+							"-",
+							"polymorph",
+							"control winds",
+							"-"
+						],
+						[
+							"Amethyst",
+							"-",
+							"protection from poison",
+							"blink",
+							"resilient sphere",
+							"-",
+							"-"
+						],
+						[
+							"Crystal",
+							"color spray",
+							"-",
+							"daylight",
+							"-",
+							"dawn",
+							"-"
+						],
+						[
+							"Emerald",
+							"-",
+							"silence",
+							"enemies abound",
+							"compulsion",
+							"-",
+							"-"
+						],
+						[
+							"Sapphire",
+							"cause fear",
+							"-",
+							"fear",
+							"-",
+							"passwall",
+							"-"
+						],
+						[
+							"Topaz",
+							"create or destroy water",
+							"ray of enfeeblement",
+							"-",
+							"blight",
+							"-",
+							"-"
+						]
+					]
+				}
+			]
+		}
+	],
+	"background": [
+		{
+			"name": "Chosen of the Community",
+			"source": "TheDemiDragon",
+			"skillProficiencies": [
+				{
+					"persuasion": true,
+					"religion": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"anyArtisansTool": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 1
+				}
+			],
+			"fluff": {
+				"entries": [
+					"You were chosen by a small community of individuals to undergo transformation. Perhaps you were a promising young warrior who was deemed ready to take part in an ancient ritual, or maybe you were part of a group of zealous dragon worshippers, honored to be selected as a vessel for their devotion. Regardless of how the rest of the world may view you now, you can always count on the small group of people that support you, perceiving you as an exalted idol."
+				]
+			},
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"equipmentType": "toolArtisan"
+						},
+						{
+							"item": "signet ring|phb",
+							"displayName": "a mark of your community (a signet ring, a religious emblem, or a branded scale)"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 1000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Persuasion}, {@skill Religion}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of {@filter artisan's tools|items|source=phb|miscellaneous=mundane|type=artisan's tools}, a mark of your community (a {@item signet ring|phb}, a religious {@item emblem|phb}, or a branded scale), and a {@item pouch|phb} containing 10 gp"
+						}
+					]
+				},
+				{
+					"name": "Shared Society",
+					"type": "entries",
+					"entries": [
+						"You previously pursued a simple profession among your community before you were chosen. Your community and your role within it have played a defining part in your life. Choose or randomly determine the nature of your community from the table below.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Community"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"You are part of an isolated clan of barbarians. Each century, a warrior is selected to take on the role of guardian and maintain balance between the elements."
+								],
+								[
+									"2",
+									"You are a member of a secret society that is searching for a way to prolong life. You are the latest experiment."
+								],
+								[
+									"3",
+									"A small group of demi-dragons travel the country-side, offering transformation to those who are willing. You accepted, and found a start to a new life."
+								],
+								[
+									"4",
+									"Selected by your village to confront an ancient dragon, you had expected to meet death. Instead, the dragon agreed to your terms, but bound you in a magical pact."
+								],
+								[
+									"5",
+									"As an acolyte of a dragon god, your prayers for strength were one day answered. The priesthood has since recognized you as a minor saint."
+								],
+								[
+									"6",
+									"You were part of an adventurer's guild for years before an unfortunate accident caused your transformation."
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Feature: Community Support",
+					"type": "entries",
+					"entries": [
+						"You are accepted as part of a community that will care for you and provide you with shelter, food, and any information that they can. Your community will shield you from the law or anyone else searching for you, though they will not risk their lives for you."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						"Though different from those around you, you've been accepted as part of the community, and have shared in local values, customs, and daily practices.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I always put others ahead of myself."
+								],
+								[
+									"2",
+									"I prefer to listen to the opinions of those around me before speaking my mind."
+								],
+								[
+									"3",
+									"I like to hear myself talk."
+								],
+								[
+									"4",
+									"I am loyal and dependable to the end."
+								],
+								[
+									"5",
+									"My life is built on secrets, as is my community."
+								],
+								[
+									"6",
+									"I always act with great solemnity and ceremony."
+								],
+								[
+									"7",
+									"I have adopted the persona that my community believes me to be, but that's not the real me."
+								],
+								[
+									"8",
+									"I feel like an outsider and a fraud, unable to really connect with those around me."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Dedication. I have an important cause that I devote myself to which will benefit everyone."
+								],
+								[
+									"2",
+									"Tradition. I uphold the traditions of my community and bring honor to us all. (Lawful)"
+								],
+								[
+									"3",
+									"Peace. We can only be truly happy in those rare moments of quiet. (Neutral)"
+								],
+								[
+									"4",
+									"Adventure. Home is well and good, but I only truly live when I break away from daily life. (Chaotic)"
+								],
+								[
+									"5",
+									"Prestige. I will spread my influence far and wide, and use it for my own ends. (Evil)"
+								],
+								[
+									"6",
+									"Bravery. To act when others quake in fear—this is the essence of the warrior. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I used to work as a craftsman, and I still have a close relationship with the artisan who taught me."
+								],
+								[
+									"2",
+									"I am a natural-born leader, and have worked for years to coordinate with my community."
+								],
+								[
+									"3",
+									"My family has taken my transformation poorly."
+								],
+								[
+									"4",
+									"My community is split into opposed factions, with me at the center of the conflict."
+								],
+								[
+									"5",
+									"My community has entrusted me with a mission. I must live up to what is expected of me."
+								],
+								[
+									"6",
+									"I have grown distant from those around me since my transformation. Things can't ever be the same again."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I desperately crave acceptance from those around me. I am terrified of being rejected."
+								],
+								[
+									"2",
+									"I worry that others now think of me as strange, and obsess over the smallest comment or glance."
+								],
+								[
+									"3",
+									"I have certain traditions and rituals that I follow routinely. I must never fail to uphold them."
+								],
+								[
+									"4",
+									"I secretly believe that I am more important than others."
+								],
+								[
+									"5",
+									"I believe in complicated conspiracy movements that explain the real truth of this world."
+								],
+								[
+									"6",
+									"I have trouble acknowledging that I have flaws. I get aggressive about it if others confront me about it."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Curse of Transformation",
+			"source": "TheDemiDragon",
+			"skillProficiencies": [
+				{
+					"arcana": true,
+					"insight": true
+				}
+			],
+			"toolProficiencies": [
+				{
+					"gaming set": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 1
+				}
+			],
+			"fluff": {
+				"entries": [
+					"You've been changed by mystical means. Some creature or event has cursed you with a magical transformation, giving you your current form. Perhaps you gave offense to a vengeful god, wore a cursed item, signed an arcane contract, or were tricked by an entity such as a fey or elder dragon. Whatever the reason, you are stuck with your curse until some condition is fulfilled, and must learn to see the world from a new perspective."
+				]
+			},
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"special": "An item that signifies the nature of your curse (a contract, a mystic sigil, or a cursed item that you wear)"
+						},
+						{
+							"equipmentType": "setGaming"
+						},
+						{
+							"item": "pouch|phb",
+							"containsValue": 2000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Arcana}, {@skill Insight}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "An item that signifies the nature of your curse (a contract, a mystic sigil, or a cursed item that you wear), one {@filter gaming set|items|source=phb|miscellaneous=mundane|type=gaming set} of your choice, and a {@item pouch|phb} containing 20 gp"
+						}
+					]
+				},
+				{
+					"name": "Feature: Shelter for the Stricken",
+					"type": "entries",
+					"entries": [
+						"Your story evokes sympathy in a select few, and those few are willing to offer you food, shelter, and secrecy. Perhaps you have loved ones who keep a space for you ready, or maybe you excel at finding those who are willing to listen to your story and offer support. Your allies will help you as they can, but they will not risk their lives for you.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Nature of Curse"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I earned the ire of a god and have been given a set of tasks to complete that will lift my curse."
+								],
+								[
+									"2",
+									"I was tricked by a fey or other creature and lost my humanity until the day I forget my past life."
+								],
+								[
+									"3",
+									"I awoke in a wizard's workshop, having been gifted life from nothing. Now I must earn my further existence."
+								],
+								[
+									"4",
+									"I signed a contract that would change me into something I was not. In return, I owe a debt."
+								],
+								[
+									"5",
+									"A dragon or other creature cursed me to walk ten thousand miles in a form of their likeness."
+								],
+								[
+									"6",
+									"The magic of a cursed item changed me."
+								]
+							]
+						},
+						"If the source of your curse is an item, choose from the table below, or decide on an appropriate item yourself.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Cursed Item"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"A golden armring"
+								],
+								[
+									"2",
+									"A pendant bearing a mystic symbol"
+								],
+								[
+									"3",
+									"A book of indecipherable lore"
+								],
+								[
+									"4",
+									"An elaborate magical machine which swapped my old body for the form I now bear"
+								],
+								[
+									"5",
+									"A soulgem of a creature whose visage I now share"
+								],
+								[
+									"6",
+									"A polished chunk of amber with a tiny creature within"
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						"Though anyone can fall victim to a curse, it is your attitude towards what has befallen you that reveals who you are.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"My curiosity comes with a price, and that's okay."
+								],
+								[
+									"2",
+									"I've become obsessed with experimenting with and resolving the terms of my curse."
+								],
+								[
+									"3",
+									"I try to go on living as always, but things are different."
+								],
+								[
+									"4",
+									"My life has been turned around and I deeply resent it."
+								],
+								[
+									"5",
+									"Being cursed has kindled an occult interest in me."
+								],
+								[
+									"6",
+									"I'm not cursed, I'm blessed! I wish I could share this."
+								],
+								[
+									"7",
+									"I deserved this curse for all the sins I've wrought."
+								],
+								[
+									"8",
+									"I've grown more comfortable in my new form."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Selflessness. Whatever befalls me, I want to help others in any way I can. (Good)"
+								],
+								[
+									"2",
+									"Discipline. It is more important than ever that I remain vigilant and in control. (Lawful)"
+								],
+								[
+									"3",
+									"Acceptance. The mistakes of the past are better left forgotten. I lead a new life now. (Neutral)"
+								],
+								[
+									"4",
+									"Exuberance. Who cares about consequences? I'll live life to the fullest! (Chaotic)"
+								],
+								[
+									"5",
+									"Greed. I was cursed for my tainted greed, yet still I want more. (Evil)"
+								],
+								[
+									"6",
+									"Pride. I deserve my own success, and will fight fiercely for every victory. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I have a close friend who readily accepts my change."
+								],
+								[
+									"2",
+									"I still keep in loose contact with my family. They don't know about my curse."
+								],
+								[
+									"3",
+									"I've found it difficult to relate to the people I used to, and instead prefer the company of a beloved pet."
+								],
+								[
+									"4",
+									"My curse was inflicted in service to the love of my life."
+								],
+								[
+									"5",
+									"It was my hated rival who cursed me."
+								],
+								[
+									"6",
+									"Since being cursed, I increasingly prefer the company of others that are like myself."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I dwell long on my mistakes and fall into despair."
+								],
+								[
+									"2",
+									"I get angry when reminded of what cursed me."
+								],
+								[
+									"3",
+									"I think everyone is constantly judging me."
+								],
+								[
+									"4",
+									"I failed, and I can never make up for it."
+								],
+								[
+									"5",
+									"I don't believe anyone can ever love me like this."
+								],
+								[
+									"6",
+									"I won't acknowledge that I did anything wrong to deserve this curse."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "True-Born Dragon",
+			"source": "TheDemiDragon",
+			"skillProficiencies": [
+				{
+					"perception": true,
+					"stealth": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 2
+				}
+			],
+			"fluff": {
+				"entries": [
+					"Born a true dragon, you are legend embodied and heir to countless myths and stories. Though true dragons don't usually lead lives of adventure—often preferring to safely amass power by growing older—something has pushed you to seek out such a life."
+				]
+			},
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"item": "pouch|phb",
+							"displayName": "A meager hoard, containing cheap gemstones and a mix of various coins totaling a value of 30 gp",
+							"containsValue": 3000
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Perception}, {@skill Stealth}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "Two of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A meager hoard, containing cheap gemstones and a mix of various coins totaling a value of 30 gp"
+						},
+						{
+							"type": "item",
+							"name": "Optional Class Features:",
+							"entry": "Use the rules for {@classFeature Resolution|Demi-Dragon|TheDemiDragon|1|TheDemiDragon|Resolution}, replacing Devour Magic"
+						}
+					]
+				},
+				{
+					"name": "Feature: Dragon's Lair",
+					"type": "entries",
+					"entries": [
+						"Your natural lifespan is counted in the thousands of years, and you never suffer any ill effects from old age.",
+						"Additionally, you have a knack for locating a suitable lair. This lair can be anything from an abandoned cave to an underwater cove, an old fort, a forest glade, a hollow glacier, or a forgotten house. The lair gains no special benefits, but readily provides you with a safe haven away from prying eyes."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Inherent Nature",
+					"type": "entries",
+					"entries": [
+						"Each of the ten draconic bloodlines share certain traits common to their kind. Although it is possible for an individual to defy their nature, they can never get rid of it. A chromatic dragon may be raised with difficulty to act out of sincere kindness, but the temptation to give in to their darker side will always remain—likewise, a metallic dragon may fall prey to evil influence, but must actively reject their own tendency towards virtue in order to be swayed to an evil worldview.",
+						{
+							"type": "table",
+							"colLabels": [
+								"Type",
+								"Inherent Nature"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"Black",
+									"You have a predisposition towards cruelty, and find great satisfaction in bringing ruination to all that is more beautiful than you. You are best at home when you are unseen, hidden by darkness or beneath fetid swamp waters."
+								],
+								[
+									"Blue",
+									"To your ordered mind, everything has its place in the world—it's just that most of it exists purely for your benefit. Other creatures are merely a means to an end, and those who don't understand their place deserve to be made an example of."
+								],
+								[
+									"Green",
+									"You see others as tools that can be manipulated with subtlety and cunning to get you what you want. Your long-lasting plots and schemes are often strongly motivated by short bursts of emotion such as anger, fear, or envy."
+								],
+								[
+									"Red",
+									"You are better than everyone and everything, and all should learn to grovel before you or face your wrath. You revel in destruction, brutality, and conquest, and often invent complex strategies to improve your odds of victory."
+								],
+								[
+									"White",
+									"You delight in your physicality, living in the moment and expressing yourself through movement and action, viewing all others as prey to be chased. You disdain speech, and have trouble grasping abstract concepts or promises."
+								],
+								[
+									"Brass",
+									"You can't help but enjoy the sound of your own voice, and can talk ceaselessly for hours on end about practically anything. You find gossip and the motivations of lesser creatures to be fascinating."
+								],
+								[
+									"Bronze",
+									"You have an inquisitive mind, and can't help but want to right wrongs and bring evildoers to justice. You tend to prefer anonymity, and only open up to a few people that are close to you."
+								],
+								[
+									"Copper",
+									"You have an appreciation for wit, wordplay, and humor. Dazzling others with your cleverness—whether by pranking them, sharing an insightful story, or causing them to laugh—has a certain intrinsic appeal to it."
+								],
+								[
+									"Gold",
+									"Reserved and insightful, you tend to consider before speaking, and view others in the light of your own high standards of order, piety, and morality. You come up with complicated plans that are meant to help others, but often miss the obvious in favor of the esoteric."
+								],
+								[
+									"Silver",
+									"You are open, honest, and tolerant, and you can't help but sympathize with those in need—especially lesser creatures who are down on their luck. The history and actions of the mortal races is a subject of your endless fascination."
+								],
+								[
+									"Amethyst",
+									"You are detached and aloof. You believe yourself the wisest of dragonkind, seeking neutrality and wisdom—the prattling and conflicts of your lessers will not distract you from unraveling the true secrets of the world."
+								],
+								[
+									"Crystal",
+									"You are curious and friendly, always pleased to meet new people and learn new things. You wish everyone could just get along, but you won't miss a chance to have a good snow fight or engage in some other mischief."
+								],
+								[
+									"Emerald",
+									"You are paranoid and isolationist. You stick together only with others for the safety that comes with strength in numbers, but you don't trust anyone easily and prefer your own kind or that of the sapphire bloodline over all others."
+								],
+								[
+									"Sapphire",
+									"You are confident in yourself and dependable to friends, but distrustful of strangers. You don't like when others intrude into your space, and you can be quite menacing, but really you just want to be left alone."
+								],
+								[
+									"Topaz",
+									"You can't help but be unfriendly and curmudgeonly. Your patience is short and you hate the nosy interference of others, especially the bronze bloodline. You like the peace of a quiet day spent sunning yourself and enjoying the breeze. Moisture annoys you."
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						"Dragons view the world differently than the humanoid races, with their perspective shaped chiefly by their inherent nature, and secondarily by their surroundings and experiences. Most dragons are lonesome outsiders that never truly belong around others-and prefer it that way-and only a few ever find genuine companionship.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I want to be remembered as a mythical dragon of which tales are told and songs are made."
+								],
+								[
+									"2",
+									"I consider myself a knowledgeable scholar of a particular subject, which holds my eternal fascination."
+								],
+								[
+									"3",
+									"I love exploring the land and trying new experiences."
+								],
+								[
+									"4",
+									"I want to change how mortals view dragonkind."
+								],
+								[
+									"5",
+									"I want to defy my inherent nature through great effort, but it is a constant, daily struggle."
+								],
+								[
+									"6",
+									"I am faithful to a god, whose decree I seek to carry out."
+								],
+								[
+									"7",
+									"I idolize a particular ancient dragon, whose stories and legends I model myself after."
+								],
+								[
+									"8",
+									"I try to rebel against the expectations that people often have of dragons, and go out of my way to be different."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Justice. I will use my strength to protect others from those that would cause harm. (Good)"
+								],
+								[
+									"2",
+									"Authority. The mortal races must be led by those who know better. (Lawful)"
+								],
+								[
+									"3",
+									"Freedom. I will not be beholden to anything or anyone. My path is mine alone. (Chaotic)"
+								],
+								[
+									"4",
+									"Might. The power to do as I please is all that matters. (Evil)"
+								],
+								[
+									"5",
+									"Treasure. Wealth is an anchor for dragon magic. I must amass treasure to expand my domain. (Any)"
+								],
+								[
+									"6",
+									"Arrogance. In fact, I am better than everyone else. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"My relationship with my siblings or parents drives me to continually seek to exceed expectations."
+								],
+								[
+									"2",
+									"I was all alone when I hatched, and an unpleasant experience soon taught me not to trust strangers."
+								],
+								[
+									"3",
+									"I was raised by a humanoid, and though I love my foster parent, I never really fit in."
+								],
+								[
+									"4",
+									"I haven't had many to speak with, and have filled the void with an imaginary friend that I talk to."
+								],
+								[
+									"5",
+									"One day, I met and befriended an explorer. We still regularly speak or exchange letters."
+								],
+								[
+									"6",
+									"My only companions are the weak minions that I subjugate to do my bidding."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am flawless. Those who say otherwise earn my ire. "
+								],
+								[
+									"2",
+									"I like to be worshiped or praised, and will aggressively encourage others to do so."
+								],
+								[
+									"3",
+									"I am full of boasts and clever jests that drive home how much better than the mortal races I am."
+								],
+								[
+									"4",
+									"I hate being questioned or second-guessed."
+								],
+								[
+									"5",
+									"I am often unpleasantly surprised when others don't give me the attention that I clearly deserve."
+								],
+								[
+									"6",
+									"As I view it, in this world, there are only predators and prey, and I will be a predator."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		},
+		{
+			"name": "Victim of Thaumaturgy",
+			"source": "TheDemiDragon",
+			"skillProficiencies": [
+				{
+					"arcana": true,
+					"insight": true
+				}
+			],
+			"languageProficiencies": [
+				{
+					"anyStandard": 1
+				}
+			],
+			"toolProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"alchemist's supplies",
+							"tinker's tools",
+							"poisoner's kit",
+							"thieves' tools"
+						]
+					}
+				}
+			],
+			"fluff": {
+				"entries": [
+					"You've met an unfortunate fate. Against your own will, you were plucked from your old life and forced to give up your humanity at the behest of your captor. Transformed and held against your will, you had plenty of time to plan, and eventually mustered an escape or reached an agreement with your captor or another entity. Regardless of how you've won your freedom, your life can never be the same again."
+				]
+			},
+			"startingEquipment": [
+				{
+					"_": [
+						{
+							"equipmentType": "toolArtisan"
+						},
+						{
+							"special": "A token belonging to your captor"
+						},
+						{
+							"item": "sack|phb",
+							"displayName": "a sack of stolen or gifted valuables totaling 15 gp",
+							"containsValue": 1500
+						}
+					]
+				}
+			],
+			"entries": [
+				{
+					"type": "list",
+					"style": "list-hang-notitle",
+					"items": [
+						{
+							"type": "item",
+							"name": "Skill Proficiencies:",
+							"entry": "{@skill Arcana}, {@skill Insight}"
+						},
+						{
+							"type": "item",
+							"name": "Languages:",
+							"entry": "One of your choice"
+						},
+						{
+							"type": "item",
+							"name": "Equipment:",
+							"entry": "A set of {@filter tools|items|source=phb|miscellaneous=mundane|type=tools}, a token belonging to your captor, a {@item sack|phb} of stolen or gifted valuables totaling 15 gp"
+						}
+					]
+				},
+				{
+					"name": "Feature: Thaumaturgic Rites",
+					"type": "entries",
+					"entries": [
+						"You've witnessed firsthand the application of blood magic or some other form of metamorphic power. With the right preparation, research, and access to materials, you believe that you could duplicate the same rites that were inflicted upon you, creating another demi-dragon."
+					],
+					"data": {
+						"isFeature": true
+					}
+				},
+				{
+					"name": "Oppressive Captor",
+					"type": "entries",
+					"entries": [
+						"Your captor has been a brief but influential figure in your life. You may have had time to watch them perform their thaumaturgic work, or perhaps even gotten to know them. While a captor may be a cruel and selfish lunatic from whom you must escape, they may just as easily be eccentric or misguided, and may have offered you your freedom of their own choice. Work with your DM to determine who your captor is, what your relationship to them is like, or use the table below.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Captor"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"A crazed wizard abducted you and used you as a test subject in their mad pursuit for immortality."
+								],
+								[
+									"2",
+									"An ancient dragon destroyed your home and offered you a choice: die, or serve and be transformed."
+								],
+								[
+									"3",
+									"The Cult of the Dragon chose you to trial their blood magics, as the first of many more to come."
+								],
+								[
+									"4",
+									"You were a ritual offering to a god. The god offered you transformation in exchange for servitude."
+								],
+								[
+									"5",
+									"An abishai used you as part of an experiment to break free from Tiamat's control, and now roams the Material Plane with an agenda of their own."
+								],
+								[
+									"6",
+									"A powerful entity punished a wyrmling dragon with mortality, and swapped your form for the dragon's. Now the dragon roams the world with your old body."
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Lingering Quirk",
+					"type": "entries",
+					"entries": [
+						"Your unique experiences have left their mark on you. Choose what this means for you, or roll on the table below.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Quirk"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Your form is a mishmash of different dragon types."
+								],
+								[
+									"2",
+									"You are haunted by the voice of your captor or another captive, and sometimes hear that voice speak to you."
+								],
+								[
+									"3",
+									"Your body is artificial and is made of stone, wood, or metal, akin to a gargoyle or draconic warforged."
+								],
+								[
+									"4",
+									"When you look at your reflection, it's the old you staring back."
+								],
+								[
+									"5",
+									"You bear the memories of a wyrmling dragon, which you've learned was slain by your captor."
+								],
+								[
+									"6",
+									"You are scaleless—flawed and incomplete."
+								]
+							]
+						}
+					]
+				},
+				{
+					"name": "Suggested Characteristics",
+					"type": "entries",
+					"entries": [
+						"You've had your body changed against your will. You might embrace this change, or rage against it.",
+						{
+							"type": "table",
+							"colLabels": [
+								"d8",
+								"Personality Trait"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I am cautious in my dealings with others."
+								],
+								[
+									"2",
+									"I am always fiddling with tools, vials, and other components relevant to my new studies and research."
+								],
+								[
+									"3",
+									"The life I left behind was dull, and I don't regret trading it for one of adventure."
+								],
+								[
+									"4",
+									"I judge people by how they treat others, rather than by what they say or how they appear."
+								],
+								[
+									"5",
+									"I joke about my condition as if it doesn't matter to me."
+								],
+								[
+									"6",
+									"It's not all bad. I love flying and exploring new places!"
+								],
+								[
+									"7",
+									"I get angry easily, and afterwards, I can't help but be a little afraid of myself."
+								],
+								[
+									"8",
+									"I must battle this monster I've become, lest I slip and hurt someone I care for."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Ideal"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"Confrontation. I adventure to make the world a safer place, and to exorcise my own demons. (Good)"
+								],
+								[
+									"2",
+									"Progress. We must advance our knowledge for the good of the world, even of darker subjects. (Lawful)"
+								],
+								[
+									"3",
+									"Self-Determination. Everyone should be free to make their own choices, be they good or bad. (Chaotic)"
+								],
+								[
+									"4",
+									"Depravity. I've seen what one dark ritual can do, and I harbor an unshakable hunger to know more. (Evil)"
+								],
+								[
+									"5",
+									"Change. Life is constant change, and I will learn to adapt to any circumstance. (Neutral)"
+								],
+								[
+									"6",
+									"Destiny. I believe that my circumstances are a road to be traveled, and that my journey has just started. (Any)"
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Bond"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I seek to undo what's been done to me, and will pursue a way to do so by any means necessary."
+								],
+								[
+									"2",
+									"I got to know one of my captor's other captives. They didn't survive, and I now seek to carry on their legacy."
+								],
+								[
+									"3",
+									"Though I didn't have a choice, my captor wasn't so bad after all, and I now work for them."
+								],
+								[
+									"4",
+									"I miss my family, but I can't face them like this."
+								],
+								[
+									"5",
+									"The few people who are nice to me are like a beacon of hope. They matter more than anything else."
+								],
+								[
+									"6",
+									"I stick up for anyone who is treated poorly."
+								]
+							]
+						},
+						{
+							"type": "table",
+							"colLabels": [
+								"d6",
+								"Flaw"
+							],
+							"colStyles": [
+								"col-1 text-center",
+								"col-11"
+							],
+							"rows": [
+								[
+									"1",
+									"I don't trust people easily."
+								],
+								[
+									"2",
+									"I feel like I don't deserve to go on when there are so many others who didn't make it."
+								],
+								[
+									"3",
+									"I will shout loudly at anyone who makes mean comments about my form until they shut up."
+								],
+								[
+									"4",
+									"Others are afraid of me now. I like that."
+								],
+								[
+									"5",
+									"I've never felt more distanced from others, and sometimes I will cry myself to sleep in loneliness."
+								],
+								[
+									"6",
+									"I always expect the worst from others. I am genuinely surprised when they occasionally prove me wrong."
+								]
+							]
+						}
+					]
+				}
+			],
+			"hasFluff": true
+		}
+	]
+}


### PR DESCRIPTION
Adopt the form of a dragon with this race-class combination for the world's greatest roleplaying game

This content includes a class, a race that goes with the class, eight subclasses, aswell as supplemental items, feats, spells, and backgrounds. It is a feature-complete and thoroughly reviewed and playtested option that makes it possible to play a balanced dragon PC—crucially without being a pain to the DM or the other players in the process. 