### PR TITLE
Aron; Demi-Dragon 4.6 Update Patch

### DIFF
--- a/class/Aron; Demi-Dragon.json
+++ b/class/Aron; Demi-Dragon.json
@@ -86,42 +86,49 @@
 			"entries": [
 				{
 					"name": "Ability Score Increase",
+					"type": "entries",
 					"entries": [
 						"Your Strength score increases by 2, and one other ability score of your choice increases by 1."
 					]
 				},
 				{
 					"name": "Age",
+					"type": "entries",
 					"entries": [
 						"A demi-dragon can live for roughly four hundred years, starting from when they were first transformed."
 					]
 				},
 				{
 					"name": "Creature Type",
+					"type": "entries",
 					"entries": [
 						"You are a Dragon."
 					]
 				},
 				{
 					"name": "Size",
+					"type": "entries",
 					"entries": [
 						"Demi-dragons have a body mass that is identical to that of their previous form. At most, a demi-dragon stands 4 feet tall from shoulder to the ground, and measures no longer than 16 feet from snout to tail tip, of which their body accounts for a maximum of 5 feet. Your size is Medium or Small, chosen when you select this race."
 					]
 				},
 				{
 					"name": "Aided Jump",
+					"type": "entries",
 					"entries": [
 						"Your wings provide you with lift. Your maximum jump distance for high and long jumps is doubled, and you do not need to take a running start. This extra distance costs movement as normal."
 					]
 				},
 				{
 					"name": "Darkvision",
+					"type": "entries",
 					"entries": [
 						"You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
 					]
 				},
 				{
 					"name": "Mythic Build",
+					"type": "entries",
 					"entries": [
 						"You count as one size category larger when determining your carrying capacity and the weight you can push, drag, or lift.",
 						"Your claws have enough manual agility to manipulate objects as normal, but you have disadvantage on attack rolls made with weapons that have the ammunition or two-handed properties, and receive no benefit from wielding shields. In order to wear armor, you must have it specially constructed, costing twice the normal rate."
@@ -129,18 +136,21 @@
 				},
 				{
 					"name": "Dragon Scales",
+					"type": "entries",
 					"entries": [
 						"Your magical essence enhances your protective scales. While you aren't wearing armor, your Armor Class equals 10 + your Constitution modifier + your Charisma modifier."
 					]
 				},
 				{
 					"name": "Natural Weapons",
+					"type": "entries",
 					"entries": [
 						"You have access to an arsenal of natural weapons. These natural weapons count as martial melee weapons for you, and you are proficient with them. You can use them to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with them. Your fanged maw deals {@damage 1d12} piercing damage on a hit. Your lashing tail has a reach of 10 feet and deals {@damage 1d10} bludgeoning damage. Your rending claws deal {@damage 1d6} slashing damage. When you take the {@action Attack} action and attack with your claw, you can use your bonus action to make an additional claw attack."
 					]
 				},
 				{
 					"name": "Class Restriction",
+					"type": "entries",
 					"entries": [
 						"You can't use the demi-dragon racial traits if you don't have at least one level of the demi-dragon class.",
 						"If your race is later changed by another effect, you lose access to all demi-dragon class features. Your race and class are invariably tied together."
@@ -148,12 +158,14 @@
 				},
 				{
 					"name": "Inheritance",
+					"type": "entries",
 					"entries": [
 						"Your connection to a particular type of true dragon manifests as a related skill. You gain proficiency with one of the following skills of your choice: Arcana, Acrobatics, Deception, History, and Persuasion."
 					]
 				},
 				{
 					"name": "Languages",
+					"type": "entries",
 					"entries": [
 						"You can speak, read, and write Common and Draconic."
 					]
@@ -3579,12 +3591,14 @@
 					"items": [
 						{
 							"name": "Gold Luck",
+							"type": "entries",
 							"entries": [
 								"You harness the mystic fortuity of the gold dragon. Whenever you or an ally that you can see makes an attack roll, an ability check, or a saving throw, you can choose to roll an additional d20. You can take this action after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw. You can use this feature once, and regain the ability to do so after finishing a short or long rest."
 							]
 						},
 						{
 							"name": "Sheltering Wings",
+							"type": "entries",
 							"entries": [
 								"Flexible armor plating grows across your wings, allowing you to use them as shelter for your allies. When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll."
 							]
@@ -3605,12 +3619,14 @@
 					"items": [
 						{
 							"name": "Ivory Charge",
+							"type": "entries",
 							"entries": [
 								"Your horns split into a branching crown of antlers, capable of punching holes through hide and armor alike. You gain an {@item antlers|TheDemiDragon} natural weapon, which counts as a martial melee weapon for you. You can use it to make melee weapon attacks, with which you are proficient. Your antlers deal piercing damage equal to {@damage 3d4} + your Strength modifier. If you move at least 10 feet in a straight line during your turn, you gain advantage on the first attack you make with your antlers."
 							]
 						},
 						{
 							"name": "Warrior's Will",
+							"type": "entries",
 							"entries": [
 								"You adorn your form with a symbol of bravery and prepare yourself to face opposition. You gain advantage on Wisdom saving throws."
 							]
@@ -3631,12 +3647,14 @@
 					"items": [
 						{
 							"name": "Draining Scales",
+							"type": "entries",
 							"entries": [
 								"You alter your scales to siphon magical energy. Whenever you are a target of any spell of 1st level or higher, you gain temporary hit points equal to your Constitution modifier (minimum 1) before the spell's effects are resolved."
 							]
 						},
 						{
 							"name": "Silver Mist",
+							"type": "entries",
 							"entries": [
 								"You take on the aspect of the silver dragon, and can walk on clouds. As a reaction that you can take when you or another creature that is Large or smaller within 60 feet of you falls, you can create a cloud beneath the target as a reaction. The cloud supports the creature's weight and can harmlessly break their fall as if it were a physical object. As part of creating the cloud, you can choose to have it immediately move up to 10 feet up or down, where it will then float in place for up to 1 hour, or until you create a new one."
 							]
@@ -3657,12 +3675,14 @@
 					"items": [
 						{
 							"name": "Stone Scales",
+							"type": "entries",
 							"entries": [
 								"You assimilate available minerals in order to create a thick layer of defensive stone scales. Your Armor Class becomes equal to 16 + your Constitution modifier. You count as wearing heavy armor, but don't suffer any penalty to your Dexterity (Stealth) or as a result of not having heavy armor proficiency."
 							]
 						},
 						{
 							"name": "Capable Form",
+							"type": "entries",
 							"entries": [
 								"Your body grows better suited to grasping and manipulating objects. You can ignore the disadvantage imposed on attack rolls by Mythic Build. Additionally, you gain proficiency with simple and martial weapons as well as with two tools of your choice. You can change your tool choices every time you finish a short or long rest."
 							]
@@ -3683,12 +3703,14 @@
 					"items": [
 						{
 							"name": "Tunnel Wyrm",
+							"type": "entries",
 							"entries": [
 								"You gain a burrowing speed equal to half your walking speed. You can tunnel through loose dirt, gravel, and similar materials, but not through solid materials. If you burrow at half speed, you can reinforce your tunnel as you move, allowing others to pass through - otherwise your tunnel slowly collapses behind you. Additionally, as an action while burrowing, you can hollow out a portion of space in the terrain into a 15-feet wide and deep sinkhole. If the sinkhole connects to the surface, it immediately collapses. Creatures caught in the area must succeed on a Dexterity saving throw against your Dragon Spark DC or fall into the sinkhole and drop prone. On a successful save, a creature can instead choose to move to the nearest available space without provoking opportunity attacks. If you spend 1 minute creating the sinkhole, it will instead collapse when the first creature that is Small or larger moves into its space. You can use this property twice, after which you must finish a short or long rest before you can use it again."
 							]
 						},
 						{
 							"name": "Reverberating Roar",
+							"type": "entries",
 							"entries": [
 								"Your voice commands the attention of your foes. As a bonus action, you can roar, inciting fear and hesitation. Each creature of your choice within 20 feet of you are forced to make a Wisdom saving throw against your Dragon Spark save DC. A target is unaffected if it can't hear or see you. On a failed save, a target can't take reactions until the start of your next turn. A creature that succeeds on this saving throw is immune to your roar until the end of your next turn."
 							]
@@ -3709,12 +3731,14 @@
 					"items": [
 						{
 							"name": "Esoteric Ward",
+							"type": "entries",
 							"entries": [
 								"Runic glyphs carved across your body guard you against a variety of magics. You gain advantage on all Intelligence, Charisma, and Strength saving throws against magical effects."
 							]
 						},
 						{
 							"name": "Veiled Wings",
+							"type": "entries",
 							"entries": [
 								"Your wings take on a new aspect. Your Glide/Fly speed increases by 10 feet, and you can take the {@action Disengage} action as a bonus action."
 							]
@@ -3735,12 +3759,14 @@
 					"items": [
 						{
 							"name": "Blasting Breath",
+							"type": "entries",
 							"entries": [
 								"Your elemental spark is always at the ready. You can use your action to exhale a bolt of elemental energy and spit it at a creature you can see within a range of 120. Make a ranged spell attack using your Dragon Spark. On a hit, the target takes {@damage 1d10} + your Charisma modifier damage. The damage is the same damage type as your Dragon's Breath. The number of damage dice increases by one at levels 5, 11, and 17."
 							]
 						},
 						{
 							"name": "Wyrm Tongue",
+							"type": "entries",
 							"entries": [
 								"Your suave voice is confident and convincing. You have advantage on your choice of Charisma (Deception) or Charisma (Persuasion) checks. Additionally, you learn two languages of your choice. You can change your choices every time you finish a short or long rest."
 							]
@@ -3761,12 +3787,14 @@
 					"items": [
 						{
 							"name": "White Cunning",
+							"type": "entries",
 							"entries": [
 								"You instill yourself with the primal awareness of the white dragon. You have advantage on initiative checks and you ignore non-magical difficult terrain."
 							]
 						},
 						{
 							"name": "Rending Jaws",
+							"type": "entries",
 							"entries": [
 								"Your jaw grows more powerful, and your fangs become serrated and cruel, capable of puncturing armor and rending flesh. When you hit with a {@item bite|TheDemiDragon} attack, the target suffers a -1 to AC for 1 minute. This effect can only be applied once per creature."
 							]
@@ -3787,6 +3815,7 @@
 					"items": [
 						{
 							"name": "Driving Strikes",
+							"type": "entries",
 							"entries": [
 								"The tip of your tail develops a tough, bony club, and the force of your blows leaves your enemies reeling. When you make a tail attack on your turn, your reach for it is 5 feet greater than normal. Additionally, when you deal damage to a creature twice on the same turn with any combination of natural weapons, the creature must succeed on a Strength saving throw or be pushed 10 feet away from you.",
 								{
@@ -3800,6 +3829,7 @@
 						},
 						{
 							"name": "Elemental Maw",
+							"type": "entries",
 							"entries": [
 								"Volatile energy fills your gullet. Once on each of your turns when you hit with a {@item bite|TheDemiDragon} attack, you deal an additional {@damage 1d6} damage of your Dragon's Breath damage type."
 							]
@@ -3820,12 +3850,14 @@
 					"items": [
 						{
 							"name": "Darting Predator",
+							"type": "entries",
 							"entries": [
 								"You adapt to better surprise your foes with short bursts of speed. You can take the {@action Dash} action as a bonus action."
 							]
 						},
 						{
 							"name": "Drowning Terror",
+							"type": "entries",
 							"entries": [
 								"You gain a swimming speed equal to your walking speed, and you can breathe both air and water. Whenever you grapple a target that is unable to breathe freely - such as an aquatic creature on land or vice versa - at the start of each of its turns, the target of your grapple must succeed on a Wisdom save against your Dragon Spark DC or become {@condition frightened} of drowning until it can again breathe freely. Additionally, when you are dragging or carrying a {@condition grappled} creature with you, your speed is no longer halved."
 							]
@@ -3846,12 +3878,14 @@
 					"items": [
 						{
 							"name": "Thorny Spines",
+							"type": "entries",
 							"entries": [
 								"You grow a series of sharp, slender spikes across your body. Whenever a creature within 5 feet of you hits you with a melee attack, they take {@damage 1d4} piercing damage. At the start of each of your turns you deal 1d4 piercing damage to any creature grappling you or any creature {@condition grappled} by you."
 							]
 						},
 						{
 							"name": "Skewering Quills",
+							"type": "entries",
 							"entries": [
 								"You develop clusters of sharp quills along your limbs which you can fire in an arc at your foes. You gain a {@item quills|TheDemiDragon} natural weapon, which counts as a martial ranged weapon for you and which you are proficient with. You can use them to make ranged weapon attacks with a range of 60/120, and you add your Strength modifier to the attack and damage rolls when you attack with them. On a hit, they deal 1d10 piercing damage. Hit or miss, one square occupied by the targeted creature is then filled with quills, and you can additionally choose two squares within 5 feet of that square to also fill with quills as your inaccurate bombardment harmlessly scatters across the area. Any creature that subsequently enters a square filled with quills must succeed on a Dexterity saving throw against your Dragon Spark save DC or stop moving this turn and take 1 piercing damage. A creature moving through the area at half speed doesn't need to make the save. You can use this attack a number of times equal to 1 + your Constitution modifier (minimum 1), after which you must finish a short or long rest to use it again."
 							]
@@ -3872,12 +3906,14 @@
 					"items": [
 						{
 							"name": "Breath of Bolstering Essence",
+							"type": "entries",
 							"entries": [
 								"Your magical essence is a wellspring of vitality waiting to be shared. As an action, you exhale revitalizing power unto a creature of your choice within 10 feet of you, restoring a number of hit points equal to your demi-dragon level. At your option, you can expend one or more of your Hit Dice, up to half your demi-dragon level. For each Hit Die spent in this way, roll the die then add your Constitution modifier, and add the result to the total amount of hit points you restore to the target. Once you use this feature, you cannot use it again until you finish a short or long rest."
 							]
 						},
 						{
 							"name": "Enthralling Dragonsong",
+							"type": "entries",
 							"entries": [
 								"You can sing a wordless aria that pacifies your audience. As a bonus action and on each subsequent turn while your song lasts, every creature of your choice within 20 feet of you must succeed on a Wisdom saving throw against your Dragon Spark or become {@condition charmed} by you until your song ends. A creature that cannot hear you or which has successfully saved against your song is immune to this use of your song. The song ends after 1 minute, if you are {@condition incapacitated}, or if you do not maintain it with a bonus action each turn. Once you use this feature, you cannot use it again until you finish a short or long rest."
 							]
@@ -3898,12 +3934,14 @@
 					"items": [
 						{
 							"name": "Numinous Dragonsong",
+							"type": "entries",
 							"entries": [
 								"As a bonus action, you can sing a wordless hymn that bolsters your allies. Your song lasts until the start of your next turn, and while it lasts you and creatures of your choice within 20 feet of you gain a bonus to death saving throws and Constitution saving throws equal to your Charisma modifier (with a minimum bonus of +1). The song ends if you are {@condition incapacitated} or if you do not maintain it with a bonus action each turn."
 							]
 						},
 						{
 							"name": "Shape Breath",
+							"type": "entries",
 							"entries": [
 								"When you breathe destructive energy, you can shape pockets of relative safety within the area of your breath. When you use your Dragon's Breath feature, you can choose a number of creatures that are within the area of the breath weapon and which you can see equal to 1 + your Charisma modifier (minimum 1). The chosen creatures need not make a saving throw, and take no damage from your Dragon's Breath."
 							]
@@ -3924,12 +3962,14 @@
 					"items": [
 						{
 							"name": "Chameleon Scales",
+							"type": "entries",
 							"entries": [
 								"Your scales gain the ability to change color, letting you blend in with your surroundings. You can take the {@action Hide} action as a bonus action on your turn. You have advantage on Stealth checks made to hide in dim light and in natural terrain, such as rocks, plants, or sand."
 							]
 						},
 						{
 							"name": "Venomous Sting",
+							"type": "entries",
 							"entries": [
 								"Your tail develops a stinger, loaded with poison. Your {@item tail|TheDemiDragon} attack deals your choice of piercing or bludgeoning damage. Once on each of your turns when you deal damage with a tail attack, the target must succeed on a Constitution saving throw against your Dragon Spark save DC. On a failure, the target takes an additional {@damage 2d6} poison damage and is {@condition poisoned} until the end of its next turn."
 							]
@@ -3950,12 +3990,14 @@
 					"items": [
 						{
 							"name": "Skittering Crawl",
+							"type": "entries",
 							"entries": [
 								"You gain a climbing speed equal to your walking speed. If you move at least 20 feet on the ground or as part of a climb, you can choose to take the {@action Dodge} action as a bonus action."
 							]
 						},
 						{
 							"name": "Snatching Tail",
+							"type": "entries",
 							"entries": [
 								"Your tail becomes flexible, letting you unexpectedly catch your foes and yank them around. When you hit a creature that is up to one size category larger than you with your {@item tail|TheDemiDragon}, you can choose to force them to roll a Strength saving throw. On a failure, they are pulled to a space of your choosing within 10 feet of you. The space must be unoccupied.",
 								{
@@ -4001,7 +4043,7 @@
 			"source": "TheDemiDragon",
 			"raceName": "Demi-Dragon",
 			"raceSource": "TheDemiDragon",
-			"data": {
+			"system": {
 				"activation.type": "action"
 			}
 		}
@@ -4013,7 +4055,7 @@
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 1,
-			"data": {
+			"system": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"actionType": "save",
@@ -4043,7 +4085,7 @@
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 1,
-			"data": {
+			"system": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"actionType": "heal",
@@ -4216,7 +4258,7 @@
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 13,
-			"data": {
+			"system": {
 				"activation.type": "special",
 				"damage": {
 					"parts": [
@@ -4235,7 +4277,7 @@
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 17,
-			"data": {
+			"system": {
 				"activation.type": "special",
 				"damage": {
 					"parts": [
@@ -4258,7 +4300,7 @@
 			"subclassShortName": "Juggernaut",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"data": {
+			"system": {
 				"activation.type": "special",
 				"uses": {
 					"value": 4,
@@ -4286,7 +4328,7 @@
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
 			"isIgnored": true,
-			"data": {
+			"system": {
 				"activation.type": "action"
 			}
 		},
@@ -4298,7 +4340,7 @@
 			"subclassShortName": "Juggernaut",
 			"subclassSource": "TheDemiDragon",
 			"level": 10,
-			"data": {
+			"system": {
 				"actionType": "heal",
 				"damage.parts": [
 					[
@@ -4316,7 +4358,7 @@
 			"subclassShortName": "Juggernaut",
 			"subclassSource": "TheDemiDragon",
 			"level": 17,
-			"data": {
+			"system": {
 				"activation.type": "special",
 				"uses": {
 					"value": 1,
@@ -4333,7 +4375,7 @@
 			"subclassShortName": "Sibilant",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"data": {
+			"system": {
 				"activation.type": "reaction",
 				"actionType": "save",
 				"save": {
@@ -4359,7 +4401,7 @@
 			"subclassShortName": "Sibilant",
 			"subclassSource": "TheDemiDragon",
 			"level": 6,
-			"data": {
+			"system": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"actionType": "save",
@@ -4382,7 +4424,7 @@
 			"subclassShortName": "Shadestalker",
 			"subclassSource": "TheDemiDragon",
 			"level": 6,
-			"data": {
+			"system": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"uses": {
@@ -4400,7 +4442,7 @@
 			"subclassShortName": "Scion",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"data": {
+			"system": {
 				"activation.type": "special",
 				"activation.cost": 1,
 				"uses": {
@@ -4418,7 +4460,7 @@
 			"subclassShortName": "Scion",
 			"subclassSource": "TheDemiDragon",
 			"level": 17,
-			"data": {
+			"system": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"uses": {
@@ -4436,7 +4478,7 @@
 			"subclassShortName": "Scion",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"data": {
+			"system": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"uses": {
@@ -4454,7 +4496,7 @@
 			"subclassShortName": "Arbiter",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"data": {
+			"system": {
 				"activation.type": "reaction",
 				"activation.cost": 1,
 				"uses": {
@@ -4472,7 +4514,7 @@
 			"subclassShortName": "Fervent Hoarder",
 			"subclassSource": "TheDemiDragon",
 			"level": 6,
-			"data": {
+			"system": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"uses": {
@@ -4490,7 +4532,7 @@
 			"subclassShortName": "Fervent Hoarder",
 			"subclassSource": "TheDemiDragon",
 			"level": 10,
-			"data": {
+			"system": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"uses": {
@@ -4518,7 +4560,7 @@
 			"subclassShortName": "Metamorph",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"data": {
+			"system": {
 				"activation.type": "1 minute",
 				"activation.cost": 1,
 				"uses": {
@@ -7512,9 +7554,6 @@
 			"type": {
 				"type": "humanoid or monstrosity"
 			},
-			"alignment": [
-				"Shares your alignment"
-			],
 			"ac": [
 				13
 			],

--- a/class/Aron; Demi-Dragon.json
+++ b/class/Aron; Demi-Dragon.json
@@ -13,19 +13,18 @@
 					"Aron",
 					"Zar Shef"
 				],
-				"version": "4.5",
+				"version": "4.6",
 				"url": "https://www.gmbinder.com/share/-LpZX_fRKhLCn-mr_64B",
 				"targetSchema": "1.0.0",
 				"color": "e34234"
 			}
 		],
 		"dateAdded": 1661716025,
-		"dateLastModified": 1671646965,
+		"dateLastModified": 1673730856,
 		"optionalFeatureTypes": {
 			"MV:J": "Maneuver, Juggernaut",
 			"Morph": "Morph Category, Metamorph"
-		},
-		"_dateLastModifiedHash": "2ae9da69fa"
+		}
 	},
 	"race": [
 		{
@@ -89,87 +88,75 @@
 					"name": "Ability Score Increase",
 					"entries": [
 						"Your Strength score increases by 2, and one other ability score of your choice increases by 1."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Age",
 					"entries": [
 						"A demi-dragon can live for roughly four hundred years, starting from when they were first transformed."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Creature Type",
 					"entries": [
 						"You are a Dragon."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Size",
 					"entries": [
-						"Demi-dragons have a body mass that is identical to that of their previous form. At most, a demi-dragon stands 4 feet tall from shoulder to the ground, and measures no longer than 16 feet from snout to tail tip, of which their body accounts for a maximum of 5 feet. Your size is Medium."
-					],
-					"type": "entries"
+						"Demi-dragons have a body mass that is identical to that of their previous form. At most, a demi-dragon stands 4 feet tall from shoulder to the ground, and measures no longer than 16 feet from snout to tail tip, of which their body accounts for a maximum of 5 feet. Your size is Medium or Small, chosen when you select this race."
+					]
 				},
 				{
 					"name": "Aided Jump",
 					"entries": [
 						"Your wings provide you with lift. Your maximum jump distance for high and long jumps is doubled, and you do not need to take a running start. This extra distance costs movement as normal."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Darkvision",
 					"entries": [
 						"You have superior vision in dark and dim conditions. You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light. You can't discern color in darkness, only shades of gray."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Mythic Build",
 					"entries": [
 						"You count as one size category larger when determining your carrying capacity and the weight you can push, drag, or lift.",
-						"Your claws have enough manual dexterity to manipulate objects as normal, but you have disadvantage on attack rolls made with weapons that have the ammunition or two-handed properties, and receive no benefit from wielding shields. In order to wear armor, you must have it specially constructed, costing two times the normal rate."
-					],
-					"type": "entries"
+						"Your claws have enough manual agility to manipulate objects as normal, but you have disadvantage on attack rolls made with weapons that have the ammunition or two-handed properties, and receive no benefit from wielding shields. In order to wear armor, you must have it specially constructed, costing twice the normal rate."
+					]
 				},
 				{
 					"name": "Dragon Scales",
 					"entries": [
 						"Your magical essence enhances your protective scales. While you aren't wearing armor, your Armor Class equals 10 + your Constitution modifier + your Charisma modifier."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Natural Weapons",
 					"entries": [
 						"You have access to an arsenal of natural weapons. These natural weapons count as martial melee weapons for you, and you are proficient with them. You can use them to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with them. Your fanged maw deals {@damage 1d12} piercing damage on a hit. Your lashing tail has a reach of 10 feet and deals {@damage 1d10} bludgeoning damage. Your rending claws deal {@damage 1d6} slashing damage. When you take the {@action Attack} action and attack with your claw, you can use your bonus action to make an additional claw attack."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Class Restriction",
 					"entries": [
 						"You can't use the demi-dragon racial traits if you don't have at least one level of the demi-dragon class.",
 						"If your race is later changed by another effect, you lose access to all demi-dragon class features. Your race and class are invariably tied together."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Inheritance",
 					"entries": [
 						"Your connection to a particular type of true dragon manifests as a related skill. You gain proficiency with one of the following skills of your choice: Arcana, Acrobatics, Deception, History, and Persuasion."
-					],
-					"type": "entries"
+					]
 				},
 				{
 					"name": "Languages",
 					"entries": [
 						"You can speak, read, and write Common and Draconic."
-					],
-					"type": "entries"
+					]
 				}
 			]
 		}
@@ -537,6 +524,7 @@
 				"Dragon's Might|Demi-Dragon|TheDemiDragon|11",
 				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|12",
 				"Dragon's Breath (three uses)|Demi-Dragon|TheDemiDragon|13",
+				"Rend and Ruin (1d6)|Demi-Dragon|TheDemiDragon|13",
 				"Fabled Resistance|Demi-Dragon|TheDemiDragon|14",
 				"Force of Self|Demi-Dragon|TheDemiDragon|15",
 				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|16",
@@ -544,7 +532,7 @@
 					"classFeature": "Embodiment feature|Demi-Dragon|TheDemiDragon|17",
 					"gainSubclassFeature": true
 				},
-				"Rend and Ruin|Demi-Dragon|TheDemiDragon|17",
+				"Rend and Ruin (3d6)|Demi-Dragon|TheDemiDragon|17",
 				"Devour Magic (two uses)|Demi-Dragon|TheDemiDragon|18",
 				"Ability Score Improvement|Demi-Dragon|TheDemiDragon|19",
 				"Fabled Resistance (three uses)|Demi-Dragon|TheDemiDragon|20"
@@ -999,6 +987,16 @@
 			]
 		},
 		{
+			"name": "Rend and Ruin (1d6)",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 13,
+			"entries": [
+				"At 13th level, your strikes leave your foes broken and crippled. Once on each of your turns if you deal damage to a target with at least two attacks, the target takes an additional 1d6 damage of the same type as the last hit, and has its speed reduced by 10 feet until the start of your next turn."
+			]
+		},
+		{
 			"name": "Fabled Resistance",
 			"source": "TheDemiDragon",
 			"className": "Demi-Dragon",
@@ -1029,13 +1027,13 @@
 			]
 		},
 		{
-			"name": "Rend and Ruin",
+			"name": "Rend and Ruin (3d6)",
 			"source": "TheDemiDragon",
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 17,
 			"entries": [
-				"At 17th level, your savage strikes leave your foes broken and bleeding. Once on each of your turns if you deal damage to a target with at least two natural weapon attacks, the target takes an additional 3d6 damage of the same type, and has its speed reduced by 10 feet until the start of your next turn."
+				"Starting at 17th level, the damage increases to 3d6."
 			]
 		},
 		{
@@ -1496,6 +1494,34 @@
 			"shortName": "Metamorph",
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Behemoth",
+			"subclassFeatures": [
+				"Embodiment of the Behemoth|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|3",
+				"Hulking Beast|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|6",
+				"Overpowering Force|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|6",
+				"Frightful Display|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|10",
+				"Wounded Defiance|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|10",
+				"Earthshaker|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Behemoth",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
+		},
+		{
+			"name": "Embodiment of the Skyterror",
+			"subclassFeatures": [
+				"Embodiment of the Skyterror|Demi-Dragon|TheDemiDragon|Skyterror|TheDemiDragon|3",
+				"Dive and Soar|Demi-Dragon|TheDemiDragon|Skyterror|TheDemiDragon|6",
+				"Aerial Acrobatics|Demi-Dragon|TheDemiDragon|Skyterror|TheDemiDragon|10",
+				"Unfettered|Demi-Dragon|TheDemiDragon|Skyterror|TheDemiDragon|17"
+			],
+			"source": "TheDemiDragon",
+			"shortName": "Skyterror",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon"
 		}
 	],
 	"subclassFeature": [
@@ -1592,7 +1618,7 @@
 			"level": 3,
 			"header": 1,
 			"entries": [
-				"By 3rd level, your horns and wings are alternative means of attack that are used as part of many of your maneuvers. These natural weapons count as martial melee weapons for you, and you are proficient with them. You can use them to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with them. Your {@item horns|TheDemiDragon} deal 2d4 piercing damage. Your {@item wings|TheDemiDragon} deal 1d4 bludgeoning damage. When you take the {@action Attack} action to attack with your claw or wing, you can use your bonus action to make an additional claw or wing attack."
+				"By 3rd level, your horns and wings are alternative means of attack that are used as part of many of your maneuvers. These natural weapons count as simple melee weapons for you, and you are proficient with them. You can use them to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with them. Your {@item horns|TheDemiDragon} deal 2d4 piercing damage. Your {@item wings|TheDemiDragon} deal 1d4 bludgeoning damage. When you take the {@action Attack} action to attack with your claw or wing, you can use your bonus action to make an additional claw or wing attack."
 			]
 		},
 		{
@@ -1824,7 +1850,7 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Starting from 6th level, you can infiltrate the minds of others to change how they see you. As a bonus action, choose a creature within 120 feet of you that you are aware of. The creature must succeed on a Wisdom saving throw or become {@condition charmed} by you for 10 minutes. Additionally, you alter the creature's perception of you, choosing from the following secondary effects:",
+				"Starting from 6th level, you can infiltrate the minds of others to change how they see you. As a bonus action, choose a creature within 120 feet of you that you are aware of. The creature must succeed on a Wisdom saving throw or become {@condition charmed} by you for 10 minutes or until you lose your concentration (as if you were concentrating on a spell). Additionally, you alter the creature's perception of you, choosing from the following secondary effects:",
 				{
 					"type": "list",
 					"items": [
@@ -1833,7 +1859,7 @@
 						"You appear to the target as a haunting vision. The target is {@condition frightened} of you and {@condition deafened} to all around it save you."
 					]
 				},
-				"If the charmed target takes any damage, the charm ends, but the secondary effect persists for the remaining duration. You can use this feature once, and must then finish a short or long rest to use it again."
+				"If the charmed target takes any damage, the charm ends, but the secondary effect persists for the remaining duration. You can use this feature twice, and must then finish a short or long rest to use it again."
 			]
 		},
 		{
@@ -1859,7 +1885,7 @@
 			"level": 17,
 			"header": 2,
 			"entries": [
-				"At 17th level, you leave a web of altered perception in your wake. When you use Obfuscate Consciousness, you can choose to concentrate (as if on a spell) for up to 1 hour afterwards. While concentrating in this manner, you can use Obfuscate Consciousness at will, but cannot target the same creature more than once."
+				"At 17th level, you leave a web of altered perception in your wake. While concentrating on your Obfuscate Consciousness, you can as a bonus action choose to target another creature within your range with the effects of Obfuscate Consciousness, but cannot target the same creature more than once."
 			]
 		},
 		{
@@ -2109,7 +2135,7 @@
 							"type": "entries",
 							"name": "Acid Barrage",
 							"entries": [
-								"As an action, you launch bursts of acid at up to 3 nearby targets that you can see and which are within a number of feet equal to your Line Range. Make a ranged Dragon Spark attack against each target. On a hit, the target takes acid damage equal to your Dragon's Breath Damage."
+								"As an action, you launch bursts of acid at up to 3 nearby targets that you can see and which are within a number of feet equal to your Line Range. Make a ranged spell attack with your Dragon Spark against each target. On a hit, the target takes acid damage equal to your Dragon's Breath Damage."
 							]
 						},
 						{
@@ -2130,7 +2156,7 @@
 							"type": "entries",
 							"name": "Desiccating Aura",
 							"entries": [
-								"As an action, you fill yourself with negative energy for 1 minute. You gain an aura equal in radius to your Cone Range. Each creature of your choice that moves into the aura's area for the first time on a turn or starts its turn there is afflicted by your baleful presence until the start of their next turn. Whenever an afflicted creature makes an attack roll or a saving throw, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw."
+								"As an action, you fill yourself with withering energy for 1 minute. You gain an aura equal in radius to your Cone Range. Each creature of your choice that moves into the aura's area for the first time on a turn or starts its turn there is afflicted by your baleful presence until the start of their next turn. Whenever an afflicted creature makes an attack roll or a saving throw, the target must roll a d4 and subtract the number rolled from the attack roll or saving throw."
 							]
 						},
 						{
@@ -2151,7 +2177,7 @@
 							"type": "entries",
 							"name": "Lightning Lance",
 							"entries": [
-								"As a bonus action, your breath forms a beam of crackling energy between yourself and a target within the range of your Line Range, creating a sustained arc of lightning. Make a Dragon Spark attack against that creature. On a hit, the target takes lightning damage, and on each of your subsequent turns for up to 1 minute thereafter, you can use your bonus action to automatically deal further lightning damage to the target. The damage follows the progression of your Dragon's Breath Damage, but using d4s in place of d8s. The effect ends if you use your bonus action to do anything else. The effect also ends if the target is ever outside the range of your Line Range or if it has total cover from you. While the effect lasts, your bite attacks deal lightning damage instead of the piercing damage normal for a {@item bite|TheDemiDragon} attack."
+								"As a bonus action, your breath forms a beam of crackling energy between yourself and a target within the range of your Line Range, creating a sustained arc of lightning. Make a ranged spell attack with your Dragon Spark against that creature. On a hit, the target takes lightning damage, and on each of your subsequent turns for up to 1 minute thereafter, you can use your bonus action to automatically deal further lightning damage to the target. The damage follows the progression of your Dragon's Breath Damage, but using d4s in place of d8s. The effect ends if you use your bonus action to do anything else. The effect also ends if the target is ever outside the range of your Line Range or if it has total cover from you. While the effect lasts, your bite attacks deal lightning damage instead of the piercing damage normal for a {@item bite|TheDemiDragon} attack."
 							]
 						},
 						{
@@ -2297,7 +2323,7 @@
 			"level": 17,
 			"header": 2,
 			"entries": [
-				"At 17th level, your heritage lets you inspire fear in those around you. As an action, each creature of your choice that is aware of you and within 60 feet of you is forced to make a Wisdom saving throw against your *Dragon Spark* save DC. On a failed save, a target becomes frightened of you for 1 minute. You can use this feature once, and regain the ability to do so after finishing a long rest."
+				"At 17th level, your heritage lets you inspire fear in those around you. As a bonus action, each creature of your choice that is aware of you and within 60 feet of you is forced to make a Wisdom saving throw against your Dragon Spark save DC. On a failed save, a target becomes frightened of you for 1 minute. You can use this feature once, and regain the ability to do so after finishing a long rest."
 			]
 		},
 		{
@@ -2662,11 +2688,11 @@
 					"entries": [
 						{
 							"type": "entries",
-							"name": "Ingenuity of the Hoard",
+							"name": "Magic of the Hoard",
 							"entries": [
 								"The centerpiece item takes the form of an amulet, a piece of clothing or jewelry, a beloved plushie, a coin or other currency, a book, or some other precious object. When you first select this option for Heart of the Hoard, you can choose one cantrip and a number of spells from the {@filter sorcerer spell list|spells|class=sorcerer}. See the table below to determine how many spells you know and the highest spell level that is available to you. When you gain a level in this class, you can choose new sorcerer spells and cantrips.",
 								"The centerpiece item acts as an arcane focus for you. While the centerpiece item is in your possession, you can cast the spells at the highest spell level available to you, using your Dragon Spark as your spellcasting ability.",
-								"Once you cast a spell in this way, you can't do so again until you finish a short or long rest. At 11th level, you can cast two spells before a rest.",
+								"Once you cast a spell in this way, you can't do so again until you finish a short or long rest. At 11th level, you can cast two spells before a rest. Additionally, you can choose to expend a use of your Dragon's Breath feature to cast a spell without expending a spell slot, but you must then complete a short or long rest before doing so again.",
 								{
 									"type": "table",
 									"colLabels": [
@@ -3058,6 +3084,326 @@
 			"entries": [
 				"Starting from 17th level, you have nigh-total control over your transformation. You can retain one additional Waning morph, and when you change morphs, you can choose to change each of your previously Waning morphs to any morph from any category you know."
 			]
+		},
+		{
+			"name": "Embodiment of the Behemoth",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"Some dragons rely on brute strength and unyielding vitality to survive in a world that means them ill. Such dragons use their size and tenacity to shrug off deadly attacks, cause upheaval by their very presence, and manhandle their foes with their natural strength.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Lumbering Behemoth|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Natural Overdrive|Demi-Dragon|TheDemiDragon|Behemoth|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Lumbering Behemoth",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Your endurance and physical might are impressive to behold. At 3rd level, you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"You gain proficiency in the Athletics skill. If you are already proficient in it, you gain proficiency in one of the following skills of your choice: Acrobatics, Animal Handling, Intimidation, Perception, or Stealth.",
+						"You can carry one additional creature on your back, provided that you are at least one size category larger than each creature you carry."
+					]
+				},
+				"Some of your archetype features require your target to make a saving throw to resist the feature's effects. The saving throw DC is calculated as follows:",
+				{
+					"type": "abilityDc",
+					"name": "Behemoth",
+					"attributes": [
+						"str"
+					]
+				}
+			]
+		},
+		{
+			"name": "Natural Overdrive",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Starting at 3rd level, as a bonus action, you can enhance your natural might by boosting the magical power of your dragon spark into overdrive. Your overdrive lasts for 1 minute and grants you the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"If you are smaller than Large, you become Large, along with anything you are wearing. If you lack the room to become Large, your size doesn't change.",
+						"You have advantage on Strength checks and Strength saving throws.",
+						"You gain temporary hit points equal to your demi-dragon level + your Constitution modifier."
+					]
+				},
+				"While in overdrive, once per round on your turn you can choose one of the following effects to activate (no action required).",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Grab",
+							"entries": [
+								"If you hit a creature that is no more than one size larger than you with a weapon attack, you can choose to force the creature to make a Strength saving throw against your Behemoth save DC. On a failed save, the creature is grappled by you."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Trampling Push",
+							"entries": [
+								"You can attempt to move into the space of creatures smaller than yourself, treating that space as difficult terrain. When you do, the creature must make a Strength saving throw against your Behemoth save DC. On a failure, you push the creature 5 feet away from you. On a success, you cannot move into that creature's space for that turn. On your turn when you activate this ability, you have a number of charges equal to your Strength modifier, and expend a charge for each creature you attempt to push. You can continue to push a creature that has failed its saving throw, expending a charge for every 5 feet you push the creature."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Guarding Wings",
+							"entries": [
+								"Until the start of your next turn, you and creatures of your choice within 5 feet of you are protected by half cover. Your cover protects from danger from all sides, except from below. If a creature moves within 5 feet of you while this ability is active, you can choose to extend this benefit to them."
+							]
+						}
+					]
+				},
+				"You can go into overdrive a number of times equal to your proficiency bonus, and you regain all expended uses of it when you finish a long rest."
+			]
+		},
+		{
+			"name": "Hulking Beast",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"You readily use your size and natural might to your benefit. Starting at 6th level, the following options are available to you. You can use each option once, and must then complete a short or long rest to use that option again.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Earth-Shaking Stomp",
+							"entries": [
+								"As a bonus action while on the ground, you can make a powerful stomp. Each creature other than yourself within 30 feet of you that is in contact with the ground must make a Dexterity saving throw against your Behemoth save DC. On a failure, a target is knocked prone."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Challenging Roar",
+							"entries": [
+								"As a bonus action, you let out a defiant roar. Each creature of your choice that is aware of you and within 60 feet of you is forced to make a Wisdom saving throw against your Dragon Spark save DC. On a failed save, that target has disadvantage on any attack roll that isn't against you for 1 minute, but only while you are in the target's line of sight. The target can repeat the saving throw at the end of each of its turns."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Feast",
+							"entries": [
+								"When a creature within 5 feet of you which is at least one size category smaller than you is reduced to 0 hit points, you can use your reaction to devour the creature whole. If the creature isn't a construct, ooze, or undead, you regain a number of hit points equal to your demi-dragon level. If the creature was carrying any magical items, you harmlessly disgorge them during your next short or long rest."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Overpowering Force",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, you understand well to push the world harder than it pushes back. When you hit with a natural weapon attack against a target that is frightened, grappled, incapacitated, prone, or restrained, you gain a +2 to the damage roll. Additionally, creatures under any of those conditions have disadvantage against your Dragon's Breath saving throw."
+			]
+		},
+		{
+			"name": "Frightful Display",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, a mere glance can terrify your foes. When you use your Feast feature, choose one creature within 60 feet of you that can see you. That creature must succeed on a Wisdom saving throw against your Dragon Spark save DC or be frightened of you for 1 minute. The creature can repeat the saving throw at the end of each of its turn, ending the effect on a success."
+			]
+		},
+		{
+			"name": "Wounded Defiance",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, you only grow more steadfast in the face of danger. If you have no more than half your hit points left, bludgeoning, piercing, and slashing damage that you take from nonmagical attacks is reduced by an amount equal to your Constitution modifier (minimum 1)."
+			]
+		},
+		{
+			"name": "Earthshaker",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Behemoth",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, the upheaval of your presence sends your foes tumbling. Each creature of your choice that is your size or smaller which starts their turn within 10 feet of you must succeed on a Dexterity saving throw against your Behemoth save DC or fall prone.",
+				"Additionally, when you use your Earth-Shaking Stomp feature, each creature of your choice which fails their saving throw against the effect takes bludgeoning damage equal to 1d6 + your Strength modifier."
+			]
+		},
+		{
+			"name": "Embodiment of the Skyterror",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Skyterror",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"entries": [
+				"An ancient martial technique amongst dragons has seen a resurgence under a new flair, wielding steel weaponry to decimate unprepared foes. Normally impractical to a grounded dragon, such weapons take on a different characteristic when swung from the air, giving the appearance of a brutal aerial dance of flashing steel and beating wings.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wing Surge|Demi-Dragon|TheDemiDragon|Skyterror|TheDemiDragon|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Draconic Armory|Demi-Dragon|TheDemiDragon|Skyterror|TheDemiDragon|3"
+				}
+			]
+		},
+		{
+			"name": "Wing Surge",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Skyterror",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"At 3rd level, you are swift on the wing. As a bonus action, you can immediately move up to half your Glide & Fly speed in a direction of your choice without provoking opportunity attacks, and immediately start gliding. Until the start of your next turn, Glide's rate of descent slows to 0 feet per round, and you can can hover in place. You can use this feature a number of times equal to your proficiency bonus, and must finish a short or long rest until you can use it again."
+			]
+		},
+		{
+			"name": "Draconic Armory",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Skyterror",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"At 3rd level, you merely need the right angle of attack when using manufactured weaponry. You gain proficiency with simple and martial weapons. While you are gliding or flying, Mythic Build does not impose disadvantage on attacks made with weapons that have the ammunition or two-handed property. Additionally, you gain the following benefits:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Whirling Destruction",
+							"entries": [
+								"Whenever you move at least 10 feet in a straight line, you can add your Charisma modifier to the damage roll of one weapon attack you make with a martial melee weapon which you are wielding and which lacks the Reach property before the end of that turn."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Unerring Momentum",
+							"entries": [
+								"When you make an attack with a martial melee weapon which you are wielding, which has the Reach property, and which deals slashing or piercing damage, you can add 1 to the damage roll (maximum of twice your proficiency bonus as extra damage) for every 5 feet you move in a straight line before making the attack."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Dragon Sight",
+							"entries": [
+								"Whenever you make a ranged weapon attack, you can use your Strength modifier in place of your Dexterity modifier for the attack and damage rolls."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Dive and Soar",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Skyterror",
+			"subclassSource": "TheDemiDragon",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, your momentum is your greatest asset. Once during each of your turns, you can activate one of the following benefits (no action required):",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Dive",
+							"entries": [
+								"While you are gliding or flying, you can dive straight down a number of feet equal to half your Glide & Fly Speed without expending movement."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Soar",
+							"entries": [
+								"When you make a melee attack against one creature of your choice, you don't provoke opportunity attacks from that creature for the rest of the turn, whether you hit or not."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Aerial Acrobatics",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Skyterror",
+			"subclassSource": "TheDemiDragon",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"At 10th level, you are both elegant and devious in your maneuvering. When you use Wing Surge, you gain advantage on Dexterity saving throws and your AC increases by 3 until the start of your next turn."
+			]
+		},
+		{
+			"name": "Unfettered",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Skyterror",
+			"subclassSource": "TheDemiDragon",
+			"level": 17,
+			"header": 2,
+			"entries": [
+				"At 17th level, you are swift and free as the wind. Your walking and flying speeds each increase by 20.",
+				"Additionally, when you use Wing Surge, your speed can't be reduced in any way until the start of your next turn."
+			]
 		}
 	],
 	"optionalfeature": [
@@ -3235,15 +3581,13 @@
 							"name": "Gold Luck",
 							"entries": [
 								"You harness the mystic fortuity of the gold dragon. Whenever you or an ally that you can see makes an attack roll, an ability check, or a saving throw, you can choose to roll an additional d20. You can take this action after you roll the die, but before the outcome is determined. You choose which of the d20s is used for the attack roll, ability check, or saving throw. You can use this feature once, and regain the ability to do so after finishing a short or long rest."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Sheltering Wings",
 							"entries": [
 								"Flexible armor plating grows across your wings, allowing you to use them as shelter for your allies. When a creature you can see attacks a target other than you that is within 5 feet of you, you can use your reaction to impose disadvantage on the attack roll."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3263,15 +3607,13 @@
 							"name": "Ivory Charge",
 							"entries": [
 								"Your horns split into a branching crown of antlers, capable of punching holes through hide and armor alike. You gain an {@item antlers|TheDemiDragon} natural weapon, which counts as a martial melee weapon for you. You can use it to make melee weapon attacks, with which you are proficient. Your antlers deal piercing damage equal to {@damage 3d4} + your Strength modifier. If you move at least 10 feet in a straight line during your turn, you gain advantage on the first attack you make with your antlers."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Warrior's Will",
 							"entries": [
 								"You adorn your form with a symbol of bravery and prepare yourself to face opposition. You gain advantage on Wisdom saving throws."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3291,15 +3633,13 @@
 							"name": "Draining Scales",
 							"entries": [
 								"You alter your scales to siphon magical energy. Whenever you are a target of any spell of 1st level or higher, you gain temporary hit points equal to your Constitution modifier (minimum 1) before the spell's effects are resolved."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Silver Mist",
 							"entries": [
 								"You take on the aspect of the silver dragon, and can walk on clouds. As a reaction that you can take when you or another creature that is Large or smaller within 60 feet of you falls, you can create a cloud beneath the target as a reaction. The cloud supports the creature's weight and can harmlessly break their fall as if it were a physical object. As part of creating the cloud, you can choose to have it immediately move up to 10 feet up or down, where it will then float in place for up to 1 hour, or until you create a new one."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3319,15 +3659,13 @@
 							"name": "Stone Scales",
 							"entries": [
 								"You assimilate available minerals in order to create a thick layer of defensive stone scales. Your Armor Class becomes equal to 16 + your Constitution modifier. You count as wearing heavy armor, but don't suffer any penalty to your Dexterity (Stealth) or as a result of not having heavy armor proficiency."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Capable Form",
 							"entries": [
 								"Your body grows better suited to grasping and manipulating objects. You can ignore the disadvantage imposed on attack rolls by Mythic Build. Additionally, you gain proficiency with simple and martial weapons as well as with two tools of your choice. You can change your tool choices every time you finish a short or long rest."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3347,15 +3685,13 @@
 							"name": "Tunnel Wyrm",
 							"entries": [
 								"You gain a burrowing speed equal to half your walking speed. You can tunnel through loose dirt, gravel, and similar materials, but not through solid materials. If you burrow at half speed, you can reinforce your tunnel as you move, allowing others to pass through - otherwise your tunnel slowly collapses behind you. Additionally, as an action while burrowing, you can hollow out a portion of space in the terrain into a 15-feet wide and deep sinkhole. If the sinkhole connects to the surface, it immediately collapses. Creatures caught in the area must succeed on a Dexterity saving throw against your Dragon Spark DC or fall into the sinkhole and drop prone. On a successful save, a creature can instead choose to move to the nearest available space without provoking opportunity attacks. If you spend 1 minute creating the sinkhole, it will instead collapse when the first creature that is Small or larger moves into its space. You can use this property twice, after which you must finish a short or long rest before you can use it again."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Reverberating Roar",
 							"entries": [
 								"Your voice commands the attention of your foes. As a bonus action, you can roar, inciting fear and hesitation. Each creature of your choice within 20 feet of you are forced to make a Wisdom saving throw against your Dragon Spark save DC. A target is unaffected if it can't hear or see you. On a failed save, a target can't take reactions until the start of your next turn. A creature that succeeds on this saving throw is immune to your roar until the end of your next turn."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3375,15 +3711,13 @@
 							"name": "Esoteric Ward",
 							"entries": [
 								"Runic glyphs carved across your body guard you against a variety of magics. You gain advantage on all Intelligence, Charisma, and Strength saving throws against magical effects."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Veiled Wings",
 							"entries": [
 								"Your wings take on a new aspect. Your Glide/Fly speed increases by 10 feet, and you can take the {@action Disengage} action as a bonus action."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3402,16 +3736,14 @@
 						{
 							"name": "Blasting Breath",
 							"entries": [
-								"Your elemental spark is always at the ready. You can use your action to exhale a bolt of elemental energy and spit it at a creature you can see within a range of 120. Make a ranged Dragon Spark attack. On a hit, the target takes {@damage 1d10} + your Charisma modifier damage. The damage is the same damage type as your Dragon's Breath. The number of damage dice increases by one at levels 5, 11, and 17."
-							],
-							"type": "entries"
+								"Your elemental spark is always at the ready. You can use your action to exhale a bolt of elemental energy and spit it at a creature you can see within a range of 120. Make a ranged spell attack using your Dragon Spark. On a hit, the target takes {@damage 1d10} + your Charisma modifier damage. The damage is the same damage type as your Dragon's Breath. The number of damage dice increases by one at levels 5, 11, and 17."
+							]
 						},
 						{
 							"name": "Wyrm Tongue",
 							"entries": [
 								"Your suave voice is confident and convincing. You have advantage on your choice of Charisma (Deception) or Charisma (Persuasion) checks. Additionally, you learn two languages of your choice. You can change your choices every time you finish a short or long rest."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3431,15 +3763,13 @@
 							"name": "White Cunning",
 							"entries": [
 								"You instill yourself with the primal awareness of the white dragon. You have advantage on initiative checks and you ignore non-magical difficult terrain."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Rending Jaws",
 							"entries": [
 								"Your jaw grows more powerful, and your fangs become serrated and cruel, capable of puncturing armor and rending flesh. When you hit with a {@item bite|TheDemiDragon} attack, the target suffers a -1 to AC for 1 minute. This effect can only be applied once per creature."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3466,15 +3796,13 @@
 										"str"
 									]
 								}
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Elemental Maw",
 							"entries": [
 								"Volatile energy fills your gullet. Once on each of your turns when you hit with a {@item bite|TheDemiDragon} attack, you deal an additional {@damage 1d6} damage of your Dragon's Breath damage type."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3494,15 +3822,13 @@
 							"name": "Darting Predator",
 							"entries": [
 								"You adapt to better surprise your foes with short bursts of speed. You can take the {@action Dash} action as a bonus action."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Drowning Terror",
 							"entries": [
 								"You gain a swimming speed equal to your walking speed, and you can breathe both air and water. Whenever you grapple a target that is unable to breathe freely - such as an aquatic creature on land or vice versa - at the start of each of its turns, the target of your grapple must succeed on a Wisdom save against your Dragon Spark DC or become {@condition frightened} of drowning until it can again breathe freely. Additionally, when you are dragging or carrying a {@condition grappled} creature with you, your speed is no longer halved."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3522,15 +3848,13 @@
 							"name": "Thorny Spines",
 							"entries": [
 								"You grow a series of sharp, slender spikes across your body. Whenever a creature within 5 feet of you hits you with a melee attack, they take {@damage 1d4} piercing damage. At the start of each of your turns you deal 1d4 piercing damage to any creature grappling you or any creature {@condition grappled} by you."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Skewering Quills",
 							"entries": [
 								"You develop clusters of sharp quills along your limbs which you can fire in an arc at your foes. You gain a {@item quills|TheDemiDragon} natural weapon, which counts as a martial ranged weapon for you and which you are proficient with. You can use them to make ranged weapon attacks with a range of 60/120, and you add your Strength modifier to the attack and damage rolls when you attack with them. On a hit, they deal 1d10 piercing damage. Hit or miss, one square occupied by the targeted creature is then filled with quills, and you can additionally choose two squares within 5 feet of that square to also fill with quills as your inaccurate bombardment harmlessly scatters across the area. Any creature that subsequently enters a square filled with quills must succeed on a Dexterity saving throw against your Dragon Spark save DC or stop moving this turn and take 1 piercing damage. A creature moving through the area at half speed doesn't need to make the save. You can use this attack a number of times equal to 1 + your Constitution modifier (minimum 1), after which you must finish a short or long rest to use it again."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3550,15 +3874,13 @@
 							"name": "Breath of Bolstering Essence",
 							"entries": [
 								"Your magical essence is a wellspring of vitality waiting to be shared. As an action, you exhale revitalizing power unto a creature of your choice within 10 feet of you, restoring a number of hit points equal to your demi-dragon level. At your option, you can expend one or more of your Hit Dice, up to half your demi-dragon level. For each Hit Die spent in this way, roll the die then add your Constitution modifier, and add the result to the total amount of hit points you restore to the target. Once you use this feature, you cannot use it again until you finish a short or long rest."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Enthralling Dragonsong",
 							"entries": [
 								"You can sing a wordless aria that pacifies your audience. As a bonus action and on each subsequent turn while your song lasts, every creature of your choice within 20 feet of you must succeed on a Wisdom saving throw against your Dragon Spark or become {@condition charmed} by you until your song ends. A creature that cannot hear you or which has successfully saved against your song is immune to this use of your song. The song ends after 1 minute, if you are {@condition incapacitated}, or if you do not maintain it with a bonus action each turn. Once you use this feature, you cannot use it again until you finish a short or long rest."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3578,15 +3900,13 @@
 							"name": "Numinous Dragonsong",
 							"entries": [
 								"As a bonus action, you can sing a wordless hymn that bolsters your allies. Your song lasts until the start of your next turn, and while it lasts you and creatures of your choice within 20 feet of you gain a bonus to death saving throws and Constitution saving throws equal to your Charisma modifier (with a minimum bonus of +1). The song ends if you are {@condition incapacitated} or if you do not maintain it with a bonus action each turn."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Shape Breath",
 							"entries": [
 								"When you breathe destructive energy, you can shape pockets of relative safety within the area of your breath. When you use your Dragon's Breath feature, you can choose a number of creatures that are within the area of the breath weapon and which you can see equal to 1 + your Charisma modifier (minimum 1). The chosen creatures need not make a saving throw, and take no damage from your Dragon's Breath."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3606,15 +3926,13 @@
 							"name": "Chameleon Scales",
 							"entries": [
 								"Your scales gain the ability to change color, letting you blend in with your surroundings. You can take the {@action Hide} action as a bonus action on your turn. You have advantage on Stealth checks made to hide in dim light and in natural terrain, such as rocks, plants, or sand."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Venomous Sting",
 							"entries": [
 								"Your tail develops a stinger, loaded with poison. Your {@item tail|TheDemiDragon} attack deals your choice of piercing or bludgeoning damage. Once on each of your turns when you deal damage with a tail attack, the target must succeed on a Constitution saving throw against your Dragon Spark save DC. On a failure, the target takes an additional {@damage 2d6} poison damage and is {@condition poisoned} until the end of its next turn."
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3634,8 +3952,7 @@
 							"name": "Skittering Crawl",
 							"entries": [
 								"You gain a climbing speed equal to your walking speed. If you move at least 20 feet on the ground or as part of a climb, you can choose to take the {@action Dodge} action as a bonus action."
-							],
-							"type": "entries"
+							]
 						},
 						{
 							"name": "Snatching Tail",
@@ -3648,8 +3965,7 @@
 										"str"
 									]
 								}
-							],
-							"type": "entries"
+							]
 						}
 					]
 				}
@@ -3685,7 +4001,7 @@
 			"source": "TheDemiDragon",
 			"raceName": "Demi-Dragon",
 			"raceSource": "TheDemiDragon",
-			"system": {
+			"data": {
 				"activation.type": "action"
 			}
 		}
@@ -3697,7 +4013,7 @@
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 1,
-			"system": {
+			"data": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"actionType": "save",
@@ -3727,7 +4043,7 @@
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 1,
-			"system": {
+			"data": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"actionType": "heal",
@@ -3895,12 +4211,31 @@
 			]
 		},
 		{
-			"name": "Rend and Ruin",
+			"name": "Rend and Ruin (1d6)",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"level": 13,
+			"data": {
+				"activation.type": "special",
+				"damage": {
+					"parts": [
+						[
+							"1d6",
+							""
+						]
+					]
+				},
+				"formula": ""
+			}
+		},
+		{
+			"name": "Rend and Ruin (3d6)",
 			"source": "TheDemiDragon",
 			"className": "Demi-Dragon",
 			"classSource": "TheDemiDragon",
 			"level": 17,
-			"system": {
+			"data": {
 				"activation.type": "special",
 				"damage": {
 					"parts": [
@@ -3923,7 +4258,7 @@
 			"subclassShortName": "Juggernaut",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"system": {
+			"data": {
 				"activation.type": "special",
 				"uses": {
 					"value": 4,
@@ -3931,6 +4266,16 @@
 					"per": "sr"
 				}
 			}
+		},
+		{
+			"name": "Maneuvers",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Juggernaut",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"isIgnored": true
 		},
 		{
 			"name": "By Any Means",
@@ -3941,7 +4286,7 @@
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
 			"isIgnored": true,
-			"system": {
+			"data": {
 				"activation.type": "action"
 			}
 		},
@@ -3953,7 +4298,7 @@
 			"subclassShortName": "Juggernaut",
 			"subclassSource": "TheDemiDragon",
 			"level": 10,
-			"system": {
+			"data": {
 				"actionType": "heal",
 				"damage.parts": [
 					[
@@ -3971,7 +4316,7 @@
 			"subclassShortName": "Juggernaut",
 			"subclassSource": "TheDemiDragon",
 			"level": 17,
-			"system": {
+			"data": {
 				"activation.type": "special",
 				"uses": {
 					"value": 1,
@@ -3988,7 +4333,7 @@
 			"subclassShortName": "Sibilant",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"system": {
+			"data": {
 				"activation.type": "reaction",
 				"actionType": "save",
 				"save": {
@@ -4014,7 +4359,7 @@
 			"subclassShortName": "Sibilant",
 			"subclassSource": "TheDemiDragon",
 			"level": 6,
-			"system": {
+			"data": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"actionType": "save",
@@ -4037,7 +4382,7 @@
 			"subclassShortName": "Shadestalker",
 			"subclassSource": "TheDemiDragon",
 			"level": 6,
-			"system": {
+			"data": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"uses": {
@@ -4055,7 +4400,7 @@
 			"subclassShortName": "Scion",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"system": {
+			"data": {
 				"activation.type": "special",
 				"activation.cost": 1,
 				"uses": {
@@ -4073,8 +4418,8 @@
 			"subclassShortName": "Scion",
 			"subclassSource": "TheDemiDragon",
 			"level": 17,
-			"system": {
-				"activation.type": "action",
+			"data": {
+				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"uses": {
 					"value": 1,
@@ -4091,7 +4436,7 @@
 			"subclassShortName": "Scion",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"system": {
+			"data": {
 				"activation.type": "bonus action",
 				"activation.cost": 1,
 				"uses": {
@@ -4109,7 +4454,7 @@
 			"subclassShortName": "Arbiter",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"system": {
+			"data": {
 				"activation.type": "reaction",
 				"activation.cost": 1,
 				"uses": {
@@ -4127,7 +4472,7 @@
 			"subclassShortName": "Fervent Hoarder",
 			"subclassSource": "TheDemiDragon",
 			"level": 6,
-			"system": {
+			"data": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"uses": {
@@ -4145,7 +4490,7 @@
 			"subclassShortName": "Fervent Hoarder",
 			"subclassSource": "TheDemiDragon",
 			"level": 10,
-			"system": {
+			"data": {
 				"activation.type": "action",
 				"activation.cost": 1,
 				"uses": {
@@ -4156,6 +4501,16 @@
 			}
 		},
 		{
+			"name": "Morphs",
+			"source": "TheDemiDragon",
+			"className": "Demi-Dragon",
+			"classSource": "TheDemiDragon",
+			"subclassShortName": "Metamorph",
+			"subclassSource": "TheDemiDragon",
+			"level": 3,
+			"isIgnored": true
+		},
+		{
 			"name": "Swift Adaptation",
 			"source": "TheDemiDragon",
 			"className": "Demi-Dragon",
@@ -4163,7 +4518,7 @@
 			"subclassShortName": "Metamorph",
 			"subclassSource": "TheDemiDragon",
 			"level": 3,
-			"system": {
+			"data": {
 				"activation.type": "1 minute",
 				"activation.cost": 1,
 				"uses": {
@@ -4364,6 +4719,26 @@
 						"If you move at least 30 feet directly toward a target on a turn, you can choose to take a -5 penalty to any attack roll made with a natural weapon. If the attack hits, you add +10 to the attack's damage."
 					]
 				}
+			]
+		},
+		{
+			"name": "Loyal Minion",
+			"source": "TheDemiDragon",
+			"prerequisite": [
+				{
+					"race": [
+						{
+							"name": "demi-dragon"
+						}
+					]
+				}
+			],
+			"entries": [
+				"You gain the services of a loyal minion, which takes the form of a Small humanoid or monstrosity of your choice. The minion has the statistics detailed below.",
+				"Your minion acts independently of you, but it always obeys your commands. In combat, it rolls its own initiative and acts on its own turn. A minion can't attack, but it can take other actions as normal.",
+				"Additionally, you learn one new language or gain a skill or tool proficiency of your choice.",
+				"If you lose your minion, you can revive the minion or recruit a new minion at the end of a long rest.",
+				"If you select this feat multiple times, the number of loyal minions you have increases by 1 for each, and you can select an additional language, skill proficiency, or tool proficiency."
 			]
 		},
 		{
@@ -4801,7 +5176,7 @@
 			"reqAttune": true,
 			"entries": [
 				"This set of thick iron chains connects to a ruby pendant, intended to be worn on the limbs and chest, respectively. The set was created by a gallant spell duelist who preferred to defeat his adversaries by turning the power of their own magic against them.",
-				"As a reaction when you see a creature within 60 feet of you casting a spell, you can attempt to interrupt the creature's spellcasting. Make an ability check using your highest mental ability score. The DC equals 10 + the spell's level. On a success, the creature's spell fails and has no effect, and you store the spell that was being cast for up to 8 hours. You can cast the spell stored in the chains, even if you can't usually cast spells. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster, but is otherwise treated as if you cast the spell. Once the spell has been cast from the chains, it is no longer stored in them.",
+				"As a reaction when you see a creature within 60 feet of you casting a spell, you can attempt to interrupt the creature's spellcasting. Make an ability check using your highest mental ability score. The DC equals 10 + the spell's level. On a success, the creature’s spell fails and has no effect, and you store the spell that was being cast for up to 8 hours. You can cast the spell stored in the chains, even if you can't usually cast spells. The spell uses the slot level, spell save DC, spell attack bonus, and spellcasting ability of the original caster, but is otherwise treated as if you cast the spell. Once the spell has been cast from the chains, it is no longer stored in them.",
 				"Once you attempt to disrupt a creature's spell, it can't be used to do so again until the next dawn."
 			]
 		},
@@ -4832,6 +5207,30 @@
 			"entries": [
 				"This sturdy adamantine-plated helmet conforms to the shape of a dragon's skull, and is padded on the inside. Forward-facing adamantine horns are designed to splinter wood and puncture armor. While wearing the helm, you gain a {@item horns|TheDemiDragon} attack, which is a natural weapon and which counts as a martial melee weapon for you, and you are proficient with it. You can use it to make melee weapon attacks, and you add your Strength modifier to the attack and damage rolls when you attack with it. Your horn attack deals 2d4 piercing damage, and whenever you hit an object with it, the hit is a critical hit.",
 				"While you wear the helm and are attuned to it, you additionally gain 3 Fury points, and learn the {@optfeature Hammering Lunge|TheDemiDragon}, {@optfeature Reprisal|TheDemiDragon}, and {@optfeature Battering Ram|TheDemiDragon} maneuvers, as described under the Embodiment of the Juggernaut."
+			]
+		},
+		{
+			"name": "Essence of Fury",
+			"source": "TheDemiDragon",
+			"rarity": "legendary",
+			"wondrous": true,
+			"reqAttune": "by a demi-dragon",
+			"entries": [
+				"This crimson orb of intangible power roils with passionate intensity. As part of attuning to it, you must absorb it with Absorb Magic, infusing you with its fervor.",
+				"While you are attuned to the essence, you gain 4 Fury points, and learn the {@optfeature Lockjaw|TheDemiDragon}, {@optfeature Reprisal|TheDemiDragon}, {@optfeature Rising Wing|TheDemiDragon}, and {@optfeature Wrath|TheDemiDragon} maneuvers, and can use the horns and wings natural weapons as described under the Embodiment of the Juggernaut.",
+				"Additionally, you can choose to go berserk (no action required). When you do, and again at the start of each of your turns, you regain all your Fury points. Your berserk lasts for 1 minute, and you can't activate it again until you have finished a long rest."
+			]
+		},
+		{
+			"name": "Essence of Transformation",
+			"source": "TheDemiDragon",
+			"rarity": "very rare",
+			"wondrous": true,
+			"reqAttune": "by a demi-dragon",
+			"entries": [
+				"This viridian orb of intangible power stirs with subtle restlessness. As part of attuning to it, you must absorb it with Absorb Magic, infusing you with its flexibility.",
+				"While you are attuned to the essence, during a short or long rest, you can choose any morph available to the Embodiment of the Metamorph. You gain the benefits of the morph until you change it during another rest.",
+				"As an action, you can immediately select a different morph, changing the morph granted by this item as if you had changed morphs during a rest. Once you do so, you can't do so again until you have finished a long rest."
 			]
 		},
 		{
@@ -4983,6 +5382,42 @@
 					]
 				}
 			]
+		},
+		{
+			"name": "Zephyr of a Starstorm",
+			"source": "TheDemiDragon",
+			"rarity": "legendary",
+			"wondrous": true,
+			"reqAttune": "by a demi-Dragon",
+			"entries": [
+				"This bottle of billowing stardust stirs ancient visions of when the stars were put in the night sky. As part of attuning to it, you must absorb it with Absorb Magic, infusing you with an aspect of creation. You gain the following benefits.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Damage Protection",
+							"entries": [
+								"You have resistance against force damage. If you already have resistance to force damage from another source, you instead have immunity to force damage."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Distant Glimmer",
+							"entries": [
+								"You can attempt to hide when you are backlit by the night sky, and can do so as a bonus action."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Shooting Star",
+							"entries": [
+								"As a reaction which you can take after moving at least 100 feet on your turn, you can make a ranged spell attack using your Dragon Spark against a target which you can see within 300 feet of you. On a hit, the target takes 10d6 force damage and is blinded until the end of their next turn. You can use this property three times, and must then wait until dusk to use it again."
+							]
+						}
+					]
+				}
+			]
 		}
 	],
 	"spell": [
@@ -5033,8 +5468,8 @@
 				"slashing"
 			],
 			"miscTags": [
-				"FMV",
-				"SCL"
+				"SCL",
+				"FMV"
 			],
 			"areaTags": [
 				"ST"
@@ -5074,11 +5509,15 @@
 			},
 			"duration": [
 				{
-					"type": "instant"
+					"type": "timed",
+					"duration": {
+						"type": "round",
+						"amount": 1
+					}
 				}
 			],
 			"entries": [
-				"You warp your own body with bone spurs and lash out with a tail natural weapon that you have. Make a melee weapon attack with your tail natural weapon against one creature within 10 feet of you. On a hit, the target suffers the attack's normal effects and a bone spur is left in them. If the target is hit again before the beginning of your next turn, it takes an additional {@damage 1d4} piercing damage, ending the spell.",
+				"You warp your own body with bone and lash out with a tail natural weapon that you have. Make a melee weapon attack with your tail natural weapon against one creature within 10 feet of you. On a hit, the target suffers the attack's normal effects and a bone spur is left in it. If the creature ends its next turn within 5 feet of any other creature, the bone spur erupts and deals an additional 1d4 piercing damage.",
 				"This spell's damage increases by 2d4 when you reach 5th level ({@damage 3d4}), 11th level ({@damage 5d4}), and 17th level ({@damage 7d4})."
 			],
 			"scalingLevelDice": [
@@ -5231,8 +5670,8 @@
 				"slashing"
 			],
 			"miscTags": [
-				"FMV",
-				"SCL"
+				"SCL",
+				"FMV"
 			],
 			"areaTags": [
 				"ST"
@@ -5278,7 +5717,7 @@
 				}
 			],
 			"entries": [
-				"You form a mote of elemental power in your palm. Choose acid, cold, fire, lightning, or poison. When you cast the spell-and as a bonus action on each of your turns thereafter-you can evoke a javelin of the chosen elemental energy from the mote and hurl it at a creature within 60 feet of you. Make a ranged spell attack. On a hit, the target takes damage equal to {@damage 2d6} of the elemental type you chose.",
+				"You form a mote of elemental power in your palm. Choose acid, cold, fire, lightning, or poison. When you cast the spell-and as a bonus action on each of your turns thereafter-you can evoke a javelin of the chosen elemental energy from the mote and hurl it at a creature within 60 feet of you. Make a ranged spell attack. On a hit, the target takes damage equal to {@damage 2d8} of the elemental type you chose.",
 				"The spell ends when you have made six javelin spell attacks."
 			],
 			"entriesHigherLevel": [
@@ -5286,7 +5725,7 @@
 					"type": "entries",
 					"name": "At Higher Levels",
 					"entries": [
-						"When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d6 for every two slot levels above 2nd."
+						"When you cast this spell using a spell slot of 4th level or higher, the damage increases by 1d8 for every two slot levels above 2nd."
 					]
 				}
 			],
@@ -5312,10 +5751,7 @@
 						"source": "PHB"
 					}
 				]
-			},
-			"miscTags": [
-				"UBA"
-			]
+			}
 		},
 		{
 			"name": "Spurious Glide",
@@ -5382,6 +5818,132 @@
 			}
 		},
 		{
+			"name": "Repulsion Wave",
+			"source": "TheDemiDragon",
+			"level": 1,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "cone",
+				"distance": {
+					"type": "feet",
+					"amount": 15
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"You release repulsion energy in a cone in front of you. Each creature in the area must succeed on a Strength saving throw or be pushed 30 feet away from you."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell using a spell level of 2nd level or higher, the range of the cone increases by 10 feet for each slot level above 1st, and the range you push each target increases by 20 feet for each slot level above 1st."
+					]
+				}
+			],
+			"savingThrow": [
+				"strength"
+			],
+			"areaTags": [
+				"N"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Gale Wings",
+			"source": "TheDemiDragon",
+			"level": 2,
+			"school": "T",
+			"time": [
+				{
+					"number": 1,
+					"unit": "bonus action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "self"
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "minute",
+						"amount": 1
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"You imbue your wings or another set of limbs with the force of a storm. For the duration, your speed increases by 15 feet and moving doesn't provoke opportunity attacks.",
+				"Once on your turn at your choice when you move within 5 feet of a creature, it must make a Strength saving throw. On a failure, the creature is knocked prone from your blast of wind."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell using a spell slot of 3rd level or higher, you can force one additional saving throw against a different creature, and you increase your speed by 10 feet for each spell slot level above 2nd."
+					]
+				}
+			],
+			"areaTags": [
+				"ST"
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "PHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "PHB"
+					}
+				]
+			}
+		},
+		{
 			"name": "Elemental Stake",
 			"source": "TheDemiDragon",
 			"level": 3,
@@ -5409,14 +5971,14 @@
 				}
 			],
 			"entries": [
-				"You summon a lance of elemental energy and hurl it at a target within range. Choose between acid, cold, fire, lightning, or poison. Make a ranged spell attack against the target. On a hit, the target takes {@damage 6d8} damage of the type you chose, and must then succeed on a Strength saving throw or pushed 30 feet away from you. If the target collides with terrain as part of this push, it is pinned by the lance and {@condition restrained} until the end of your next turn."
+				"You summon a lance of elemental energy and hurl it at a target within range. Choose between acid, cold, fire, lightning, or poison. Make a ranged spell attack against the target. On a hit, the target takes {@damage 6d10} damage of the type you chose, and must then succeed on a Strength saving throw or pushed 30 feet away from you. If the target collides with terrain as part of this push, it is pinned by the lance and {@condition restrained} until the end of your next turn."
 			],
 			"entriesHigherLevel": [
 				{
 					"type": "entries",
 					"name": "At Higher Levels",
 					"entries": [
-						"When you cast this spell using a spell slot of 4th level or higher, the damage increases by {@scaledamage 6d8|3-9|1d8} for each slot level above 4th."
+						"When you cast this spell using a spell slot of 4th level or higher, the damage increases by {@scaledamage 6d8|3-9|1d10} for each slot level above 4th."
 					]
 				}
 			],
@@ -6938,6 +7500,75 @@
 				}
 			],
 			"hasFluff": true
+		}
+	],
+	"monster": [
+		{
+			"name": "Loyal Minion",
+			"source": "TheDemiDragon",
+			"size": [
+				"S"
+			],
+			"type": {
+				"type": "humanoid or monstrosity"
+			},
+			"alignment": [
+				"Shares your alignment"
+			],
+			"ac": [
+				13
+			],
+			"hp": {
+				"special": "5 + twice your level (the minion has a number of Hit Dice [d4s] equal to your level)"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 9,
+			"dex": 16,
+			"con": 14,
+			"int": 14,
+			"wis": 15,
+			"cha": 11,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"passive": "12",
+			"languages": [
+				"Shares your languages known"
+			],
+			"trait": [
+				{
+					"name": "Gifted Adaptation",
+					"entries": [
+						"The minion is resistant to the damage type you chose for Dragon's Breath, and is proficient in the saving throw you use for that feature."
+					]
+				},
+				{
+					"name": "Shared Skillset",
+					"entries": [
+						"The minion shares your proficiency bonus, knows all of your languages, and shares your skill and tool proficiencies."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Deploy Trap (2/Day)",
+					"entries": [
+						"The minion sets up a trap in a square adjacent to itself. Any creature that subsequently moves into that square must make a Dexterity saving throw against your Dragon Spark save DC or become restrained. A restrained creature can as an action make a Strength saving throw against the same DC to end the effect."
+					]
+				},
+				{
+					"name": "Grappling Hook",
+					"entries": [
+						"The minion can latch on to any surface or to a willing creature that it can see within 30 feet of itself and immediately pull itself to an adjacent space. If the minion latches on to you, you can choose to allow the minion to immediately mount you as part of the grappling hook action, provided that all other rules for mounting are met."
+					]
+				}
+			],
+			"pbNote": "equals your bonus",
+			"hasToken": false,
+			"hasFluff": false,
+			"hasFluffImages": false
 		}
 	]
 }


### PR DESCRIPTION
This patch focuses chiefly on two new subclasses, as well as a handful of additional content in the form of feats, items, and spells. After four years of dedicated work on this content, the Demi-Dragon has been so thoroughly tested and patched that few concerns remain in the class itself; go try it for yourself—it's good fun!

Changes since last version:

Class and Race.

* Demi-Dragons can now choose to be Small

* Rend and Ruin can now trigger on any attack (from any natural weapon attack), and moved Rend and Ruin up to start at level 13 with 1d6

Subclasses.

* Added a new subclass, the Embodiment of the Behemoth, a dedicated tank as concepted by Robert Sparda, with the features Lumbering Behemoth, Natural Overdrive, Hulking Beast, Overpowering Force, Frightful Display, Wounded Defiance, and Earthshaker

* Redesigned and reimplemented a very old subclass, the Embodiment of the Skyterror, in the style of an aerial weapons-expert, with the features Wing Surge, Draconic Armory, Dive and Soar, Aerial Acrobatics, and Unfettered

* Obfuscate Consciousness can now be used twice before a rest (from once)

* Frightful Roar is now a bonus action

* Changed the Juggernaut's wings and horns to count as simple weapons

* Fervent Hoarder's Ingenuity of the Hoard can now replace a charge of Dragon's Breath with a spell once per short rest, and renamed it to Magic of the Hoard

Feats, Items, and Other.

* Removed the feat also named Skyterror

* Added a new feat, Loyal Minion, and a matching statblock

* Added three new high-level items, Essence of Fury, Essence of Transformation, and Zephyr of the Starstorm

* Added two new spells, Repulsion Wave and Gale Wings

* Redesigned Malygris' Cadeverous Tail-Sting to require the target to end its turn to an adjacent creature, rather than to be simply hit

* Increased Elemental Javelin's damage to d8s, from d6s

* Increased Elemental Stake's damage to d10s, from d8s