### PR TITLE
LaserLlama's Alt Ranger Update 3.7.1 -> 3.8.1

### DIFF
--- a/ProfForp and Ignimortis; LaserLlama's Alternate Ranger.json
+++ b/ProfForp and Ignimortis; LaserLlama's Alternate Ranger.json
@@ -1,0 +1,5095 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "LLAR",
+				"abbreviation": "LLAR",
+				"full": "Alternate Ranger",
+				"authors": [
+					"LaserLlama"
+				],
+				"convertedBy": [
+					"ProfForp#0242",
+					"Ignimortis#8570"
+
+				],
+				"color": "2BAE2A",
+				"version": "3.8.1",
+				"url": "https://www.gmbinder.com/share/-M7iu19Af89SH2G_5RGa",
+				"targetSchema": "1.1.0"
+			},
+			{
+				"json": "LLAR:E",
+				"abbreviation": "LLAR:E",
+				"full": "Alternate Ranger Expanded",
+				"authors": [
+					"LaserLlama"
+				],
+				"convertedBy": [
+					"ProfForp#0242",
+					"Ignimortis#8570"
+				],
+				"color": "2BAE2A",
+				"version": "3.8.1",
+				"url": "https://www.gmbinder.com/share/-MW4c30CbGMWLRNgJxgb",
+				"targetSchema": "1.1.0"
+			}
+		],
+		"dependencies": {
+			"spell": [
+				"PHB",
+				"XGE",
+				"TCE"
+			]
+		},
+		"optionalFeatureTypes": {
+			"FS:AR": "Fighting Style; Alternate Ranger",
+			"LL:SK": "Survivalist Knacks"
+		},
+		"dateAdded": 1671459763455,
+		"dateLastModified": 1671459763455,
+		"_dateLastModifiedHash": "412bf9cbbe"
+	},
+	"class": [
+		{
+			"name": "Ranger (Alternate)",
+			"source": "LLAR",
+			"fluff": [
+				{
+					"name": "Alternate Ranger",
+					"type": "section",
+					"source": "LLAR",
+					"entries": [
+						"As the graying man made his way through the underbrush of the forest his faded green cloak made him nearly invisible. The exceptionally large troll he had been stalking through the night had finally stopped to rest. As the great brute laid down to sleep, a silent green shape emerged from the trees to snuff out the life of the hideous monster.",
+						"As the massive blue dragon descended upon the small town, a small half-elven man rolled out of the path of a blast of lightning. With the small hairs on the back of their neck still standing up from the residual electricity, the practiced hunter knocked an arrow and let it fly in the direction of the terrible beast. As the biting dart struck true, the azure dragon let out a horrible roar and plummeted to the ground where it lay in a broken heap.",
+						"As the massive owlbear slowly lumbered toward the tiny hamlet that she called home, a small halfling girl whistled to her companion in the brush. At her signal, a giant hound that seemed to be more fur then anything else, leaped out from hiding and stood defiantly in front of the owlbear. Distracted by her partner, the owlbear was caught completely unawares by the diminutive ranger. Once their foe was unconscious, the halfling and her dog released the great owlbear miles away where it could live without menacing the town they protected.",
+						"The three adventurers described above are considered Rangers, wild warriors and defenders of the natural world."
+					]
+				},
+				{
+					"name": "Defenders of Balance",
+					"type": "section",
+					"source": "LLAR",
+					"entries": [
+						"Rangers spend their lives between two worlds. On one hand they stand as guardians of civilization, protecting those who dwell on the edges of society. On the other, rangers are expert survivalists, deeply acquainted with the flora and fauna of the natural world. Rangers protect the balance between society and the wilderness. When wild creatures wander from their natural habitat, rangers will track them down before they can harm innocent farmers and travelers. When people encroach upon the wilderness, rangers will push back against industry and expansion that doesn't respect the natural balance.",
+						"Rangers dedicate their lives to guarding the places where civilization and the wilderness meet, never fully joining either of the worlds that they spend their lives defending."
+					]
+				},
+				{
+					"name": "Prepared for Anything",
+					"type": "section",
+					"source": "LLAR",
+					"entries": [
+						"Ready to face any challenge, rangers are survivalists at their core. The wilderness is a harsh place, and those who cannot adapt to their surroundings will die. In the wild, rangers learn to be adaptable. Drawing on their knowledge of the natural world, their connection to primal magic, and the skills passed down to them by their mentors, there is rarely a challenge a ranger cannot overcome with enough time to prepare.",
+						"Each ranger has their own philosophy on how they fit into the interconnected web that is the natural world. Some view themselves as apex predators, using their martial skill and ruthless hunting abilities to keep the wild in line. Others see themselves as humble servants of nature that serve the wild."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Creating Your Ranger",
+					"source": "LLAR",
+					"entries": [
+						"Consider the nature of your ranger's training. Did you train with a mentor, wandering the wilds together, learning all you could? Or did you forge your primal connection to the natural world on your own? What is it that motivates your ranger? Do you have a vendetta against a certain type of monster? Are you a warrior of the wild who feels more comfortable in the silence of the forest then in city streets or sleepy towns?",
+						"No matter their origin, almost all rangers take up a life of adventuring to impart their knowledge of the wild to the next generation. Often, in their later years, these wild warriors will take on an apprentice, passing on all they know and so that the safety of the wilderness is secured for years to come.",
+						{
+							"type": "entries",
+							"name": "Quick Build",
+							"entries": [
+								"You can make a ranger quickly by using these suggestions. First, make Dexterity your highest ability score, followed by your Wisdom. Second, choose the {@background outlander} background."
+							]
+						}
+					]
+				}
+			],
+			"hd": {
+				"number": 1,
+				"faces": 10
+			},
+			"proficiency": [
+				"str",
+				"dex"
+			],
+			"startingProficiencies": {
+				"armor": [
+					"light",
+					"medium",
+					"{@item shield|phb|shields}"
+				],
+				"weapons": [
+					"simple",
+					"martial"
+				],
+				"skills": [
+					{
+						"choose": {
+							"from": [
+								"animal handling",
+								"athletics",
+								"history",
+								"insight",
+								"investigation",
+								"medicine",
+								"nature",
+								"perception",
+								"stealth",
+								"survival"
+							],
+							"count": 3
+						}
+					}
+				]
+			},
+			"startingEquipment": {
+				"additionalFromBackground": true,
+				"default": [
+					"(a) {@item chain shirt|phb} and a {@item shield|phb} or (b) {@item leather armor|phb}",
+					"(a) two {@item shortsword|phb|shortswords} or (b) two {@filter simple melee weapons|items|source=phb|category=basic|type=simple weapon;melee weapon=sand}",
+					"(a) a {@item longbow|phb} and a {@item quiver|phb} of {@item arrows (20)|phb|20 arrows} or (b) a {@filter martial weapon|items|source=phb|category=basic|type=martial weapon}",
+					"(a) a {@item dungeoneer's pack|phb} or (b) an {@item explorer's pack|phb}"
+				],
+				"defaultData": [
+					{
+						"a": [
+							"chain shirt|phb",
+							"shield|phb"
+						],
+						"b": [
+							"leather armor|phb"
+						]
+					},
+					{
+						"a": [
+							{
+								"item": "shortsword|phb",
+								"quantity": 2
+							}
+						],
+						"b": [
+							{
+								"equipmentType": "weaponSimpleMelee",
+								"quantity": 2
+							}
+						]
+					},
+					{
+						"a": [
+							"longbow|phb",
+							"arrows (20)|phb"
+						],
+						"b": [
+							{
+								"equipmentType": "weaponMartial"
+							}
+						]
+					},
+					{
+						"a": [
+							"dungeoneer's pack|phb"
+						],
+						"b": [
+							"explorer's pack|phb"
+						]
+					}
+				]
+			},
+			"multiclassing": {
+				"requirements": {
+					"wis": 13,
+					"or": [
+						{
+							"str": 13,
+							"dex": 13
+						}
+					]
+				},
+				"proficienciesGained": {
+					"armor": [
+						"light",
+						"medium",
+						"{@item shield|phb|shields}"
+					],
+					"skills": [
+						{
+							"choose": {
+								"from": [
+									"animal handling",
+									"athletics",
+									"history",
+									"insight",
+									"investigation",
+									"medicine",
+									"nature",
+									"perception",
+									"stealth",
+									"survival"
+								],
+								"count": 1
+							}
+						}
+					],
+					"weapons": [
+						"simple",
+						"martial"
+					]
+				}
+			},
+			"classFeatures": [
+				"Survivalist Knacks|Ranger (Alternate)|LLAR|1",
+				"Wilderness Expertise|Ranger (Alternate)|LLAR|1",
+				"Fighting Style|Ranger (Alternate)|LLAR|2",
+				"Favored Foe|Ranger (Alternate)|LLAR|2",
+				"Spellcasting|Ranger (Alternate)|LLAR|2",
+				{
+					"classFeature": "Ranger Archetype|Ranger (Alternate)|LLAR|3",
+					"gainSubclassFeature": true
+				},
+				"Ability Score Improvement|Ranger (Alternate)|LLAR|4",
+				"Extra Attack|Ranger (Alternate)|LLAR|5",
+				"Favored Foe Improvement|Ranger (Alternate)|LLAR|6",
+				{
+					"classFeature": "Ranger Archetype Feature|Ranger (Alternate)|LLAR|7",
+					"gainSubclassFeature": true
+				},
+				"Ability Score Improvement|Ranger (Alternate)|LLAR|8",
+				"Wilderness Expertise|Ranger (Alternate)|LLAR|9",
+				"Favored Foe Improvement|Ranger (Alternate)|LLAR|10",
+				"Adaptable|Ranger (Alternate)|LLAR|11",
+				{
+					"classFeature": "Ranger Archetype Feature|Ranger (Alternate)|LLAR|11",
+					"gainSubclassFeature": true
+				},
+				"Ability Score Improvement|Ranger (Alternate)|LLAR|12",
+				"Favored Foe Improvement|Ranger (Alternate)|LLAR|14",
+				{
+					"classFeature": "Ranger Archetype Feature|Ranger (Alternate)|LLAR|15",
+					"gainSubclassFeature": true
+				},
+				"Ability Score Improvement|Ranger (Alternate)|LLAR|16",
+				"Favored Foe Improvement|Ranger (Alternate)|LLAR|18",
+				"Feral Senses|Ranger (Alternate)|LLAR|18",
+				"Ability Score Improvement|Ranger (Alternate)|LLAR|19",
+				"Foe Slayer|Ranger (Alternate)|LLAR|20"
+			],
+			"subclassTitle": "Ranger Archetype",
+			"classTableGroups": [
+				{
+					"colLabels": [
+						"Favored Foe",
+						"{@filter 1st|spells|level=1|class=Ranger (LLAR)}",
+						"{@filter 2nd|spells|level=2|class=Ranger (LLAR)}",
+						"{@filter 3rd|spells|level=3|class=Ranger (LLAR)}",
+						"{@filter 4th|spells|level=4|class=Ranger (LLAR)}",
+						"{@filter 5th|spells|level=5|class=Ranger (LLAR)}",
+						"{@filter Knacks Known|optionalfeatures|feature type=LL:SK}"
+					],
+					"rows": [
+						[
+							"-",
+							"-",
+							"-",
+							"-",
+							"-",
+							"-",
+							"2"
+						],
+						[
+							"d4",
+							"2",
+							"-",
+							"-",
+							"-",
+							"-",
+							"2"
+						],
+						[
+							"d4",
+							"3",
+							"-",
+							"-",
+							"-",
+							"-",
+							"3"
+						],
+						[
+							"d4",
+							"3",
+							"-",
+							"-",
+							"-",
+							"-",
+							"3"
+						],
+						[
+							"d4",
+							"4",
+							"2",
+							"-",
+							"-",
+							"-",
+							"3"
+						],
+						[
+							"d6",
+							"4",
+							"2",
+							"-",
+							"-",
+							"-",
+							"4"
+						],
+						[
+							"d6",
+							"4",
+							"3",
+							"-",
+							"-",
+							"-",
+							"4"
+						],
+						[
+							"d6",
+							"4",
+							"3",
+							"-",
+							"-",
+							"-",
+							"4"
+						],
+						[
+							"d6",
+							"4",
+							"3",
+							"2",
+							"-",
+							"-",
+							"5"
+						],
+						[
+							"d8",
+							"4",
+							"3",
+							"2",
+							"-",
+							"-",
+							"5"
+						],
+						[
+							"d8",
+							"4",
+							"3",
+							"3",
+							"-",
+							"-",
+							"5"
+						],
+						[
+							"d8",
+							"4",
+							"3",
+							"3",
+							"-",
+							"-",
+							"6"
+						],
+						[
+							"d8",
+							"4",
+							"3",
+							"3",
+							"1",
+							"-",
+							"6"
+						],
+						[
+							"d10",
+							"4",
+							"3",
+							"3",
+							"1",
+							"-",
+							"7"
+						],
+						[
+							"d10",
+							"4",
+							"3",
+							"3",
+							"2",
+							"-",
+							"7"
+						],
+						[
+							"d10",
+							"4",
+							"3",
+							"3",
+							"2",
+							"-",
+							"8"
+						],
+						[
+							"d10",
+							"4",
+							"3",
+							"3",
+							"3",
+							"1",
+							"8"
+						],
+						[
+							"d12",
+							"4",
+							"3",
+							"3",
+							"3",
+							"1",
+							"9"
+						],
+						[
+							"d12",
+							"4",
+							"3",
+							"3",
+							"3",
+							"2",
+							"9"
+						],
+						[
+							"d12",
+							"4",
+							"3",
+							"3",
+							"3",
+							"2",
+							"10"
+						]
+					]
+				}
+			],
+			"spellcastingAbility": "wis",
+			"casterProgression": "1/2",
+			"classSpells": [
+				"absorb elements|xge",
+				"alarm",
+				"animal friendship",
+				"beast bond|xge",
+				"cure wounds",
+				"detect magic",
+				"detect poison and disease",
+				"ensnaring strike",
+				"entangle",
+				"expeditious retreat",
+				"fog cloud",
+				"goodberry",
+				"hail of thorns",
+				"jump",
+				"longstrider",
+				"purify food and drink",
+				"searing smite",
+				"snare|xge",
+				"speak with animals",
+				"zephyr strike|xge",
+				"aid",
+				"animal messenger",
+				"barkskin",
+				"beast sense",
+				"continual flame",
+				"cordon of arrows",
+				"darkvision",
+				"enhance ability",
+				"find traps",
+				"gust of wind",
+				"healing spirit|xge",
+				"lesser restoration",
+				"locate animals or plants",
+				"locate object",
+				"magic weapon",
+				"pass without trace",
+				"protection from poison",
+				"silence",
+				"spike growth",
+				"summon beast|tce",
+				"blinding smite",
+				"conjure animals",
+				"conjure barrage",
+				"daylight",
+				"dispel magic",
+				"elemental weapon",
+				"flame arrows|xge",
+				"leomund's tiny hut",
+				"lightning arrow",
+				"meld into stone",
+				"nondetection",
+				"plant growth",
+				"revivify",
+				"speak with plants",
+				"summon fey|tce",
+				"water breathing",
+				"water walk",
+				"wind wall",
+				"conjure woodland beings",
+				"death ward",
+				"divination",
+				"dominate beast",
+				"freedom of movement",
+				"grasping vine",
+				"guardian of nature|xge",
+				"locate creature",
+				"staggering smite",
+				"stoneskin",
+				"summon elemental|tce",
+				"awaken",
+				"commune with nature",
+				"conjure volley",
+				"contagion",
+				"greater restoration",
+				"steel wind strike|xge",
+				"swift quiver",
+				"tree stride",
+				"wrath of nature|xge"
+			]
+		}
+	],
+	"classFeature": [
+		{
+			"name": "Survivalist Knacks",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 1,
+			"entries": [
+				"In the wild you have gathered bits of primal knowledge that bolster your exploration, hunting, and tracking skills, known as {@filter Survivalist Knacks|optionalfeatures|feature type=LL:SK}. At 1st level, you learn two Knacks of your choice from the list at the end of this class description.",
+				"You learn additional Knacks as you gain ranger levels, as shown in the Knacks Known column on the Ranger table.",
+				"Each time you gain a level in this class, you can choose one of the Knacks you know and replace it with another Knack of your choice for which you meet the prerequisites."
+			]
+		},
+		{
+			"name": "Wilderness Expertise",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 1,
+			"entries": [
+				"Your skill in the wild is without peer. At 1st level, choose one of your skill proficiencies you gained from the ranger class skill list. Your proficiency bonus is doubled for any ability check you make that uses that skill. You also learn to speak, read, and write one additional language of your choice. Most rangers learn the language spoken by the enemies they hunt.",
+				"At 9th level, you select another Ranger class skill you are proficient in to gain the benefits of this feature, and you learn to speak, read, and write another language of your choice."
+			]
+		},
+		{
+			"name": "Fighting Style",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 2,
+			"entries": [
+				"Your skill in battle surpasses that of most warriors. At 2nd level you gain a Fighting Style of your choice from the list below. You can't learn a Fighting Style more than once, even if another feature allows you to learn another Fighting Style.",
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Archery|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Defensive Fighting|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Druidic Warrior|LLAR:E"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Dual Wielding|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Dueling|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Featherweight Fighting|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Marine Fighting|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Melee Marksman|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Mountaineer|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Mounted Warrior|LLAR:E"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Protection|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Strongbow|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Thrown Weapon Fighting|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Versatile Fighting|LLAR"
+				},
+				{
+					"type": "refOptionalfeature",
+					"optionalfeature": "Unarmed Fighting|LLAR:E"
+				},
+				{
+					"type": "inset",
+					"name": "Additional Fighting Styles",
+					"entries": [
+						"The Alternate Ranger class is compatible with all official Fighting Styles found in published content."
+					]
+				}
+			]
+		},
+		{
+			"name": "Favored Foe",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 2,
+			"entries": [
+				"You hunt as the creatures of the wild. Beginning at 2nd level, you can use a bonus action to mark a creature you can see as your Favored Foe, granting you the benefits below for 1 hour, until the creature is slain, or you mark another creature:",
+				{
+					"type": "list",
+					"items": [
+						"Each time you hit the creature with a weapon attack you deal bonus damage equal to your Favored Foe die. This die begins as d4 and changes as you gain Ranger levels, as shown in the Favored Foe column of the Ranger table.",
+						"You have advantage on Wisdom (Perception) and Wisdom (Survival) checks you make to locate or track the creature."
+					]
+				},
+				"You can mark a creature this way a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest. If you have no uses of this feature remaining, you can expend a spell slot of 1st-level or higher to use this feature one additional time.",
+				"At certain Ranger levels, the duration of your Favored Foe mark increases: at 6th level (8 hours), 10th level (24 hours), 14th level (1 week), and finally at 17th level (indefinite)."
+			]
+		},
+		{
+			"name": "Spellcasting",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 2,
+			"entries": [
+				"Also at 2nd level, you learn to draw upon the primal magic of the natural world to enhance your survival and combat skills.",
+				{
+					"type": "entries",
+					"name": "Preparing and Casting Spells",
+					"entries": [
+						"The Ranger table above shows how many spell slots you have to cast spells. To cast a {@filter ranger spell|spells|class=Ranger (LLAR)} of 1st-level or higher, you must expend a slot of the spell's level or higher. You regain all of your expended spell slots when you finish a long rest.",
+						"At the end of each long rest, you prepare a list of spells that are available for you to cast. Choose a number of spells equal to your Wisdom modifier + half Ranger level, rounded down. The spells must all be from the Ranger spell list at the end of this class, and be of a level for which you have spell slots.",
+						"For example, as a 5th level ranger with 14 Wisdom, you can prepare any four spells of 1st or 2nd-level and cast each spell any number of times by using a 1st or 2nd-level slot."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Ability",
+					"entries": [
+						"Wisdom is your spellcasting ability for Ranger spells as you draw magic from your connection to nature. You use your Wisdom when a Ranger spell refers to your spellcasting ability, and you use your Wisdom modifier whenever you set the saving throw DC or make a spell attack roll for one of your Ranger spells.",
+						{
+							"type": "abilityDc",
+							"name": "Spell",
+							"attributes": [
+								"wis"
+							]
+						},
+						{
+							"type": "abilityAttackMod",
+							"name": "Spell",
+							"attributes": [
+								"wis"
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Focus",
+					"entries": [
+						"You can use a druidic focus as a spellcasting focus for your ranger spells. See the Player's Handbook for examples."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Ritual Casting",
+					"entries": [
+						"Your knowledge of the natural world allows you to draw out its innate magic. You can cast a ranger spell as a ritual if that spell has the ritual tag and you have the spell prepared."
+					]
+				}
+			]
+		},
+		{
+			"name": "Ranger Archetype",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"At 3rd level, you choose an Archetype from the list below that best represents the training and skills of your Ranger: Beast Master, Hunter, Spellbreaker, or Shadowbane.",
+				"The Ranger Archetype you choose grants you features at 3rd level, and again when you reach 7th, 11th, and 15th level.",
+				"Additionally, each Ranger Archetype has a list of Archetype Spells that you always have prepared once you reach the Ranger levels noted in your Archetype's description. Your Archetype Spells count as Ranger spells for you, but they do not count against your total number of spells that you can prepare each day."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 4,
+			"entries": [
+				"When you reach 4th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+				"If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+			]
+		},
+		{
+			"name": "Extra Attack",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 5,
+			"entries": [
+				"Beginning at 5th level, you can attack twice, instead of once, whenever you take the {@action Attack} action on your turn."
+			]
+		},
+		{
+			"name": "Favored Foe Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 6,
+			"entries": [
+				"At 6th level, your Favored Foe mark can last up to 8 hours."
+			]
+		},
+		{
+			"name": "Ranger Archetype Feature",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 7,
+			"entries": [
+				"At 7th level, you gain a feature granted by your Ranger Archetype."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 8,
+			"entries": [
+				"When you reach 8th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+				"If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+			]
+		},
+		{
+			"name": "Wilderness Expertise",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 9,
+			"entries": [
+				"At 9th level, you select another ranger class skill you are proficient in to gain the benefits of this feature, and you learn to speak, read, and write another language of your choice."
+			]
+		},
+		{
+			"name": "Favored Foe Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 10,
+			"entries": [
+				"At 10th level, your Favored Foe mark can last up to 8 hours."
+			]
+		},
+		{
+			"name": "Ranger Archetype Feature",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 11,
+			"entries": [
+				"At 11th level, you gain a feature granted by your Ranger Archetype."
+			]
+		},
+		{
+			"name": "Adaptable",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 11,
+			"entries": [
+				"Your time in the wilderness has taught you that anything that doesn't change dies. Starting at 11th level, when you finish a long rest, you can replace one {@filter Knack|optionalfeatures|feature type=LL:SK} you know with another Knack of your choice, so long as you meet its prerequisites."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 12,
+			"entries": [
+				"When you reach 12th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+				"If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+			]
+		},
+		{
+			"name": "Favored Foe Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 14,
+			"entries": [
+				"At 14th level, your Favored Foe mark can last up to 1 week."
+			]
+		},
+		{
+			"name": "Ranger Archetype Feature",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 15,
+			"entries": [
+				"At 15th level, you gain a feature granted by your Ranger Archetype."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 16,
+			"entries": [
+				"When you reach 16th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+				"If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+			]
+		},
+		{
+			"name": "Favored Foe Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 17,
+			"entries": [
+				"At 17th level, your Favored Foe mark can last indefinitely."
+			]
+		},
+		{
+			"name": "Feral Senses",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 18,
+			"entries": [
+				"You hunt as an apex predator, never losing track of your prey. Starting at 18th level, you cannot have disadvantage on any attack roll you make that targets a creature within 30 feet of you or a creature that is marked as your Favored Foe."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 19,
+			"entries": [
+				"When you reach 19th level, you can increase one ability score of your choice by 2, or two ability scores by 1. As normal, you can't increase one of your ability scores above 20 using this feature.",
+				"If your DM allows the use of feats, you may instead take a {@5etools feat|feats.html}."
+			]
+		},
+		{
+			"name": "Foe Slayer",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"level": 20,
+			"entries": [
+				"You are a Ranger of mythic skill, rivaling the great huntsmen of legend. At 20th level, when you hit your Favored Foe with a weapon attack, you can immediately end the mark and cause that attack to deal maximum damage instead of rolling.",
+				"If the damage from this attack reduces the target to 50 hit points or fewer, it is instantly reduced to 0 hit points.",
+				"Once you use this feature you must finish a short or long rest before you can use it again."
+			]
+		}
+	],
+	"subclass": [
+		{
+			"name": "Beast Master",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Beast Master",
+			"subclassFeatures": [
+				"Beast Master|Ranger (Alternate)|LLAR|Beast Master|LLAR|3",
+				"Exceptional Training|Ranger (Alternate)|LLAR|Beast Master|LLAR|7",
+				"Bestial Fury|Ranger (Alternate)|LLAR|Beast Master|LLAR|11",
+				"Primal Bond|Ranger (Alternate)|LLAR|Beast Master|LLAR|15"
+			],
+			"subclassSpells": [
+				"beast bond|xge",
+				"speak with animals",
+				"beast sense",
+				"warding bond",
+				"haste",
+				"protection from energy",
+				"death ward",
+				"freedom of movement",
+				"awaken",
+				"commune with nature"
+			]
+		},
+		{
+			"name": "Hunter",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Hunter",
+			"subclassFeatures": [
+				"Hunter|Ranger (Alternate)|LLAR|Hunter|LLAR|3",
+				"Defensive Tactics|Ranger (Alternate)|LLAR|Hunter|LLAR|7",
+				"Flexible Hunter|Ranger (Alternate)|LLAR|Hunter|LLAR|11",
+				"Multiattack|Ranger (Alternate)|LLAR|Hunter|LLAR|11",
+				"Superior Hunter's Defense|Ranger (Alternate)|LLAR|Hunter|LLAR|15"
+			],
+			"subclassSpells": [
+				"expeditious retreat",
+				"snare|xge",
+				"cordon of arrows",
+				"pass without trace",
+				"conjure barrage",
+				"nondetection",
+				"freedom of movement",
+				"locate creature",
+				"conjure volley",
+				"swift quiver"
+			]
+		},
+		{
+			"name": "Spellbreaker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Spellbreaker",
+			"subclassFeatures": [
+				"Spellbreaker|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3",
+				"Arcane Defense|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|7",
+				"Mage Breaker|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|11",
+				"Mantle of the Master|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|15"
+			],
+			"subclassSpells": [
+				"absorb elements|xge",
+				"detect magic",
+				"blindness/deafness",
+				"silence",
+				"counterspell",
+				"dispel magic",
+				"arcane eye",
+				"otiluke's resilient sphere",
+				"dispel evil and good",
+				"wall of force"
+			]
+		},
+		{
+			"name": "Shadowbane",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Shadowbane",
+			"subclassFeatures": [
+				"Shadowbane|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3",
+				"Iron Focus|Ranger (Alternate)|LLAR|Shadowbane|LLAR|7",
+				"Bane of Darkness|Ranger (Alternate)|LLAR|Shadowbane|LLAR|11",
+				"Ruthless Counter|Ranger (Alternate)|LLAR|Shadowbane|LLAR|15"
+			],
+			"subclassSpells": [
+				"compelled duel",
+				"protection from evil and good",
+				"see invisibility",
+				"zone of truth",
+				"magic circle",
+				"protection from energy",
+				"banishment",
+				"mordenkainen's faithful hound",
+				"dispel evil and good",
+				"hold monster"
+			]
+		},
+		{
+			"name": "Gloom Stalker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Gloom Stalker",
+			"subclassFeatures": [
+				"Gloom Stalker|Ranger (Alternate)|LLAR|Gloom Stalker|LLAR|3",
+				"Iron Mind|Ranger|PHB|Gloom Stalker|XGE|7",
+				"Stalker's Flurry|Ranger|PHB|Gloom Stalker|XGE|11",
+				"Shadowy Dodge|Ranger|PHB|Gloom Stalker|XGE|15"
+			],
+			"subclassSpells": [
+				"cause fear|xge",
+				"disguise self",
+				"darkness",
+				"rope trick",
+				"fear",
+				"nondetection",
+				"greater invisibility",
+				"phantasmal killer",
+				"mislead",
+				"seeming"
+			]
+		},
+		{
+			"name": "Horizon Walker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Horizon Walker",
+			"subclassFeatures": [
+				"Horizon Walker|Ranger (Alternate)|LLAR|Horizon Walker|LLAR|3",
+				"Ethereal Step|Ranger|PHB|Horizon Walker|XGE|7",
+				"Distant Strike|Ranger|PHB|Horizon Walker|XGE|11",
+				"Spectral Defense|Ranger|PHB|Horizon Walker|XGE|15"
+			],
+			"subclassSpells": [
+				"alarm",
+				"protection from evil and good",
+				"misty step",
+				"rope trick",
+				"haste",
+				"magic circle",
+				"banishment",
+				"dimension door",
+				"banishing smite",
+				"teleportation circle"
+			]
+		},
+		{
+			"name": "Fey Wanderer",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Fey Wanderer",
+			"subclassFeatures": [
+				"Fey Wanderer|Ranger (Alternate)|LLAR|Fey Wanderer|LLAR|3",
+				"Beguiling Twist|Ranger|PHB|Fey Wanderer|TCE|7",
+				"Fey Reinforcements|Ranger|PHB|Fey Wanderer|TCE|11",
+				"Misty Wanderer|Ranger|PHB|Fey Wanderer|TCE|15"
+			],
+			"subclassSpells": [
+				"cause fear|xge",
+				"charm person",
+				"enthrall",
+				"misty step",
+				"dispel magic",
+				"fear",
+				"charm monster|xge",
+				"dimension door",
+				"geas",
+				"mislead"
+			]
+		},
+		{
+			"name": "Swarmkeeper",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Swarmkeeper",
+			"subclassFeatures": [
+				"Swarmkeeper|Ranger (Alternate)|LLAR|Swarmkeeper|LLAR|3",
+				"Writhing Tide|Ranger|PHB|Swarmkeeper|TCE|7",
+				"Mighty Swarm|Ranger|PHB|Swarmkeeper|TCE|11",
+				"Swarming Dispersal|Ranger|PHB|Swarmkeeper|TCE|15"
+			],
+			"subclassSpells": [
+				"mage hand",
+				"entangle",
+				"faerie fire",
+				"spider climb",
+				"web",
+				"fly",
+				"gaseous form",
+				"arcane eye",
+				"giant insect",
+				"bigby's hand",
+				"insect plague"
+			]
+		},
+		{
+			"name": "Drakewarden",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Drakewarden",
+			"subclassFeatures": [
+				"Drakewarden|Ranger|PHB|Drakewarden|FTD|3",
+				"Drakewarden Spells|Ranger (Alternate)|LLAR|Drakewarden|LLAR|3",
+				"Bond of Fang and Scale|Ranger|PHB|Drakewarden|FTD|7",
+				"Drake's Breath|Ranger|PHB|Drakewarden|FTD|11",
+				"Perfected Bond|Ranger|PHB|Drakewarden|FTD|15"
+			],
+			"subclassSpells": [
+				"thaumaturgy",
+				"absorb elements|xge",
+				"command",
+				"dragon's breath|xge",
+				"warding bond",
+				"elemental weapon",
+				"fear",
+				"dominate beast",
+				"elemental bane|xge",
+				"awaken",
+				"dominate person"
+			]
+		},
+		{
+			"name": "Bounty Hunter",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Bounty Hunter",
+			"subclassFeatures": [
+				"Bounty Hunter|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|3",
+				"Cunning Technique|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|7",
+				"Improved Exploits (d6)|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|7",
+				"Unwavering|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|11",
+				"Improved Exploits (d8)|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|15",
+				"Most Dangerous Game|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|15"
+			]
+		},
+		{
+			"name": "Buccaneer",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Buccaneer",
+			"subclassFeatures": [
+				"Buccaneer|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|3",
+				"Buccaneer Spells|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|3",
+				"Deep Sea Diver|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|7",
+				"Wrath of the Waves|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|11",
+				"Watery Resilience|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"compelled duel",
+				"fog cloud",
+				"gust of wind",
+				"locate object",
+				"call lightning|xge",
+				"water breathing",
+				"control water",
+				"watery sphere|xge",
+				"control winds|xge",
+				"maelstrom|xge"
+			]
+		},
+		{
+			"name": "Druidic Guardian",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Druidic Guardian",
+			"subclassFeatures": [
+				"Druidic Guardian|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|3",
+				"Druidic Guardian Spells|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|3",
+				"Wild Bound|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|7",
+				"Empowered Shapes|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|11",
+				"Thousand Forms|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"ensnaring strike",
+				"entangle",
+				"alter self",
+				"spike growth",
+				"erupting earth",
+				"plant growth",
+				"grasping vine",
+				"guardian of nature|xge",
+				"tree stride",
+				"wrath of nature|xge"
+			]
+		},
+		{
+			"name": "Dunestrider",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Dunestrider",
+			"subclassFeatures": [
+				"Dunestrider|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|3",
+				"Dunestrider Spells|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|3",
+				"Rugged Resilience|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|7",
+				"Illusory Strikes|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|11",
+				"Illusory Transposition|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"absorb elements|xge",
+				"silent image",
+				"invisibility",
+				"mirror image",
+				"wall of sand|xge",
+				"major image",
+				"greater invisibility",
+				"hallucinatory terrain",
+				"commune with nature",
+				"mislead"
+			]
+		},
+		{
+			"name": "Grim Warden",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Grim Warden",
+			"subclassFeatures": [
+				"Grim Warden|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3",
+				"Dark Augmentation|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|7",
+				"Greater Crimson Brand|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|11",
+				"Sanguine Mastery|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"bane",
+				"hex",
+				"hold person",
+				"shadow blade|xge",
+				"bestow curse",
+				"vampiric touch",
+				"blight",
+				"shadow of moil|xge",
+				"enervation|xge",
+				"hold monster"
+			]
+		},
+		{
+			"name": "Nomad",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Nomad",
+			"subclassFeatures": [
+				"Nomad|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3",
+				"Memory of One Thousand Steps|Ranger (Alternate)|LLAR|Nomad|LLAR:E|7",
+				"Expunging Strike (2d4)|Ranger (Alternate)|LLAR|Nomad|LLAR:E|11",
+				"Strange Movement|Ranger (Alternate)|LLAR|Nomad|LLAR:E|11",
+				"Mystical Burst|Ranger (Alternate)|LLAR|Nomad|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"comprehend languages",
+				"disguise self",
+				"detect thoughts",
+				"misty step",
+				"clairvoyance",
+				"tongues",
+				"dimension door",
+				"divination",
+				"commune",
+				"seeming"
+			]
+		},
+		{
+			"name": "Stargazer",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Stargazer",
+			"subclassFeatures": [
+				"Stargazer|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|3",
+				"Threads of Fate|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|7",
+				"Starlight Strikes|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|11",
+				"Resplendent Soul|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"vicious mockery",
+				"inflict wounds",
+				"gust|xge",
+				"zephyr strike|xge",
+				"guidance",
+				"bless",
+				"minor illusion",
+				"longstrider",
+				"shillelagh",
+				"compelled duel",
+				"resistance",
+				"shield",
+				"primal savagery|xge",
+				"guiding bolt",
+				"mind spike|xge",
+				"moonbeam",
+				"beacon of hope",
+				"clairvoyance",
+				"divination",
+				"guardian of faith",
+				"dawn|xge",
+				"wall of light|xge"
+			]
+		},
+		{
+			"name": "Wrangler",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"shortName": "Wrangler",
+			"subclassFeatures": [
+				"Wrangler|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|3",
+				"Bring to Heel|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|7",
+				"Master Tamer|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|11",
+				"Wrangler of Legends|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|15"
+			],
+			"subclassSpells": [
+				"charm person",
+				"command",
+				"calm emotions",
+				"summon beast|tce",
+				"conjure animals",
+				"slow",
+				"charm monster|xge",
+				"dominate beast",
+				"awaken",
+				"hold monster"
+			]
+		}
+	],
+	"subclassFeature": [
+		{
+			"name": "Beast Master",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Beast Master",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Some Rangers that develop intense bonds with nature have been known to attract the attention of guardian spirits known as Primal Beasts. Primal Beasts fight side by side with their partners, changing their shape to face the challenge at hand.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Beast Master Spells|Ranger (Alternate)|LLAR|Beast Master|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Primal Companion|Ranger (Alternate)|LLAR|Beast Master|LLAR|3"
+				}
+			]
+		},
+		{
+			"name": "Beast Master Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Beast Master",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Beast Master feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Beast Master Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell beast bond|xge}, {@spell speak with animals}"
+						],
+						[
+							"5th",
+							"{@spell beast sense}, {@spell warding bond}"
+						],
+						[
+							"9th",
+							"{@spell haste}, {@spell protection from energy}"
+						],
+						[
+							"13th",
+							"{@spell death ward}, {@spell freedom of movement}"
+						],
+						[
+							"17th",
+							"{@spell awaken}, {@spell commune with nature}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Primal Companion",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Beast Master",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Beast Master feature}",
+				"You have formed a bond with a Primal Beast. You choose the form it takes, selecting one of the stat blocks at the end of this class: {@creature Beast of the Cave|LLAR}, {@creature Beast of the Land|LLAR}, {@creature Beast of the Sea|LLAR}, or {@creature Beast of the Sky|LLAR}. These stat blocks use your proficiency bonus (PB) in several places.",
+				"The Primal Beast is friendly to you and your allies and obeys your commands. In combat, it acts on your turn. It can move and use its reaction on its own, but it can only take the Dodge action unless you use a bonus action to order it to take an action from its stat block, or another combat action. If you are incapacitated, your Primal Beast can act on its own.",
+				"If your Primal Beast has died within the last hour, you can use your action to touch it and expend a spell slot of 1st-level or higher to return it to life with its maximum hit points.",
+				"During a long rest, you can spend 1 hour performing a ritual that causes your Primal Beast to take on a new form, choosing a new stat block and appearance for it."
+			]
+		},
+		{
+			"name": "Exceptional Training",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Beast Master",
+			"subclassSource": "LLAR",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Beast Master feature}",
+				"As a reaction, you and your Primal Beast can grant the other advantage on any saving throw they are forced to make, so long as you can see and are within 30 feet of each other.",
+				"Also, your Beast's attacks count as magical for the sake of overcoming resistance and immunity to non-magical attacks."
+			]
+		},
+		{
+			"name": "Bestial Fury",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Beast Master",
+			"subclassSource": "LLAR",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Beast Master feature}",
+				"When you command your Beast to take the Attack action, it can make two natural weapon attacks as part of that action."
+			]
+		},
+		{
+			"name": "Primal Bond",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Beast Master",
+			"subclassSource": "LLAR",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Beast Master feature}",
+				"The bond with your Primal Beast has reached its apex. When you cast a Ranger spell that targets yourself, your Beast also gains the benefits as long as it is within 30 feet of you."
+			]
+		},
+		{
+			"name": "Hunter",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Rangers are as varied as the lands that they hail from. Some use their knowledge of the wilderness to become guides and naturalists. Others use their skills to become trackers or traders. Some wander the countryside, while others stand as guardians of sacred forests. While they fulfill various roles, deep down inside every Ranger beats the heart of a Hunter.",
+				"Marauding hordes of Orcs, vile trolls, great and terrible dragons, or great beasts of the wild, it matters not to a true Hunter. They always find a way to overcome their quarry.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hunter Spells|Ranger (Alternate)|LLAR|Hunter|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Hunter's Prey|Ranger (Alternate)|LLAR|Hunter|LLAR|3"
+				}
+			]
+		},
+		{
+			"name": "Hunter Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Hunter feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Hunter Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell expeditious retreat}, {@spell snare|xge}"
+						],
+						[
+							"5th",
+							"{@spell cordon of arrows}, {@spell pass without trace}"
+						],
+						[
+							"9th",
+							"{@spell conjure barrage}, {@spell nondetection}"
+						],
+						[
+							"13th",
+							"{@spell freedom of movement}, {@spell locate creature}"
+						],
+						[
+							"17th",
+							"{@spell conjure volley}, {@spell swift quiver}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Hunter's Prey",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Hunter feature}",
+				"You are ruthless in pursuing your chosen prey. You gain the features below, but once you use one of these features you cannot use another until the beginning of your next turn:",
+				{
+					"type": "entries",
+					"name": "Cripple",
+					"entries": [
+						"When you hit a Favored Foe with a weapon attack, you can force it to make a Dexterity saving throw against your Spell Save DC. On a failed save, its speed is reduced to 0 until the beginning of your next turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Flurry",
+					"entries": [
+						"When you hit your Favored Foe with a weapon attack, you can make an additional weapon attack with the same weapon against another creature within 5 feet of your Favored Foe and within the weapon's range."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Focus",
+					"entries": [
+						"When you hit your Favored Foe with a weapon attack and it has fewer then its maximum hit points, you can double your Favored Foe damage bonus against it."
+					]
+				}
+			]
+		},
+		{
+			"name": "Defensive Tactics",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Hunter feature}",
+				"You have trained to defend yourself against your prey. You gain one of the features below of your choice:",
+				{
+					"type": "entries",
+					"name": "Counter",
+					"entries": [
+						"When a creature that is at least one size larger than you hits or misses you with an attack, you can use a reaction to make one weapon attack against it."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Iron Will",
+					"entries": [
+						"When you are forced to make a saving throw to resist being {@condition charmed}, {@condition frightened}, and {@condition stunned}, you gain a bonus to your roll equal to one roll of your Favored Foe die."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Nimble",
+					"entries": [
+						"Opportunity attacks against you are made at disadvantage, and if your Favored Foe makes an opportunity attack against you it misses unless they roll a critical hit."
+					]
+				}
+			]
+		},
+		{
+			"name": "Flexible Hunter",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Hunter feature}",
+				"At the end of a long rest you can do one of the following:",
+				{
+					"type": "list",
+					"items": [
+						"Replace your Fighting Style with another Fighting Style, choosing from those available to the Ranger class.",
+						"Replace your Defensive Tactics feature with another feature of your choice from Defensive Tactics."
+					]
+				}
+			]
+		},
+		{
+			"name": "Multiattack",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Hunter feature}",
+				"You have mastered specialized techniques to thwart your foes. At 11th level, you gain one of the following features:",
+				{
+					"type": "entries",
+					"name": "Volley",
+					"entries": [
+						"As an action, you can make a ranged attack against your Favored Foe and any number of creatures within 10 feet of it, so long as the targets are also within the range of your weapon. You must roll a separate attack roll for each target, and you must have ammunition for each individual attack."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Whirlwind Attack",
+					"entries": [
+						"As an action, you make a melee attack against your Favored Foe and any number of other creatures within range. Make a separate attack roll for each target."
+					]
+				}
+			]
+		},
+		{
+			"name": "Superior Defense",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Hunter",
+			"subclassSource": "LLAR",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Hunter feature}",
+				"You have mastered defending yourself from wild and vicious prey. At 15th level, you gain one of the following features:",
+				{
+					"type": "entries",
+					"name": "Evasion",
+					"entries": [
+						"When your Favored Foe subjects you to an effect that allows you to make a Dexterity saving throw to take half damage, such as you instead take no damage if you succeed on a saving throw, and only half damage if you fail."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Uncanny Dodge",
+					"entries": [
+						"When your Favored Foe hits you with an attack, you can use a reaction to halve the damage you take."
+					]
+				}
+			]
+		},
+		{
+			"name": "Spellbreaker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Spellbreakers are a small but dedicated fraternity of Rangers that specialize in hunting mages who use their arcane power for evil. While most pursue the life of a Spellbreaker for noble reasons, there are some who seek to destroy anyone with the potential to use magic. Most Spellbreakers work in secrecy, only striking when success is a certainty. When one wrong move could end in disintegration, there is no room for error.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellbreaker Spells|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellsight|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Reflect Spell|Ranger (Alternate)|LLAR|Spellbreaker|LLAR|3"
+				}
+			]
+		},
+		{
+			"name": "Spellbreaker Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Spellbreaker feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Spellbreaker Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell absorb elements|xge}, {@spell detect magic}"
+						],
+						[
+							"5th",
+							"{@spell blindness/deafness}, {@spell silence}"
+						],
+						[
+							"9th",
+							"{@spell counterspell}, {@spell dispel magic}"
+						],
+						[
+							"13th",
+							"{@spell arcane eye}, {@spell otiluke's resilient sphere}"
+						],
+						[
+							"17th",
+							"{@spell dispel evil and good}, {@spell wall of force}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Spellsight",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Spellbreaker feature}",
+				"You have learned to detect the innate arcane potential of others. When you mark a creature as your Favored Foe you instantly learn its spellcasting ability (if it has one) and the level of the highest spell that it has the ability to cast.",
+				"If the creature is hidden from divination magic, such as a nondetection spell, it appears as if it cannot cast spells."
+			]
+		},
+		{
+			"name": "Reflect Spell",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Spellbreaker feature}",
+				"You can cast {@spell absorb elements|xge} at 1st-level, without expending a spell slot a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses of this feature when you finish a long rest.",
+				"After you cast absorb elements, if your next melee weapon attack is against the creature whose spell you absorbed, you treat the absorb elements damage as its maximum amount."
+			]
+		},
+		{
+			"name": "Arcane Defense",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Spellbreaker feature}",
+				"Whenever you are forced to make a saving throw to resist a spell or another magical effect, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
+			]
+		},
+		{
+			"name": "Mage Breaker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Spellbreaker feature}",
+				"You are a hunter of mages. When you mark a spellcaster as your Favored Foe, you gain the following additional benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Your weapon attacks against it deal force damage.",
+						"When you damage it, it has disadvantage on any saving throw it makes to maintain concentration on any spells.",
+						"When you hit it with a weapon attack, you can expend a spell slot to deal additional force damage equal to one roll of your Favored Foe bonus per level of the slot you expend."
+					]
+				}
+			]
+		},
+		{
+			"name": "Mantle of the Master",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Spellbreaker",
+			"subclassSource": "LLAR",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Spellbreaker feature}",
+				"Your training as a Spellbreaker has reached its apex. You are resistant to all damage from spells and other magical effects."
+			]
+		},
+		{
+			"name": "Shadowbane",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Shadowbane",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Every culture tells stories of evil spirits and monsters that live just beyond the walls of civilization. Thanks to the quiet vigilance of dedicated Rangers, these terrible monsters remain nothing more than a story. These guardian Rangers take up the mantle of Shadowbane, vowing to protect the innocent from the things of the night. They seek out vampires, evil fey, spirits, werewolves, and other vile creatures and destroy them without hesitation.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Shadowbane Spells|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Slayer's Insight|Ranger (Alternate)|LLAR|Shadowbane|LLAR|3"
+				}
+			]
+		},
+		{
+			"name": "Shadowbane Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Shadowbane",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Shadowbane feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Shadowbane Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell compelled duel}, {@spell protection from evil and good}"
+						],
+						[
+							"5th",
+							"{@spell see invisibility}, {@spell zone of truth}"
+						],
+						[
+							"9th",
+							"{@spell magic circle}, {@spell protection from energy}"
+						],
+						[
+							"13th",
+							"{@spell banishment}, {@spell mordenkainen's faithful hound}"
+						],
+						[
+							"17th",
+							"{@spell dispel evil and good}, {@spell hold monster}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Slayer's Insight",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Shadowbane",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Shadowbane feature}",
+				"You have a keen eye for the weak points of foes. When you roll initiative, so long as you are not surprised, you can use your reaction to mark one creature that you can see as your Favored Foe.",
+				"Moreover, when you mark a creature as your Favored Foe you immediately learn if it has any damage immunities resistances, or vulnerabilities and what they are. If it is hidden from divination magic, such as by a nondetection spell you sense that the creature has no immunities, resistances, or vulnerabilities."
+			]
+		},
+		{
+			"name": "Iron Focus",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Shadowbane",
+			"subclassSource": "LLAR",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Shadowbane feature}",
+				"When your Favored Foe forces you to make a saving throw, you gain a bonus to your roll equal to your Favored Foe die."
+			]
+		},
+		{
+			"name": "Bane of Darkness",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Shadowbane",
+			"subclassSource": "LLAR",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Shadowbane feature}",
+				"Your hatred for evil empowers your weapons. Once per turn when you hit a creature with a weapon attack, you can deal additional radiant damage equal to your Favored Foe die."
+			]
+		},
+		{
+			"name": "Ruthless Counter",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Shadowbane",
+			"subclassSource": "LLAR",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Shadowbane feature}",
+				"If your Favored Foe forces you to make a saving throw, casts a spell, or attempts to teleport, you can use your reaction to make a single weapon attack against it using a weapon you are holding. On hit, you automatically succeed on the saving throw, or its spell or teleport automatically fails."
+			]
+		},
+		{
+			"name": "Gloom Stalker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Gloom Stalker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Gloom Stalkers are at home in the darkest places: deep under the earth, in gloomy alleyways, in primeval forests, and wherever else the light dims. Most folk enter such places with trepidation, but a Gloom Stalker ventures boldly into the darkness, seeking to ambush threats before they can reach the broader world. Such rangers are often found in the Underdark, but they will go any place where evil lurks in the shadows. The full subclass is found in Xanathar's Guide to Everything.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Gloom Stalker Spells|Ranger (Alternate)|LLAR|Gloom Stalker|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Dread Ambusher|Ranger|PHB|Gloom Stalker|XGE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Umbral Sight|Ranger|PHB|Gloom Stalker|XGE|3"
+				}
+			]
+		},
+		{
+			"name": "Gloom Stalker Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Gloom Stalker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Gloom Stalker Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell cause fear|xge}, {@spell disguise self}"
+						],
+						[
+							"5th",
+							"{@spell darkness}, {@spell rope trick}"
+						],
+						[
+							"9th",
+							"{@spell fear}, {@spell nondetection}"
+						],
+						[
+							"13th",
+							"{@spell greater invisibility}, {@spell phantasmal killer}"
+						],
+						[
+							"17th",
+							"{@spell mislead}, {@spell seeming}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Dread Ambusher",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Gloom Stalker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"During the first turn you take in combat, your walking speed increases by 10 feet, which lasts until the end of that turn.",
+				"If you take the Attack action on that turn, you can make an additional weapon attack as part of that action. If it hits, the target takes bonus damage equal to one roll of your Favored Foe die. In addition, when you roll initiative and aren't surprised, you roll your Favored Foe die and add it to your initiative rolls."
+			]
+		},
+		{
+			"name": "Horizon Walker",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Horizon Walker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Defend your home from extraplanar incursions and threats! The full subclass is found in Xanathar's Guide to Everything.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Horizon Walker Spells|Ranger (Alternate)|LLAR|Horizon Walker|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Detect Portal|Ranger|PHB|Horizon Walker|XGE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Planar Warrior|Ranger|PHB|Horizon Walker|XGE|3"
+				}
+			]
+		},
+		{
+			"name": "Horizon Walker Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Horizon Walker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Horizon Walker Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell alarm}, {@spell protection from evil and good}"
+						],
+						[
+							"5th",
+							"{@spell misty step}, {@spell rope trick}"
+						],
+						[
+							"9th",
+							"{@spell haste}, {@spell magic circle}"
+						],
+						[
+							"13th",
+							"{@spell banishment}, {@spell dimension door}"
+						],
+						[
+							"17th",
+							"{@spell banishing smite}, {@spell teleportation circle}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Detect Portal",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Horizon Walker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"As an action, you can detect the distance and direction of any planar portals within a number of miles equal to your level.",
+				"Once you successfully use this feature to locate a planar portal, you must finish a short or long rest before you can use it again. When you have no uses remaining, you can expend a spell slot of 1st-level or higher to use this feature again."
+			]
+		},
+		{
+			"name": "Planar Warrior",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Horizon Walker",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"As a bonus action, choose a creature you can see within 30 feet. The next time you hit that creature on this turn with a weapon attack, all damage dealt by the attack becomes force damage, and the creature takes additional force damage equal to two rolls of your Favored Foe die."
+			]
+		},
+		{
+			"name": "Fey Wanderer",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Fey Wanderer",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Draw on the power of the Feywild to pursue and beguile foes! The full subclass is found in Tasha's Cauldron of Everything.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Dreadful Strikes|Ranger|PHB|Fey Wanderer|TCE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Fey Wanderer Spells|Ranger (Alternate)|LLAR|Fey Wanderer|LLAR|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Otherworldly Glamour|Ranger|PHB|Fey Wanderer|TCE|3"
+				}
+			]
+		},
+		{
+			"name": "Fey Wanderer Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Fey Wanderer",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Fey Wanderer feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Fey Wanderer Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell cause fear|xge}, {@spell charm person}"
+						],
+						[
+							"5th",
+							"{@spell enthrall}, {@spell misty step}"
+						],
+						[
+							"9th",
+							"{@spell dispel magic}, {@spell fear}"
+						],
+						[
+							"13th",
+							"{@spell charm monster|xge}, {@spell dimension door}"
+						],
+						[
+							"17th",
+							"{@spell geas}, {@spell mislead}"
+						]
+					]
+				},
+				"You also possess a preternatural blessing from a fey ally or a place of fey power. Choose your blessing from the Feywild Gifts table or determine it randomly.",
+				{
+					"type": "table",
+					"caption": "Feywild Gifts",
+					"colLabels": [
+						"{@dice d6}",
+						"Gift"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"1",
+							"Illusory butterflies flutter around you while you take a short or long rest."
+						],
+						[
+							"2",
+							"Fresh, seasonal flowers sprout from your hair each dawn."
+						],
+						[
+							"3",
+							"You faintly smell of cinnamon, lavender, nutmeg, or another comforting herb or spice."
+						],
+						[
+							"4",
+							"Your shadow dances while no one is looking directly at it."
+						],
+						[
+							"5",
+							"Horns or antlers sprout from your head."
+						],
+						[
+							"6",
+							"Your skin and hair change color to match the season at each dawn."
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Dreadful Strikes",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Fey Wanderer",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"Once per turn when you hit a creature with a weapon attack, you can deal additional psychic damage to the target equal to one roll of your Favored Foe die.",
+				"Moreover, when you mark a creature as your Favored Foe, you can choose for the bonus damage to by psychic damage."
+			]
+		},
+		{
+			"name": "Swarmkeeper",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Swarmkeeper",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"Feeling a deep connection to the environment around them, some rangers reach out through their magical connection to the world and bond with a swarm of nature spirits. The swarm becomes a potent force in battle, as well as helpful company for the ranger. Some Swarmkeepers are outcasts or hermits, keeping to themselves and their attendant swarms rather than dealing with the discomfort of others. Other Swarmkeepers enjoy building vibrant communities that work for the mutual benefit of all those they consider part of their swarm.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Gathered Swarm|Ranger|PHB|Swarmkeeper|TCE|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Swarmkeeper Spells|Ranger (Alternate)|LLAR|Swarmkeeper|LLAR|3"
+				}
+			]
+		},
+		{
+			"name": "Swarmkeeper Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Swarmkeeper",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Swarmkeeper feature}",
+				"You learn the {@spell mage hand} cantrip if you don't already know it. When you cast it, the hand takes the form of your swarming nature spirits.",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Swarmkeeper Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell entangle}, {@spell faerie fire}"
+						],
+						[
+							"5th",
+							"{@spell spider climb}, {@spell web}"
+						],
+						[
+							"9th",
+							"{@spell fly}, {@spell gaseous form}"
+						],
+						[
+							"13th",
+							"{@spell arcane eye}, {@spell giant insect}"
+						],
+						[
+							"17th",
+							"{@spell bigby's hand}, {@spell insect plague}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Gathered Swarm",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Swarmkeeper",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"Once per turn, after you hit a creature with a weapon attack, your swarm can assist you in one of the following ways:",
+				{
+					"type": "list",
+					"items": [
+						"It takes piercing damage equal to your Favored Foe die.",
+						"It must succeed on a Strength saving throw against your Spell Save DC or be moved up to 15 feet horizontally.",
+						"You move 5 feet horizontally in a direction of your choice."
+					]
+				}
+			]
+		},
+		{
+			"name": "Mighty Swarm",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Swarmkeeper",
+			"subclassSource": "LLAR",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"Your Gathered Swarm grows mightier in the following ways:",
+				{
+					"type": "list",
+					"items": [
+						"If a creature fails its saving throw against being moved by your Gathered Swarm, you can also knock it prone.",
+						"When you are moved by your Gathered Swarm, you gain the benefits of half cover until the start of your next turn."
+					]
+				}
+			]
+		},
+		{
+			"name": "Drakewarden Spells",
+			"source": "LLAR",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Drakewarden",
+			"subclassSource": "LLAR",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Drakewarden feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Drakewarden Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell absorb elements|xge}, {@spell command}"
+						],
+						[
+							"5th",
+							"{@spell dragon's breath|xge}, {@spell warding bond}"
+						],
+						[
+							"9th",
+							"{@spell elemental weapon}, {@spell fear}"
+						],
+						[
+							"13th",
+							"{@spell dominate beast}, {@spell elemental bane|xge}"
+						],
+						[
+							"17th",
+							"{@spell awaken}, {@spell dominate person}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Bounty Hunter",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"Bounty Hunters protect humanoids from their own. Trained to hunt in cities and towns, they can track their prey through the dark alleyways and underbellies of any town or city. Trained to use various martial techniques, these rangers can confidently confront and subdue any dangerous humanoid.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Ear to the Ground|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Martial Exploits|Ranger (Alternate)|LLAR|Bounty Hunter|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Ear to the Ground",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Bounty Hunter feature}",
+				"Starting at 3rd level, once you spend a long rest in a settlement, city, or town you have advantage on any ability checks you make to gather information on contacts or factions, and to navigate the underworld of that settlement.",
+				"You have also learned the language of the criminal world. You can identify, read, and communicate in {@language Thieves' Cant|phb}."
+			]
+		},
+		{
+			"name": "Martial Exploits",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Bounty Hunter feature}",
+				"You have studied various martial exploits to better counter humanoid foes. At 3rd level, you gain the following features:",
+				{
+					"type": "table",
+					"caption": "Bounty Hunter Exploits",
+					"colLabels": [
+						"Ranger Level",
+						"Exploits Known",
+						"Exploit Die",
+						"Exploit Dice",
+						"High Degree"
+					],
+					"colStyles": [
+						"col-3 text-center",
+						"col-3 text-center",
+						"col-3 text-center",
+						"col-3 text-center",
+						"col-3 text-center"
+					],
+					"rows": [
+						[
+							"3rd",
+							"2",
+							"{@dice d4}",
+							"2",
+							"1st"
+						],
+						[
+							"4th",
+							"2",
+							"{@dice d4}",
+							"2",
+							"1st"
+						],
+						[
+							"5th",
+							"3",
+							"{@dice d4}",
+							"2",
+							"1st"
+						],
+						[
+							"6th",
+							"3",
+							"{@dice d4}",
+							"2",
+							"1st"
+						],
+						[
+							"7th",
+							"4",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"8th",
+							"4",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"9th",
+							"4",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"10th",
+							"4",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"11th",
+							"5",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"12th",
+							"5",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"13th",
+							"5",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"141th",
+							"5",
+							"{@dice d6}",
+							"3",
+							"2nd"
+						],
+						[
+							"15th",
+							"6",
+							"{@dice d8}",
+							"4",
+							"3rd"
+						],
+						[
+							"16th",
+							"6",
+							"{@dice d8}",
+							"4",
+							"3rd"
+						],
+						[
+							"17th",
+							"6",
+							"{@dice d8}",
+							"4",
+							"3rd"
+						],
+						[
+							"18th",
+							"6",
+							"{@dice d8}",
+							"4",
+							"3rd"
+						],
+						[
+							"19th",
+							"7",
+							"{@dice d8}",
+							"4",
+							"3rd"
+						],
+						[
+							"20th",
+							"7",
+							"{@dice d8}",
+							"4",
+							"3rd"
+						]
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Exploits",
+					"entries": [
+						"You learn two {@filter Exploits|optionalfeatures|feature type=ll:1de;ll:me=sand} of your choice from those available to the Alternate Fighter. You can only use one Exploit per ability check, attack, or saving throw. When you gain a ranger level, you can replace one of your Exploits with another of your choice."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Exploit Dice",
+					"entries": [
+						"The Bounty Hunter Exploits table shows how many Exploit Dice you have to use Exploits. To use an Exploit, you expend an Exploit Die, and you regain all your expended Exploit Dice when you finish a short or long rest."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "High Degree",
+					"entries": [
+						"Your Ranger level limits the technicality of the Exploits you are able to perform. This limit is reflected in the High Degree column of the Bounty Hunter Exploits table."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Saving Throws",
+					"entries": [
+						"If an Exploit requires a creature to make a saving throw, the saving throw DC is calculated as follows:",
+						{
+							"type": "abilityDc",
+							"name": "Exploit",
+							"attributes": [
+								"str",
+								"dex"
+							]
+						}
+					]
+				},
+				{
+					"type": "inset",
+					"name": "Multiclassing and Exploits",
+					"entries": [
+						"Your martial skill depends partly on your combined levels in classes that learn Exploits, and partly on your individual levels in each class. If your group uses the optional rule for multiclassing and you learn Exploits from more than one class, you use the following rules: https://www.gmbinder.com/share/-NGUL51kfZCPlESxL1wq"
+					]
+				}
+			]
+		},
+		{
+			"name": "Cunning Technique",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Bounty Hunter feature}",
+				"Your martial skills are especially potent when used against your chosen foe. Once per turn, when you force your Favored Foe to make a saving throw to resist the effects of an Exploit, you can force it to make its saving throw with disadvantage."
+			]
+		},
+		{
+			"name": "Improved Exploits (d6)",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Bounty Hunter feature}",
+				"Your skills improve. Upon reaching 7th level, you gain one additional Exploit Die, and your Exploit Dice become {@dice d6}s. You can also learn {@filter 2nd degree Exploits|optionalfeatures|feature type=ll:2de;ll:me=sand}."
+			]
+		},
+		{
+			"name": "Unwavering",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Bounty Hunter feature}",
+				"You are a master of disabling foes. Starting at 11th level, when your favored foe misses you with a melee attack, you can force it to make a Dexterity saving throw as a reaction. On a failed save, it falls {@condition prone}, and if you have a free hand you can choose to automatically grapple the creature."
+			]
+		},
+		{
+			"name": "Improved Exploits (d8)",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Bounty Hunter feature}",
+				"At 15th level, your skills increase further. You gain another Exploit Die (for a total of four), and your Exploit Dice become {@dice d8}s. You can also learn {@filter 3rd degree Exploits|optionalfeatures|feature type=ll:3de;ll:me=sand}."
+			]
+		},
+		{
+			"name": "Most Dangerous Game",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Bounty Hunter",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Bounty Hunter feature}",
+				"Your supernatural instincts allow you to predict your foe's attacks. Beginning at 15th level, any time you take damage from your favored foe, the damage is reduced by an amount equal to your Wisdom modifier (minimum of 1 hit point)."
+			]
+		},
+		{
+			"name": "Buccaneer",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Buccaneer feature}",
+				"Combining their survival skills, an affinity for nature magic, and passion for the high seas, Buccaneers are Rangers who feel more at home on the water than on solid ground. Serving as sailors, pirates, marines, or privateers, they are often one of the most valuable crew members on board their vessels. How did you come to sail the seas? Were you pressed into the service of a pirate captain, or have you sworn to kill a certain sea monster?",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Buccaneer Spells|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mariner's Eye|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Sea Legs|Ranger (Alternate)|LLAR|Buccaneer|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Buccaneer Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Buccaneer feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Buccaneer Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell compelled duel}, {@spell fog cloud}"
+						],
+						[
+							"5th",
+							"{@spell gust of wind}, {@spell locate object}"
+						],
+						[
+							"9th",
+							"{@spell call lightning|xge}, {@spell water breathing}"
+						],
+						[
+							"13th",
+							"{@spell control water}, {@spell watery sphere|xge}"
+						],
+						[
+							"17th",
+							"{@spell control winds|xge}, {@spell maelstrom|xge}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Mariner's Eye",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Buccaneer feature}",
+				"Your sight has become especially keen. Whenever you make a Wisdom ({@skill Perception}) check that relies on your sense of sight, you can treat a roll of 7 or lower on the d20 as an 8.",
+				"Also, when you make a weapon attack against a Favored Foe that is swimming, you have advantage on your attack roll."
+			]
+		},
+		{
+			"name": "Sea Legs",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Buccaneer feature}",
+				"The time you have spent at sea has granted you abilities that land-locked Rangers lack. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You gain the Mariner Fighting Style. If you already know this Fighting Style you learn another Fighting Style of your choice from those available to the Ranger class.",
+						"You can hold your breath underwater for a number of minutes equal to 10 + your Constitution modifier.",
+						"You have advantage on saving throws to resist being knocked {@condition prone} or moved against your will."
+					]
+				}
+			]
+		},
+		{
+			"name": "Deep Sea Diver",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Buccaneer feature}",
+				"You have to spend significant time underwater. You can cast {@spell water breathing}, targeting only yourself, without expending a spell slot. Once you cast water breathing in this way you must finish a long rest before you can do so again.",
+				"Moreover, whenever you cast water breathing, the targets of the spell gain the following additional benefits:",
+				{
+					"type": "list",
+					"items": [
+						"They gain resistance to cold damage.",
+						"They gain a swimming speed equal to their walking speed. If the target already has a swimming speed, it can take the Dash action as a bonus action while it is swimming.",
+						"They gain darkvision out to a 60-foot radius. If the target already has darkvision, its radius increases by 30 feet."
+					]
+				}
+			]
+		},
+		{
+			"name": "Wrath of the Waves",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Buccaneer feature}",
+				"You carry the magic of the high seas whether you are on sea or land. Once per turn when you hit a creature with a weapon attack, you can imbue your strike with watery magic. When you do, the creature takes additional cold damage equal to one roll of your Favored Foe die, and it must succeed on a Strength saving throw against your Spell Save DC or be knocked back from you 10 feet in a straight line.",
+				"Any creature that is at least one size larger than you has advantage on its Strength saving throw."
+			]
+		},
+		{
+			"name": "Watery Resilience",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Buccaneer",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Buccaneer feature}",
+				"When you are hit by an attack, you can use your reaction to temporarily take on a liquid watery form, gaining resistance to all damage from the triggering attack. As part of the same reaction, you can immediately move up to your full movement speed without provoking opportunity attacks.",
+				"You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all of your expended uses when you finish a long rest. If you have no uses remaining, you can expend a spell slot of 1st-level or higher to use this reaction on additional time."
+			]
+		},
+		{
+			"name": "Druidic Guardian",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Druidic Guardian",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Druidic Guardian feature}",
+				"While most Rangers stand with one foot in the wild and one in the civilized world, some side firmly with the natural world. When cities and settlements encroach on ancient groves and wild forests, the Rangers known as Druidic Guardians stand as defenders of the wild. Drawing upon primeval magic, these warriors use the power of nature to defend their homes.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Druidic Guardian Spells|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Limited Wild Shape|Ranger (Alternate)|LLAR|Druidic Guardian|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Druidic Guardian Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Druidic Guardian",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Druidic Guardian feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Druidic Guardian Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell ensnaring strike}, {@spell entangle}"
+						],
+						[
+							"5th",
+							"{@spell alter self}, {@spell spike growth}"
+						],
+						[
+							"9th",
+							"{@spell erupting earth}, {@spell plant growth}"
+						],
+						[
+							"13th",
+							"{@spell grasping vine}, {@spell guardian of nature|xge}"
+						],
+						[
+							"17th",
+							"{@spell tree stride}, {@spell wrath of nature|xge}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Limited Wild Shape",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Druidic Guardian",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Druidic Guardian feature}",
+				"You can draw on primal nature magic to take the shape of beasts, much like a {@class Druid} does. You gain the ability to Wild Shape. As a bonus action on your turn, you can assume the form of any beast that you have physically touched.",
+				"Your Ranger level determines the maximum CR of beasts that you can transform into, as shown in the table below. You must follow all the other rules for Wild Shape as detailed in the Wild Shape feature description for the Druid class.",
+				{
+					"type": "table",
+					"colLabels": [
+						"Ranger Level",
+						"Max CR",
+						"Limitations",
+						"Example"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-2 text-center",
+						"col-7",
+						"col-5"
+					],
+					"rows": [
+						[
+							"3rd",
+							"0",
+							"No Flying or Swimming Speed",
+							"Deer"
+						],
+						[
+							"7th",
+							"1/4",
+							"No Flying Speed",
+							"Octopus"
+						],
+						[
+							"11th",
+							"1/2",
+							"—",
+							"Hawk"
+						],
+						[
+							"15th",
+							"1",
+							"—",
+							"Giant Eagle"
+						]
+					]
+				},
+				"You can stay in Wild Shape for up to one hour, at which point you revert to your normal form. You can revert to your normal form earlier if you use a bonus action to do so, or if you fall unconscious, you drop to 0 hit points, or you die.",
+				"Once you use your Wild Shape you must complete a short or long rest before you can use it again, unless you expend a spell slot of 1st-level or higher to use Wild Shape again."
+			]
+		},
+		{
+			"name": "Wild Bound",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Druidic Guardian",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Druidic Guardian feature}",
+				"The Druidic magic you wield has permeated body and spirit. You learn Druidic, the secret language of the Druids. You can speak the language and use it to leave hidden messages. While speaking Druidic, you gain the benefits of {@spell speak with animals}.",
+				"Also, your attacks in your Wild Shape beast forms count as magical for overcoming any resistances or immunities to non-magical attacks and damage."
+			]
+		},
+		{
+			"name": "Empowered Shapes",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Druidic Guardian",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Druidic Guardian feature}",
+				"You have learned to empower your Wild Shape with the Druidic magic you wield. When you use Wild Shape, you can expend a spell slot of 1st-level or higher to transform into a beast with a CR equal to or lower than the level of the spell slot you expended to transform.",
+				"Once you use this feature you must finish a short or long rest before you can use it to empower your Wild Shape again."
+			]
+		},
+		{
+			"name": "Thousand Forms",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Druidic Guardian",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Druidic Guardian feature}",
+				"You are so in tune with your abilities that you can change your form in subtle ways at will. You can cast {@spell alter self} at will, targeting only yourself, without expending a spell slot."
+			]
+		},
+		{
+			"name": "Dunestrider",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Dunestrider feature}",
+				"While all Rangers have the skills necessary to live out in the wilderness, those known as Dunestriders are the true masters of survival. These rugged wanderers have adapted to live in the harshest lands imaginable; arid deserts, frozen tundra, great alpine heights, and magical wastelands. These survivalists combine a talent for illusion magic and protective gear to survive in all but the most extreme hostile conditions.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Dunestrider Spells|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wilderness Adept|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wasteland Weaver|Ranger (Alternate)|LLAR|Dunestrider|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Dunestrider Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Dunestrider feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Dunestrider Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell absorb elements|xge}, {@spell silent image}"
+						],
+						[
+							"5th",
+							"{@spell invisibility}, {@spell mirror image}"
+						],
+						[
+							"9th",
+							"{@spell wall of sand|xge}, {@spell major image}"
+						],
+						[
+							"13th",
+							"{@spell greater invisibility}, {@spell hallucinatory terrain}"
+						],
+						[
+							"17th",
+							"{@spell commune with nature}, {@spell mislead}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Wilderness Adept",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Dunestrider feature}",
+				"You are able to survive the most inhospitable environments. You learn one of the following Knacks of your choice: {@optfeature Alpine Adept|LLAR}, {@optfeature Arctic Adept|LLAR:E}, {@optfeature Desert Adept|LLAR:E}, or {@optfeature Jungle Adept|LLAR:E}. You learn another Knack from this list at 7th, 11th, and 15th levels.",
+				"The Knacks you learn through this feature do not count against your total number of Knacks Known. Also, when you gain a Ranger level, you can only replace a Knack you learned through this feature with another Knack from the list above."
+			]
+		},
+		{
+			"name": "Wasteland Weaver",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Dunestrider feature}",
+				"You have mastered an ancient pattern of weaving and enhancing clothing, that when worn, enables a near-supernatural level of survivability. You gain proficiency with {@item weaver's tools|phb}, and you can add double your proficiency bonus to any check you make that uses your weaver's tools.",
+				"At the end of each long rest, you can use weaver's tools to enhance one set of clothing or cloak. While a creature wears this enhanced garment it gains the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"It gains a bonus to Dexterity ({@skill Stealth}) checks to hide in wasteland and wilderness equal to your Favored Foe die.",
+						"It requires one-quarter as much water in order to survive.",
+						"It has advantage on saving throws to resist the effects of harsh environments and subsequent exhaustion levels."
+					]
+				},
+				"During each long rest, you must spend time maintaining any garments you have enhanced or they lose any beneficial properties. You can maintain a total number of enhanced garments equal to your Wisdom modifier (minimum of 1).",
+				{
+					"type": "inset",
+					"name": "Elemental Wastelands",
+					"entries": [
+						"While most Dunestriders hail from the deserts of the material plane, it is not unheard of for them to come from the chaotic inner planes. Some high-level Dunestriders call the harsh elemental planes of air, earth, fire, and water home."
+					]
+				}
+			]
+		},
+		{
+			"name": "Rugged Resilience",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Dunestrider feature}",
+				"You imbue the mystical weave of your enhanced garments with illusion magic. A creature wearing one of your enhanced garments can use a bonus action to cast {@spell invisibility} on itself.",
+				"It can do so three times, but when the last use is expended, the garment loses any beneficial properties. Your enhanced garments regain all uses of this feature when you spend time during a long rest maintaining your enhanced garments."
+			]
+		},
+		{
+			"name": "Illusory Strikes",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Dunestrider feature}",
+				"You can use potent illusion magic to enhance your combat abilities. When you take the Attack action on your turn, you can use a bonus action to create an Illusory Duplicate of yourself in an unoccupied space you can see within 30 feet.",
+				"Your Illusory Duplicate instantly makes one weapon attack with an illusory version of your weapon against a target of your choice within its range. On hit, it deals force damage in place of your weapon's normal damage and disappears."
+			]
+		},
+		{
+			"name": "Illusory Transposition",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Dunestrider",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Dunestrider feature}",
+				"Your skill with illusions has greatly increased. You can use a bonus action to create your Illusory Duplicate even when you do not take the Attack action. Your Illusory Duplicate must still make a weapon attack when it appears.",
+				"Immediately after your Illusory Duplicate makes an attack, you can teleport, instantly switching places with your Illusory Duplicate, without provoking opportunity attacks."
+			]
+		},
+		{
+			"name": "Grim Warden",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Grim Warden feature}",
+				"Sometimes it takes a monster to destroy a monster. Rangers that take up the mantle of Grim Warden undergo a dark alchemical ritual, known as the Warden's Rite, to enhance their physical abilities. They sacrifice any chance they have at a normal life, mingling their blood with that of monsters, in order to gain dark, unnatural power to destroy their foes.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Grim Warden Spells|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Warden's Rite|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Crimson Brand|Ranger (Alternate)|LLAR|Grim Warden|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Grim Warden Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Grim Warden feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Grim Warden Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell bane}, {@spell hex}"
+						],
+						[
+							"5th",
+							"{@spell hold person}, {@spell shadow blade|xge}"
+						],
+						[
+							"9th",
+							"{@spell bestow curse}, {@spell vampiric touch}"
+						],
+						[
+							"13th",
+							"{@spell blight}, {@spell shadow of moil|xge}"
+						],
+						[
+							"17th",
+							"{@spell enervation|xge}, {@spell hold monster}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Warden's Rite",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Grim Warden feature}",
+				"At 3rd level, you undergo the Warden's Rite, an alchemical ritual that suffuses your blood with sinister magic. You gain proficiency with {@item alchemist's supplies|phb} and in the {@skill Religion} skill.",
+				"In addition, whenever you make an Intelligence ({@skill Religion}) check related to fiends, undead creatures, or necromancy magic you gain a bonus to your roll equal to one roll of your Favored Foe die."
+			]
+		},
+		{
+			"name": "Crimson Brand",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Grim Warden feature}",
+				"The sinister magic within your blood allows you to enhance your strikes with your own life force. When you hit a Favored Foe with a weapon attack, you can expend a Hit Die to cause all the damage of your attack to become necrotic, and to deal bonus necrotic damage equal to a roll of your Hit Die.",
+				"Any necrotic damage dealt by this feature ignores resistance to necrotic damage, and can treat immunity to necrotic damage as resistance.",
+				"Lastly, when you use Crimson Brand against a fiend or undead creature, you can maximize the necrotic damage roll of your Hit Die in place of rolling."
+			]
+		},
+		{
+			"name": "Dark Augmentation",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Grim Warden feature}",
+				"Sinister magic enhances your physical capability. Whenever you make a Strength, Dexterity, or Constitution ability check, you gain a bonus to your roll equal to one roll of your Favored Foe die.",
+				"In addition, your movement speed increases by 5 feet."
+			]
+		},
+		{
+			"name": "Greater Crimson Brand",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Grim Warden feature}",
+				"Once per turn, when you hit a creature with a melee weapon attack, you can deal an additional {@dice 1d10} necrotic damage to it."
+			]
+		},
+		{
+			"name": "Sanguine Mastery",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Grim Warden",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Grim Warden feature}",
+				"The magic of your Warden's Rite manifests its full potential. You have advantage on saving throws to resist the {@condition frightened} condition, and you are always under the effects of {@spell protection from good and evil} while you are conscious."
+			]
+		},
+		{
+			"name": "Nomad",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Nomad feature}",
+				"Whether by birth, happenstance, or a ritual, the mind of every Nomad has been connected to the mystical web of knowledge known as the Noosphere. This psionic link allows Nomads to access knowledge from far-off places and distant lives. These strange wanderers spend their lives collecting hidden lore to add to this web of information that connects every Nomad.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Nomad Spells|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Expunging Strikes|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mystic Knowledge|Ranger (Alternate)|LLAR|Nomad|LLAR:E|3"
+				},
+				{
+					"type": "inset",
+					"name": "Optional Rule: Psionic Spellcasting",
+					"entries": [
+						"For mechanics to match the fantasy of a Ranger who wields the psionic power of the Noosphere, consider replacing all Wisdom-based Ranger class and Nomad Archetype features with Intelligence."
+					]
+				}
+			]
+		},
+		{
+			"name": "Nomad Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Nomad feature}",
+				"You always have the spells from the table listed below prepared once you reach certain Ranger levels. See the Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Nomad Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell comprehend languages}, {@spell disguise self}"
+						],
+						[
+							"5th",
+							"{@spell detect thoughts}, {@spell misty step}"
+						],
+						[
+							"9th",
+							"{@spell clairvoyance}, {@spell tongues}"
+						],
+						[
+							"13th",
+							"{@spell dimension door}, {@spell divination}"
+						],
+						[
+							"17th",
+							"{@spell commune}, {@spell seeming}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Expunging Strikes",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Nomad feature}",
+				"You can imbue your strikes with psionic energy to disrupt your foe's memory. Once per turn when you hit a Favored Foe with a weapon attack, you can force it to make an Intelligence saving throw against your Spell Save DC. On a failed save, all damage dealt by your attack becomes psychic damage, and the creature cannot see, hear, smell, or sense you in any way until the start of your next turn."
+			]
+		},
+		{
+			"name": "Mystic Knowledge",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Nomad feature}",
+				"You can use your connection to the Noosphere to draw knowledge from Nomads past and present. When you finish a long rest, you gain proficiency in one skill or tool, or learn to speak, read, and write one language of your choice. You retain that proficiency or language until you finish a long rest.",
+				"When you reach 11th level, you gain two proficiencies or languages from this feature at the end of a long rest."
+			]
+		},
+		{
+			"name": "Nomadic Step",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Nomad feature}",
+				"You can merge your consciousness with the Noosphere to avoid harm. As a reaction when you are hit by an attack, you can disappear into the Noosphere, causing the attack to miss. You then instantly reappear in an unoccupied space that you occupied at some point since the start of your previous turn.",
+				"You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all of your expended uses when you finish a long rest. When you have no uses remaining, you can expend a spell slot of 1st-level or higher to use this reaction one additional time."
+			]
+		},
+		{
+			"name": "Strange Movement",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Nomad feature}",
+				"As an action, you can expend your remaining movement to instead teleport a number of feet equal to your remaining movement, appearing in an unoccupied space you can see."
+			]
+		},
+		{
+			"name": "Mystical Burst",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Nomad",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Nomad feature}",
+				"When you travel through the Noosphere you can assault your foes with the residual psionic power. When you teleport with a Nomad Spell or Nomad feature, you can force creatures of your choice within 10 feet of the point you appear to make an Intelligence saving throw against your Spell Save DC. They take psychic damage equal to one roll of your Favored Foe die on a failed save, and half as much on a successful one."
+			]
+		},
+		{
+			"name": "Stargazer",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Stargazer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"Mortals have always looked to the stars to tell stories of the past, omens for the present, and some believe that by observing motions of the heavenly bodies one can even predict the fates of others. Stargazers spend their lives studying stars and constellations, and learn to draw on their radiant power to vanquish their foes.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Celestial Guidance|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Stargazer Spells|Ranger (Alternate)|LLAR|Stargazer|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Celestial Guidance",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Stargazer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Stargazer feature}",
+				"The great constellations of the night sky guide your life. You gain proficiency with {@item navigator's tools|phb}, and you cannot become lost, even by magical means, so long as you can see the stars or the night sky.",
+				"Also, each time you finish a long rest, you can attune yourself to one of the Constellations from the table below. While attuned, you have both the cantrip and 1st-level spell that correspond to that Constellation prepared. Both become Ranger spells for you, but they don't count against the total number of Ranger spells that you can prepare each day.",
+				"You can cast your Constellation spell at 1st-level without expending a spell slot or material components a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest.",
+				{
+					"type": "table",
+					"caption": "Constellation Spells",
+					"colLabels": [
+						"Constellation",
+						"Cantrip",
+						"1st-level Spell"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-5 text-center",
+						"col-5 text-center"
+					],
+					"rows": [
+						[
+							"Adder",
+							"{@spell vicious mockery}",
+							"{@spell inflict wounds}"
+						],
+						[
+							"Eagle",
+							"{@spell gust|xge}",
+							"{@spell zephyr strike|xge}"
+						],
+						[
+							"Elephant",
+							"{@spell guidance}",
+							"{@spell bless}"
+						],
+						[
+							"Hare",
+							"{@spell minor illusion}",
+							"{@spell longstrider}"
+						],
+						[
+							"Stag",
+							"{@spell shillelagh}",
+							"{@spell compelled duel}"
+						],
+						[
+							"Turtle",
+							"{@spell resistance}",
+							"{@spell shield}"
+						],
+						[
+							"Wolf",
+							"{@spell primal savagery|xge}",
+							"{@spell guiding bolt}"
+						]
+					]
+				},
+				{
+					"type": "inset",
+					"name": "Many Worlds, Many Constellations",
+					"entries": [
+						"The Constellations included in this Archetype are generic animals that can be applied to any setting. However, when playing a Stargazer, players should consider Constellations unique to their world."
+					]
+				}
+			]
+		},
+		{
+			"name": "Stargazer Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Stargazer",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Stargazer feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Stargazer Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"Constellation Spells"
+						],
+						[
+							"5th",
+							"{@spell mind spike|xge}, {@spell moonbeam}"
+						],
+						[
+							"9th",
+							"{@spell beacon of hope}, {@spell clairvoyance}"
+						],
+						[
+							"13th",
+							"{@spell divination}, {@spell guardian of faith}"
+						],
+						[
+							"17th",
+							"{@spell dawn|xge}, {@spell wall of light|xge}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Threads of Fate",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Stargazer",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Stargazer feature}",
+				"You can use the insights you gain from the stars to twist the threads of fate. As a reaction when you, or another creature you can see within 30 feet, makes an ability check or saving throw, you can add your Wisdom modifier (minimum of +1) to the result of the roll. You can use this reaction after the roll, but before you know if the roll succeeds or fails.",
+				"You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all of your expended uses when you finish a long rest."
+			]
+		},
+		{
+			"name": "Starlight Strikes",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Stargazer",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Stargazer feature}",
+				"As a bonus action on your turn, you can enter a trance that allows the celestial bodies of the night to guide your attacks. This trance lasts for 1 minute, or until you are incapacitated. When you roll a 9 or lower on the d20 for an attack roll while you are in this trance, you can treat the roll as a 10. You can do so no more than once per turn.",
+				"Once you use this ability you must finish a long rest before you can use it again. When you have no uses remaining, you can expend a spell slot of 3rd-level or higher to use it again."
+			]
+		},
+		{
+			"name": "Resplendent Soul",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Stargazer",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15-level Stargazer feature}",
+				"Your very being is suffused with starlight. When a creature you can see within 30 feet hits you with an attack, you can use your reaction to release a targeted flash of light, forcing the attacker to make a Constitution saving throw against your Spell Save DC. On a failed save, the target takes {@dice 3d10} radiant damage and is {@condition blinded} until the start of its next turn. On a successful save, the target takes half damage and is not blinded.",
+				"You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all of your expended uses when you finish a long rest. When you have no uses remaining, you can expend a spell slot of 1st-level or higher to use this reaction one additional time."
+			]
+		},
+		{
+			"name": "Wrangler",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Wrangler",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"entries": [
+				"{@i 3rd-level Wrangler feature}",
+				"While most Rangers have some skill with animals, those who pursue the life of a Wrangler are true masters at taming wild beasts. Drawing upon their intimate understanding of animal behavior, they tame and control all sorts of fantastical beasts. Rugged and wild, Wranglers are always on the hunt for ever more strange and exotic creatures to tame and befriend.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wrangler Spells|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Monster Tamer|Ranger (Alternate)|LLAR|Wrangler|LLAR:E|3"
+				}
+			]
+		},
+		{
+			"name": "Wrangler Spells",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Wrangler",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Wrangler feature}",
+				"You always have the spells from the table below prepared once you reach certain levels in this class. See the Ranger Archetype class feature for how Archetype Spells work.",
+				{
+					"type": "table",
+					"caption": "Wrangler Spells",
+					"colLabels": [
+						"Ranger Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 teWranglert-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"3rd",
+							"{@spell charm person}, {@spell command}"
+						],
+						[
+							"5th",
+							"{@spell calm emotions}, {@spell summon beast|tce}"
+						],
+						[
+							"9th",
+							"{@spell conjure animals}, {@spell slow}"
+						],
+						[
+							"13th",
+							"{@spell charm monster|xge}, {@spell dominate beast}"
+						],
+						[
+							"17th",
+							"{@spell awaken}, {@spell hold monster}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Monster Tamer",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Wrangler",
+			"subclassSource": "LLAR:E",
+			"level": 3,
+			"header": 2,
+			"entries": [
+				"{@i 3rd-level Wrangler feature}",
+				"Your intimate understanding of animal behaviors and habits grants you certain benefits. You gain the following features:",
+				{
+					"type": "list",
+					"items": [
+						"Your weapon attacks against beasts and monstrosities score a critical hit on a roll of 19 or 20 on the d20.",
+						"You have advantage on Strength ({@skill Athletics}) checks to grapple, climb, or wrestle beasts and monstrosities.",
+						"Any {@filter enchantment spell you have prepared that targets a humanoid|spells|class=ranger (llar)|subclass=ranger (alternate): wrangler (llar:e)|school=e|affects creature types=humanoid} can also target beasts and monstrosities."
+					]
+				}
+			]
+		},
+		{
+			"name": "Bring to Heel",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Wrangler",
+			"subclassSource": "LLAR:E",
+			"level": 7,
+			"header": 2,
+			"entries": [
+				"{@i 7th-level Wrangler feature}",
+				"You can bend creatures of the wild to your will. When a beast or monstrosity that is charmed by you makes a saving throw to end the charmed condition, you can use your reaction to force it to make that saving throw with disadvantage.",
+				"You can also command the monsters you tame. Any beast or monstrosity charmed by you acts during your turn for the duration of your charm, and if you are within 30 feet and the creature can hear you, you can use your action to command it to take one of the actions from its stat block."
+			]
+		},
+		{
+			"name": "Master Tamer",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Wrangler",
+			"subclassSource": "LLAR:E",
+			"level": 11,
+			"header": 2,
+			"entries": [
+				"{@i 11th-level Wrangler feature}",
+				"Your abilities are nearly supernatural Your Wrangler features now affect celestials, dragons, fey, fiends, giants, and plants with an Intelligence score less than or equal to your level.",
+				"Also, you can command any beast or monstrosity charmed by you to take an action from its stat block as a bonus action."
+			]
+		},
+		{
+			"name": "Wrangler of Legends",
+			"source": "LLAR:E",
+			"className": "Ranger (Alternate)",
+			"classSource": "LLAR",
+			"subclassShortName": "Wrangler",
+			"subclassSource": "LLAR:E",
+			"level": 15,
+			"header": 2,
+			"entries": [
+				"{@i 15th-level Wrangler feature}",
+				"Once you charm a creature, there is little it can do to escape. Any enchantment spells you cast on beasts and monstrosities last until your concentration is broken.",
+				"Also, short and long rests do not break your concentration on enchantment spells you cast on beasts or monstrosities."
+			]
+		}
+	],
+	"optionalfeature": [
+		{
+			"name": "Archery",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"You gain a +2 bonus to attack rolls with ranged weapons."
+			]
+		},
+		{
+			"name": "Defensive Fighting",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"While you are wearing armor or wielding a shield, you gain a +1 bonus to your Armor Class."
+			]
+		},
+		{
+			"name": "Druidic Warrior",
+			"source": "LLAR:E",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"You learn two cantrips of your choice from the {@filter Druid spell list|spells|class=Druid} spell list. They count as Ranger spells for you, and Wisdom is your spellcasting ability for them. Whenever you gain a level in this class, you can replace one of these cantrips with another cantrip of your choice from the Druid spell list."
+			]
+		},
+		{
+			"name": "Dual Wielding",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When you take the Attack action while two-weapon fighting, you can make a single additional attack with your off-hand weapon as part of your action instead of your bonus action, adding your ability modifier to the damage of this attack."
+			]
+		},
+		{
+			"name": "Dueling",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with it."
+			]
+		},
+		{
+			"name": "Featherweight Fighting",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"While wielding only light weapons, your speed increases by 10 feet and you gain a +1 bonus to damage rolls, so long as you aren't wearing medium or heavy armor, or using a shield."
+			]
+		},
+		{
+			"name": "Marine Fighting",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When you are not wearing medium or heavy armor, or using a shield, you have a swimming speed equal to your movement speed, and you gain a +1 bonus to your Armor Class."
+			]
+		},
+		{
+			"name": "Melee Marksman",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When you make a ranged attack targeting a creature within 5 feet of you, you do not have disadvantage on the attack roll.",
+				"If you make a ranged attack against a creature within 5 feet, you can strike the creature with your ranged weapon as a bonus action, dealing {@dice 1d4} bludgeoning damage on hit."
+			]
+		},
+		{
+			"name": "Mountaineer",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When you are not wearing medium or heavy armor or using a shield, you have a climbing speed equal to your walking speed, and you gain a +1 bonus to your Armor Class."
+			]
+		},
+		{
+			"name": "Mounted Warrior",
+			"source": "LLAR:E",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"While you are riding a controlled mount, both you and your mount gain a +1 bonus to your Armor Class, and you can use a bonus action on your turn to command your mount to take one action from its stat block."
+			]
+		},
+		{
+			"name": "Protection",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When a creature you can see attacks a target within 5 feet of you, you can impose disadvantage on their attack roll as a reaction. You must be wielding a melee weapon or a shield."
+			]
+		},
+		{
+			"name": "Strongbow",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"You can use your Strength score, in place of Dexterity, for your attack and damage rolls with longbows and shortbows."
+			]
+		},
+		{
+			"name": "Thrown Weapon Fighting",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"You can draw a weapon that has the thrown property as part of the attack you make with the weapon. Moreover, whenever you hit with a ranged weapon attack using a thrown weapon, you gain a +2 bonus to the damage roll of that attack."
+			]
+		},
+		{
+			"name": "Versatile Fighting",
+			"source": "LLAR",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"When wielding a versatile weapon with two hands you gain a +2 bonus to damage rolls. When wielding a versatile weapon with one hand, and nothing in your other hand, you gain a +1 bonus to both your attack rolls and your Armor Class.",
+				"You can also make a shove or unarmed strike attack as a bonus action so long as you have a free hand to do so."
+			]
+		},
+		{
+			"name": "Unarmed Fighting",
+			"source": "LLAR:E",
+			"featureType": [
+				"FS:AR"
+			],
+			"entries": [
+				"Your unarmed strikes can deal bludgeoning damage equal to 1d6 + your Strength modifier on a hit. If you have two free hands when you make the attack roll, the d6 becomes a d8.",
+				"At the beginning of each of your turns, you can deal 1d4 bludgeoning damage to one creature you are grappling."
+			]
+		},
+		{
+			"name": "Alpine Adept",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You are amazingly surefooted. You gain a 30-foot climbing speed, and you can use your reaction to reduce any falling damage you take by an amount equal to your Ranger level. If you already have a climbing speed it increases by 10 feet."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Aquatic Adept",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You can swim through the water like a native creature of the sea. You gain a 30-foot swimming speed, and while you are underwater, you can hold your breath for up to 1 hour. If you already have a swimming speed it increases by 10 feet."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Explorer I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Whenever you make a Wisdom ({@skill Survival}) check to navigate in the wild, forage for food and water, or to avoid becoming lost, you can treat a roll of 7 or lower on the d20 as an 8."
+			]
+		},
+		{
+			"name": "Explorer II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"At the end of a long rest, you can attune to your surrounding environment. Examples include, but are not limited to: arctic, coastal, desert, forest, grassland, mountain, or swamp. While in your attuned environment you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You have advantage on Intelligence and Wisdom checks related to the native plants, animals, or ecosystem.",
+						"You find twice as much food when foraging or hunting.",
+						"You cannot be surprised unless you are {@condition incapacitated}.",
+						"You gain a bonus to your initiative rolls equal to your Wisdom modifier (minimum of 1)."
+					]
+				}
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Explorer I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Herbalist I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have a deep knowledge of plants and their healing properties. You have advantage on Intelligence ({@skill Nature}) checks to identify the medicinal properties of plants, and Wisdom ({@skill Medicine}) checks made to stabilize creatures."
+			]
+		},
+		{
+			"name": "Herbalist II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have learned to use natural plants and herbs to create healing potions. You gain proficiency with the {@item herbalism kit|phb}.",
+				"At the end of a long rest, you can use a herbalism kit to create a {@item potion of healing}. It retains its potency for a number of days equal to your proficiency bonus, after which it spoils."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Herbalist I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Herbalist III",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"When you take a short rest, you and any friendly creatures who rest with you, regain an extra {@dice 1d8} hit points as long as they expend at least one of their Hit Dice to regain hit points."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Herbalist II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Natural Regeneration",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"During a short rest, you can recover spell slots of a combined level equal to your Wisdom modifier. Once you do so, you must finish a long rest before you can use this feature again."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 14,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Slayer I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"When you hit a creature with a weapon attack you can mark it as your Favored Foe as part of the same attack, and apply your Favored Foe damage bonus to the damage roll.",
+				"Moreover, whenever you make a Wisdom ({@skill Perception}) or a Wisdom ({@skill Survival}) check to locate or track your Favored Foe, you can treat a roll of 7 or lower on the d20 as an 8."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Slayer II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Your tracking abilities have become supernaturally accurate. You always know the exact direction and distance of your Favored Foe while you are on the same plane of existence."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Slayer I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Slayer III",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Once per turn, when you hit your Favored Foe with a weapon attack, you can force it to make a Constitution saving throw against your Spell Save DC. On a failed save, it is {@condition blinded}, {@condition deafened}, {@condition frightened}, {@condition poisoned}, or {@condition restrained} (your choice) until the beginning of your next turn."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 14,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Slayer II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Stalker I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You are a master at covering your tracks. While moving at a normal pace, you and any creatures of your choice who travel with you (maximum 10), produce no tracks nor scent, and cannot be tracked by mundane means unless you wish to be."
+			]
+		},
+		{
+			"name": "Stalker II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have learned to hunt your prey while remaining unseen. You can take the {@action Hide} action as a bonus action on your turn."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Stalker I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Stalker III",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You cannot be tracked, even by magic. You are always under the effects of the {@spell nondetection} spell, and you can't be tracked divination magic or magical means unless you wish to be."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Stalker II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Stalker IV",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You can ward yourself to briefly disappear from sight. When you take the {@action Hide} action, you, along with anything you are wearing or carrying, become {@condition invisible} until the start of your next turn. This ends early if you attack or cast a spell."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 14,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Stalker III"
+					]
+				}
+			]
+		},
+		{
+			"name": "Strider I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You ignore the effects of difficult terrain imposed by natural environments, such as undergrowth, snow, or marshlands. Also, you and creatures of your choice who travel with you (maximum 10) don't have travel slowed by difficult terrain."
+			]
+		},
+		{
+			"name": "Strider II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Once in your sights, you pursue your quarries relentlessly. You can take the {@action Dash} action as a bonus action on your turn."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Strider I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Strider III",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You can surmount almost any obstacle that would block your path. Your base walking speed increases by 10 feet, and you ignore the effects of difficult terrain imposed by spells, magical phenomena, and any other magical effect."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Strider II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Strider IV",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You move through the world unhindered by even the most powerful magic and restraints. You are always under the effects of the {@spell freedom of movement} spell while conscious."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 14,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Strider III"
+					]
+				}
+			]
+		},
+		{
+			"name": "Survivor I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Your time in the wilds has hardened your body. As a bonus action on your turn, you can grant yourself temporary hit points equal to your Constitution modifier (minimum of 1)."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Survivor II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Your body can rapidly recover from injury. When you expend a Hit Die to regain hit points, you regain additional hit points equal to your Wisdom modifier (minimum of 1 hit point)."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Survivor I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Survivor III",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You persevere even in the face of death. When you make a death saving throw, you can add your Wisdom modifier to the roll (minimum of +1). If the result of your roll is 20 or higher, you treat it as if you had rolled a 20 on the d20."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 14,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Survivor II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Trapper",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"As an action, you can set a hidden trap made out of natural materials in an adjacent 5-foot space. The first creature to move into the area must succeed on a Dexterity saving throw against your Spell Save DC or become restrained.",
+				"A creature repeats its saving throw at the start of each turn, ending the effect on a success. A creature can detect a trap by succeeding on an Intelligence (Investigation) check against your Spell Save DC. You can have a number of active traps equal to your Wisdom modifier (minimum of 1 trap)."
+			]
+		},
+		{
+			"name": "Wild Insights I",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have a way with wild animals. You can communicate simple ideas to beasts using sounds and gestures. Also, whenever you make a Wisdom ({@skill Animal Handling}) check that targets an animal or beast that is friendly toward you, you can treat a roll of 7 or lower on the d20 at 8."
+			]
+		},
+		{
+			"name": "Wild Insights II",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have bound yourself with a minor nature spirit. You learn the {@spell find familiar} spell. It counts as a Ranger spell for you, you always have it prepared, but it doesn't count against the total number of spells you prepare each day. When you cast this spell your summoned familiar is always a fey creature."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Wild Insights I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Wild Insights III",
+			"source": "LLAR",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"The power of your nature spirit grows. When you cast {@spell find familiar}, it can take the form of {@filter any beast of CR 1/2 or lower|bestiary|Challenge Rating=[&0;&1/2]|type=beast}."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Wild Insights II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Arctic Adept",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have adapted to the frozen tundra. You gain resistance to cold damage. Also, you and creatures of your choice who travel with you (maximum 10), have advantage on saving throws to resist the negative effects of arctic environments."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Desert Adept",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have adapted to scorching deserts. You gain resistance to fire damage. Also, you and creatures of your choice who travel with you (maximum 10), have advantage on saving throws to resist the negative effects of desert environments."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Fell Handed I",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"When you score a critical hit with a weapon attack against a creature, you have advantage on the next attack you make against that creature before the end of your next turn."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Fell Handed II",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"When you score a critical hit against a creature, your critical hit range for attack rolls against that creature expands by 1.",
+				"For example, if you score a critical hit against a creature for the first time, you then score a critical hit on a roll of 19 or 20 when you make an attack roll against the creature."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 9,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Fell Handed I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Jungle Adept",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have adapted to the jungles. You gain resistance to poison damage. Also, you and creatures of your choice who travel with you (maximum 10) have advantage on saving throws to resist negative effects of jungle environments."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Ranger Knight I",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Though you spend your time in the wilderness you still have some military training. You gain proficiency in heavy armor."
+			]
+		},
+		{
+			"name": "Ranger Knight II",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Though you are a warrior of the wild you understand chivalry and politics. Whenever you make an Intelligence ({@skill History}) or Charisma ({@skill Persuasion}) check you gain a bonus to the roll equal to your Wisdom modifier (minimum of +1)."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Rider I",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"Whenever you make a Wisdom (Animal Handling) check to control, train, or tame a mount, you can treat a roll of 7 or lower on a d20 as an 8. Also, dismounting from a trained mount only costs you 5 feet of movement."
+			]
+		},
+		{
+			"name": "Rider II",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You have trained to fight from your mount. You gain the Mounted Warrior Fighting Style. If you already know this Fighting Style you learn another Ranger Fighting Style of your choice.",
+				"Also, you can ride mounts that are your size or larger."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Rider I"
+					]
+				}
+			]
+		},
+		{
+			"name": "Rider III",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You are a master of mounted combat. When you are riding mount and it is hit by an attack, you can use a reaction to become the target of that attack instead.",
+				"Also, if your mount makes a saving throw while you ride it, you can use your reaction to grant it advantage on its roll."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Rider II"
+					]
+				}
+			]
+		},
+		{
+			"name": "Underground Adept",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You are especially skilled at navigating the winding tunnels under the earth. You gain darkvision out to a range of 60 feet. If you already have darkvision its range increases by 60 feet.",
+				"Also, you can close your eyes and gain tremmorsense in a 60-foot radius. Within that radius, you can sense anything touching the ground. This special sense lasts for 1 minute, or until you open your eyes. Once you use this action you must finish a short or long rest before you can use it again."
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 6,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Woodsman I",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You are familiar with forests, trees, and timber of all kinds. You gain proficiency with {@item woodcarver's tools|phb}, and you have advantage on any Intelligence ({@skill Nature}) checks to identify, recall information, and construct things from wood.",
+				"Also, if you hit a tree, raw timber, or a wooden structure with a melee weapon attack, it is an automatic critical hit."
+			]
+		},
+		{
+			"name": "Woodsman II",
+			"source": "LLAR:E",
+			"featureType": [
+				"LL:SK"
+			],
+			"entries": [
+				"You can identify the strengths and weak points of wooden objects and creatures. You gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You gain proficiency with {@item carpenter's tools|phb}. Anything you construct from wood has twice as many hit points.",
+						"At the end of each long rest, if you have timber available, you can craft a total number of {@item club|phb|clubs}, {@item greatclub|phb|greatclubs}, {@item javelin|phb|javelins}, and {@item quarterstaff|phb|quarterstaffs} equal to your proficiency bonus.",
+						"When you hit a plant or a wooden construct with a {@item battleaxe|phb} or {@item greataxe|phb}, you score a critical hit on a roll of 19 or 20."
+					]
+				}
+			],
+			"prerequisite": [
+				{
+					"level": {
+						"level": 3,
+						"class": {
+							"name": "Ranger (Alternate)",
+							"source": "LLAR",
+							"visible": true
+						}
+					},
+					"feature": [
+						"Woodsman I"
+					]
+				}
+			]
+		}
+	],
+	"monster": [
+		{
+			"name": "Beast of the Cave",
+			"source": "LLAR",
+			"summonedByClass": "Ranger (Alternate)|LLAR",
+			"size": [
+				"M"
+			],
+			"type": "beast",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"special": "13 + PB (natural armor)"
+				}
+			],
+			"hp": {
+				"special": "5 + five times your ranger level (the beast has a number of hit dice [d8s] equal to your ranger level)"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 10
+			},
+			"str": 14,
+			"dex": 14,
+			"con": 13,
+			"int": 8,
+			"wis": 14,
+			"cha": 11,
+			"senses": [
+				"darkvision 120 ft.",
+				"tremorsense 30 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"understands the languages you speak"
+			],
+			"pbNote": "equals your bonus",
+			"trait": [
+				{
+					"name": "Primal Bond",
+					"entries": [
+						"You can add your PB to any ability check or saving throw that the beast makes."
+					]
+				},
+				{
+					"name": "Tremorsense",
+					"entries": [
+						"Your Beast knows the location of anything in contact with the ground within 30 feet."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d6 + 2 + PB} piercing or slashing damage (your choice)."
+					]
+				}
+			]
+		},
+		{
+			"name": "Beast of the Land",
+			"source": "LLAR",
+			"summonedByClass": "Ranger (Alternate)|LLAR",
+			"size": [
+				"M"
+			],
+			"type": "beast",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"special": "13 + PB (natural armor)"
+				}
+			],
+			"hp": {
+				"special": "5 + five times your ranger level (the beast has a number of hit dice [d8s] equal to your ranger level)"
+			},
+			"speed": {
+				"walk": 40,
+				"climb": 40
+			},
+			"str": 14,
+			"dex": 14,
+			"con": 15,
+			"int": 8,
+			"wis": 14,
+			"cha": 11,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"understands the languages you speak"
+			],
+			"pbNote": "equals your bonus",
+			"trait": [
+				{
+					"name": "Charge",
+					"entries": [
+						"If the beast moves at least 20 feet toward a target and then hits it with a maul attack on the same turn, the target takes extra slashing damage equal to your Favored Foe die. If the target is a Large or smaller creature, it must succeed on a Strength saving throw against your spell save DC or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Primal Bond",
+					"entries": [
+						"You can add your PB to any ability check or saving throw that the beast makes."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Maul",
+					"entries": [
+						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d8 + 2 + PB} piercing or slashing damage (your choice)."
+					]
+				}
+			]
+		},
+		{
+			"name": "Beast of the Sea",
+			"source": "LLAR",
+			"summonedByClass": "Ranger (Alternate)|LLAR",
+			"size": [
+				"M"
+			],
+			"type": "beast",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"special": "13 + PB (natural armor)"
+				}
+			],
+			"hp": {
+				"special": "5 + five times your ranger level (the beast has a number of hit dice [d8s] equal to your ranger level)"
+			},
+			"speed": {
+				"walk": 10,
+				"swim": 60
+			},
+			"str": 14,
+			"dex": 14,
+			"con": 15,
+			"int": 8,
+			"wis": 14,
+			"cha": 11,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"understands the languages you speak"
+			],
+			"pbNote": "equals your bonus",
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The beast can breathe in air and water."
+					]
+				},
+				{
+					"name": "Binding Strike",
+					"entries": [
+						"When the beast hits a Large or smaller creature with its Pseudopod, it can choose to grapple the target (escape DC equal to your spell save DC). Until this grapple ends, the beast can't use its Pseudopod attack on another target."
+					]
+				},
+				{
+					"name": "Primal Bond",
+					"entries": [
+						"You can add your PB to any ability check or saving throw that the beast makes."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Pseudopod",
+					"entries": [
+						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d6 + 2 + PB} piercing or bludgeoning damage (your choice)."
+					]
+				}
+			]
+		},
+		{
+			"name": "Beast of the Sky",
+			"source": "LLAR",
+			"summonedByClass": "Ranger (Alternate)|LLAR",
+			"size": [
+				"S"
+			],
+			"type": "beast",
+			"alignment": [
+				"N"
+			],
+			"ac": [
+				{
+					"special": "13 + PB (natural armor)"
+				}
+			],
+			"hp": {
+				"special": "4 + five times your ranger level (the beast has a number of hit dice [d6s] equal to your ranger level)"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": 60
+			},
+			"str": 6,
+			"dex": 16,
+			"con": 13,
+			"int": 8,
+			"wis": 14,
+			"cha": 11,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"passive": 12,
+			"languages": [
+				"understands the languages you speak"
+			],
+			"pbNote": "equals your bonus",
+			"trait": [
+				{
+					"name": "Flyby",
+					"entries": [
+						"The beast doesn't provoke opportunity attacks when it flies out of an enemies reach."
+					]
+				},
+				{
+					"name": "Primal Bond",
+					"entries": [
+						"You can add your PB to any ability check or saving throw that the beast makes."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Shred",
+					"entries": [
+						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target. {@h}{@damage 1d4 + 3 + PB} piercing or slashing damage (your choice)."
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
An update to LaserLlama's Alternate Ranger (plus Expanded) homebrew. Includes three new subclasses and alterations to old subclasses, all according to the LL's PDFs on GMBinder.