### PR TITLE
Fix typo in Ghostfire Gaming; Grim Hollow Campaign Guide

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
@@ -12360,7 +12360,7 @@
 				"reqAttune": true,
 				"entries": [
 					"Another deadly invention, but not by gnomes, Shadow Steel is said to require souls to be produced. According to rumours, the souls are torn into pieces using dark spells and transformed into a raw spiritual essence of pain, which takes a pitch-black sheen reflecting no light. Weapons made from it cannot be resisted by conventional metals. They cut through the spiritual essence of living flesh, discharging excruciating pain into the victim. The rare survivors of these weapons report levels of pain that can render a person inert for hours.",
-					"When weilding a weapon made of Shadow Steel, you have advantage on attack rolls made against any target wearing medium or heavy armour. A creature hit by a Shadow Steel Blade must make a DC 14 Constitution saving throw, becoming {@condition stunned} until the end of its next turn on a failed save."
+					"When wielding a weapon made of Shadow Steel, you have advantage on attack rolls made against any target wearing medium or heavy armour. A creature hit by a Shadow Steel Blade must make a DC 14 Constitution saving throw, becoming {@condition stunned} until the end of its next turn on a failed save."
 				]
 			}
 		}


### PR DESCRIPTION
"weilding" --> "wielding" in Shadow Steel weapon
![image](https://user-images.githubusercontent.com/111462580/193338744-82898967-b6e1-44d7-8195-e3a7d8ad528a.png)
