### PR TITLE
Fix typos in johnofbohemia; Witcher Class.json

### DIFF
--- a/class/johnofbohemia; Witcher Class.json
+++ b/class/johnofbohemia; Witcher Class.json
@@ -367,7 +367,7 @@
 						"Salts worth 10gp"
 					]
 				},
-				"When lobbed up to 30 feet as an action, the bomb detonates dealing {@duce 2d6} fire damage to each creature within a 10 foot radius, or half as much damage on a successful DC 14 Dexterity saving throw. The bomb creates a 10 foot radius patch of fire, dealing {@dice 1d6} fire damage to creatures that enter it or start their turn in it. The fire lasts 1 minute or until extinguished."
+				"When lobbed up to 30 feet as an action, the bomb detonates dealing {@dice 2d6} fire damage to each creature within a 10 foot radius, or half as much damage on a successful DC 14 Dexterity saving throw. The bomb creates a 10 foot radius patch of fire, dealing {@dice 1d6} fire damage to creatures that enter it or start their turn in it. The fire lasts 1 minute or until extinguished."
 			]
 		},
 		{
@@ -452,7 +452,7 @@
 						"Salts worth 5gp, herbs worth 5gp"
 					]
 				},
-				"When lobbed up to 30 feet as an action, the bomb detonates in a bright flash. Creatures within 10 feet of the explosion take {@dice 1d8} radiant damage and must make a DC 14 Constitution saving throw or be {@conditioning blinded} until the end of their next turn."
+				"When lobbed up to 30 feet as an action, the bomb detonates in a bright flash. Creatures within 10 feet of the explosion take {@dice 1d8} radiant damage and must make a DC 14 Constitution saving throw or be {@condition blinded} until the end of their next turn."
 			]
 		}
 	],


### PR DESCRIPTION
- `@duce` -> `@dice`
- `@conditioning` -> `@condition`