### PR TITLE
Adds Web spell link to "Abiding Webs" spell desc

### DIFF
--- a/spell/Frog God Games; Book of Lost Spells.json
+++ b/spell/Frog God Games; Book of Lost Spells.json
@@ -60,7 +60,7 @@
 				]
 			},
 			"entries": [
-				"You create a 20-foot cube of sticky webs at a point you can see. Abiding webs works identically to web, except as noted otherwise.",
+				"You create a 20-foot cube of sticky webs at a point you can see. Abiding webs works identically to {@spell web}, except as noted otherwise.",
 				"These webs are crawling with tiny, harmless spiders. Damage to the web is repaired by the spiders that live in it, at the rate of one 5-foot cube per round (125 cubic feet; the entire volume of the webs can be sixteen times this size). This repair occurs on initiative count 20. If the webs are completely destroyed, the spell ends. The spiders themselves are immortal and need neither air nor food to survive; the magic of the spell produces more spiders as needed."
 			],
 			"miscTags": [


### PR DESCRIPTION
I saw the [Abiding Webs](https://5etools-mirror-1.github.io/spells.html#abiding%20webs_bols) spell the other day and noticed the description references the [Web](https://5etools-mirror-1.github.io/spells.html#web_phb) spell, yet it doesn't link to the web spell itself. This change should (theoretically) create a link to the web spell.

I also don't really do the code thing that much, so I just looked at the files and how they did things, and I -think- this is the correct way to do what I want to do. Hopefully I didn't make any mistakes. Thanks!

BeAuMaN#1025 on 5eTools discord.