### PR TITLE
Update badooga; Minecraft 5e.json

### DIFF
--- a/creature/badooga; Minecraft 5e.json
+++ b/creature/badooga; Minecraft 5e.json
@@ -12,12 +12,11 @@
 				"convertedBy": [
 					"badooga"
 				],
-				"version": "unknown"
+				"version": "1.1"
 			}
 		],
-		"dateAdded": 1671012123,
-		"dateLastModified": 1671012123,
-		"_dateLastModifiedHash": "f92dc77792"
+		"dateAdded": 1674173948,
+		"dateLastModified": 1674173948
 	},
 	"monster": [
 		{
@@ -255,6 +254,322 @@
 			]
 		},
 		{
+			"name": "Ender Dragon",
+			"shortName": "dragon",
+			"source": "MC",
+			"page": 7,
+			"size": [
+				"G"
+			],
+			"type": "dragon",
+			"alignment": [
+				"L",
+				"E"
+			],
+			"ac": [
+				{
+					"ac": 21,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"formula": "26d20 + 234",
+				"average": 507
+			},
+			"speed": {
+				"walk": 60,
+				"burrow": 60,
+				"fly": {
+					"number": 120,
+					"condition": "(hover)"
+				},
+				"canHover": true
+			},
+			"str": 28,
+			"dex": 14,
+			"con": 29,
+			"int": 30,
+			"wis": 24,
+			"cha": 25,
+			"save": {
+				"dex": "+10",
+				"con": "+17",
+				"wis": "+15",
+				"cha": "+15"
+			},
+			"skill": {
+				"arcana": "+18",
+				"perception": "+15",
+				"history": "+18",
+				"intimidation": "+15"
+			},
+			"senses": [
+				"truesight 120 ft."
+			],
+			"passive": 25,
+			"resist": [
+				{
+					"resist": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical attacks"
+				}
+			],
+			"immune": [
+				"force",
+				"psychic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"paralyzed",
+				"petrified"
+			],
+			"languages": [
+				"understands all but doesn't speak",
+				"telepathy 1 mile"
+			],
+			"cr": "26",
+			"spellcasting": [
+				{
+					"name": "Innate Psionics",
+					"headerEntries": [
+						"The dragon's spellcasting ability is Intelligence (spell save {@dc 26}). She can cast the following spells using psionics, requiring no components:"
+					],
+					"will": [
+						"{@spell locate creature}",
+						"{@spell mirage arcane}",
+						"{@spell reverse gravity}"
+					],
+					"daily": {
+						"1e": [
+							"{@spell dominate person}",
+							"{@spell forcecage}",
+							"{@spell time stop}"
+						],
+						"2e": [
+							"{@spell dream}*",
+							"{@spell scrying}*",
+							"{@spell slow}"
+						]
+					},
+					"footerEntries": [
+						"*The target needn't be on the same plane of existence as the dragon."
+					],
+					"ability": "int",
+					"type": "spellcasting"
+				}
+			],
+			"trait": [
+				{
+					"name": "Tunneler",
+					"entries": [
+						"The dragon can burrow through any nonmagical material and leaves a 15-foot-diameter tunnel in her wake. She can also move through creatures and magical objects as if they were difficult terrain, but she takes 5 ({@damage 1d10}) necrotic damage if she ends her turn inside of an object."
+					]
+				},
+				{
+					"name": "Psychic Barrier",
+					"entries": [
+						"At the start of each of her turns, the dragon gains 10 temporary hit points and can end one condition on herself, provided the dragon has at least 1 hit point."
+					]
+				},
+				{
+					"name": "Legendary Reaction",
+					"entries": [
+						"The dragon can spend one legendary action to take a reaction, even when she has already used her normal reaction."
+					]
+				},
+				{
+					"name": "Draconic Might",
+					"entries": [
+						"The dragon's weapon attacks are magical and deal quadruple damage to objects and structures. When she hits a target with a melee attack, if the attack roll meets or exceeds the target's passive Strength ({@skill Athletics}) score, the dragon can push it up to 10 feet away, or 20 feet away if her mythic trait is active."
+					]
+				},
+				{
+					"name": "Shockwave (Mythic Trait; Once Per Rest)",
+					"entries": [
+						"If the dragon would be reduced to 0 hit points, she instead resets to maximum hit points, and she can end any spells of her choice on herself. She then releases a huge roar that disrupts gravity in a 1 mile radius, causing an {@spell earthquake} spell (spell save {@dc 26}) to ravage the area for 1 minute (no concentration required)."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The dragon makes three attacks: one with her bite and two with her claws."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 15 ft., one target. {@h} 20 ({@damage 2d10 + 9}) piercing damage plus 16 ({@damage 3d10}) force damage."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 10 ft., one target. {@h}18 ({@damage 2d8 + 9}) slashing damage. If the target is a Huge or smaller creature, it is {@condition grappled} (escape {@dc 19}) and is {@condition restrained} until this grapple ends. The dragon can have only one creature {@condition grappled} in this way at a time."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 20 ft., one target. {@h} 22 ({@damage 2d12 + 9}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 25} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Breath Weapon {@recharge 5}",
+					"entries": [
+						"The dragon exhales psychic energy in a 300-foot cone. Each creature and object in that area takes 77 ({@damage 11d12}) damage ({@dc 25} saving throw for half; see below), with the damage type, save type, and determined by the option she chooses below.",
+						"The dragon can't use the same option twice in a row.",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Blinding Breath",
+									"entry": "The breath does radiant damage, and the save type is Constitution. On a failed save, a creature is also {@condition blinded} until the end of its next turn."
+								},
+								{
+									"type": "item",
+									"name": "Disorienting Breath",
+									"entry": "The breath does psychic damage, and the save type is Intelligence. The area is then infused with psychic dissonance for 1 minute; creatures other than the dragon that end their turn in the area must subtract a {@dice d6} from each of their attack rolls, ability checks, and saving throws until the end of their next turn."
+								},
+								{
+									"type": "item",
+									"name": "Gravity Breath",
+									"entry": "The breath does force damage, and the save type is Strength. Until the end of the dragon's next turn, the entire area is affected by a {@spell reverse gravity} spell, except that the dragon can orient gravity in any direction."
+								}
+							]
+						}
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Psychic Step",
+					"entries": [
+						"The dragon uses psionics to teleport to an unoccupied space it can see within 30 feet of her."
+					]
+				},
+				{
+					"name": "Telekinetic Slide",
+					"entries": [
+						"The dragon uses psionics to telekinetically one creature of her choice up to 30 feet in a horizontal direction of her choice ({@dc 26} Strength save for half distance)."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Psychic Barrier",
+					"entries": [
+						"The dragon halves the damage it takes from a ranged attack. To do so, the dragon must see the attacker."
+					]
+				},
+				{
+					"name": "Telekinetic Backlash",
+					"entries": [
+						"In response to taking damage from a melee attack, the dragon can push the attacker up to 30 feet away from her ({@dc 26} Strength save for half distance)."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Wild Talent",
+					"entries": [
+						"The dragon uses Psychic Step or Telekinetic Slide."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"The dragon makes a tail attack."
+					]
+				},
+				{
+					"name": "Innate Psionics (Costs 2 Actions)",
+					"entries": [
+						"The dragon uses her Innate Psionics."
+					]
+				}
+			],
+			"mythicHeader": [
+				"If the dragon's mythic trait has been activated within the last hour, she can use the options below as legendary actions."
+			],
+			"mythic": [
+				{
+					"name": "Potent Psionics",
+					"entries": [
+						"The dragon uses Psychic Step or Telekinetic Slide, and the distance teleported or moved by them is doubled."
+					]
+				},
+				{
+					"name": "Psionic Mastery",
+					"entries": [
+						"The dragon regains one use of one of her spells."
+					]
+				},
+				{
+					"name": "Tail Sweep",
+					"entries": [
+						"The dragon makes a tail attack against each creature of her choice within 20 feet of her."
+					]
+				}
+			],
+			"fluff": {
+				"images": [
+					{
+						"type": "image",
+						"href": {
+							"type": "external",
+							"url": "https://static.wikia.nocookie.net/minecraft_gamepedia/images/0/0a/Ender_Dragon.gif"
+						}
+					}
+				]
+			},
+			"senseTags": [
+				"U"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"languageTags": [
+				"TP",
+				"XX"
+			],
+			"damageTags": [
+				"B",
+				"N",
+				"O",
+				"P",
+				"S"
+			],
+			"damageTagsSpell": [
+				"Y"
+			],
+			"spellcastingTags": [
+				"I",
+				"P"
+			],
+			"miscTags": [
+				"AOE",
+				"MW",
+				"RCH"
+			],
+			"conditionInflict": [
+				"blinded",
+				"grappled",
+				"prone",
+				"restrained"
+			]
+		},
+		{
 			"name": "Enderman",
 			"source": "MC",
 			"page": 2,
@@ -478,6 +793,9 @@
 						"The ghast sends a ball of fire streaking toward a point within 120 feet of it. Once the ball reaches its destination or impacts against a solid surface, the ball explodes. Each creature within 10 feet of the point where the ball explodes takes 14 ({@damage 4d6}) fire damage ({@dc 18} Dexterity save for half)."
 					]
 				}
+			],
+			"legendaryHeader": [
+				"The ghast can take 3 legendary actions each round, choosing from the options below."
 			],
 			"legendary": [
 				{
@@ -1249,6 +1567,9 @@
 						"When a humanoid within 30 feet of the wither dies, it can use Summon Spawn to raise its corpse as a {@creature wither skeleton|MC}. This undead does not count towards the maximum of four wither skeletons listed in that ability."
 					]
 				}
+			],
+			"legendaryHeader": [
+				"The wither can take 3 legendary actions each round, choosing from the options below."
 			],
 			"legendary": [
 				{


### PR DESCRIPTION
adds Ender Dragon stat block, abbreviates two legendary headers