### PR TITLE
Add probably most creature fluff tags

### DIFF
--- a/adventure/JVC Parry; Call from the Deep.json
+++ b/adventure/JVC Parry; Call from the Deep.json
@@ -17,6 +17,7 @@
 				]
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1579711362,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "ecff83112e"

--- a/adventure/Kobold Press; Tome of Beasts 2 Lairs.json
+++ b/adventure/Kobold Press; Tome of Beasts 2 Lairs.json
@@ -19,6 +19,7 @@
 				"color": "89181A"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1616030766,
 		"dateLastModified": 1616030766,
 		"_dateLastModifiedHash": "9f6bec3e5b"

--- a/adventure/Kurtis J Wiebe; The Hangover.json
+++ b/adventure/Kurtis J Wiebe; The Hangover.json
@@ -16,6 +16,7 @@
 				"targetSchema": "1.0.0"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1592179890,
 		"dateLastModified": 1592179890,
 		"_dateLastModifiedHash": "aecac8cc26"

--- a/book/2CGaming; Total Party Kill Bestiary - Vol. 1.json
+++ b/book/2CGaming; Total Party Kill Bestiary - Vol. 1.json
@@ -7884,7 +7884,8 @@
 					"name": "Abominable Hybrids",
 					"source": "TPK"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Sharpythorapspidopustle",
@@ -8085,7 +8086,8 @@
 					"name": "Abominable Hybrids",
 					"source": "TPK"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Living Abjuration",
@@ -10676,7 +10678,8 @@
 					"name": "Beasts of Legend",
 					"source": "TPK"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Giant Elk of Legend",
@@ -10828,7 +10831,8 @@
 					"name": "Beasts of Legend",
 					"source": "TPK"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Tiger of Legend",
@@ -10980,7 +10984,8 @@
 					"name": "Beasts of Legend",
 					"source": "TPK"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Living Galleon",
@@ -22904,7 +22909,8 @@
 					"name": "Sleipnirian Pegasus",
 					"source": "TPK"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Brynhildr War Queen",

--- a/book/Darrington Press; Tal'Dorei Campaign Setting Reborn.json
+++ b/book/Darrington Press; Tal'Dorei Campaign Setting Reborn.json
@@ -12717,7 +12717,9 @@
 						}
 					]
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Master Adranach",
@@ -12970,7 +12972,9 @@
 						}
 					]
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ashari Firetamer",
@@ -14473,7 +14477,9 @@
 			"environment": [
 				"forest",
 				"underdark"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Demonfeed Spiderling",
@@ -14574,7 +14580,9 @@
 					"name": "Demonfeed Spider",
 					"source": "TDCSR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ember Roc",
@@ -15998,7 +16006,9 @@
 			"environment": [
 				"mountain",
 				"underdark"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Young Magma Landshark",
@@ -16109,7 +16119,9 @@
 			"environment": [
 				"mountain",
 				"underdark"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Plainscow",
@@ -17596,7 +17608,9 @@
 			],
 			"group": [
 				"Serpentfolk"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Vos'skyriss Serpentfolk Ghost",
@@ -17756,7 +17770,9 @@
 			],
 			"group": [
 				"Serpentfolk"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Wraithroot Tree",
@@ -17886,7 +17902,9 @@
 			"environment": [
 				"forest",
 				"mountain"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Grog Strongjaw",

--- a/collection/Arcana Games; Arkadia.json
+++ b/collection/Arcana Games; Arkadia.json
@@ -8586,7 +8586,8 @@
 			"conditionInflictSpell": [
 				"charmed",
 				"unconscious"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Siren (Arkadian)",
@@ -8698,7 +8699,8 @@
 			"conditionInflictSpell": [
 				"charmed",
 				"unconscious"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Centaur (Arkadian)",
@@ -8819,7 +8821,8 @@
 			},
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Harpy (Arkadian)",
@@ -8945,7 +8948,8 @@
 			},
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Chimera (Arkadian)",
@@ -9063,7 +9067,8 @@
 			"conditionInflict": [
 				"restrained",
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Minotaur (Arkadian)",
@@ -9161,7 +9166,8 @@
 					"name": "Minotaur (Arkadian)",
 					"source": "arkadia"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Dryad (Arkadian)",
@@ -9305,7 +9311,8 @@
 			],
 			"damageTagsSpell": [
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Exiled Sphynx",
@@ -9466,7 +9473,8 @@
 			"damageTagsSpell": [
 				"N",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		}
 	],
 	"monsterFluff": [

--- a/collection/Benevolent Evil; The Elements and Beyond.json
+++ b/collection/Benevolent Evil; The Elements and Beyond.json
@@ -24527,7 +24527,8 @@
 				"MW",
 				"RCH",
 				"RW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Green Giant Warden",
@@ -24751,7 +24752,8 @@
 			],
 			"damageTagsSpell": [
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Gnoll Beastmage",
@@ -25226,7 +25228,8 @@
 			],
 			"actionTags": [
 				"Breath Weapon"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Lava Golem Armor",
@@ -25367,7 +25370,8 @@
 			],
 			"actionTags": [
 				"Breath Weapon"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Metal Golem Armor",
@@ -25499,7 +25503,8 @@
 			],
 			"actionTags": [
 				"Breath Weapon"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Stone Golem Armor",
@@ -25638,7 +25643,8 @@
 			],
 			"actionTags": [
 				"Breath Weapon"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Crimson Hag",

--- a/collection/DnD Beyond; Legends of Runeterra Dark Tides of Bilgewater.json
+++ b/collection/DnD Beyond; Legends of Runeterra Dark Tides of Bilgewater.json
@@ -3998,7 +3998,9 @@
 					"name": "Abyssal Eye",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Barkbeast",
@@ -4103,7 +4105,9 @@
 			},
 			"miscTags": [
 				"HPR"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Commander Ledros",
@@ -4231,7 +4235,9 @@
 					"name": "Commander Ledros",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Dragon Shark",
@@ -4315,7 +4321,8 @@
 					"name": "Dragon Shark",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Gangplank",
@@ -4450,7 +4457,9 @@
 					"name": "Gangplank",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ironback",
@@ -4558,7 +4567,8 @@
 					"name": "Ironback",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Miss Fortune",
@@ -4688,7 +4698,9 @@
 					"name": "Miss Fortune",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Pool Shark",
@@ -4794,7 +4806,9 @@
 					"name": "Pool Shark",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Powder Monkey",
@@ -4902,7 +4916,9 @@
 					"name": "Powder Monkey",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Wharf Rat",
@@ -4976,7 +4992,9 @@
 					"name": "Wharf Rat",
 					"source": "LoRDToB"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		}
 	],
 	"monsterFluff": [

--- a/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 1.json
+++ b/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 1.json
@@ -14869,7 +14869,8 @@
 					"name": "Sporehusk",
 					"source": "tgs1"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Scout Sporehusk",
@@ -15014,7 +15015,8 @@
 					"name": "Sporehusk",
 					"source": "tgs1"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Invisiboar",
@@ -15107,7 +15109,8 @@
 					"name": "Invisiboar",
 					"source": "tgs1"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Swordbeak",
@@ -15192,7 +15195,8 @@
 					"name": "Swordbeak",
 					"source": "tgs1"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Winged Wretch",
@@ -15301,7 +15305,8 @@
 					"name": "Winged Wretch",
 					"source": "tgs1"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Greater Winged Wretch",
@@ -15426,7 +15431,8 @@
 					"name": "Winged Wretch",
 					"source": "tgs1"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Nicrone Dendallen",
@@ -15620,7 +15626,8 @@
 				"N",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Spirit of Dendallen",
@@ -15968,7 +15975,9 @@
 				"N",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Tendril of Dendallen",

--- a/collection/Hit Point Press; Humblewood Campaign Setting.json
+++ b/collection/Hit Point Press; Humblewood Campaign Setting.json
@@ -18,6 +18,7 @@
 				"targetSchema": "1.1.3"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1575675839,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "ca507ee3c4"

--- a/collection/Jetpack7; Gods and Goddesses Redux.json
+++ b/collection/Jetpack7; Gods and Goddesses Redux.json
@@ -20,6 +20,7 @@
 				"targetSchema": "1.6.3"
 			}
 		],
+		"status": "wip",
 		"dateAdded": 1619751661,
 		"dateLastModified": 1663792415,
 		"_dateLastModifiedHash": "657a49af1d"

--- a/collection/Jonoman3000; Dark Arts Players Companion.json
+++ b/collection/Jonoman3000; Dark Arts Players Companion.json
@@ -7316,7 +7316,8 @@
 				"MW",
 				"RCH",
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Ogre Skeleton",
@@ -7400,7 +7401,8 @@
 				"MW",
 				"RW",
 				"THW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Shadowtouched Umber Hulk",
@@ -7526,7 +7528,8 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Shadow Elemental",
@@ -7663,7 +7666,8 @@
 			"miscTags": [
 				"MW",
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Seafallen Host",
@@ -7789,7 +7793,8 @@
 				"grappled",
 				"restrained",
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Seafallen Captain",
@@ -7904,7 +7909,8 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Seafallen Crew",
@@ -8004,7 +8010,8 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Rothorror",
@@ -8100,7 +8107,8 @@
 			],
 			"conditionInflict": [
 				"incapacitated"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Swarm of Maggots",
@@ -8403,7 +8411,8 @@
 			"damageTagsSpell": [
 				"I",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Necrotic Slime",
@@ -8842,7 +8851,8 @@
 					],
 					"type": "variant"
 				}
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Fleshwurm",
@@ -9238,7 +9248,8 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Fleshfiend",
@@ -9377,7 +9388,8 @@
 			"miscTags": [
 				"MW",
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Deathcrest Ape",
@@ -9476,7 +9488,8 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Cursed Oak",
@@ -9595,7 +9608,8 @@
 			},
 			"conditionInflict": [
 				"restrained"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Cruorhulk",
@@ -10064,7 +10078,8 @@
 						"Once per turn, when the bloodbeast hits a creature with {@spell cruorwhip|DAPC} or with a bite attack, the target takes an extra 10 ({@damage 3d6}) damage, and the bloodbeast regains hit points equal to the extra damage dealt."
 					]
 				}
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Archlich",
@@ -10370,7 +10385,8 @@
 				"N",
 				"O",
 				"T"
-			]
+			],
+			"hasFluff": true
 		}
 	],
 	"monsterFluff": [

--- a/collection/Kobold Press; Deep Magic 01 Clockwork Magic.json
+++ b/collection/Kobold Press; Deep Magic 01 Clockwork Magic.json
@@ -25,6 +25,7 @@
 				"color": "BF8000"
 			}
 		},
+		"status": "ready",
 		"dateAdded": 1542063914,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "bd1d02426e"

--- a/collection/Kobold Press; Deep Magic 03 Void Magic.json
+++ b/collection/Kobold Press; Deep Magic 03 Void Magic.json
@@ -25,6 +25,7 @@
 				"color": "7155AA"
 			}
 		},
+		"status": "ready",
 		"dateAdded": 1578601678,
 		"dateLastModified": 1671569306,
 		"_dateLastModifiedHash": "362d4adeef"

--- a/collection/Kobold Press; Deep Magic 04 Illumination Magic.json
+++ b/collection/Kobold Press; Deep Magic 04 Illumination Magic.json
@@ -17,6 +17,7 @@
 				"url": "https://koboldpress.com/kpstore/product/deep-magic-illumination-magic-pdf-5th-edition/"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1580670213,
 		"dateLastModified": 1638650513,
 		"_dateLastModifiedHash": "ee83dd8e4d"

--- a/collection/Kobold Press; Deep Magic 17 Mythos Magic.json
+++ b/collection/Kobold Press; Deep Magic 17 Mythos Magic.json
@@ -17,6 +17,7 @@
 				"url": "https://koboldpress.com/kpstore/product/deep-magic-illumination-magic-pdf-5th-edition/"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1580670213,
 		"dateLastModified": 1671569306,
 		"_dateLastModifiedHash": "f813fb4c23"

--- a/collection/MCDM Productions; Strongholds and Followers.json
+++ b/collection/MCDM Productions; Strongholds and Followers.json
@@ -28,6 +28,7 @@
 			"Psi. Man.": "Psionic Manifestation",
 			"Unit": "Unit"
 		},
+		"status": "ready",
 		"dateAdded": 1546266054,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "b739b42497"

--- a/collection/MCDM Productions; Strongholds and Followers.json
+++ b/collection/MCDM Productions; Strongholds and Followers.json
@@ -2148,7 +2148,8 @@
 				"MW",
 				"RW",
 				"THW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "SaF",
@@ -2276,7 +2277,9 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -2390,7 +2393,9 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -2552,7 +2557,9 @@
 				"N",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -2679,7 +2686,9 @@
 				"RW",
 				"MW",
 				"THW"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -2855,7 +2864,9 @@
 				"F",
 				"I",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -3018,7 +3029,9 @@
 				"MW",
 				"RW",
 				"RNG"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -3196,7 +3209,9 @@
 				"F",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -3309,7 +3324,8 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "SaF",
@@ -3425,7 +3441,9 @@
 			"damageTagsSpell": [
 				"F",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4017,7 +4035,9 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4151,7 +4171,9 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4281,7 +4303,9 @@
 			"damageTags": [
 				"F",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4411,7 +4435,9 @@
 			"conditionInflict": [
 				"grappled",
 				"restrained"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4574,7 +4600,9 @@
 			],
 			"conditionInflict": [
 				"frightened"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4704,7 +4732,9 @@
 				"MW",
 				"RW",
 				"THW"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -4835,7 +4865,9 @@
 				"RW",
 				"RNG",
 				"MW"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -5043,7 +5075,9 @@
 				"O",
 				"P",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -5255,7 +5289,9 @@
 				"L",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -5397,7 +5433,9 @@
 			],
 			"conditionInflict": [
 				"poisoned"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -5595,7 +5633,9 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -5732,7 +5772,9 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -5918,7 +5960,9 @@
 			],
 			"damageTagsSpell": [
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6084,7 +6128,9 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6223,7 +6269,9 @@
 			],
 			"actionTags": [
 				"Breath Weapon"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6426,7 +6474,9 @@
 				"F",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6643,7 +6693,9 @@
 				"L",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6762,7 +6814,9 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6886,7 +6940,9 @@
 			"conditionInflict": [
 				"petrified",
 				"restrained"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -6994,7 +7050,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/SaF/tokens/Pillar%20of%20Water.png",
 			"damageTags": [
 				"B"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -7136,7 +7194,8 @@
 			],
 			"damageTagsSpell": [
 				"B"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "SaF",
@@ -7340,7 +7399,9 @@
 				"F",
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -7494,7 +7555,9 @@
 				"MW",
 				"RCH",
 				"AOE"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -7700,7 +7763,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "ancient"
+			"dragonAge": "ancient",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -7902,7 +7967,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "adult"
+			"dragonAge": "adult",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -8047,7 +8114,9 @@
 				"MW",
 				"RCH"
 			],
-			"dragonAge": "young"
+			"dragonAge": "young",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -8175,7 +8244,9 @@
 				"MW",
 				"RCH"
 			],
-			"dragonAge": "wyrmling"
+			"dragonAge": "wyrmling",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -8380,7 +8451,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "ancient"
+			"dragonAge": "ancient",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -8581,7 +8654,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "adult"
+			"dragonAge": "adult",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -8725,7 +8800,9 @@
 				"MW",
 				"RCH"
 			],
-			"dragonAge": "young"
+			"dragonAge": "young",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -8850,7 +8927,9 @@
 			"miscTags": [
 				"MW"
 			],
-			"dragonAge": "wyrmling"
+			"dragonAge": "wyrmling",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -9057,7 +9136,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "ancient"
+			"dragonAge": "ancient",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -9260,7 +9341,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "adult"
+			"dragonAge": "adult",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -9405,7 +9488,9 @@
 				"MW",
 				"RCH"
 			],
-			"dragonAge": "young"
+			"dragonAge": "young",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -9529,7 +9614,9 @@
 			"miscTags": [
 				"MW"
 			],
-			"dragonAge": "wyrmling"
+			"dragonAge": "wyrmling",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -9734,7 +9821,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "ancient"
+			"dragonAge": "ancient",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -9935,7 +10024,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "adult"
+			"dragonAge": "adult",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10081,7 +10172,9 @@
 				"MW",
 				"RCH"
 			],
-			"dragonAge": "young"
+			"dragonAge": "young",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10210,7 +10303,9 @@
 			"miscTags": [
 				"MW"
 			],
-			"dragonAge": "wyrmling"
+			"dragonAge": "wyrmling",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10416,7 +10511,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "ancient"
+			"dragonAge": "ancient",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10618,7 +10715,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"dragonAge": "adult"
+			"dragonAge": "adult",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10763,7 +10862,9 @@
 				"MW",
 				"RCH"
 			],
-			"dragonAge": "young"
+			"dragonAge": "young",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10889,7 +10990,9 @@
 			"miscTags": [
 				"MW"
 			],
-			"dragonAge": "wyrmling"
+			"dragonAge": "wyrmling",
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -10997,7 +11100,9 @@
 			],
 			"languageTags": [
 				"XX"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -11129,7 +11234,9 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -11239,7 +11346,9 @@
 			],
 			"languageTags": [
 				"XX"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -11359,7 +11468,9 @@
 			],
 			"languageTags": [
 				"XX"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -11480,7 +11591,9 @@
 			],
 			"languageTags": [
 				"XX"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -11615,7 +11728,9 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "SaF",
@@ -11758,7 +11873,9 @@
 			"tokenUrl": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew/master/_img/SaF/tokens/Virtue.png",
 			"damageTags": [
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Reaver",

--- a/collection/Mage Hand Press; Mimic Book of Mimics.json
+++ b/collection/Mage Hand Press; Mimic Book of Mimics.json
@@ -17,6 +17,7 @@
 				]
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1585952791,
 		"dateLastModified": 1673556096,
 		"unlisted": true,

--- a/collection/MonkeyDM; Dark Tides of Bilgewater - Rebalanced.json
+++ b/collection/MonkeyDM; Dark Tides of Bilgewater - Rebalanced.json
@@ -398,7 +398,9 @@
 					"name": "Abyssal Eye",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Barkbeast",
@@ -503,7 +505,9 @@
 			},
 			"miscTags": [
 				"HPR"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Commander Ledros",
@@ -631,7 +635,9 @@
 					"name": "Commander Ledros",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Dragon Shark",
@@ -715,7 +721,8 @@
 					"name": "Dragon Shark",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Gangplank",
@@ -850,7 +857,9 @@
 					"name": "Gangplank",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ironback",
@@ -958,7 +967,8 @@
 					"name": "Ironback",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"name": "Miss Fortune",
@@ -1088,7 +1098,9 @@
 					"name": "Miss Fortune",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Pool Shark",
@@ -1194,7 +1206,9 @@
 					"name": "Pool Shark",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Powder Monkey",
@@ -1302,7 +1316,9 @@
 					"name": "Powder Monkey",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Wharf Rat",
@@ -1376,7 +1392,9 @@
 					"name": "Wharf Rat",
 					"source": "LoRDToBR"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		}
 	],
 	"monsterFluff": [

--- a/collection/Nord Games; Treacherous Traps.json
+++ b/collection/Nord Games; Treacherous Traps.json
@@ -20,6 +20,7 @@
 				]
 			}
 		],
+		"status": "wip",
 		"dateAdded": 1584497865,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "72817708ea"

--- a/collection/badooga; Elder Evils.json
+++ b/collection/badooga; Elder Evils.json
@@ -1011,7 +1011,8 @@
 				"L",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Hive Mother",
@@ -2254,7 +2255,9 @@
 				"deception": "+12",
 				"perception": "+10",
 				"intimidation": "+12"
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Inferno Tyrant",
@@ -2972,7 +2975,8 @@
 			"damageTagsSpell": [
 				"I",
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Giorge Forsworn",
@@ -5107,7 +5111,9 @@
 				"B",
 				"F",
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Death Cultist",
@@ -5793,7 +5799,9 @@
 			"damageTagsSpell": [
 				"C",
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Atropal Scion",
@@ -5944,7 +5952,9 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Dread Boneyard",
@@ -7157,7 +7167,8 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Humanoid Whelp of Zargon",
@@ -7303,7 +7314,8 @@
 			],
 			"miscTags": [
 				"MW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Vanessa Mackelroy",
@@ -8631,7 +8643,9 @@
 			"actionTags": [
 				"Breath Weapon",
 				"Swallow"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ulgurstasta",
@@ -8768,7 +8782,9 @@
 			"actionTags": [
 				"Breath Weapon",
 				"Swallow"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Forest Giant Skeleton",
@@ -9082,7 +9098,8 @@
 			],
 			"damageTagsSpell": [
 				"F"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Gravecrawler",
@@ -9420,7 +9437,9 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Leechwalker",
@@ -9547,7 +9566,9 @@
 			"miscTags": [
 				"MW",
 				"RCH"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Century Worm",
@@ -11244,7 +11265,8 @@
 			],
 			"miscTags": [
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Vanguard Cleric of Beauty",
@@ -11443,7 +11465,8 @@
 				"R",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Vanguard Cleric of Destruction",
@@ -11618,7 +11641,8 @@
 				"R",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Fiendish Anaconda",
@@ -13486,7 +13510,9 @@
 				"paralyzed",
 				"frightened",
 				"incapacitated"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Grisgol",
@@ -14160,7 +14186,8 @@
 			"damageTagsSpell": [
 				"N",
 				"Y"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Lucather Majii",
@@ -16833,7 +16860,8 @@
 				"RCH",
 				"RW",
 				"RNG"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ogre Tempest",
@@ -20859,7 +20887,8 @@
 			"damageTagsSpell": [
 				"B",
 				"C"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Brood Spawn Barbarian",
@@ -21156,7 +21185,8 @@
 				"MW",
 				"RCH",
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Brood Spawn Ogre",
@@ -21312,7 +21342,8 @@
 				"MW",
 				"RCH",
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Father Llymic",
@@ -23272,7 +23303,9 @@
 					"tokenUrl": "https://i.imgur.com/qEWQckL.png",
 					"source": "EdE"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Corrupture",

--- a/creature/Andrew Cawood; Monsters of the Underworld.json
+++ b/creature/Andrew Cawood; Monsters of the Underworld.json
@@ -16,6 +16,7 @@
 				"version": "0.1.0"
 			}
 		],
+		"status": "wip",
 		"dateAdded": 1587114613,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "bc9f040465"

--- a/creature/Chris Avellone; Planescape Torment Bestiary.json
+++ b/creature/Chris Avellone; Planescape Torment Bestiary.json
@@ -17,6 +17,7 @@
 				]
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1591117986,
 		"dateLastModified": 1591117986,
 		"_dateLastModifiedHash": "bee1f79e23"

--- a/creature/Dragonix; Monster Manual Expanded II.json
+++ b/creature/Dragonix; Monster Manual Expanded II.json
@@ -17,6 +17,7 @@
 				"color": "BD7044"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1579601514,
 		"dateLastModified": 1673562612,
 		"_dateLastModifiedHash": "2be87bb909"

--- a/creature/Dragonix; Monster Manual Expanded III.json
+++ b/creature/Dragonix; Monster Manual Expanded III.json
@@ -12175,7 +12175,9 @@
 					"name": "Spectral Dragon",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -13345,7 +13347,9 @@
 					"name": "Young Adult Illithidragon",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -14230,7 +14234,9 @@
 				"B",
 				"N",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -14428,7 +14434,8 @@
 			"damageTagsSpell": [
 				"I",
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -14623,7 +14630,8 @@
 				"I",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -14851,7 +14859,9 @@
 				"L",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -14957,7 +14967,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -15115,7 +15127,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -15260,7 +15274,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -15496,7 +15512,9 @@
 				"B",
 				"C",
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -15671,7 +15689,8 @@
 				"I",
 				"N",
 				"O"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -15875,7 +15894,8 @@
 				"N",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -16096,7 +16116,8 @@
 				"F",
 				"N",
 				"O"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -16495,7 +16516,9 @@
 				"L",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -16718,7 +16741,8 @@
 			"damageTagsSpell": [
 				"I",
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -16908,7 +16932,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -17124,7 +17150,8 @@
 			"damageTagsSpell": [
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -17321,7 +17348,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -17529,7 +17558,9 @@
 			"damageTagsSpell": [
 				"B",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -17693,7 +17724,9 @@
 				"F",
 				"O",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -17894,7 +17927,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -19419,7 +19454,9 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -19558,7 +19595,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -19730,7 +19769,8 @@
 					"name": "Thug Gang Boss",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -19855,7 +19895,8 @@
 					"name": "Thug Captain",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -20266,7 +20307,9 @@
 				"B",
 				"F",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -20947,7 +20990,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -21099,7 +21144,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -21255,7 +21302,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -21410,7 +21459,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -21553,7 +21604,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -21753,7 +21806,8 @@
 				"F",
 				"N",
 				"R"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -21895,7 +21949,8 @@
 			"damageTagsSpell": [
 				"N",
 				"R"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -22090,7 +22145,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -22452,7 +22509,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -22684,7 +22743,9 @@
 			],
 			"damageTagsSpell": [
 				"F"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -22886,7 +22947,9 @@
 			],
 			"damageTagsSpell": [
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -23074,7 +23137,9 @@
 				"I",
 				"P",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -23243,7 +23308,9 @@
 				"L",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -23425,7 +23492,9 @@
 			],
 			"damageTagsSpell": [
 				"B"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -23608,7 +23677,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -23843,7 +23914,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24018,7 +24091,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24160,7 +24235,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24294,7 +24371,9 @@
 					"name": "Monstrous Shocker Lizard",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24419,7 +24498,9 @@
 					"name": "Giant Shocker Lizard",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24528,7 +24609,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24642,7 +24725,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -24848,7 +24933,9 @@
 					"name": "Shedu, Greater",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -25087,7 +25174,9 @@
 					"name": "Shedu Enlightened One",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -25277,7 +25366,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -25548,7 +25639,9 @@
 				"I",
 				"L",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -25813,7 +25906,9 @@
 			],
 			"damageTagsSpell": [
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -26000,7 +26095,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -26178,7 +26275,9 @@
 				"I",
 				"L",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -26361,7 +26460,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -26547,7 +26648,8 @@
 				"C",
 				"N",
 				"R"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -27059,7 +27161,8 @@
 			"damageTagsSpell": [
 				"F",
 				"R"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -27254,7 +27357,8 @@
 			"damageTagsSpell": [
 				"L",
 				"P"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -27403,7 +27507,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -27563,7 +27669,9 @@
 			"damageTagsSpell": [
 				"C",
 				"F"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -27715,7 +27823,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -27874,7 +27984,9 @@
 			"damageTagsSpell": [
 				"F",
 				"L"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -28029,7 +28141,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -28200,7 +28314,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 7"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -28594,7 +28710,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -28735,7 +28853,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -28932,7 +29051,9 @@
 				"L",
 				"N",
 				"P"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -29136,7 +29257,9 @@
 				"N",
 				"P",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -29297,7 +29420,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -29484,7 +29609,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -29660,7 +29787,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -29838,7 +29967,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -30024,7 +30155,9 @@
 				"O",
 				"R",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -30207,7 +30340,9 @@
 				"O",
 				"R",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -30349,7 +30484,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -31212,7 +31349,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -31400,7 +31539,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -31568,7 +31709,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -31710,7 +31853,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -31910,7 +32055,8 @@
 			],
 			"miscTags": [
 				"AOE"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -32271,7 +32417,9 @@
 				"P",
 				"S",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -32439,7 +32587,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -32608,7 +32757,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -33442,7 +33593,9 @@
 				"P",
 				"S",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -33600,7 +33753,9 @@
 					"name": "Sahuagin Malenti",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -33761,7 +33916,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -33959,7 +34116,8 @@
 				"F",
 				"L",
 				"T"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -34146,7 +34304,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -34363,7 +34523,9 @@
 				"C",
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -34578,7 +34740,9 @@
 			],
 			"damageTagsSpell": [
 				"F"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -34920,7 +35084,8 @@
 			"damageTagsSpell": [
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -35097,7 +35262,9 @@
 			"damageTagsSpell": [
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -35346,7 +35513,9 @@
 				"N",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -35530,7 +35699,9 @@
 				"N",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -35719,7 +35890,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -35878,7 +36051,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -36114,7 +36289,9 @@
 			"damageTagsSpell": [
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -36454,7 +36631,9 @@
 			},
 			"damageTagsSpell": [
 				"B"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -36653,7 +36832,9 @@
 			],
 			"damageTagsSpell": [
 				"B"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -36836,7 +37017,9 @@
 				"F",
 				"L",
 				"P"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -37023,7 +37206,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -37288,7 +37473,9 @@
 			],
 			"damageTagsSpell": [
 				"F"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -37487,7 +37674,9 @@
 				"B",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -37696,7 +37885,9 @@
 			"damageTagsSpell": [
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -37859,7 +38050,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -38027,7 +38219,9 @@
 			],
 			"damageTagsSpell": [
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -38231,7 +38425,9 @@
 			},
 			"damageTagsSpell": [
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -38429,7 +38625,9 @@
 			],
 			"damageTagsSpell": [
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -39592,7 +39790,9 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -40079,7 +40279,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -40254,7 +40456,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -40388,7 +40592,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -40804,7 +41010,9 @@
 				"L",
 				"R",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -40984,7 +41192,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -41138,7 +41348,9 @@
 				"C",
 				"F",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -41333,7 +41545,9 @@
 			"damageTagsSpell": [
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -41555,7 +41769,9 @@
 				"O",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -41750,7 +41966,9 @@
 			"damageTagsSpell": [
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -41918,7 +42136,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42130,7 +42350,9 @@
 				"I",
 				"L",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42277,7 +42499,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42429,7 +42653,9 @@
 				"L",
 				"P",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42545,7 +42771,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42666,7 +42894,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42806,7 +43036,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -42946,7 +43178,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -43142,7 +43376,8 @@
 				"F",
 				"N",
 				"R"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -44371,7 +44606,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -44831,7 +45068,9 @@
 				"O",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -44993,7 +45232,9 @@
 			],
 			"damageTagsSpell": [
 				"B"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -45157,7 +45398,9 @@
 			"damageTagsSpell": [
 				"N",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -45417,7 +45660,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -45632,7 +45877,8 @@
 			"damageTagsSpell": [
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -45794,7 +46040,9 @@
 			"damageTagsSpell": [
 				"F",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -45983,7 +46231,9 @@
 			"damageTagsSpell": [
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -46139,7 +46389,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -46324,7 +46576,9 @@
 			},
 			"damageTagsSpell": [
 				"F"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -46490,7 +46744,9 @@
 				"B",
 				"F",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -46725,7 +46981,9 @@
 				"N",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -46842,7 +47100,9 @@
 					"name": "Gnoll Witherling, Greater",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -47002,7 +47262,9 @@
 				"F",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -47190,7 +47452,9 @@
 			"damageTagsSpell": [
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -47389,7 +47653,9 @@
 				"I",
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -47624,7 +47890,9 @@
 			],
 			"damageTagsSpell": [
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -47766,7 +48034,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -47943,7 +48213,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -48103,7 +48374,9 @@
 				"L",
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -48260,7 +48533,9 @@
 				"C",
 				"I",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -48433,7 +48708,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -48606,7 +48882,8 @@
 					"name": "Gatorfolk Chieftain",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -48741,7 +49018,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -48921,7 +49200,9 @@
 			],
 			"damageTagsSpell": [
 				"P"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -49093,7 +49374,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -49253,7 +49536,9 @@
 				"B",
 				"C",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -49423,7 +49708,9 @@
 				"C",
 				"P",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -49585,7 +49872,8 @@
 					"name": "Frost Giant Revenant",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -49700,7 +49988,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -49838,7 +50128,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -50003,7 +50295,9 @@
 				"F",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -50177,7 +50471,9 @@
 			"damageTagsSpell": [
 				"A",
 				"F"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -50319,7 +50615,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -50458,7 +50756,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -50673,7 +50973,9 @@
 				"N",
 				"R",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -50859,7 +51161,9 @@
 				"B",
 				"F",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -51329,7 +51633,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -51555,7 +51861,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -51754,7 +52062,9 @@
 			],
 			"damageTagsSpell": [
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -51950,7 +52260,9 @@
 				"N",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -52159,7 +52471,8 @@
 				"O",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -52286,7 +52599,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -52406,7 +52720,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -52771,7 +53086,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -53336,7 +53652,8 @@
 				"P",
 				"S",
 				"T"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -54029,7 +54346,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -55658,7 +55977,9 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -55793,7 +56114,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -56075,7 +56398,9 @@
 				"R",
 				"S",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -56280,7 +56605,9 @@
 			"damageTagsSpell": [
 				"I",
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -56531,7 +56858,9 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -56781,7 +57110,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 3"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -56984,7 +57315,9 @@
 				"F",
 				"L",
 				"N"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -57150,7 +57483,9 @@
 				"I",
 				"N",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -57338,7 +57673,8 @@
 				"N",
 				"R",
 				"T"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -57538,7 +57874,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -57682,7 +58020,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -57893,7 +58233,9 @@
 			],
 			"damageTagsSpell": [
 				"I"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -58102,7 +58444,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -58338,7 +58682,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -58499,7 +58845,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -58717,7 +59064,9 @@
 			],
 			"damageTagsSpell": [
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -58909,7 +59258,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -59125,7 +59476,9 @@
 				"B",
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -59483,7 +59836,9 @@
 				"L",
 				"P",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -59622,7 +59977,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -62510,7 +62867,9 @@
 			"damageTagsSpell": [
 				"F",
 				"O"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -62683,7 +63042,8 @@
 				"C",
 				"F",
 				"O"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -62906,7 +63266,8 @@
 				"R",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -63109,7 +63470,8 @@
 				"N",
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -63296,7 +63658,9 @@
 				"N",
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -63464,7 +63828,9 @@
 				"B",
 				"P",
 				"T"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -63630,7 +63996,9 @@
 				"B",
 				"N",
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -63775,7 +64143,9 @@
 					"name": "Bariaur",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -63919,7 +64289,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -64116,7 +64488,8 @@
 				"R",
 				"T",
 				"Y"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -64301,7 +64674,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -64472,7 +64846,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -64678,7 +65053,9 @@
 			],
 			"damageTagsSpell": [
 				"L"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -64857,7 +65234,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -65096,7 +65475,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -65221,7 +65602,9 @@
 					"name": "Aurumvorax",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -65345,7 +65728,9 @@
 					"name": "Aurumvorax",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -65481,7 +65866,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border 2"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -65645,7 +66032,8 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -65868,7 +66256,8 @@
 				"F",
 				"L",
 				"O"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -66089,7 +66478,8 @@
 				"I",
 				"R",
 				"S"
-			]
+			],
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -66356,7 +66746,9 @@
 				"P",
 				"S",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -67918,7 +68310,9 @@
 			"damageTagsLegendary": [
 				"B",
 				"P"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -68470,7 +68864,9 @@
 					"source": "MonsterManualExpanded3",
 					"name": "Roll20-style border"
 				}
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -68657,7 +69053,9 @@
 			],
 			"damageTagsSpell": [
 				"R"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -69009,7 +69407,9 @@
 			"damageTagsSpell": [
 				"B",
 				"C"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -69201,7 +69601,9 @@
 					"name": "Gnoll War Leader of Yeenoghu",
 					"source": "MonsterManualExpanded3"
 				}
-			}
+			},
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"source": "MonsterManualExpanded3",
@@ -69446,7 +69848,9 @@
 				"L",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true,
+			"hasFluffImages": true
 		}
 	],
 	"legendaryGroup": [

--- a/creature/Dragonix; Monster Manual Expanded III.json
+++ b/creature/Dragonix; Monster Manual Expanded III.json
@@ -26,6 +26,7 @@
 		"internalCopies": [
 			"monsterFluff"
 		],
+		"status": "ready",
 		"dateAdded": 1640053537,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "4c00a5a981"

--- a/creature/Dragonix; Monster Manual Expanded.json
+++ b/creature/Dragonix; Monster Manual Expanded.json
@@ -18,6 +18,7 @@
 				"color": "BD7044"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1579291901,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "f426bee6df"

--- a/creature/Glen Cooper; Monsters of the Guild.json
+++ b/creature/Glen Cooper; Monsters of the Guild.json
@@ -17,6 +17,7 @@
 				"targetSchema": "1.2.0"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1537874753,
 		"dateLastModified": 1668987711,
 		"_dateLastModifiedHash": "84ca16089a"

--- a/creature/Isabel Beis; Critter Compendium.json
+++ b/creature/Isabel Beis; Critter Compendium.json
@@ -17,6 +17,7 @@
 				"targetSchema": "1.3.4"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1537874753,
 		"dateLastModified": 1663792415,
 		"_dateLastModifiedHash": "a3d2458ace"

--- a/creature/Jonoman3000; Monster Module.json
+++ b/creature/Jonoman3000; Monster Module.json
@@ -726,7 +726,8 @@
 			"damageTags": [
 				"S",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -821,7 +822,8 @@
 			"damageTags": [
 				"S",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -1024,7 +1026,8 @@
 				"P",
 				"R",
 				"T"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -1197,7 +1200,8 @@
 			],
 			"conditionInflict": [
 				"charmed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -1595,7 +1599,8 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -1719,7 +1724,8 @@
 			"damageTags": [
 				"B",
 				"A"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -1844,7 +1850,8 @@
 			"conditionInflict": [
 				"grappled",
 				"exhaustion"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -1983,7 +1990,8 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2153,7 +2161,8 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2330,7 +2339,8 @@
 			],
 			"spellcastingTags": [
 				"I"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2491,7 +2501,8 @@
 				"F",
 				"O",
 				"T"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2618,7 +2629,8 @@
 			"damageTagsSpell": [
 				"F",
 				"O"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2719,7 +2731,8 @@
 			],
 			"damageTags": [
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2837,7 +2850,8 @@
 			],
 			"damageTags": [
 				"S"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -2942,7 +2956,8 @@
 			],
 			"conditionInflict": [
 				"blinded"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -3061,7 +3076,8 @@
 			],
 			"damageTags": [
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -3292,7 +3308,8 @@
 			],
 			"conditionInflict": [
 				"grappled"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -3405,7 +3422,8 @@
 			"damageTags": [
 				"B",
 				"F"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -3536,7 +3554,8 @@
 			"damageTags": [
 				"B",
 				"F"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -3734,7 +3753,8 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -3905,7 +3925,8 @@
 			],
 			"miscTags": [
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4027,7 +4048,8 @@
 			"conditionInflict": [
 				"petrified",
 				"restrained"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4133,7 +4155,8 @@
 			"conditionInflict": [
 				"petrified",
 				"restrained"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4283,7 +4306,8 @@
 				"grappled",
 				"restrained",
 				"stunned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4435,7 +4459,8 @@
 				"paralyzed",
 				"unconscious",
 				"blinded"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4554,7 +4579,8 @@
 			],
 			"conditionInflict": [
 				"poisoned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4668,7 +4694,8 @@
 				"grappled",
 				"restrained",
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4761,7 +4788,8 @@
 			],
 			"damageTags": [
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -4884,7 +4912,8 @@
 			"damageTags": [
 				"S",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -5049,7 +5078,8 @@
 				"N",
 				"O",
 				"R"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -5174,7 +5204,8 @@
 			],
 			"damageTags": [
 				"B"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -5313,7 +5344,8 @@
 			],
 			"conditionInflict": [
 				"poisoned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -5480,7 +5512,8 @@
 			"damageTagsSpell": [
 				"F",
 				"T"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -5668,7 +5701,8 @@
 			],
 			"damageTagsSpell": [
 				"O"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -5887,7 +5921,8 @@
 			],
 			"conditionInflictSpell": [
 				"charmed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6093,7 +6128,8 @@
 			],
 			"damageTagsSpell": [
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6225,7 +6261,8 @@
 			"conditionInflict": [
 				"paralyzed",
 				"poisoned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6397,7 +6434,8 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6534,7 +6572,8 @@
 			],
 			"damageTagsSpell": [
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6683,7 +6722,8 @@
 			],
 			"spellcastingTags": [
 				"CR"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6794,7 +6834,8 @@
 			"damageTags": [
 				"S",
 				"B"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -6963,7 +7004,8 @@
 			"conditionInflict": [
 				"blinded",
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7128,7 +7170,8 @@
 			],
 			"conditionInflict": [
 				"frightened"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7252,7 +7295,8 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7442,7 +7486,8 @@
 				"I",
 				"F",
 				"C"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7561,7 +7606,8 @@
 			"damageTags": [
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7710,7 +7756,8 @@
 				"grappled",
 				"restrained",
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7865,7 +7912,8 @@
 			],
 			"conditionInflict": [
 				"paralyzed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -7976,7 +8024,8 @@
 			"conditionInflict": [
 				"petrified",
 				"restrained"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -8154,7 +8203,8 @@
 			"damageTagsSpell": [
 				"I",
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -8373,7 +8423,8 @@
 			"damageTagsSpell": [
 				"B",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -8539,7 +8590,8 @@
 			"spellcastingTags": [
 				"P",
 				"I"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -8638,7 +8690,8 @@
 			],
 			"conditionInflict": [
 				"grappled"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -8787,7 +8840,8 @@
 			"conditionInflict": [
 				"poisoned",
 				"stunned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "MModule",
@@ -8903,7 +8957,8 @@
 			],
 			"damageTags": [
 				"B"
-			]
+			],
+			"hasFluff": true
 		}
 	],
 	"monsterFluff": [

--- a/creature/Jonoman3000; Monster Module.json
+++ b/creature/Jonoman3000; Monster Module.json
@@ -19,6 +19,7 @@
 				"color": "BD6D31"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1555319662,
 		"dateLastModified": 1655240342,
 		"_dateLastModifiedHash": "733cbe1d2c"

--- a/creature/Kobold Press; Creature Codex.json
+++ b/creature/Kobold Press; Creature Codex.json
@@ -31,6 +31,7 @@
 				]
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1555492476,
 		"dateLastModified": 1673556096,
 		"_dateLastModifiedHash": "95aa1100fc"

--- a/creature/Kobold Press; Tome of Beasts 2.json
+++ b/creature/Kobold Press; Tome of Beasts 2.json
@@ -25,6 +25,7 @@
 				"version": "1.0.2"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1604273451,
 		"dateLastModified": 1668340915,
 		"_dateLastModifiedHash": "3098466cce"

--- a/creature/Kobold Press; Tome of Beasts 3.json
+++ b/creature/Kobold Press; Tome of Beasts 3.json
@@ -33,6 +33,7 @@
 				"MM"
 			]
 		},
+		"status": "wip",
 		"dateAdded": 1674313296,
 		"dateLastModified": 1674313296,
 		"_dateLastModifiedHash": "ad59946511"

--- a/creature/Kobold Press; Tome of Beasts.json
+++ b/creature/Kobold Press; Tome of Beasts.json
@@ -23,6 +23,7 @@
 				"targetSchema": "1.3.4"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1537874753,
 		"dateLastModified": 1663792415,
 		"_dateLastModifiedHash": "7bd7026125"

--- a/creature/Nerzugal Role-Playing; Nerzugal's Extended Bestiary.json
+++ b/creature/Nerzugal Role-Playing; Nerzugal's Extended Bestiary.json
@@ -16,6 +16,7 @@
 				"version": "1.0.0"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1646628533,
 		"dateLastModified": 1655240342,
 		"_dateLastModifiedHash": "d5b9e87991"

--- a/creature/Regerem; Book of Beautiful Horrors.json
+++ b/creature/Regerem; Book of Beautiful Horrors.json
@@ -1509,7 +1509,8 @@
 				"unconscious",
 				"stunned",
 				"exhaustion"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -1630,7 +1631,8 @@
 			},
 			"miscTags": [
 				"AOE"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -1767,7 +1769,8 @@
 			"conditionInflict": [
 				"charmed",
 				"incapacitated"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -2114,7 +2117,8 @@
 			"conditionInflict": [
 				"blinded",
 				"deafened"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -2213,7 +2217,8 @@
 			"conditionInflict": [
 				"restrained",
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -2539,7 +2544,8 @@
 				"RW",
 				"RNG",
 				"MW"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -2762,7 +2768,8 @@
 				"N",
 				"P",
 				"R"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -2981,7 +2988,8 @@
 				"N",
 				"R",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -3115,7 +3123,8 @@
 			},
 			"languageTags": [
 				"LF"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -3400,7 +3409,8 @@
 			"conditionInflict": [
 				"paralyzed",
 				"stunned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -3537,7 +3547,8 @@
 				"paralyzed",
 				"prone",
 				"frightened"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -3735,7 +3746,8 @@
 			],
 			"damageTagsSpell": [
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -3866,7 +3878,8 @@
 			"conditionInflict": [
 				"paralyzed",
 				"poisoned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -4026,7 +4039,8 @@
 			],
 			"damageTagsSpell": [
 				"B"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -4192,7 +4206,8 @@
 			],
 			"damageTagsSpell": [
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -4313,7 +4328,8 @@
 				"petrified",
 				"restrained",
 				"paralyzed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -4440,7 +4456,8 @@
 				"grappled",
 				"restrained",
 				"stunned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -4596,7 +4613,8 @@
 				"restrained",
 				"stunned",
 				"charmed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -4884,7 +4902,8 @@
 			},
 			"conditionInflict": [
 				"poisoned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -5333,7 +5352,8 @@
 			"damageTagsSpell": [
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -6594,7 +6614,8 @@
 					"name": "Nekker",
 					"source": "BoBH"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -7072,7 +7093,8 @@
 			"conditionInflict": [
 				"prone",
 				"incapacitated"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -7175,7 +7197,8 @@
 					"name": "Primal Beast",
 					"source": "BoBH"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -7261,7 +7284,8 @@
 			},
 			"conditionInflict": [
 				"blinded"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -7361,7 +7385,8 @@
 			},
 			"conditionInflict": [
 				"poisoned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -7741,7 +7766,8 @@
 				"prone",
 				"blinded",
 				"unconscious"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -7963,7 +7989,8 @@
 			],
 			"damageTagsSpell": [
 				"F"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -8085,7 +8112,8 @@
 			},
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -8257,7 +8285,8 @@
 				"prone",
 				"charmed",
 				"stunned"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -8357,7 +8386,8 @@
 					"name": "Siren",
 					"source": "BoBH"
 				}
-			}
+			},
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -11950,7 +11980,8 @@
 			"conditionInflict": [
 				"prone",
 				"charmed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -12112,7 +12143,8 @@
 			},
 			"actionTags": [
 				"Multiattack"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",
@@ -16925,7 +16957,8 @@
 				"deafened",
 				"charmed",
 				"paralyzed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "BoBH",

--- a/creature/The_Unapproachable; Fighting Chance.json
+++ b/creature/The_Unapproachable; Fighting Chance.json
@@ -213,7 +213,8 @@
 				"poisoned",
 				"paralyzed",
 				"restrained"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",
@@ -1859,7 +1860,8 @@
 				"grappled",
 				"petrified",
 				"restrained"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",
@@ -2030,7 +2032,8 @@
 			"actionTags": [
 				"Multiattack",
 				"Tentacles"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",
@@ -2222,7 +2225,8 @@
 			],
 			"actionTags": [
 				"Multiattack"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",
@@ -2430,7 +2434,8 @@
 				"N",
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",
@@ -2574,7 +2579,8 @@
 			],
 			"miscTags": [
 				"HPR"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",
@@ -2741,7 +2747,8 @@
 			],
 			"languageTags": [
 				"LF"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "FightingC",

--- a/creature/The_Unapproachable; Veiled Threats.json
+++ b/creature/The_Unapproachable; Veiled Threats.json
@@ -204,7 +204,8 @@
 			],
 			"conditionInflict": [
 				"frightened"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -373,7 +374,8 @@
 			"conditionInflict": [
 				"restrained",
 				"blinded"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -544,7 +546,8 @@
 			],
 			"conditionInflictSpell": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -732,7 +735,8 @@
 				"grappled",
 				"restrained",
 				"frightened"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -857,7 +861,8 @@
 			"conditionInflict": [
 				"incapacitated",
 				"charmed"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -1094,7 +1099,8 @@
 				"F",
 				"N",
 				"O"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -1262,7 +1268,8 @@
 			],
 			"damageTagsSpell": [
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -1386,7 +1393,8 @@
 			],
 			"damageTags": [
 				"B"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -1526,7 +1534,8 @@
 			],
 			"damageTags": [
 				"B"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -1763,7 +1772,8 @@
 				"N",
 				"R",
 				"T"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -1919,7 +1929,8 @@
 				"S",
 				"B",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -2122,7 +2133,8 @@
 			"damageTagsSpell": [
 				"O",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -2215,7 +2227,8 @@
 			],
 			"conditionInflict": [
 				"prone"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -2328,7 +2341,8 @@
 			],
 			"actionTags": [
 				"Breath Weapon"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -2515,7 +2529,8 @@
 			],
 			"damageTagsSpell": [
 				"C"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -2669,7 +2684,8 @@
 			],
 			"conditionInflict": [
 				"grappled"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -2867,7 +2883,8 @@
 			"damageTagsSpell": [
 				"F",
 				"Y"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -3102,7 +3119,8 @@
 				"O",
 				"P",
 				"S"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -3253,7 +3271,8 @@
 			"damageTagsSpell": [
 				"C",
 				"N"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -3370,7 +3389,8 @@
 			"damageTags": [
 				"P",
 				"A"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -3609,7 +3629,8 @@
 				"B",
 				"C",
 				"F"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"source": "VeiledT",
@@ -4379,7 +4400,8 @@
 				"stunned",
 				"poisoned",
 				"paralyzed"
-			]
+			],
+			"hasFluff": true
 		}
 	],
 	"monsterFluff": [

--- a/creature/badooga; Better Greatwyrms.json
+++ b/creature/badooga; Better Greatwyrms.json
@@ -362,7 +362,8 @@
 			"damageTagsLegendary": [
 				"C",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Black Greatwyrm",
@@ -700,7 +701,8 @@
 			"damageTagsLegendary": [
 				"I",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Green Greatwyrm",
@@ -1045,7 +1047,8 @@
 			"damageTagsLegendary": [
 				"B",
 				"P"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Blue Greatwyrm",
@@ -1397,7 +1400,8 @@
 			"damageTagsLegendary": [
 				"B",
 				"L"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Red Greatwyrm",
@@ -1728,7 +1732,8 @@
 			"dragonAge": "greatwyrm",
 			"damageTagsLegendary": [
 				"F"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Tiamat",

--- a/trap/James Introcaso; 20 New Traps.json
+++ b/trap/James Introcaso; 20 New Traps.json
@@ -15,6 +15,7 @@
 				]
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1581466476,
 		"dateLastModified": 1585422724,
 		"_dateLastModifiedHash": "b35fd47386"


### PR DESCRIPTION
Added a bunch of tags now that `hasFluff` and `hasFluffImages` are mandatory for creatures using a `_monsterFluff`.

You might be interested in [this](https://github.com/Spappz/Tools45eTools/blob/main/creature%20fluff%20tagger.ps1) for the future 👀