### PR TITLE
Bugfix: Missing Curly Bracket ( } ) on line 235

### DIFF
--- a/subclass/PosTavern; Artificer Specialist - Caravaneer.json
+++ b/subclass/PosTavern; Artificer Specialist - Caravaneer.json
@@ -232,7 +232,7 @@
 						],
 						[
 							"5th",
-							"{@spell cordon of arrows, {@spell prayer of healing}"
+							"{@spell cordon of arrows}, {@spell prayer of healing}"
 						],
 						[
 							"9th",


### PR DESCRIPTION
Missing curly bracket on line 235 causes an error when hovering over or clicking on the Cordon of Arrows spell and the Prayer of Healing spell.