### PR TITLE
Update Amellwind; Monster Hunter Monster Manual.json

### DIFF
--- a/class/KibblesTasty; Occultist.json
+++ b/class/KibblesTasty; Occultist.json
@@ -29,6 +29,7 @@
 				"KibblesTasty:CC"
 			]
 		},
+		"status": "ready",
 		"dateAdded": 1603793256,
 		"dateLastModified": 1674758815,
 		"_dateLastModifiedHash": "1fe7d4dcf8"

--- a/class/KibblesTasty; Occultist.json
+++ b/class/KibblesTasty; Occultist.json
@@ -29,9 +29,8 @@
 				"KibblesTasty:CC"
 			]
 		},
-		"status": "wip",
 		"dateAdded": 1603793256,
-		"dateLastModified": 1671544279,
+		"dateLastModified": 1674758815,
 		"_dateLastModifiedHash": "1fe7d4dcf8"
 	},
 	"class": [
@@ -1243,6 +1242,39 @@
 		}
 	],
 	"optionalfeature": [
+		{
+			"name": "Reliable Casting",
+			"source": "KT:O",
+			"page": 8,
+			"featureType": [
+				"ktcs"
+			],
+			"entries": [
+				"When you roll a 1 or 2 on a damage die for an Occultist cantrip, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2."
+			]
+		},
+		{
+			"name": "Habitual Casting",
+			"source": "KT:O",
+			"page": 8,
+			"featureType": [
+				"ktcs"
+			],
+			"entries": [
+				"When you cast an Occultist cantrip that requires concentration, you can instead cause the effect to persist without concentration a number of rounds equal to your Occultist level (for example, as 1st level Occultist, it would end at the start of your next turn). You can end a spell persisting in this way early as an action."
+			]
+		},
+		{
+			"name": "Tactical Casting",
+			"source": "KT:O",
+			"page": 8,
+			"featureType": [
+				"ktcs"
+			],
+			"entries": [
+				"When you take the {@action Ready} action with an Occultist cantrip, it does not require concentration to keep the spell readied."
+			]
+		},
 		{
 			"name": "Animate Broom",
 			"source": "KT:O",

--- a/collection/Amellwind; Amellwind's Guide to Monster Hunting.json
+++ b/collection/Amellwind; Amellwind's Guide to Monster Hunting.json
@@ -18,6 +18,7 @@
 		"optionalFeatureTypes": {
 			"HWF": "Hunter Weapon Feature"
 		},
+		"status": "ready",
 		"dateAdded": 1620294246,
 		"dateLastModified": 1674136931,
 		"_dateLastModifiedHash": "2123e8154d"

--- a/collection/Amellwind; Monster Hunter Monster Manual.json
+++ b/collection/Amellwind; Monster Hunter Monster Manual.json
@@ -20,6 +20,7 @@
 				"targetSchema": "1.0.0"
 			}
 		],
+		"status": "ready",
 		"dateAdded": 1539558000,
 		"dateLastModified": 1674604866,
 		"_dateLastModifiedHash": "ede1d1c6e6"

--- a/collection/Amellwind; Monster Hunter Monster Manual.json
+++ b/collection/Amellwind; Monster Hunter Monster Manual.json
@@ -72355,9 +72355,244 @@
 							"Gore Magalas are highly aggressive, elusive monsters. These monsters show great amounts of aggression and have shown great amounts of intelligence. Some have even been shown to play dead before slipping away when given an opportunity too. Despite competing with other powerful predators, Gore Magalas have rarely been seen with any wounds or scars on their body. Though these monsters are aggressive, they are more aggressive when its time for them to return to the Heaven's Mount and go to the Sanctuary. The reason for this is for the Gore Magala to molt into a legendary Shagaru Magala that once nearly wiped out every living thing in the mountains.",
 							"Interestingly, Gore Magala have been known to attack seafaring ships during their voyages across the great seas.",
 							{
+								"type": "inset",
+								"name": "Tempered Gore Magala",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"21",
+												"Carves/Capture",
+												"6"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-3",
+												"1-5",
+												"Gore Magala Carapace",
+												"(A,W)"
+											],
+											[
+												"4-5",
+												"6-7",
+												"Gore Magala Ripclaw",
+												"(A,W)"
+											],
+											[
+												"6",
+												"8-10",
+												"Gore Magala Wing",
+												"(A,W)"
+											],
+											[
+												"7-10",
+												"-",
+												"Gore Magala Tail",
+												"(A,W)"
+											],
+											[
+												"11-13",
+												"11-13",
+												"Frenzy Crystal",
+												"(O)"
+											],
+											[
+												"14-15",
+												"14-15",
+												"Gore Magala Feeler",
+												"(A,W)"
+											],
+											[
+												"16-17",
+												"16-18",
+												"Defiled Scale",
+												"(A,W)"
+											],
+											[
+												"18-19",
+												"19",
+												"Gore Magala Plate",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"Gore Magala Nyctgem",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Gore Magala Carapace",
+												"entries": [
+													"{@i Frenzy Res.} Whenever you make a saving throw against the {@disease frenzy virus|MHMM}, you do so with advantage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Ripclaw",
+												"entries": [
+													"{@i Evasion.} You have advantage on Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Wing",
+												"entries": [
+													"{@i Biology}. You become proficient with {@item dung bomb|AGMH}s while you are wearing this armor, and you are immune to blight effects such as {@condition waterblight|MHMM}, {@condition iceblight|MHMM}, or the {@spell blight} spell."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Tail",
+												"entries": [
+													"Your passive Perception increases by 5 and you have advantage on Dexterity ({@skill Stealth}) checks made to hide while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Feeler",
+												"entries": [
+													"You have resistance to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Defiled Scale",
+												"entries": [
+													"While you wear this armor, it projects an illusion that makes you appear to be standing in a place near your actual location, causing any creature to have disadvantage on attack rolls against you. If you take damage, the property ceases to function until the start of your next turn. This property is suppressed while you are {@condition incapacitated}, {@condition restrained}, or otherwise unable to move."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Plate",
+												"entries": [
+													"You are immune to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Nyctgem",
+												"entries": [
+													"If you aren't wearing light, medium, or heavy armor; your base Armor Class is 15 + your Dexterity modifier."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Gore Magala Carapace",
+												"entries": [
+													"When held, this weapon draws in light, snuffing all nonmagical flames within 30 feet out. It turns dim light into darkness and bright light into dim light."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Ripclaw",
+												"entries": [
+													"{@i (Melee Weapon only)} When you attack a creature with this weapon and roll a 20 on the attack roll, that target takes an extra {@damage 4d6} weapon damage. Then roll another d20. If you roll a 20, you remove one of the target's limbs, with the effect of such loss determined by the GM. If the creature has no limb to sever, you lop off a portion of its body instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Wing",
+												"entries": [
+													"{@i Spirit.} When fighting a Huge or larger creature, your weapon deals 1d6 extra damage and its crit range is increased by 1."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Tail",
+												"entries": [
+													"Your weapon deals an extra 1d8 necrotic damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Feeler",
+												"entries": [
+													"{@i (Melee Weapon only)} This Weapon has 3 Runes. While holding it, you can use an action and expend 1 rune to release a wave of terror. Each creature of your choice in a 30-foot radius extending from you must succeed on a {@dc 15} Wisdom saving throw or become {@condition frightened} of you for 1 minute. While it is frightened in this way, a creature must spend its turns trying to move as far away from you as it can, and it can't willingly move to a space within 30 feet of you. It also can't take reactions. For its action it can use only the dash action or try to escape from an effect that prevents it from moving. If it has nowhere it can move, the creature can use the {@action dodge} action. At the end of each of its turns, a creature can repeat the saving throw, ending the effect on itself on a success.",
+													"The weapon regains 1d3 expended Runes daily at dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Defiled Scale",
+												"entries": [
+													"Your weapon deals an extra 1d10 necrotic damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Plate",
+												"entries": [
+													"You gain a +3 bonus to your spell attack rolls and spell save DC while attuned to this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Nyctgem",
+												"entries": [
+													"{@i (Cleric & Druid only)} This weapon has 10 runes. While holding it, you can use an action to expend 1 or more of its runes to cast one of the following Spells from it, using your spell save DC: {@spell inflict wounds} (3rd level, 3 runes), {@spell blindness/deafness} (2 runes), {@spell bestow curse} (3 runes), {@spell blight} (4 runes), {@spell circle of death} (6 runes), or {@spell eyebite} (sickened) (6 runes). This weapon regains 1d6 + 4 expended runes daily at dawn. If you expend the last rune it cannot regain any runes for one week."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Frenzy Crystal",
+												"entries": [
+													"A legendary research material {@i (up to your DM how this might be useful in your game)} and quite valuable."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
 								"type": "homebrew",
 								"entries": [
-									"No loot table is printed for Tempered Gore Magala. When a variant lacks fluff I usually leave up the base fluff because it has no mechanical impact and looks nicer, but inserting the base monster's loot table here would feel like an extra editorial step."
+									"Amellwind has helpfully confirmed that Tempered Gore Magala uses Gore Magala's loot table."
 								]
 							}
 						]

--- a/collection/Amellwind; Monster Hunter Monster Manual.json
+++ b/collection/Amellwind; Monster Hunter Monster Manual.json
@@ -21,7 +21,7 @@
 			}
 		],
 		"dateAdded": 1539558000,
-		"dateLastModified": 1674448148,
+		"dateLastModified": 1674604866,
 		"_dateLastModifiedHash": "ede1d1c6e6"
 	},
 	"book": [
@@ -31,7 +31,7 @@
 			"source": "MHMM",
 			"group": "homebrew",
 			"author": "Amellwind",
-			"published": "2021-05-22",
+			"published": "2023-01-12",
 			"contents": [
 				{
 					"name": "Introduction"
@@ -2375,7 +2375,7 @@
 												"9",
 												"7-9",
 												"Agnaktor Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"10-11",
@@ -2432,6 +2432,13 @@
 												"name": "Agnaktor Hide",
 												"entries": [
 													"You suffer no harm from temperatures as warm as 120 degrees Fahrenheit while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Agnaktor Claw",
+												"entries": [
+													"{@i Geologist.} When you successfully gather a {@table minerals|AGMH|mining} resource, you instead gather 2."
 												]
 											},
 											{
@@ -4849,7 +4856,7 @@
 											[
 												"11-13",
 												"Altaroth Jaw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"14-20",
@@ -4881,7 +4888,7 @@
 												"type": "entries",
 												"name": "Altaroth Jaw",
 												"entries": [
-													"{@i Entomologist.} When you capture an {@table insects|AGMH|insect} with a {@item bug net|AGMH}, you instead catch two."
+													"{@i Forager.} When you harvest mushrooms, you instead gather two."
 												]
 											}
 										]
@@ -5863,7 +5870,7 @@
 												"14-16",
 												"11-14",
 												"Anjanath Nosebone",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"17-19",
@@ -5960,6 +5967,13 @@
 												"name": "Anjanath Fang",
 												"entries": [
 													"{@i (Clerics, Druids, and Rangers only)} You know the {@spell produce flame} cantrip while attuned to this weapon. If you already know it, you gain a +1 bonus to its spell attack roll."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Anjanath Nosebone",
+												"entries": [
+													"{@i (Bow only) Bow Charge Plus.} While attuned to this weapon, you can use your dragonpiercer one additional time between rests and it recharges after a Short or Long rest."
 												]
 											},
 											{
@@ -6679,7 +6693,7 @@
 									[
 										"10",
 										"AT.Gushing Magma",
-										"(A)"
+										"(A,W)"
 									],
 									[
 										"11-13",
@@ -6689,7 +6703,7 @@
 									[
 										"14-15",
 										"AT.Miralis Smelter",
-										"(W)"
+										"(A,W)"
 									],
 									[
 										"16-17",
@@ -6743,6 +6757,13 @@
 									},
 									{
 										"type": "entries",
+										"name": "AT.Miralis Smelter",
+										"entries": [
+											"{@i Geologist+.} When you successfully gather a mining resource, you gather an extra 1d4 more."
+										]
+									},
+									{
+										"type": "entries",
 										"name": "AT.Miralis Hellwing",
 										"entries": [
 											"You have immunity to fire damage while you wear this armor."
@@ -6774,6 +6795,13 @@
 										"name": "AT.Miralis Fireclaw",
 										"entries": [
 											"Your weapon deals an extra 2d6 fire damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "AT.Gushing Magma",
+										"entries": [
+											"{@i Bow Charge Plus++.} While attuned to this weapon, you can use your dragonpiercer three additional times between rests and it recharges after a Short or Long rest."
 										]
 									},
 									{
@@ -7871,7 +7899,7 @@
 												"18",
 												"14-17",
 												"Azure Jumbo Bone",
-												"(W,O)"
+												"(A,W,O)"
 											],
 											[
 												"19-20",
@@ -7898,6 +7926,13 @@
 												"name": "Arzuros Shell",
 												"entries": [
 													"You have a +1 bonus to {@skill Athletics} checks while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Azure Jumbo Bone",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
 												]
 											},
 											{
@@ -8474,6 +8509,382 @@
 			],
 			"conditionInflict": [
 				"paralyzed"
+			]
+		},
+		{
+			"name": "Aurora Somnacanth",
+			"size": [
+				"H"
+			],
+			"type": "leviathan",
+			"group": [
+				"Leviathans"
+			],
+			"environment": [
+				"arctic",
+				"hill",
+				"mountain"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 16,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 184,
+				"formula": "16d12 + 80"
+			},
+			"speed": {
+				"walk": 60
+			},
+			"str": 20,
+			"dex": 16,
+			"con": 20,
+			"int": 7,
+			"wis": 10,
+			"cha": 20,
+			"save": {
+				"dex": "+8",
+				"con": "+8"
+			},
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"immune": [
+				"cold",
+				"necrotic"
+			],
+			"passive": 10,
+			"cr": "10",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Hold Breath",
+					"entries": [
+						"The somnacanth can hold its breath for 12 hours."
+					]
+				},
+				{
+					"name": "Ice Walk",
+					"entries": [
+						"The somnacanth can move across and climb icy surfaces without needing to make an ability check. Additionally, difficult terrain composed of ice or snow doesn't cost it extra moment."
+					]
+				},
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The somnacanth's long jump is up to 40 feet and its high jump is up to 20 feet, without a running start. In addition, the somnacanth does not incur attacks of opportunity while moving with a jump."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The somnacanth makes five Frill Quill attacks."
+					]
+				},
+				{
+					"name": "Frill Quill",
+					"entries": [
+						"{@atk rw} {@hit 10} to hit, range 60/240 ft., one target. {@h}8 ({@damage 1d6 + 5}) piercing damage. If the quill misses, it stabs into the ground in an unoccupied space within 5 feet of the target. When a creature enters the quill's space, it takes 3 ({@damage 1d6}) piercing damage and the quill is destroyed."
+					]
+				},
+				{
+					"name": "Headbutt",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 10 ft., two targets. {@h}18 ({@damage 3d8 + 5}) bludgeoning damage plus 7 ({@damage 2d6}) cold damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d6 + 5}) bludgeoning damage plus 14 ({@damage 4d6}) cold damage."
+					]
+				},
+				{
+					"name": "Deadly Leap",
+					"entries": [
+						"If the somnacanth jumps at least 10 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a {@dc 18} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 22 ({@damage 5d6 + 5}) bludgeoning damage plus 14 ({@damage 4d6}) cold damage. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 feet out of the somnacanth's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the somnacanth's space."
+					]
+				},
+				{
+					"name": "Icy Wasteland (Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the somnacanth is below half of its maximum hit points, it can use this action to cause a freezing chill to emanate in a 60-foot radius from a point 60 feet away from it. For 1 minute, that area is icy and becomes difficult terrain.",
+						"It then extends its body and screams, creating multiple icy explosions in a 60-foot cone. Each creature in that area must make a {@dc 18} Constitution saving throw, taking 42 ({@damage 12d6}) cold damage and be diseased with {@disease iceblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't diseased with iceblight on a successful one. A creature can repeat its saving throw at the end of its turn, ending the effecting on a success."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The somnacanth makes one Tail attack."
+					]
+				},
+				{
+					"name": "Frozen Mist",
+					"entries": [
+						"The somnacanth releases freezing mist in a 5-foot radius around it. Each creature in that area must succeed on a {@dc 18} Constitution saving throw or be diseased with {@disease iceblight|MHMM} for 1 minute on a failed save. A creature can repeat its saving throw at the end of its turn, ending the effecting on a success."
+					]
+				},
+				{
+					"name": "Aurora Breath (Costs 2 Actions)",
+					"entries": [
+						"The somnacanth exhales ice in 60-foot long line that is 5 feet wide, that sweeps across a 180 degree area in front of it. Each creature in that area must make a {@dc 18} Constitution saving throw, taking 28 ({@damage 8d6}) cold damage and be diseased with {@disease iceblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't diseased with iceblight on a successful one. A creature can repeat its saving throw at the end of its turn, ending the effecting on a success."
+					]
+				},
+				{
+					"name": "Writher (Costs 2 Actions)",
+					"entries": [
+						"The somnacanth moves up to half its speed without provoking opportunity attacks and then makes one Headbutt attack."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"The aurora somnacanth is similar in appearance to {@creature somnacanth|MHMM}, however, its body is pale yellow, while its fins are ice-blue with some dark purple gradient. The bioluminescence is white instead of light blue, and frost can be seen forming on its head-crest and tail.",
+							"Instead of sleep mist, the aurora somnacanth uses powerful ice attacks in combat. These include an ice beam and a cry that can cause several frost explosions. Aurora somnacanth spend more time on land than its counterpart.",
+							"It is an aggressive monster that attack anyone who invades its territory. It uses its siren like voice to lure prey in before freezing them to death. It will then drag away its prey to eat in a hidden location. It preys on small monsters like {@creature izuchi|MHMM}.",
+							{
+								"type": "inset",
+								"name": "Aurora Somnacanth",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"14",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-7",
+												"1-3",
+												"Auroracanth Icescale",
+												"(A,W)"
+											],
+											[
+												"8-12",
+												"4-9",
+												"Auroracanth Icecortex",
+												"(A,W)"
+											],
+											[
+												"-",
+												"10-11",
+												"Lg Monster Bone",
+												"(O)"
+											],
+											[
+												"13-14",
+												"-",
+												"Auroracanth Fin",
+												"(A,W)"
+											],
+											[
+												"15-17",
+												"12-15",
+												"Cryo Sac",
+												"(A,W)"
+											],
+											[
+												"18-19",
+												"16-19",
+												"Auroracanth Iceclaw",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"Aurora Gem",
+												"(W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Auroracanth Icescale",
+												"entries": [
+													"While you wear this armor, you ignore difficult terrain created by ice or snow and you can tolerate temperatures as low as -50 degrees Fahrenheit without any additional protection. If you wear heavy clothes, you can tolerate temperatures as low as -100 degrees Fahrenheit."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Auroracanth Icecortex",
+												"entries": [
+													"{@i Divine Blessing+.} When you take damage you are not immune or resistant to, roll a d6 and reduce the damage you take by the number rolled. You can use this property a number of times equal to your proficiency bonus. You regain all expended uses when you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Auroracanth Fin",
+												"entries": [
+													"{@i Item Prolonger+.} Whenever you use a consumable item that has a duration, its duration is increased by an additional 12 seconds."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Cryo Sac",
+												"entries": [
+													"You have resistance to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Auroracanth Iceclaw",
+												"entries": [
+													"{@i Evade Extender (M).} You gain a +2 bonus to Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Aurora Gem",
+												"entries": [
+													"You are immune to cold damage while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Auroracanth Icescale",
+												"entries": [
+													"This weapon has a reservoir of ice magic that can freeze the ground. While holding it, you can use a bonus action to plant the weapon in the ground, releasing the ice magic within, causing the ground in a 15-foot radius around the weapon to become icy and difficult terrain for the duration, or until you remove from the ground as a bonus action. You can use this property for up to 1 minute, all at once or in several shorter uses, each one using a minimum of 6 seconds from the duration. This weapon recharges 6 seconds of energy to the weapon's reservoir for every 12 hours it isn't used."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Auroracanth Icecortex",
+												"entries": [
+													"When you roll a 20 on an attack roll with this weapon, the ground in the direction of the target in either a 15-foot cone or line 30 feet long and 5 feet wide (your choice) is covered in a layer of slick ice for 1 minute, making it difficult terrain."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Auroracanth Fin",
+												"entries": [
+													"Depending on which weapon this material is placed into, it gains the following benefits:",
+													{
+														"type": "list",
+														"items": [
+															"{@b Bow.} When you hit a creature with a poison coated arrow, you can inflict {@condition iceblight|MHMM} instead of the {@condition poisoned} condition.",
+															"{@b Dual Repeaters.} Your cryo ammo now inflicts {@condition iceblight|MHMM} instead of {@condition waterblight|MHMM} when empowered.",
+															"{@b Heavy Bowgun.} When you hit a creature with your poison ammo, you can inflict {@condition waterblight|MHMM} instead of the {@condition poisoned} condition.",
+															"{@b Light Bowgun.} When you hit a creature with water ammo, its movement speed is reduced by 5 feet until the end of its next turn."
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Cryo Sac",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d6} cold damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Auroracanth Iceclaw",
+												"entries": [
+													"{@i Critical Element (cold+).} When you critically hit with a weapon or spell that deals cold damage, you deal an extra {@damage 1d8} cold damage. Additionally if a creature fails its saving throw by 5 or more against a spell that deals cold damage, you deal an extra {@damage 1d8} cold damage to it."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Aurora Gem",
+												"entries": [
+													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra {@damage 1d6} weapon damage. {@i (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")}"
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Lg Monster Bone",
+												"entries": [
+													"Very rare armor upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"miscTags": [
+				"MW",
+				"RW",
+				"AOE",
+				"RCH"
+			],
+			"damageTags": [
+				"B",
+				"S",
+				"P",
+				"C"
+			],
+			"senseTags": [
+				"D"
+			],
+			"traitTags": [
+				"Hold Breath"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
 			]
 		},
 		{
@@ -9400,7 +9811,7 @@
 											[
 												"8-12",
 												"Baggi Hide",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"13-16",
@@ -9424,6 +9835,13 @@
 										"style": "list-hang",
 										"name": "ARMOR MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Baggi Hide",
+												"entries": [
+													"{@i Geologist.} When you successfully gather a {@table minerals|AGMH|mining} resource, you instead gather 2."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Baggi Scale",
@@ -10324,13 +10742,13 @@
 												"4-8",
 												"4-8",
 												"Barroth Ridge",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"9-11",
 												"9-13",
 												"Barroth Shell",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"12-15",
@@ -10373,6 +10791,13 @@
 											},
 											{
 												"type": "entries",
+												"name": "Barroth Shell",
+												"entries": [
+													"{@i Geologist.} When you successfully gather a mining resource, you instead gather 2."
+												]
+											},
+											{
+												"type": "entries",
 												"name": "Barroth Scalp",
 												"entries": [
 													"{@i Marathon Runner.} While wearing this armor, your walking speed increases by 5 feet."
@@ -10392,6 +10817,13 @@
 										"style": "list-hang",
 										"name": "WEAPON MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Barroth Ridge",
+												"entries": [
+													"{@i Bow Charge Plus.} While attuned to this weapon, you can use your dragonpiercer one additional time between rests and it recharges after a Short or Long rest."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Barroth Shell",
@@ -13147,6 +13579,347 @@
 			]
 		},
 		{
+			"name": "Blood Orange Bishaten",
+			"size": [
+				"L"
+			],
+			"type": {
+				"type": "beast",
+				"tags": [
+					"fanged"
+				]
+			},
+			"group": [
+				"Fanged Beasts"
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"hill"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 17,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"formula": "16d10 + 64",
+				"average": 152
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 20,
+			"dex": 16,
+			"con": 18,
+			"int": 7,
+			"wis": 14,
+			"cha": 7,
+			"passive": 15,
+			"cr": "12",
+			"page": 160,
+			"save": {
+				"dex": "+7",
+				"con": "+8"
+			},
+			"skill": {
+				"acrobatics": "+7",
+				"perception": "+6"
+			},
+			"trait": [
+				{
+					"name": "Gliding",
+					"entries": [
+						"When the bishaten falls and isn't {@condition incapacitated}, it can subtract up to 100 feet from the fall when calculating falling damage, and it can move up to 2 feet horizontally for every 1 foot it descends."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The bishaten makes three Tail attacks or two Firecone attacks."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}8 ({@damage 1d6 + 5}) slashing damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}14 ({@damage 2d8 + 5}) bludgeoning damage. If it is holding a pinecone in its tail, each creature in a 15-foot cone behind the target must make a {@dc 17} Dexterity saving throw, taking 14 ({@damage 4d6}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Firecone",
+					"entries": [
+						"{@atk rw} {@hit 9} to hit, range 20/60 ft., one target. {@h}12 ({@damage 2d6 + 5}) fire damage."
+					]
+				},
+				{
+					"name": "Fruit Toss {@recharge 5}",
+					"entries": [
+						"The bishaten exhales fire in a 60-foot line that is 5 feet wide. Each creature in that line must make a {@dc 16} Dexterity saving throw, taking 45 ({@damage 13d6}) fire damage on a failed save, or half as much damage on a successful one)."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Grasp {@recharge 6}",
+					"entries": [
+						"The bishaten grabs a pinecone with its tail and holds onto it until it makes an attack with its tail."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The bishaten makes one claw attack."
+					]
+				},
+				{
+					"name": "Pinecone Mines",
+					"entries": [
+						"The bishaten throw three unlit firecones that land in a random unoccupied space within a 30-foot cone in front of it. When the pinecone takes at least 1 fire damage it explodes dealing 7 ({@damage 2d6}) fire damage to each creature in a 5-foot radius around it."
+					]
+				},
+				{
+					"name": "Firecone Slam (Costs 2 Actions)",
+					"entries": [
+						"The bishaten smashes a fiery pinecone into the ground creating multiple explosions along a 30-foot line that is 5 feet wide. Each creature in that line must make a {@dc 17} Dexterity saving throw, taking 14 ({@damage 4d6}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Corkscrew (Costs 3 Actions)",
+					"entries": [
+						"The bishaten moves up to its glide speed in a straight line, While doing so, it can enter Large or smaller creatures' spaces without provoking opportunity attacks. The first time the bishaten enters a creature's space, the creature must make a {@dc 17} Dexterity saving throw or take 15 ({@damage 3d6 + 5}) bludgeoning damage and is knocked {@condition prone}, or half as much damage on and can choose to be pushed 5 feet to the side of the bishaten on a successful one."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					"Blood orange bishaten is similar in appearance to a standard {@creature bishaten|MHMM}; however, the primary colors of its feathers are orange and black instead of the standard bishaten's blue and white. The tips of its wings are yellow, and various parts of its body (namely its face, legs, and tail) are white.",
+					"The main difference between blood orange bishaten and the normal bishaten is the blood orange bishaten's ability to breathe fire. Another key difference is that instead of throwing persimmons, blood orange bishaten throws highly explosive pinecones in which it can ignite with its fire breath or through impact force. They are able to masterfully spin these pinecones around itself like a top, or be stuck to the ground like mines that can be later set off.",
+					"Blood orange bishaten is an aggressive monster that retains the cleverness of the normal bishaten. If provoked, it retaliates back with fire moves. It is even willing to attack other bishaten and throw explosive pinecones at them for its amusement. Unlike its counterpart, Blood orange bishaten is strong enough to fight {@creature Almudron|MHMM} into a stalemate. However, it must deal with competition like the {@creature rathalos|MHMM}.",
+					{
+						"type": "inset",
+						"name": "Blood Orange Bishaten",
+						"entries": [
+							{
+								"type": "table",
+								"colStyles": [
+									"col-1 bold",
+									"col-1",
+									"col-2 bold text-right",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"Challenge Rating",
+										"12",
+										"Carves/Capture",
+										"3"
+									]
+								]
+							},
+							{
+								"type": "table",
+								"colLabels": [
+									"Carve Chance",
+									"Capture Chance",
+									"Material",
+									"Slots"
+								],
+								"colStyles": [
+									"col-1 text-center",
+									"col-1 text-center",
+									"col-2 text-center",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"1",
+										"1",
+										"1d6 Firecones",
+										"(O)"
+									],
+									[
+										"2-5",
+										"2-5",
+										"Orangaten Fur",
+										"(A,W)"
+									],
+									[
+										"6-10",
+										"6-11",
+										"Orangaten Feather",
+										"(A,W)"
+									],
+									[
+										"11-14",
+										"12-15",
+										"Orangaten Talon",
+										"(A,W)"
+									],
+									[
+										"15-16",
+										"16-17",
+										"Lg Monster Bone",
+										"(O)"
+									],
+									[
+										"17-19",
+										"18",
+										"Orangaten Tailcase",
+										"(A,W)"
+									],
+									[
+										"20",
+										"19-20",
+										"Orangaten Horn",
+										"(A,W)"
+									]
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "ARMOR MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Orangaten Fur",
+										"entries": [
+											"{@i Handicraft.} For 24 hours, you gain proficiency with one artisan tool of your choice each dawn."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Feather",
+										"entries": [
+											"When you place this material into your armor it gains a gliding membrane, which extends from your forearms to your hindlegs. As an action or reaction, you can extend your arms to reduce your fall speed to 10 feet per round while traveling in a forward motion until you reach the ground, you are {@condition grappled}, or you use your action to end the effect early. If you are falling straight down, you may choose the direction you travel when you begin your glide. You can use this property a number of times equal to your proficiency bonus, regaining all expended uses when you finish a short or long rest."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Talon",
+										"entries": [
+											"{@i Recovery Speed.} Whenever you roll a Hit Die to regain hit points, double the number of hit points it restores."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Tailcase",
+										"entries": [
+											"While wearing this armor, you grow a monkey-like tail with a fist at the end of it. You can use the tail to hold an object, or stow or retrieve an item from your bags. The tail can't attack, activate magic items, or carry more than 20 pounds."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Horn",
+										"entries": [
+											"You have resistance to fire damage while you wear this armor."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "WEAPON MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Orangaten Fur",
+										"entries": [
+											"{@i Quick Sheath.} While attuned to this weapon, you can always sheath it as a free action even if you have already drawn a weapon as part of your move action."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Feather",
+										"entries": [
+											"{@i Spread up.} When you hit a creature with spread ammo and they are within half your normal bowgun range, increase the damage die size by 1."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Talon",
+										"entries": [
+											"{@i Protective Polish.} This weapon is so finely constructed it never needs maintenance, cannot rust or tarnish, and deals an extra {@damage 1d6} weapon damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Tailcase",
+										"entries": [
+											"Your unarmed strikes deal an extra {@damage 1d6} fire damage and your weapon has 3 runes that recharge at dawn. When you hit a creature with a melee weapon attack you can expend a rune to generate an explosion on impact. You can only expend one rune per round. The target and all creatures other than yourself within 5 feet of the target must make a {@dc 16} Constitution saving throw, taking {@damage 2d6} fire damage on a failed save or half as much damage on a successful one."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Orangaten Horn",
+										"entries": [
+											"{@i Latent Power +1.} When you are reduced to a quarter of your maximum hit points for the first time in combat or at the start of your turn on the 10th round of combat, whichever comes first, you gain the effects of the {@spell haste} spell for 1 minute. Once used, you must finish a short or long rest before you can use this property again."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "OTHER MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Lg Monster Bone",
+										"entries": [
+											"Very Rare armor upgrade material."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Firecone",
+										"entries": [
+											"As an action you can light this firecone and throw at a point within 40 feet of you. Each creature within 5 feet of that point must make a {@dc 14} Dexterity saving throw, taking {@damage 4d6} fire damage on a failed save, or half as much damage on a successful one."
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"S",
+				"B",
+				"F"
+			],
+			"miscTags": [
+				"MW",
+				"RW",
+				"RCH",
+				"AOE"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
 			"name": "Blood Soaked Arzuros",
 			"size": [
 				"L"
@@ -14217,6 +14990,231 @@
 				"paralyzed",
 				"blinded",
 				"unconscious"
+			]
+		},
+		{
+			"name": "Boggi",
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "beast",
+				"tags": [
+					"theropod"
+				]
+			},
+			"group": [
+				"Theropods"
+			],
+			"environment": [
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 11,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 19,
+				"formula": "3d8 + 6"
+			},
+			"speed": {
+				"walk": 30,
+				"swim": 30
+			},
+			"str": 15,
+			"dex": 13,
+			"con": 14,
+			"int": 4,
+			"wis": 10,
+			"cha": 6,
+			"passive": 10,
+			"cr": "1",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Pack Tactics",
+					"entries": [
+						"The boggi has advantage on attack rolls against a creature if at least one of the Baggi's allies is within 5 feet of the creature and the ally isn't {@condition incapacitated}."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d6 + 2}) piercing damage."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hit 4} to hit, reach 5 ft., one target. {@h}5 ({@damage 1d6 + 2}) slashing damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Nimble Escape",
+					"entries": [
+						"The boggi takes the {@action Disengage} or {@action Hide} action."
+					]
+				}
+			],
+			"traitTags": [
+				"Pack Tactics"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Boggi has a body structure similar to like of {@creature wroggi|MHMM} or {@creature baggi|MHMM}, with a scaly yellow hide and brown markings. Its head quite resembles a hyena, with large ears, oversized lower canines, and a patch of dark hair on its shoulders, back, and along the tail. Its tongue is normally seen hanging out of its mouth.",
+							"Boggi work together in packs in order to hunt down prey. Boggi are known to use their speed to wear down potential prey. They use their claws in battle, so one must be wary of them. Due to be low on the food chain they must avoid dangerous predators such as {@creature garangolm|MHMM}, {@creature goss harag|MHMM}, and {@creature gore magala|MHMM}.",
+							"Boggi are cunning and cauclating monsters that patiently wait for openings to strike. However, they will flee when there is danger.",
+							{
+								"type": "inset",
+								"name": "Boggi",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"1",
+												"Carves",
+												"1"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-7",
+												"Bird Wyvern Fang",
+												"(W)"
+											],
+											[
+												"8-12",
+												"Boggi Thickhide",
+												"(A)"
+											],
+											[
+												"13-16",
+												"Boggi Scale",
+												"(A)"
+											],
+											[
+												"17-18",
+												"Sm Monster Bone",
+												"(O)"
+											],
+											[
+												"19-20",
+												"Bird Wyvern Bone",
+												"(O)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Boggi Thickhide",
+												"entries": [
+													"While attuned to this armor you can take the {@action Disengage} or {@action Hide} action as a bonus action. Once you use this property you can't use it again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Baggi Scale",
+												"entries": [
+													"You have a +1 bonus to {@skill Survival} checks while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Bird Wyvern Fang",
+												"entries": [
+													"Your piercing weapon deals an extra 1 piercing damage."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Sm Monster Bone",
+												"entries": [
+													"Uncommon weapon upgrade material."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Bird Wyvern Bone",
+												"entries": [
+													"Uncommon armor upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"S"
+			],
+			"miscTags": [
+				"MW"
+			],
+			"conditionInflict": [
+				"Incapacitated"
 			]
 		},
 		{
@@ -15580,6 +16578,13 @@
 												"entries": [
 													"You have a +1 bonus to {@skill Intimidation} checks while you wear this armor."
 												]
+											},
+											{
+												"type": "entries",
+												"name": "Bullfango Head",
+												"entries": [
+													"{@i Forager.} When you harvest mushrooms, you instead gather two."
+												]
 											}
 										]
 									},
@@ -15748,7 +16753,7 @@
 											[
 												"14-18",
 												"Shoat Head",
-												"(O)"
+												"(W,O)"
 											],
 											[
 												"19-20",
@@ -16791,7 +17796,7 @@
 											[
 												"16-19",
 												"Piscine Fang",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"20",
@@ -16805,6 +17810,13 @@
 										"style": "list-hang",
 										"name": "ARMOR MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Piscine Fang",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Cephalos Fin",
@@ -17624,6 +18636,460 @@
 			]
 		},
 		{
+			"name": "Chaotic Gore Magala",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"unknown"
+				]
+			},
+			"group": [
+				"Unknown"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				{
+					"ac": 21,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 333,
+				"formula": "29d12 + 145"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 30,
+			"dex": 20,
+			"con": 20,
+			"int": 12,
+			"wis": 9,
+			"cha": 19,
+			"save": {
+				"str": "+17",
+				"wis": "+6",
+				"cha": "+11"
+			},
+			"skill": {
+				"perception": "+6"
+			},
+			"resist": [
+				"cold"
+			],
+			"immune": [
+				"acid",
+				{
+					"immune": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical weapons",
+					"cond": true
+				}
+			],
+			"conditionImmune": [
+				"blind",
+				"charmed",
+				"frightened"
+			],
+			"passive": 16,
+			"cr": "24",
+			"page": 0,
+			"senses": [
+				"blindsight 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Frenzied State (Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the magala would be reduced to 0 hit points, its current hit point total instead resets to 241 (21d12 + 105) hit points, it gains a +2 bonus to its AC, it recharges its Breath Weapon, and it regains any expended uses of Legendary Resistance. Additionally, the magala can now use its Super Frenzy Explosion during the next hour and some of its actions gain additional effects for the same duration."
+					]
+				},
+				{
+					"name": "Frenzy Dust",
+					"entries": [
+						"When a creature has 3 Frenzy Charges, they must makes a {@dc 23} Constitution saving throw. On a fail, the target is afflicted with the {@disease Frenzy Virus|MHMM} until dispelled by a {@spell Greater Restoration} spell. On a success, the frenzy charges reset to 0."
+					]
+				},
+				{
+					"name": "Frenzy Dust",
+					"entries": [
+						"Every 15 feet the magala moves, it leaves a purple cloud filled with the frenzy virus in a 10-foot cube in a space adjacent to it. The clouds disperse after 1 hour, or until a wind of moderate or greater speed (at least 10 miles per hour) disperses it. When a creature starts its turn in a cloud or enters it for the first time on a turn, it gains 1 frenzy charge."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the magala fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The magala makes one Horn attack and two Winged Arm attacks."
+					]
+				},
+				{
+					"name": "Horns",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 10 ft., one target. {@h}23 ({@damage 3d8 + 10}) bludgeoning damage and the target gains 2 frenzy charges."
+					]
+				},
+				{
+					"name": "Winged Arm",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 10 ft., one target. {@h}24 ({@damage 4d6 + 10}) bludgeoning. If the target is Huge or smaller, it is {@condition grappled} (escape {@dc 20}). If the magala's Frenzied State has activated in the last hour, it also creates explosions of the frenzy virus (on a hit or miss) in a 20-foot-long line that is 5-feet wide originating in the target's space. Each creature in that line must make a {@dc 20} Dexterity saving throw, taking 21 ({@damage 6d6}) necrotic damage and gain 1 frenzy charge on a failed save, or half as much damage and doesn't gain a charge on a successful one."
+					]
+				},
+				{
+					"name": "Frenzy Breath {@recharge 5}",
+					"entries": [
+						"The magala exhales three orbs of concentrated frenzy virus that zigzag across a 90-foot cone. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 63 ({@damage 14d8}) necrotic damage and gain 1 frenzy charge on a failed save. On a successful save, a target takes half as much damage, and does not gain a frenzy charge.",
+						"If the magala's frenzied state has activated in the last hour, it deals an extra 18 ({@damage 4d8}) necrotic damage and a creature gains two frenzy charges on a failed save."
+					]
+				},
+				{
+					"name": "Super Frenzy Explosion (Frenzied State Only; Recharges after a Short or Long Rest)",
+					"entries": [
+						"The magala expels a blast of frenzy clouds at a point within 120 feet of it. Each creature in a 30-foot-radius sphere centered on that point must make a {@dc 20} Dexterity or Constitution saving throw (target's choice), taking 99 ({@damage 22d8}) necrotic damage and gains two frenzy charge on a failed save, or half as much damage and doesn't gain charges on a successful one."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Detect",
+					"entries": [
+						"The magala makes a Wisdom ({@skill Perception}) Check."
+					]
+				},
+				{
+					"name": "Viral Discharge",
+					"entries": [
+						"{@atk rw} {@hit 17} to hit, range 60/240 ft., one target. {@h}21 ({@damage 6d6}) necrotic damage or 28 ({@damage 8d6}) if the magala's Frenzied State has activated in the last hour, and the target gains 1 frenzy charge."
+					]
+				},
+				{
+					"name": "Aerial Lunge (Costs 2 Actions)",
+					"entries": [
+						"While flying, the magala moves up to half its fly speed straight towards a target and makes on Winged Arm attack against it."
+					]
+				},
+				{
+					"name": "Close Range Frenzy Burst (Costs 2 Actions)",
+					"entries": [
+						"The magala releases three explosions of the frenzy virus in a 5-foot long line that is 15-feet wide centered on a point in front of it. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 28 ({@damage 8d6}) necrotic damage and gain 1 frenzy charge on a failed save, or half as much damage and doesn't gain a frenzy charge on a successful one.",
+						"If the magala's frenzied state has activated in the last hour, it instead creates five explosions in a 5-foot long line that is 25-feet wide centered on a point in front of it."
+					]
+				},
+				{
+					"name": "Ground Slam (Costs 2 Actions)",
+					"entries": [
+						"The magala rises up and slams its winged arms down on the ground beneath it. Each creature in a 15-foot square originating from the magala must make a {@dc 25} Dexterity saving throw, taking 24 ({@damage 4d6 + 10}) bludgeoning damage and be pushed up to 10 feet away and knocked {@condition prone} on a failed save, or half as much damage, isn't pushed away, or knocked {@condition prone} on a successful one."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"B"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"The chaotic gore magala is a rare special {@creature gore magala|MHMM} individual that has failed to molt properly into a {@creature shagaru magala|MHMM} and has only molted half way on one side of its body. This failure to molt has to do with molting in the vicinity of a shagaru magala's territory and effects from the shagaru magala's virus prevent the gore magala from molting properly. Just like gore magala, chaotic gore magala is in the unknown class.",
+							"Chaotic gore magala, like normal gore magala and shagaru magala, are a predator high in the food chain, though chaotic gore magalas rarely feed on prey. Despite their deadly strength and weaponry, these beasts must compete with other large predators. Even with this competition, chaotic gore magalas don't show any scars or injuries on their bodies and this is due to most predators tending to avoid these monsters at all costs. Those who encounter chaotic gore magala are killed on sight by it, showing how high it is in the food chain.",
+							"The chaotic gore magala has many of the same adaptions as gore magala, however, has a few minor differences. On one side of its body, it has some traits from shagaru magala. It has partially developed scales on its wing, neck, and head that come from its adult form. The horn on its head isn't fully developed and has really no use, unlike a gore magala's antennae.",
+							"One of the most disturbing traits is its \"eye\". This eye doesn't seem to have developed completely, meaning the eye could be useless to it. When in its Frenzy State, this eye can be seen glowing red though very rarely. Due to only one side partially developing, its strength is far greater than a normal individual.",
+							"The chaotic gore magala is a lot more aggressive and a lot more violent than normal gore magala. This is due to their failed molting causing them constant pain. This has also changed their habits compared to a normal gore magala. It has even been found that the chaotic gore magala are slowly dying from the virus after failing to molt properly.",
+							{
+								"type": "inset",
+								"name": "Chaotic Gore Magala",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"24",
+												"Carves/Capture",
+												"8"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-3",
+												"1",
+												"Gore Magala Carapace",
+												"(A,W)"
+											],
+											[
+												"4-5",
+												"2-3",
+												"S. Magala Cortex",
+												"(A,W)"
+											],
+											[
+												"6-7",
+												"4-5",
+												"Antinomic Wing",
+												"(A,W)"
+											],
+											[
+												"8-9",
+												"-",
+												"Gore Magala Tail",
+												"(A,W)"
+											],
+											[
+												"10-11",
+												"6-7",
+												"Chaos Scale",
+												"(A,W)"
+											],
+											[
+												"12-13",
+												"8-10",
+												"S.Magala Hardhorn",
+												"(A,W)"
+											],
+											[
+												"14-15",
+												"11-13",
+												"Gore Magala Shredder",
+												"(A,W)"
+											],
+											[
+												"16-17",
+												"14-18",
+												"Diametrical Horn",
+												"(A,W)"
+											],
+											[
+												"18-19",
+												"19",
+												"Contrary Scale",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"C. Magala Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Gore Magala Carapace",
+												"entries": [
+													"{@i Frenzy Res.} Whenever you make a saving throw against the {@disease frenzy virus|MHMM}, you do so with advantage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Cortex",
+												"entries": [
+													"{@i Gourmand.} While attuned to this armor, you double the amount of days you can go without food or water before suffering a level of {@condition exhaustion}."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Antinomic Wing",
+												"entries": [
+													"{@i Airborne.} While wearing this armor, you can cast the {@spell jump} spell from it as a bonus action at will, but can target only yourself when you do so."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Tail",
+												"entries": [
+													"Your passive Perception increases by 5 and you have advantage on Dexterity ({@skill Stealth}) checks made to hide while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Chaos Scale",
+												"entries": [
+													"{@i Evasion.} You have advantage on Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Shredder",
+												"entries": [
+													"{@i Stamina Recovery.} When you take a long rest, you reduce your {@condition exhaustion} by 5 levels instead of 1."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Diametrical Horn",
+												"entries": [
+													"You are immune to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Contrary Scale",
+												"entries": [
+													"If you aren't wearing light, medium, or heavy armor; your base Armor Class is 15 + your Dexterity Modifier."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "C. Magala Mantle",
+												"entries": [
+													"{@i Berserker.} While you are attuned to this armor you can use an action to reduce your maximum hit points to 1 and convert your current hit points into temporary hit points until you finish a long rest. While these temporary hit points remain, they can't be replaced, you have resistance to all damage except psychic, you are immune to all conditions, and your maximum hit points can't be reduced below 1."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Gore Magala Carapace",
+												"entries": [
+													"When held, this weapon draws in light, snuffing all nonmagical flames within 30 feet out. It turns dim light into darkness and bright light into dim light."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Cortex",
+												"entries": [
+													"{@i Quick Load.} You can reload as a free action while you are attuned to this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Antinomic Wing",
+												"entries": [
+													"{@i Spirit+.} When fighting a Huge or larger creature, this weapon deals {@damage 1d8} extra weapon damage and its crit range is increased by 2."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Tail",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d8} necrotic damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Chaos Scale",
+												"entries": [
+													"{@i Resentment+.} Until the end of your turn, you gain a +2 bonus to attack and damage rolls against any creature that has damaged you since the end of your last turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Hardhorn",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d10} radiant damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gore Magala Shredder",
+												"entries": [
+													"{@i Coalescence+2.} Whenever you succeed on a saving throw to end a condition, you gain a +3 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra 1d8 cold, fire, or lightning damage (your choice) until the end of your next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Diametrical Horn",
+												"entries": [
+													"You gain a +3 bonus to your spell attack rolls and spell save DC while attuned to this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Contrary Scale",
+												"entries": [
+													"{@i (Cleric & Druid only)} This weapon has 10 runes. While holding it, you can use an action to expend 1 or more of its runes to cast one of the following Spells from it, using your spell save DC: {@spell inflict wounds} (3rd level, 3 runes), {@spell blindness/deafness} (2 runes), {@spell bestow curse} (3 runes), {@spell blight} (4 runes), {@spell circle of death} (6 runes), or {@spell eyebite} (sickened) (6 runes). This weapon regains 1d6 + 4 expended runes daily at dawn. If you expend the last rune it cannot regain any runes for one week."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "C. Magala Mantle",
+												"entries": [
+													"{@i Bloodlust.} While you are attuned to this weapon and fall below half of your maximum hit points you are infected with the {@condition frenzy virus|MHMM} (even if you are normally immune to disease for 1 minute. Once you use this property, you can't use it again until you finish a long rest.",
+													"In addition, whenever you are infected with the frenzy virus, you ignore the negative effects of the frenzy virus (Impaired Healing, Suppressed Immunities, Vulnerability), but you lose {@damage 1d6} hit points at the end of each of your turns, if you did not attack a creature since the end of your last turn."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"S",
+				"P",
+				"N",
+				"B"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"RW"
+			],
+			"conditionInflict": [
+				"grappled",
+				"prone"
+			]
+		},
+		{
 			"name": "Conga",
 			"size": [
 				"M"
@@ -17742,7 +19208,7 @@
 											[
 												"1-10",
 												"Conga Pelt",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"11-16",
@@ -17775,6 +19241,13 @@
 										"style": "list-hang",
 										"name": "WEAPON MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Conga Pelt",
+												"entries": [
+													"{@i Forager.} When you harvest mushrooms, you instead gather two."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Sharp Claw",
@@ -19623,12 +21096,6 @@
 					"entries": [
 						"The hermitaur can breathe air and water."
 					]
-				},
-				{
-					"name": "Scuttle",
-					"entries": [
-						"As a bonus action, the daimyo hermitaur can moves up to its speed in a straight line."
-					]
 				}
 			],
 			"action": [
@@ -19654,6 +21121,14 @@
 					"name": "Crush {@recharge 5}",
 					"entries": [
 						"If the hermitaur jumps at least 15 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a {@dc 18} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 22 ({@damage 4d8 + 4}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the hermitaur's space into an unoccupied space of the creature's choice. If no unoccupied space is with in range, the creature instead falls {@condition prone} in the hermitaur's space."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Scuttle",
+					"entries": [
+						"The hermitaur can moves up to its half speed in a straight line."
 					]
 				}
 			],
@@ -20076,7 +21551,7 @@
 											[
 												"5-6",
 												"Dalamadur Glaive",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"7-8",
@@ -20130,6 +21605,13 @@
 										"style": "list-hang",
 										"name": "ARMOR MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Dalamadur Glaive",
+												"entries": [
+													"{@i Archaeologist+.} When you successfully gather a bone resource, you gather an extra 1d4 more."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Dalamadur Fanblade",
@@ -21467,7 +22949,7 @@
 									[
 										"10",
 										"Gushing Magma",
-										"(A)"
+										"(A,W)"
 									],
 									[
 										"11-13",
@@ -21477,7 +22959,7 @@
 									[
 										"14-15",
 										"Miralis Smelter",
-										"(W)"
+										"(A,W)"
 									],
 									[
 										"16-17",
@@ -21531,6 +23013,13 @@
 									},
 									{
 										"type": "entries",
+										"name": "Miralis Smelter",
+										"entries": [
+											"{@i Geologist+.} When you successfully gather a mining resource, you gather an extra 1d4 more."
+										]
+									},
+									{
+										"type": "entries",
 										"name": "Miralis Hellwing",
 										"entries": [
 											"You have resistance to fire damage while you wear this armor."
@@ -21562,6 +23051,13 @@
 										"name": "Miralis Fireclaw",
 										"entries": [
 											"Your weapon deals an extra 1d6 fire damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Gushing Magma",
+										"entries": [
+											"{@i Bow Charge Plus.} While attuned to this weapon, you can use your dragonpiercer one additional time between rests and it recharges after a Short or Long rest."
 										]
 									},
 									{
@@ -22730,7 +24226,7 @@
 											[
 												"17-20",
 												"Hydro Hide",
-												"(A)"
+												"(A,W)"
 											]
 										]
 									},
@@ -22744,6 +24240,20 @@
 												"name": "Hydro Hide",
 												"entries": [
 													"While wearing this armor, you have a swimming speed equal to your walking speed."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Hydro Hide",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
 												]
 											}
 										]
@@ -22790,6 +24300,402 @@
 				"MW"
 			],
 			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
+			"name": "Espinas",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"flying"
+				]
+			},
+			"group": [
+				"Flying Wyverns"
+			],
+			"environment": [
+				"coastal",
+				"desert",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 20,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 172,
+				"formula": "15d12 + 75"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 21,
+			"dex": 12,
+			"con": 21,
+			"int": 10,
+			"wis": 13,
+			"cha": 19,
+			"save": {
+				"con": "+9"
+			},
+			"skill": {
+				"perception": "+5"
+			},
+			"resist": [
+				"lightning"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"passive": 15,
+			"cr": "12",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Barbed Hide",
+					"entries": [
+						"At the start of each of its turns, the espinas deals 11 ({@damage 2d10}) poison damage to any creature grappling it."
+					]
+				},
+				{
+					"name": "Enrage (Recharges After a Short or Long Rest)",
+					"entries": [
+						"When the espinas hit points drop below half of its maximum, it enrages for 1 minute. While enraged, the espinas AC is reduced by 2, its movement is increased by 10 feet, and it has advantage on melee attack rolls."
+					]
+				},
+				{
+					"name": "Heavy Sleeper",
+					"entries": [
+						"The espinas gains a +5 bonus to its AC, while it is {@condition unconscious}. Additionally, if the espinas is subjected to an effect that allows it to make a Strength or Dexterity saving throw to take only half damage, the espinas instead makes a Constitution saving throw and takes no damage if it succeeds on the saving throw and only half damage if it fails, provided the espinas is unconscious."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The espinas makes one Tail attack and one Bite attack."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}15 ({@damage 3d6 + 5}) piercing damage."
+					]
+				},
+				{
+					"name": "Horn",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 5 ft., one target. {@h}15 ({@damage 3d6 + 5}) piercing damage. If the espinas moved at least 20 feet straight toward the target immediately before the hit, the target takes an extra 21 ({@damage 6d6}) piercing damage. If the target is a creature, it must succeed on a {@dc 17} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d10 + 5}) piercing damage. If the target is a creature, it must succeed on a {@dc 17} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Blight Breath {@recharge 5}",
+					"entries": [
+						"The expinas use one of the following breaths attacks:",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Giant Fireball",
+									"entries": [
+										"The espinas spews a large blighted fireball at a point within 120 feet of it. Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 17} Dexterity or Constitution saving throw, taking 16 ({@damage 3d10}) fire damage plus 10 ({@damage 3d6}) poison damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't {@condition poisoned} on a successful one.",
+										"If the saving throw fails by 5 or more, the target is {@condition paralyzed} while {@condition poisoned} in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Triple Fireball",
+									"entries": [
+										"The expinas spews out three blighted fireballs in a 20-foot line that is 60-feet wide and 20-feet tall. Each creature in that area must make a {@dc 17} Dexterity or Constitution saving throw, taking 11 ({@damage 2d10}) fire damage plus 7 ({@damage 2d6}) poison damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't {@condition poisoned} on a successful one. A creature in the radius of more than one fireball, makes its saving throw at disadvantage, but does not take any additional damage.",
+										"If the saving throw fails by 5 or more, the target is {@condition paralyzed} while {@condition poisoned} in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Body Slam",
+					"entries": [
+						"The espinas leaps up and slams its body onto the ground. Each creature in a 5-foot radius around it must succeed on a {@dc 17} Strength saving throw or saving throw or be pushed 5 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Swerving Chomp",
+					"entries": [
+						"The espinas moves up to 10 feet in a straight line. It can then makes one Bite attack."
+					]
+				},
+				{
+					"name": "Tackle (Costs 2 Actions)",
+					"entries": [
+						"The espinas moves up to its speed. During this move it can move through the spaces of other creatures without provoking opportunity attacks. Each creature the espinas moves through must succeed on a {@dc 17} Dexterity saving throw or take 15 ({@damage 3d6 + 5}) bludgeoning damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Poison Breath (Costs 2 Actions)",
+					"entries": [
+						"The espinas spews a fireball at a point within 10-feet of it. Each creature in a 5-foot-radius sphere centered on that point must make a {@dc 17} Dexterity saving throw, taking 11 ({@damage 2d10}) fire damage plus 7 ({@damage 2d6}) poison damage. The espinas can then fly up to half its flying speed.",
+						"If the saving throw fails by 5 or more, the target is {@condition poisoned} for 1 minute and ignites. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Espinas are physically similar to {@creature rathian|MHMM}s, but alongside scales its body is covered in hot pink spikes full of venom and rough green armor plating. A long, pink, venom-filled horn protrudes from the front of its head, in a similar fashion to {@creature monoblos|MHMM}. Venomous thorns also protrude from its body, wings, tail, feet, and head. Its body, tail, and feet are bigger and more muscular than those of other flying wyverns. It has four pink claws upon its feet. Red-orange veins will appear when it is in its enraged state, similar to {@creature tigrex|MHMM}.",
+							"Espinas is an unusually passive flying wyvern. In the wild, it can almost always be found sleeping. Even when disturbed and woken up, it still responds disinterestedly to any attacks, casually walking back and forth whilst relying on its thick hide to protect itself.",
+							"However, if injured, it will become enraged. When this occurs, it becomes much faster and more brutal, charging aggressors down, ramming them with its horn, and shooting toxic fireballs.",
+							"Espinas can usually be fought in flora filled places like the great forest, although there have been much rarer sightings in areas like fortress ruins, as well as swamps.",
+							{
+								"type": "inset",
+								"name": "Espinas",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"12",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-3",
+												"1-4",
+												"Espinas Shard",
+												"(A,W)"
+											],
+											[
+												"4-7",
+												"5-7",
+												"Espinas Cortex",
+												"(A,W)"
+											],
+											[
+												"-",
+												"8-13",
+												"Espinas Hardhorn",
+												"(A,W)"
+											],
+											[
+												"6-9",
+												"14-15",
+												"Espinas Toxic Blood",
+												"(A,W)"
+											],
+											[
+												"10-14",
+												"16-19",
+												"Espinas Lash",
+												"(A,W)"
+											],
+											[
+												"15-18",
+												"-",
+												"Espinas Surspike",
+												"(A,W)"
+											],
+											[
+												"19-20",
+												"20",
+												"Espinas Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Espinas Shard",
+												"entries": [
+													"While attuned to this armor, it grows numerous dull tip spines which rise and move when agitated or in danger."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Cortex",
+												"entries": [
+													"{@i Heavy Sleeper.} While attuned to this armor, you don't suffer any ill effects from sleeping in your armor. Additionally, when you are subjected to an effect that allows you to make a Strength or Dexterity saving throw to take only half damage, you can choose to make a Constitution saving throw and takes no damage if you succeed on the saving throw and only half damage if you fail, provided you are {@condition unconscious}."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Hardhorn",
+												"entries": [
+													"While wearing this armor you have resistance to fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Toxic Blood",
+												"entries": [
+													"You have advantage on saving throws against being {@condition paralyzed} and {@condition poisoned} while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Lash",
+												"entries": [
+													"{@i Stamina Surge+2.} While wearing this armor, you can use an action to cast the {@spell haste} spell from it once per day, but can target only yourself when you do so and you gain 1 level of {@condition exhaustion} when the spell ends."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Surspike",
+												"entries": [
+													"While you wear this armor, any creature that hits you with a melee attack takes {@damage 1d6} poison damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Mantle",
+												"entries": [
+													"While wearing this armor you have resistance to poison damage and you cannot be {@condition poisoned}."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Espinas Shard",
+												"entries": [
+													"{@i Protective Polish.} This weapon is so finely constructed it never needs maintenance, cannot rust or tarnish, and deals an extra {@damage 1d6} weapon damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Cortex",
+												"entries": [
+													"While you are attuned to this weapon, you can use a bonus action to speak its command word and exhale a blighted fireball at a point within 30 feet of you. Each creature in a 5-foot-radius sphere of that point must make a {@dc 14} Dexterity saving throw, taking {@damage 3d6} fire damage and be {@condition poisoned} for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. If the creature rolled a 1 on the saving throw, it is also {@condition paralyzed} until the end of its next turn. A poisoned creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Once used, this property cannot be used again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Hardhorn",
+												"entries": [
+													"{@i Partbreaker+1.} You deal an extra {@damage 1d6} damage when you critically hit with this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Toxic Blood",
+												"entries": [
+													"When you inflict the {@condition poisoned} condition on a creature that has a duration of 1 minute or more, it must succeed on their Constitution saving throw one additional time to end the effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Lash",
+												"entries": [
+													"This weapon has 6 runes and regains 1d6 runes daily at dawn. You can use a bonus action to shoot a spark out of the weapon at a creature, up to 60 feet away. The targeted creature must make a {@dc 13} Constitution saving throw, or become burned for 1 minute. A burned creature takes {@damage 1d6} fire damage at the start of their turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Surspike",
+												"entries": [
+													"When a creature fails its saving throw against being poisoned by you by 5 or more it is also {@condition incapacitated} and its movement speed is reduced to 0 until the end of its next turn. When the effect ends for it, the creature is immune to this property for the next 24 hours."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Espinas Mantle",
+												"entries": [
+													"{@i Foray.} If the target is afflicted with a blight, is {@condition poisoned}, or {@condition paralyzed} your critical hit range is increased by 1 and you deal an extra {@damage 1d6} poison damage."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"F",
+				"I"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			],
+			"conditionInflict": [
+				"paralyzed",
+				"poisoned",
 				"prone"
 			]
 		},
@@ -23626,6 +25532,387 @@
 			],
 			"miscTags": [
 				"MW"
+			]
+		},
+		{
+			"name": "Flaming Espinas",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"flying"
+				]
+			},
+			"group": [
+				"Flying Wyverns"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 21,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 184,
+				"formula": "16d12 + 80)"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 21,
+			"dex": 12,
+			"con": 21,
+			"int": 10,
+			"wis": 13,
+			"cha": 19,
+			"save": {
+				"dex": "+6",
+				"con": "+10"
+			},
+			"skill": {
+				"perception": "+6"
+			},
+			"resist": [
+				"cold"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"passive": 16,
+			"cr": "15",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Barbed Hide",
+					"entries": [
+						"At the start of each of its turns, the espinas deals 11 ({@damage 2d10}) acid damage to any creature grappling it."
+					]
+				},
+				{
+					"name": "Heavy Sleeper+",
+					"entries": [
+						"The espinas gains a +5 bonus to its AC, while it is {@condition unconscious}. Additionally, if the espinas is subjected to an effect that allows it to make a Strength or Dexterity saving throw to take only half damage, the espinas instead makes a Constitution saving throw and takes no damage if it succeeds on the saving throw and only half damage if it fails, provided the espinas is unconscious or it is the round immediately after it woke up."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The espinas makes one Tail attack and one Bite attack."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}15 ({@damage 3d6 + 5}) piercing damage."
+					]
+				},
+				{
+					"name": "Horn",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}15 ({@damage 3d6 + 5}) piercing damage. If the espinas moved at least 20 feet straight toward the target immediately before the hit, the target takes an extra 28 ({@damage 8d6}) piercing damage. If the target is a creature, it must succeed on a {@dc 18} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d10 + 5}) piercing damage. If the target is a creature, it must succeed on a {@dc 18} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Blight Breath {@recharge 5}",
+					"entries": [
+						"The expinas use one of the following breaths attacks:",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Giant Fireball",
+									"entries": [
+										"The espinas spews a large blighted fireball at a point within 150 feet of it. Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 18} Dexterity or Constitution saving throw, taking 16 ({@damage 3d10}) fire damage plus 10 ({@damage 3d6}) acid damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't {@condition poisoned} on a successful one.",
+										"If the saving throw fails by 5 or more, creatures have advantage on attack rolls against the target while {@condition poisoned} in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Triple Fireball",
+									"entries": [
+										"The expinas spews out three blighted fireballs in a 20-foot line that is 60-feet wide and 20-feet tall. Each creature in that area must make a {@dc 17} Dexterity or Constitution saving throw, taking 11 ({@damage 2d10}) fire damage plus 7 ({@damage 2d6}) acid damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't {@condition poisoned} on a successful one. A creature in the radius of more than one fireball, makes its saving throw at disadvantage, but does not take any additional damage.",
+										"If the saving throw fails by 5 or more, creatures have advantage on attack rolls against the target while {@condition poisoned} in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Fiery Finale {@recharge 6}",
+					"entries": [
+						"If the espinas used Waddle since the end of its last turn, it can use this action to create a massive explosion around it. Each creature within 20-feet of the espinas must make a {@dc 18} Dexterity saving throw, taking taking 44 ({@damage 8d10}) fire damage plus 17 ({@damage 5d6}) acid damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't poisoned on a successful one.",
+						"If the saving throw fails by 5 or more, creatures have advantage on attack rolls against the target while poisoned in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A poisoned creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Body Slam",
+					"entries": [
+						"The espinas leaps up and slams its body onto the ground. Each creature in a 5-foot radius around it must succeed on a {@dc 18} Strength saving throw or saving throw or be pushed 5 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Swerving Chomp",
+					"entries": [
+						"The espinas moves up to 10 feet in a straight line. It can then makes one Bite attack."
+					]
+				},
+				{
+					"name": "Waddle (Costs 3 Actions)",
+					"entries": [
+						"The Espinas moves up to half its movement speed while charging up its fiery breath. It can only use this legendary action immediately after the creature's turn that goes after it in the initiative order."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"The flaming espinas has all the adaptations of its green counterpart, though a few key differences. It gets the title, Brown Thorn Wyvern, from its color. Unlike its cousin's poisons, the poison produced by flaming espinas is much deadlier from its acidic nature, thanks to the sulfur found in its body mixed into the poison. The acid that flaming espinas produces is said to corrode armor in a single touch. The thorns on it, wither all plants it touches. Two sticks from these thorns and prey will never wake up again! This poison can kill up to a thousand velociprey in near minutes! Or so I have heard. The biggest difference that flaming espinas has is its ability to charge up its attacks. By charging up its attacks, it is able to kill prey with a single powerful blow.",
+							"Similarly to the common {@creature espinas|MHMM}, it is a docile and passive wyvern which will only attack when provoked. It sleeps for much of the day, and is usually encountered in this state. The flaming espinas is known to inhabit the Tower and Forlorn Arena, where it resides in solitude at the very top. In addition, it can be found in gorges, ancient ruins, and in great forests.",
+							{
+								"type": "inset",
+								"name": "Flaming Espinas",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"15",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-3",
+												"1-4",
+												"Flaming Espinas Shard",
+												"(A,W)"
+											],
+											[
+												"4-7",
+												"5-7",
+												"Flaming Espinas Cortex",
+												"(A,W)"
+											],
+											[
+												"-",
+												"8-13",
+												"Flaming Espinas Hardhorn",
+												"(A,W)"
+											],
+											[
+												"6-9",
+												"14-15",
+												"Flaming Espinas Sulfur",
+												"(A,W)"
+											],
+											[
+												"10-14",
+												"16-19",
+												"Flaming Espinas Lash",
+												"(A,W)"
+											],
+											[
+												"15-18",
+												"-",
+												"Flaming Espinas Surspike",
+												"(A,W)"
+											],
+											[
+												"19-20",
+												"20",
+												"Flaming Espinas Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Shard",
+												"entries": [
+													"While attuned to this armor, it grows numerous dull tip spines which rise and move when agitated or in danger."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Cortex",
+												"entries": [
+													"{@i Heavy Sleeper.} While attuned to this armor, you don't suffer any ill effects from sleeping in your armor. Additionally, when you are subjected to an effect that allows you to make a Strength or Dexterity saving throw to take only half damage, you can choose to make a Constitution saving throw and takes no damage if you succeed on the saving throw and only half damage if you fail, provided you are {@condition unconscious}."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Hardhorn",
+												"entries": [
+													"While wearing this armor you have resistance to cold damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Sulfur",
+												"entries": [
+													"{@i Marathon Runner+.} While wearing this armor, your walking speed increases by 10 feet and you ignore difficult terrain if it was not created by a magical effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Lash",
+												"entries": [
+													"You are immune to fire damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Surspike",
+												"entries": [
+													"While you wear this armor, any creature that hits you with a melee attack takes {@damage 1d6} acid damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Mantle",
+												"entries": [
+													"{@i Intrepid Heart.} When you score a critical hit against a creature, you have resistance against the next attack that hits you, and the attacker takes {@damage 1d10} fire damage if it is within 5 feet of you."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Shard",
+												"entries": [
+													"{@i Protective Polish.} This weapon is so finely constructed it never needs maintenance, cannot rust or tarnish, and deals an extra {@damage 1d6} weapon damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Cortex",
+												"entries": [
+													"{@i FastCharge+.} When you roll for initiative, your greatsword, longsword, charge blade, or tonfas gains 2 charges, spirit, or phial charges."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Hardhorn",
+												"entries": [
+													"{@i Partbreaker+1.} You deal an extra {@damage 1d6} damage when you critically hit with this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Sulfur",
+												"entries": [
+													"{@i Ammo Saver+.} When you make a ranged weapon attack and roll a 15 or higher on the attack die, the ammunition returns to you unbroken after hitting the target(s)."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Lash",
+												"entries": [
+													"This weapon has 6 runes and regains 1d6 runes daily at dawn. You can use a bonus action to shoot a spark out of the weapon at a creature, up to 60 feet away. The targeted creature must make a {@dc 13} Constitution saving throw, or become burned for 1 minute. A burned creature takes {@damage 1d6} fire damage at the start of their turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Surspike",
+												"entries": [
+													"{@i Razor Sharp+.} Once per turn, when you hit a creature with this weapon, anytime it would regain hit points before the end of its next turn, it regains half as many. If this attack is a critical hit, the target can't regain hit points until the end of its next turn. Additionally, if the creature is afflicted with a wound, such as the odogaron's bloody wound, it can only be closed by magical healing for 1 minute."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Flaming Espinas Mantle",
+												"entries": [
+													"{@i Chain Crit.} Every consecutive hit on a creature increases your crit range by 1 until you score a critical hit, miss an attack, or hit a different creature."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"F",
+				"A"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			],
+			"conditionInflict": [
+				"paralyzed",
+				"poisoned",
+				"prone"
 			]
 		},
 		{
@@ -24803,6 +27090,443 @@
 			]
 		},
 		{
+			"name": "Gaismagorm",
+			"size": [
+				"G"
+			],
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Elder Dragons"
+			],
+			"environment": [
+				"mountain",
+				"underdark",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 25,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 492,
+				"formula": "24d20 + 240"
+			},
+			"speed": {
+				"walk": 50,
+				"climb": 50
+			},
+			"str": 29,
+			"dex": 14,
+			"con": 30,
+			"int": 12,
+			"wis": 20,
+			"cha": 18,
+			"save": {
+				"str": "+17",
+				"con": "+18",
+				"wis": "+13",
+				"cha": "+12"
+			},
+			"immune": [
+				"cold",
+				{
+					"immune": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical attacks",
+					"cond": true
+				}
+			],
+			"conditionImmune": [
+				"charmed",
+				"exhaustion",
+				"frightened",
+				"paralyzed",
+				"petrified",
+				"poisoned",
+				"stunned",
+				"unconscious"
+			],
+			"passive": 15,
+			"languages": [
+				"Draconic"
+			],
+			"cr": "28",
+			"page": 0,
+			"senses": [
+				"darkvision 240 ft."
+			],
+			"trait": [
+				{
+					"name": "Archdemon Mode (Mythic Trait; Recharges after a Short or Long Rest).",
+					"entries": [
+						"If the gaismagorm would be reduced to 0 hit points, its current hit point total instead resets to 307 (15d20 + 150) hit points, and it regains any expended uses of Legendary Resistance. Additionally, the gaismagorm can now use its Meteor Rain and the options in the \"Mythic Actions\" section for 1 hour."
+					]
+				},
+				{
+					"name": "Gargantuan Monster",
+					"entries": [
+						"When the gaismagorm moves, it can move through and end its turn in a Medium or smaller creature space. When it does, that creature must succeed on a {@dc 25} Strength or Dexterity saving throw or take 10 ({@damage 3d6}) bludgeoning damage, be pushed 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day).",
+					"entries": [
+						"If the gaismagorm fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The gaismagorm's long jump is up to 30 feet and its high jump is up to 15 feet, without a running start."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The gaismagorm makes one Bite attack and two Wingarm attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 10 ft., one target. {@h}36 ({@damage 6d8 + 9}) piercing damage."
+					]
+				},
+				{
+					"name": "Boulder",
+					"entries": [
+						"{@atk rw} {@hit 17} to hit, range 90/360 ft., one target. {@h}45 ({@damage 8d8 + 9}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Wingarm",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 15 ft., one target. {@h}23 ({@damage 4d6 + 9}) bludgeoning damage plus 14 ({@damage 4d6}) fire damage. If the gaismagorn jumped at least 10 feet straight toward the target immediately before the hit, it creates a pillar of rock from underneath the target, filling a 5-foot-square that is 10-feet tall and the target must succeed on a {@dc 25} Strength or Dexterity saving throw or take 14 ({@damage 4d6}) bludgeoning damage, be pushed 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 17} to hit, reach 20 ft., one target. {@h}31 ({@damage 4d10 + 9}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 25} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Vacuum Explosive Clap (Normal State Only; {@recharge 5})",
+					"entries": [
+						"The gaismagorm jumps up to 30 feet into an unoccupied space and takes a deep breath. Each creature in a 300-foot cone must succeed on a {@dc 26} Strength saving throw or take 55 ({@damage 10d10}) thunder damage and be pulled into an unoccupied space near the cone's origin. The gaismagorm must use its Explosive Clap at the end of the next creature's next turn."
+					]
+				},
+				{
+					"name": "Meteor Rain (Archdemon Mode Only; {@recharge 6})",
+					"entries": [
+						"The gaismagorm fires a fireball into the sky causing a swirling orange vortex above it. Blazing orbs of fire plummet to the ground at four different points within 300-feet of the gaismagorm. Each creature in a 40-foot-radius sphere centered on each point must make a {@dc 26} Dexterity saving throw, taking 70 ({@damage 20d6}) fire damage plus 70 ({@damage 20d6}) bludgeoning damage on a failed save, or half as much damage on a successful one. The sphere spreads around corners. A creature in the area of more than one fiery burst is affected only once."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The gaismagorm makes one Bite or Tail attack."
+					]
+				},
+				{
+					"name": "Explosive Clap (Normal State Only; Costs 2 Actions)",
+					"entries": [
+						"The gaismagorm spits out an explosive ball, charging it up before detonating it. Each creature in a 30-foot cube originating from the gaismagorm must make a {@dc 25} Dexterity saving throw, taking 38 ({@damage 11d6}) fire damage and be pushed 10 feet away on a failed save, or half as much damage and isn't pushed on a successful one."
+					]
+				},
+				{
+					"name": "Wingarm Sweep (Costs 2 Actions)",
+					"entries": [
+						"The gaismagorm swipes its arm across a 15-foot long line that is 35-feet wide. Each creature in that area must make a {@dc 25} Dexterity saving throw or take 23 ({@damage 4d6 + 9}) bludgeoning damage plus 14 ({@damage 4d6}) fire damage, be pushed 10 feet away, and knocked prone on a failed save, or half as much damage, is still pushed 10 feet away, but isn't knocked prone."
+					]
+				}
+			],
+			"mythicHeader": [
+				"If the gaismagorm's Archdemon Mode trait has activated in the last hour, it can use the options below as legendary actions."
+			],
+			"mythic": [
+				{
+					"name": "Backblast",
+					"entries": [
+						"The gaismagorm charges up an explosive ball before firing it downwards. Each creature in a 15-foot cube originating from the gaismagorm must make a {@dc 26} Dexterity saving throw, taking 17 ({@damage 5d6}) fire damage and be pushed 10 feet away on a failed save, or half as much damage and isn't pushed on a successful one. The gaismagorm then uses the explosion's momentum to jump 15 feet away from the blast."
+					]
+				},
+				{
+					"name": "Qurio Breath (Costs 2 Actions)",
+					"entries": [
+						"The gaismagorm fires a qurio powered beam across a 300-foot cone. Each creature in that area must make a {@dc 26} Dexterity saving throw, taking 52 ({@damage 15d6}) necrotic damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Rampage (Costs 3 Actions)",
+					"entries": [
+						"The gaismagorm makes three Wingarm attacks. If it hits with all three, the third attack's damage is doubled."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Gaismagorm is a massive Elder Dragon similar in size and structure to {@creature Gogmazios|MHMM}, though seemingly with a more pseudowyvern-like gait. Its back legs appear to be vestigial, as they drag along as it crawls along using its front legs and massive forearms, which appear to have been adapted from its wings like those of {@creature Gore Magala|MHMM} and {@creature Shagaru Magala|MHMM}. These forearms are incredibly dexterous, allowing it to easily climb vertical surfaces and even grip and toss objects at opponents.",
+							"Gaismagorm has a stout, angular head compared to its body with two horns and a mouth that functions as a unique sort of \"split mouth\" with four folding segments that come out from the jaw. The bottom two of which, possess two hooks that assist it when scooping up large amounts of matter that it either scoops out of the ground, or forces towards its mouth.",
+							"In addition, Gaismagorm has a barbed tongue, thick ridged plating covering its body with large central spikes around the shoulder region, and vents lining the surface of the body that it uses to expel energy absorbed from the {@creature Qurio|MHMM}, seen as \"flames\" which it uses to enhance its attacks and propel itself forwards. The Qurio themselves are violently protective of their host and swarm around it at all times.",
+							"Gaismagorm is the true host of the Qurio, and much like {@creature Malzeno|MHMM}, it shares a symbiotic relationship with them, and feeds on the life force they steal from their vctims for energy. It can manipulate the Qurio into doing a variety of attack and skills, such as creating crystal armor for defense and beam attacks. It has a vacuum breath which allows it to draw in foes before hitting them or absorb more Qurio to power itself up.",
+							"Gaismagorm can further use the energy gained by the Qurio to launch explosive fireball attacks from its mouth or any of the vents lining its arms, propel itself forwards in a similar fashion to Magnamalo, fire beams that infuse into the ground to make aftershocks, imbue its physical attacks with explosive aftershocks, and finally shoot it up into the air to cause a field wide effect where chunks of explosive red crystal drop from the sky.",
+							"Gaismagorm is also durable enough that even when impaled by three {@object Dragonator|AGMH}s, which the last one being explosive, it can still fight the hunter(s) with no sign of injury at all, and can even take two more during that fight.",
+							"Much of its time is spent dormant in a nest it creates underground to rest. After around 50 years has passed, it then creates a giant hole from its lair to the surface for the Qurio to emerge from so they can feed on the local monster populations. Gaismagorm then waits underground until the Qurio return with life energy from the surface in order to absorb it. Once it has enough energy, however, it will surface from its nest. It is known to be bitter rivals with Malzeno, the latter of which has kept it underground for decades, if not centuries by preventing it from obtaining enough energy to surface through the use of hijacking the Qurio it uses to feed. Gaismagorm is an aggressive and gluttonous Elder Dragon that desires to consume all forms of life in order to become stronger. This demonic looking monster was responsible for the near destruction of the Kingdom in the past.",
+							{
+								"type": "inset",
+								"name": "Gaismagorm",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"28",
+												"Carves",
+												"4 (or 8 as a mythic encounter)"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-2",
+												"Abyssal Dragonscale",
+												"(A,W)"
+											],
+											[
+												"3-5",
+												"Archdemon Backshell",
+												"(A,W)"
+											],
+											[
+												"6-8",
+												"Archdemon Piercetalon",
+												"(A,W)"
+											],
+											[
+												"9-10",
+												"Consumption Parasite",
+												"(A,W)"
+											],
+											[
+												"11-14",
+												"Archdemon Wingtalon",
+												"(A,W)"
+											],
+											[
+												"15-16",
+												"Archdemon Tailhook",
+												"(A,W)"
+											],
+											[
+												"17-19",
+												"Archdemon Doomhorn",
+												"(A,W)"
+											],
+											[
+												"20",
+												"Abyssal Dragonsphire",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Abyssal Dragonscale",
+												"entries": [
+													"Your armor is covered in crystals formed by the energy from qurios. When you are reduced to half of your hit point maximum or less, the crystals shatter creating maroon flames in their place for 1 hour. The crystals reform on your armor when you finish a short or long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Backshell",
+												"entries": [
+													"While wearing this armor, you gain a bonus to your AC equal to your Constitution modifier (max 3) in addition to the armor's normal AC."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Piercetalon",
+												"entries": [
+													"You can see normally in darkness, both magical and nonmagical, to a distance of 120 feet and you have advantage on Wisdom ({@skill Perception}) checks that rely on sight while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Consumption Parasite",
+												"entries": [
+													"{@i Recovery Up+.} You regain the maximum number of hit points possible from potions or plants that you consume."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Wingtalon",
+												"entries": [
+													"{@i Wellness.} While wearing this armor, you cannot be unwillingly put to sleep, {@condition poisoned}, {@condition paralyzed}, or {@condition stunned}."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Tailhook",
+												"entries": [
+													"You are immune to cold damage and have resistance to fire damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Doomhorn",
+												"entries": [
+													"While wearing this armor you have advantage on saving throws against spells and other magical effects."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Abyssal Dragonsphire",
+												"entries": [
+													"While attuned to this armor, you have a climbing speed of 50 feet, your walking speed increases by 10 feet, and you ignore difficult terrain if it was not created by a magical effect."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Abyssal Dragonscale",
+												"entries": [
+													"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Backshell",
+												"entries": [
+													"While you are attuned to this weapon, you can use this weapon as your spellcasting focus, and your fire spells bypass a creature resistance and immunities."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Piercetalon",
+												"entries": [
+													"Your weapon deals an extra {@damage 2d6} fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Consumption Parasite",
+												"entries": [
+													"{@i (Dual Blades Only)} Your Archdemon Mode is always active when you are holding both blades and the damage die of your archdemon mode increases by 1."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Wingtalon",
+												"entries": [
+													"{@i Chain Crit.} Every consecutive hit on a creature increases your crit range by 1 until you score a critical hit, miss an attack, or hit a different creature."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Tailhook",
+												"entries": [
+													"{@i Resentment+.} Until the end of your turn, you gain a +2 bonus to attack and damage rolls against any creature that has damaged you since the end of your last turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Archdemon Doomhorn",
+												"entries": [
+													"{@i Dereliction.} While you are attuned to this weapon you can use your bonus action to roll a d20. Your hit point maximum is reduced by the roll and the next attack you hit with before the start of your next turn, deals extra damage equal to double the roll. The reduction lasts until you finish a long rest. You die if this effect reduces your hit point maximum to 0."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Abyssal Dragonsphire",
+												"entries": [
+													"{@i Sorcerer & Wizard Only)} While attuned to this weapon you know the {@spell meteor swarm} spell. If you already know this spell, the DC of this spell increases by 3."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"B",
+				"T",
+				"F"
+			],
+			"miscTags": [
+				"MW",
+				"RW",
+				"RCH",
+				"AOE"
+			]
+		},
+		{
 			"name": "Gajalaka",
 			"size": [
 				"S"
@@ -25555,6 +28279,392 @@
 			]
 		},
 		{
+			"name": "Garangolm",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "beast",
+				"tags": [
+					"fanged"
+				]
+			},
+			"group": [
+				"Fanged Beasts"
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"swamp"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 21,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 202,
+				"formula": "15d12 + 105"
+			},
+			"speed": {
+				"walk": 40
+			},
+			"str": 26,
+			"dex": 15,
+			"con": 25,
+			"int": 14,
+			"wis": 16,
+			"cha": 16,
+			"save": {
+				"str": "+13",
+				"con": "+12",
+				"wis": "+8"
+			},
+			"skill": {
+				"athletics": "+13",
+				"perception": "+8"
+			},
+			"resist": [
+				{
+					"resist": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical attacks",
+					"cond": true
+				}
+			],
+			"conditionImmune": [
+				"frightened"
+			],
+			"passive": 18,
+			"cr": "16",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Enrage (Recharges after a Short or Long Rest)",
+					"entries": [
+						"When the garangolm is reduced to half of its maximum hit points, it goes into a rage for 10 minutes and it immediately saves against all ongoing conditions and effects, then thrusts its arms into the earth to form gauntlet-like masses, semi-molten rock on its right arm whilst its left is covered in mossy growths that drips water."
+					]
+				},
+				{
+					"name": "Standing Leap (Enraged Only)",
+					"entries": [
+						"The garangolm's long jump is up to 40 feet and its high jump is up to 25 feet, without a running start."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The garangolm makes two Fist attacks. While enraged it can make one Molten Fist attack and one Mossy Fist attack."
+					]
+				},
+				{
+					"name": "Boulders",
+					"entries": [
+						"{@atk rw} {@hit 13} to hit, range 60/240 ft., Up to three targets in a 240-cone. {@h}14 ({@damage 2d8 + 8}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Fist",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 5 ft., one target. {@h}17 ({@damage 2d8 + 8}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Headbutt",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 5 ft., one target. {@h}24 ({@damage 3d10 + 8}) bludgeoning damage. If the garangolm moved at least 20 feet straight toward the target immediately before the hit, the target takes an extra 16 ({@damage 3d10}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 21} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Molten Fist (Enraged Only)",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 5 ft., one target. {@h}14 ({@damage 2d8 + 8}) bludgeoning damage plus 7 ({@damage 2d6}) fire damage and the target ignites in flames. At the start of each of its turns, the target must make a {@dc 18} Constitution saving throw or take 7 ({@damage 2d6}) fire damage on a failed save. On a successful save, the flames are doused. If the target or a creature within 5 feet of it uses an action to put out the flames, or if some other effect douses the flames (such as the target being submerged in water), the effect ends."
+					]
+				},
+				{
+					"name": "Mossy Fist (Enraged Only)",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 5 ft., one target. {@h}14 ({@damage 2d8 + 8}) bludgeoning damage plus 7 ({@damage 2d6}) cold damage and the target must succeed on a {@dc 20} Constitution saving throw or be afflicted with {@condition waterblight|MHMM} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Elemental Slam ({@recharge 5}; Enrage Only)",
+					"entries": [
+						"The garangolm pulls a large chunk of heated earth from the ground and smashes it with both fists, creating an explosion in a 30-foot radius around it. Each creature in that area must make a {@dc 21} Dexterity saving throw, taking 24 ({@damage 7d6}) cold damage plus 24 ({@damage 7d6}) fire damage and be afflicted with {@condition waterblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with {@condition waterblight|MHMM} on a successful one. The target can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The garangolm makes one Fist attack. If it is enraged, it can instead make one Molten Fist attack or one Mossy Fist attack."
+					]
+				},
+				{
+					"name": "Bellyflop",
+					"entries": [
+						"The garangolm falls {@condition prone} in a space within 10 feet of it that contains one or more other creatures. Each of those creatures must succeed on a {@dc 21} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 17 ({@damage 4d6 + 8}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the garangolm's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls {@condition prone} in the garangolm's space. The garangolm can then expend an extra legendary action to stand up."
+					]
+				},
+				{
+					"name": "Rocket Jump (Costs 2 Actions; Enraged Only)",
+					"entries": [
+						"The garangolm uses its molten fist to jump up to 80 feet away into an unoccupied space without provoking opportunity attacks. It then makes one Mossy Fist attack."
+					]
+				},
+				{
+					"name": "Violent Roar (Costs 3 Actions)",
+					"entries": [
+						"The garangolm releases a guttural roar. Each creature that is within 20 feet of the garangolm must succeed on a {@dc 20} Constitution saving throw or be {@condition incapacitated} until the end of its next turn. If the saving throw fails by 5 or more, the target is instead {@condition stunned} until the end of its next turn."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Garangolm is a gigantic fanged beast similar in appearance to a gorilla. The dorsal side is covered in thick, rigid green and brown thick shell, and its head is protected by the same shell, forming a giant crown and chin plate. Curiously, grangolm have a thick, long tail that ends in prongs.",
+							"Aside from its incredible strength and hard body, garangolm emits a sap-like fluid from its body that promotes plant growth. This causes various plants to grow all over its body. It can also use the sap it emits to harden its body or the soil around it. When enraged, Garangolm will thrust its arms into the earth to form gauntlet-like masses, semi-molten rock on it's right arm whilst its left will be covered in mossy growths that drip water, dealing Fireblight and {@condition Waterblight|MHMM} respectively. The explosion from the right arm can send Garangolm high into the air, and sometimes also leave behind Blast clouds. When threatened it will cover both arms with larger quantities of molten rock and moss, while also getting some on its face.",
+							"Garangolm are rather peaceful and docile creatures that are usually seen sleeping or traveling around its territory. However, it will turn hostile the moment it gets attacked or provoked. The more angry a garangolm gets, the stronger it becomes. It won't stop until the foe is dead or its rage is settled. Often, a garangolm will have to deal with powerful monsters like {@creature lunagaron|MHMM} for territories, often resulting in turf wars.",
+							{
+								"type": "inset",
+								"name": "Garangolm",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"16",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-2",
+												"1-2",
+												"Garangolm Cortex",
+												"(A,w)"
+											],
+											[
+												"3-6",
+												"3-5",
+												"Garangolm Shard",
+												"(A,W)"
+											],
+											[
+												"7-11",
+												"6-10",
+												"Garangolm Hardfang",
+												"(A,W)"
+											],
+											[
+												"12-13",
+												"11-12",
+												"Golm Thick Juice",
+												"(A,W)"
+											],
+											[
+												"14-15",
+												"13-16",
+												"Garangolm Fist",
+												"(A,W)"
+											],
+											[
+												"16-19",
+												"17-19",
+												"Golm Ploughtail",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"Garangolm Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Garangolm Cortex",
+												"entries": [
+													"When you place this material into your armor, choose one of the options below:",
+													{
+														"type": "list",
+														"items": [
+															"Your armor looks like its made of rocks and natural materials but also has the appearance of being far heavier than it actually is.",
+															"Your armor has water flowing over it with embers orbiting your arms. There is a slight aura of steam coming off of you."
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Shard",
+												"entries": [
+													"{@i Flinch Free.} While wearing this armor you cannot be knocked {@condition prone}, or unwillingly moved from your current location by any means."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Hardfang",
+												"entries": [
+													"{@i Botanist+.} When you successfully gather a {@table plants|AGMH|plant} resource, you gather an extra 1d4 more."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Golm Thick Juice",
+												"entries": [
+													"While attuned to this armor water flows through it, keeping you cool. While wearing it, you suffer no harm from temperatures as warm as 120 degrees Fahrenheit. Additionally, when you take fire damage you use your reaction to superheat the water inside of the armor and halve the fire damage you take. The superheated water is released as dense cloud of steam centered on a point adjacent to you, heavily obscuring the area in a 15-foot radius sphere that spreads around corners. The cloud does not move with you and lasts for 1 minute or until a wind of moderate or greater speed (at least 10 miles per hour) disperses it. Once you use this property, you can't use it again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Fist",
+												"entries": [
+													"{@i Fortitude.} You have advantage on {@skill Survival} skill checks to track, forage, or travel while you are attuned to this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Golm Ploughtail",
+												"entries": [
+													"You are immune to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Mantle",
+												"entries": [
+													"{@i Iron Wall.} You have a +2 bonus to your armor class while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Garangolm Cortex",
+												"entries": [
+													"When you finish a short or long rest you choose a damage type. This damage type can be either cold or fire damage. A creature hit by this weapon takes an extra {@damage 1d8} of the chosen damage type. If you are using a weapon with a main hand and offhand, instead of choosing a damage type your main hand deals cold damage and your offhand deals fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Shard",
+												"entries": [
+													"{@i Critical Status (waterblight & fireblight).} When you hit a creature with a weapon or spell that deals cold or fire damage and roll a 20 for the attack roll, one of the following effects happens depending on the damage type:",
+													{
+														"type": "list",
+														"items": [
+															"If the damage is cold, the creature is afflicted with {@condition waterblight|MHMM} for 1 minute. A creature can make a {@dc 15} Constitution saving throw at the end of each of its turns, ending the effect on itself on a success.",
+															"If the damage is fire, the target is set ablaze. Until a creature uses an action to douse the fire, the target takes {@damage 1d6} fire damage at the start of each of its turns."
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Hardfang",
+												"entries": [
+													"{@i FastCharge+.} When you roll for initiative, your greatsword, longsword, charge blade, or tonfas gains 2 charges, spirit, or phial charges."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Golm Thick Juice",
+												"entries": [
+													"{@i Maximum Might.} While your hit points are full and you are not suffering from any levels of exhaustion, you deal maximum weapon damage with your attacks."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Fist",
+												"entries": [
+													"{@i (Hammer Only) Slugger.} While attuned to this weapon, you may use the Hammer's Mighty Weapon skill two additional times between rests."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Golm Ploughtail",
+												"entries": [
+													"{@i Stamina Thief.} Once per turn when you hit a creature with this weapon, it must make a {@dc 10} Constitution saving throw or gain one level of {@condition exhaustion}. A creature cannot gain more than 2 levels of exhaustion from this weapon's property."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Garangolm Mantle",
+												"entries": [
+													"{@i Rocket Jump.} If you have not moved on this turn you can use your action to jump up to 60 feet into an unoccupied space without provoking opportunity attacks. You can then make one melee weapon or spell attack. You can use this property a number of times equal to your Constitution modifier, regaining all expended uses when you finish a long rest."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"F",
+				"C",
+				"B"
+			]
+		},
+		{
 			"name": "Gargwa",
 			"size": [
 				"L"
@@ -25659,7 +28769,7 @@
 											[
 												"20",
 												"Gargwa Egg",
-												"(O)"
+												"(A,O)"
 											]
 										]
 									},
@@ -25673,6 +28783,13 @@
 												"name": "Gargwa Feather",
 												"entries": [
 													"{@i Detect.} You gain a +1 bonus to your passive Perception while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gargwa Egg",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
 												]
 											}
 										]
@@ -27008,7 +30125,7 @@
 									[
 										"1-13",
 										"Giggi Stinger",
-										"(W)"
+										"(A,W)"
 									],
 									[
 										"14-17",
@@ -27027,6 +30144,13 @@
 								"style": "list-hang",
 								"name": "ARMOR MATERIAL EFFECTS",
 								"items": [
+									{
+										"type": "entries",
+										"name": "Giggi Stinger",
+										"entries": [
+											"{@i Entomologist.} When you capture an insect with a bug net, you instead catch two."
+										]
+									},
 									{
 										"type": "entries",
 										"name": "Velvety Hide",
@@ -28637,7 +31761,7 @@
 												"16-17",
 												"-",
 												"Gobul Fin",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"18-19",
@@ -28714,6 +31838,13 @@
 												"name": "Gobul Paralysis Sac",
 												"entries": [
 													"This weapon has 3 runes which are regained every day at dawn. When you hit a creature with this weapon, you may expend a rune to have the target make a {@dc 13} Constitution saving throw. On a fail the creature is {@condition incapacitated} and has its movement speed is reduced to 0 for 1 minute. The creature may repeat its saving throw at the end of its turn, ending the effect on a success."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gobul Fin",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
 												]
 											},
 											{
@@ -29995,6 +33126,211 @@
 			]
 		},
 		{
+			"name": "Gowngoat",
+			"size": [
+				"L"
+			],
+			"type": "beast",
+			"group": [
+				"Herbivores"
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"hill",
+				"mountain",
+				"underdark",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 12,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 6,
+				"formula": "1d10+1"
+			},
+			"speed": {
+				"walk": 30
+			},
+			"str": 13,
+			"dex": 10,
+			"con": 12,
+			"int": 2,
+			"wis": 10,
+			"cha": 5,
+			"passive": 10,
+			"cr": "1/8",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Fluffy Tail",
+					"entries": [
+						"A Medium or smaller creature can {@action hide} underneath the gowngoat's tail. While underneath the tail, the creature is heavily obscured, can only see the ground beneath the gowngoat unless it uses an action to peer through the tail's fur, and a Medium creature's movement speed is halved. If the gowngoat moves while a creature is underneath its tail, that creature can use its reaction to move up to its speed until the end of the turn, to remain underneath the gowngoat's tail."
+					]
+				},
+				{
+					"name": "Rocky Camouflage",
+					"entries": [
+						"The gowngoat has advantage on Dexterity ({@skill Stealth}) checks made to hide in rocky terrain."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Ram",
+					"entries": [
+						"{@atk mw} {@hit 3} to hit, reach 5 ft., one target. {@h}3 ({@damage 1d4 + 1}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"The gowngoat creates a small blast of wind in a 15-foot cone that is capable of moving one object that is neither held nor carried and that weighs no more than 5 pounds. The object is pushed up to 10 feet away from it. It isn't pushed with enough force to cause damage. The gust disperses gas or vapor, and it extinguishes candles, torches, and similar unprotected flames in the area. It causes protected flames, such as those of lanterns, to dance wildly and has a 50 percent chance to extinguish them."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Gowngoats have a body structure similar to {@creature slagtoth|MHMM}, with brown furry patches around their neck and extending from their back. A large patch of fur runs from their lower backs to their tail, which are incredibly long and fluffy. They have long ear-like tuffs on their ears that droop below their head and a crest on their forehead with two short horns extending from it. The center of their back and forelegs are hairless and covered in scales. They have cloven hooves.",
+							"Gowngoats are docile herbivores that live in a herd and spend most of their time grazing or sleeping. Their long fluffy tail is theorized to either allow these creatures to curl into balls to mimic the appearance of rocks to fool predators or to hide and protect their young. If they sense danger, they will flee to safety rather than fight.",
+							{
+								"type": "inset",
+								"name": "Gowngoat",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"1/8",
+												"Carves",
+												"1"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-2",
+												"Raw Meat",
+												"(O)"
+											],
+											[
+												"3-10",
+												"Gowngoat Thickfur",
+												"(O)"
+											],
+											[
+												"11-16",
+												"Large Herbivore Bone",
+												"(A,O)"
+											],
+											[
+												"17-20",
+												"Gowngoat Fleeceball",
+												"(A,O)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Gowngoat Thickfur",
+												"entries": [
+													"You reduce slashing damage you take by 2 while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Large Herbivore Bone",
+												"entries": [
+													"{@i Botanist.} When you successfully gather a plant resource, you instead gather 2."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gowngoat Fleeceball",
+												"entries": [
+													"{@i Entomologist.} When you capture an insect with a bug net, you instead catch two."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Raw Meat",
+												"entries": [
+													"Provides 2 days rations when cooked."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gowngoat Fleeceball",
+												"entries": [
+													"When placed into a trinket, it transforms into a cotton sheet or a fluffy pillow. When you spend at least 6 hours sleeping with this pillow or sheet while taking a long rest, you regain a number of expended hit die equal to your proficiency bonus (in addition to the ones you normally regain) when you finish it."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Large Herbivore Bone",
+												"entries": [
+													"Uncommon armor upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"B"
+			],
+			"miscTags": [
+				"MW"
+			]
+		},
+		{
 			"name": "Gravios",
 			"size": [
 				"G"
@@ -30210,7 +33546,7 @@
 												"18",
 												"-",
 												"Gravios Medulla",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"18",
@@ -30341,6 +33677,13 @@
 												"name": "Gravios Wing",
 												"entries": [
 													"When you hit a Huge or smaller creature with this weapon, it must succeed on a {@dc 15} Strength check or be pushed back 5 feet."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Gravios Medulla",
+												"entries": [
+													"{@i (Bow Only) Bow Charge Plus+.} While attuned to this weapon, you can use your dragonpiercer two additional times between rests and it recharges after a Short or Long rest."
 												]
 											},
 											{
@@ -30549,7 +33892,7 @@
 												"13-17",
 												"8-10",
 												"Great Baggi Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"-",
@@ -30588,6 +33931,13 @@
 												"name": "Great Baggi Hide",
 												"entries": [
 													"You reduce cold damage you take by 3 while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Great Baggi Claw",
+												"entries": [
+													"{@i Geologist.} When you successfully gather a {@table minerals|AGMH|mining} resource, you instead gather 2."
 												]
 											},
 											{
@@ -31409,7 +34759,7 @@
 												"13-17",
 												"8-10",
 												"Great Jaggi Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"-",
@@ -31452,7 +34802,14 @@
 											},
 											{
 												"type": "entries",
-												"name": "Great Jaggi Hide",
+												"name": "Great Jaggi Claw",
+												"entries": [
+													"{@i Forager.} When you harvest mushrooms, you instead gather two."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Great Jaggi Head",
 												"entries": [
 													"{@i Item Prolonger.} Whenever you use a consumable item that has a duration, its duration is increased by an additional 6 seconds."
 												]
@@ -31892,7 +35249,7 @@
 												"1-3",
 												"-",
 												"Maccao Scale",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"4-5",
@@ -31973,6 +35330,13 @@
 										"style": "list-hang",
 										"name": "WEAPON MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Maccao Scale",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Maccao Tailspike",
@@ -32371,7 +35735,7 @@
 												"13-17",
 												"8-10",
 												"Great Wroggi Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"-",
@@ -32410,6 +35774,13 @@
 												"name": "Great Wroggi Hide",
 												"entries": [
 													"You reduce poison damage you take by 3 while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Great Wroggi Claw",
+												"entries": [
+													"{@i Forager.} When you harvest mushrooms, you instead gather two."
 												]
 											},
 											{
@@ -33979,7 +37350,7 @@
 												"6-8",
 												"6-7",
 												"Hypno Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"9-10",
@@ -34037,6 +37408,13 @@
 												"name": "H.Sleep Sac",
 												"entries": [
 													"Whenever you make a saving throw against the {@condition unconscious} condition or other sleep-like effects, you do so with a +1 bonus."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Hypno Claw",
+												"entries": [
+													"{@i Entomologist.} When you capture an insect with a bug net, you instead catch two."
 												]
 											},
 											{
@@ -34277,7 +37655,7 @@
 												"11-17",
 												"8-18",
 												"Iodrome Hide",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"18-19",
@@ -34345,6 +37723,13 @@
 												"name": "Iodrome Poison Sac",
 												"entries": [
 													"When you cast a spell that deals poison damage, you gain a +1 bonus to its spell attack roll."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Iodrome Hide",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
 												]
 											},
 											{
@@ -34807,7 +38192,7 @@
 											[
 												"14-17",
 												"Izuchi Tail",
-												"(A)"
+												"(W)"
 											],
 											[
 												"18-20",
@@ -34826,6 +38211,13 @@
 												"name": "Izuchi Hide",
 												"entries": [
 													"When you successfully gather from a {@table bonepiles|AGMH|bonepile} resource, you roll twice on the resource table."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Izuchi Tail",
+												"entries": [
+													"{@i Geologist.} When you successfully gather a {@table minerals|AGMH|mining} resource, you instead gather 2."
 												]
 											}
 										]
@@ -36194,7 +39586,7 @@
 												"7-9",
 												"9-12",
 												"J.Dodogama Jaw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"10-14",
@@ -36226,6 +39618,13 @@
 												"name": "J.Dodogama Hide",
 												"entries": [
 													"You reduce fire damage you take by 2 while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "J.Dodogama Jaw",
+												"entries": [
+													"{@i Geologist.} When you successfully gather a mining resource, you instead gather 2."
 												]
 											},
 											{
@@ -36698,7 +40097,7 @@
 												"9-13",
 												"10-14",
 												"Juv.Zinogre Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"14-18",
@@ -36738,6 +40137,13 @@
 												"name": "Zinogre Shell",
 												"entries": [
 													"When you take lightning or thunder damage while wearing this armor, your walking speed increases by 20 feet until the end of your next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Juv.Zinogre Claw",
+												"entries": [
+													"{@i Entomologist.} When you capture an insect with a bug net, you instead catch two."
 												]
 											},
 											{
@@ -36980,7 +40386,7 @@
 												"13-15",
 												"12-14",
 												"Jyuratodus Fang",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"-",
@@ -37019,6 +40425,13 @@
 												"name": "Jyuratodus Shell",
 												"entries": [
 													"While wearing this armor, you have a swimming speed equal to your walking speed."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Jyuratodus Fang",
+												"entries": [
+													"{@i Forager+.} When you harvest mushrooms, you harvest an extra 1d4 more."
 												]
 											},
 											{
@@ -38935,9 +42348,13 @@
 			"wis": 10,
 			"cha": 9,
 			"save": {
-				"dex": "+5",
-				"con": "+6",
-				"cha": "+2"
+				"dex": "+4",
+				"con": "+5",
+				"cha": "+1"
+			},
+			"skill": {
+				"investigation": "+1",
+				"perception": "+2"
 			},
 			"passive": 12,
 			"cr": "4",
@@ -39179,10 +42596,6 @@
 				"MW",
 				"RW"
 			],
-			"skill": {
-				"perception": "+2",
-				"investigation": "+1"
-			},
 			"conditionInflict": [
 				"prone"
 			]
@@ -40243,7 +43656,7 @@
 												"1-5",
 												"1-5",
 												"Lagiacrus Hide",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"6-8",
@@ -40342,6 +43755,13 @@
 										"style": "list-hang",
 										"name": "WEAPON MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Lagiacrus Hide",
+												"entries": [
+													"{@i (Bow Only) Bow Charge Plus.} While attuned to this weapon, you can use your dragonpiercer one additional time between rests and it recharges after a Short or Long rest."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Lagiacrus Scale",
@@ -40585,7 +44005,7 @@
 												"14-15",
 												"16-18",
 												"Lagombi Jumbo Bone",
-												"(W,O)"
+												"(A,W,O)"
 											],
 											[
 												"16-20",
@@ -40619,6 +44039,13 @@
 												"name": "Lagombi Iceclaw",
 												"entries": [
 													"You reduce cold damage you take by 3 while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lagombi Jumbo Bone",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
 												]
 											},
 											{
@@ -40822,7 +44249,7 @@
 											[
 												"8-15",
 												"Lagombi Kit Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"16-20",
@@ -40841,6 +44268,13 @@
 												"name": "Lagombi Kit Pelt",
 												"entries": [
 													"You have a +1 bonus to {@skill Acrobatics} checks while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lagombi Kit Claw",
+												"entries": [
+													"{@i Forager.} When you harvest mushrooms, you instead gather two."
 												]
 											},
 											{
@@ -41489,7 +44923,7 @@
 											[
 												"11-20",
 												"Larinoth Hide",
-												"(A)"
+												"(A,W)"
 											]
 										]
 									},
@@ -41503,6 +44937,20 @@
 												"name": "Larinoth Hide",
 												"entries": [
 													"{@i Detect.} You gain a +1 bonus to your passive Perception while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Larinoth Hide",
+												"entries": [
+													"{@i Botanist.} When you successfully gather a plant resource, you instead gather 2."
 												]
 											}
 										]
@@ -42510,6 +45958,420 @@
 			]
 		},
 		{
+			"name": "Lucent Nargacuga",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"flying"
+				]
+			},
+			"group": [
+				"Flying Wyverns"
+			],
+			"environment": [
+				"coastal",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"swamp",
+				"underdark",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 22,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 250,
+				"formula": "20d12+120"
+			},
+			"speed": {
+				"walk": 50,
+				"fly": 30
+			},
+			"str": 18,
+			"dex": 25,
+			"con": 22,
+			"int": 12,
+			"wis": 16,
+			"cha": 10,
+			"save": {
+				"dex": "+14",
+				"con": "+11",
+				"wis": "+10"
+			},
+			"skill": {
+				"acrobatics": "+14",
+				"perception": "+10",
+				"stealth": "+14"
+			},
+			"immune": [
+				"fire",
+				"lightning"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"passive": 20,
+			"cr": "21",
+			"page": 0,
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Legendary Resistance (2/Day)",
+					"entries": [
+						"If the nargacuga fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Pounce",
+					"entries": [
+						"If the nargacuga moves at least 20 feet straight toward a creature and then hits it with a Bladed Wing attack on the same turn, that target must succeed on a {@dc 22} Strength saving throw or be knocked {@condition prone}. If the target is {@condition prone}, the nargacuga can make one Bladed Wing attack against it as a bonus action."
+					]
+				},
+				{
+					"name": "Surprise Attack",
+					"entries": [
+						"When the nargacuga uses an action or legendary action, while {@condition invisible}, that forces a creature to make a Dexterity saving throw, that creature makes the saving throw with disadvantage."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The nargacuga makes one Bladed Wing attack and one Tail Swipe attack, two Tail Swipe attacks, or three Poisoned Tail Spike attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 14} to hit, reach 5 ft., one target. {@h}25 ({@damage 4d8 + 7}) piercing damage."
+					]
+				},
+				{
+					"name": "Bladed Wings",
+					"entries": [
+						"{@atk mw} {@hit 14} to hit, reach 5 ft., one target. {@h}20 ({@damage 3d8 + 7}) slashing damage."
+					]
+				},
+				{
+					"name": "Poisoned Tail Spike",
+					"entries": [
+						"{@atk rw} {@hit 14} to hit, reach 60/180 ft., one target. {@h}14 ({@damage 2d6 + 7}) piercing damage plus 7 ({@damage 2d6}) poison damage and the target must succeed on a {@dc 21} Constitution saving throw or be {@condition poisoned} for 1 minute. A creature can repeat its saving throw at the end of its turn, ending the effecting on a success."
+					]
+				},
+				{
+					"name": "Tail Swipe",
+					"entries": [
+						"{@atk mw} {@hit 14} to hit, reach 10 ft., one target. {@h}26 ({@damage 3d12 + 7}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Invisible Passage",
+					"entries": [
+						"While under the light of the moon the nargacuga magically turns {@condition invisible} until it attacks or until its concentration ends (as if concentrating on a spell). While invisible, the nargacuga leaves no physical evidence of its passage, so it can be tracked only by magic."
+					]
+				},
+				{
+					"name": "Tail Slam {@recharge 5}",
+					"entries": [
+						"The nargacuga uses one of the following tail slams:",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Double",
+									"entries": [
+										"The nargacuga slams its tail down in two different 40-foot lines that are 5 feet wide. Each creature in that line must make a {@dc 22} Dexterity saving throw, taking 28 ({@damage 8d6}) bludgeoning damage plus 17 ({@damage 5d6}) piercing damage, be pushed 5 feet in a random direction and knocked {@condition prone} on a failed save, or half as much damage and isn't pushed or knocked {@condition prone} on a successful save."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Heavy",
+									"entries": [
+										"The nargacuga jumps up to 20 feet in a straight line before performing a somersault and slamming its tail down in a 40-foot line that is 5 feet wide. Each creature in that line must make a {@dc 22} Dexterity saving throw, taking 31 ({@damage 9d6}) bludgeoning damage plus 21 ({@damage 6d6}) piercing damage, be pushed 5 feet in a random direction and knocked {@condition prone} on a failed save, or half as much damage, isn't pushed or knocked {@condition prone} on a successful save. If the saving throw fails by 5 or more, the creature is also stunned until the end of its next turn."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The nargacuga makes one Bite attack."
+					]
+				},
+				{
+					"name": "Reflect Moonlight",
+					"entries": [
+						"The nargacuga uses Invisible Passage."
+					]
+				},
+				{
+					"name": "Poison Rain (Costs 2 Actions)",
+					"entries": [
+						"The nargacuga launches toxic spikes into the air that fall over a 30-foot line that is 5 feet wide, originating from a space within 15 feet of the nargacuga. Each creature in that line must make a {@dc 21} Constitution saving throw, taking 32 ({@damage 6d10}) poison damage and be {@condition poisoned} for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. A creature can repeat its saving throw at the end of its turn, ending the effecting on a success.",
+						"The nargacuga can expend one additional legendary action to change the area from a line to a 15-foot radius around it."
+					]
+				},
+				{
+					"name": "Tornado Tackle (Costs 2 Actions)",
+					"entries": [
+						"The nargacuga moves up to its speed in a straight line while quickly spinning its body. During this move it can move through the spaces of other creatures without provoking opportunity attacks. Each creature the nargacuga moves through must succeed on a {@dc 22} Dexterity saving throw or take 20 ({@damage 3d8 + 7}) bludgeoning damage and be knocked {@condition prone}."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Known as the Moon Swift Wyvern, this species of {@creature nargacuga|MHMM} is capable of rendering itself completely invisible. This unusual adaptation is caused by its dapples, which reflect the light around itself. Although usable at anytime, this powerful ability is at its strongest when the moon is at its brightest. This adaptation can greatly assist these nargacuga in hunting their prey and avoid being seen by rival predators such as silver rathalos from above. This may also have contributed to them not being discovered until recently.",
+							"Another adaptation that separates this nargacuga from its relatives are its tail spikes, which contain a powerful toxin capable of making a rathalos woozy and killing a hunter in a matter of moments. Interestingly, the wyverns appear to produce these toxins in their tail but how is a mystery. The jaws of the Lucent Nargacuga are the strongest of the three nargacuga species and are capable of biting through the toughest of armors. Its razors (the blades on its arms) are as well much tougher and, unsurprisingly sharper than its counterparts.",
+							"Lucent nargacuga are territorial and highly aggressive towards both rival predators and hunters. Their toxic tail spikes and invisibility during the night make these creatures deadly opponents and should not be underestimated by even experienced hunters.",
+							{
+								"type": "inset",
+								"name": "Lucent Nargacuga",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"21",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-7",
+												"1-4",
+												"Lucent Narga Shard",
+												"(A,W)"
+											],
+											[
+												"8-11",
+												"5-11",
+												"Nargacuga Lash",
+												"(A)"
+											],
+											[
+												"12-13",
+												"12-15",
+												"Lucent Narga Tailspear",
+												"(A,W)"
+											],
+											[
+												"14-15",
+												"-",
+												"Lucent Narga Dapple",
+												"(A,W)"
+											],
+											[
+												"16",
+												"16-17",
+												"Lucent Narga Hardfang",
+												"(A,W)"
+											],
+											[
+												"17-19",
+												"18-20",
+												"Lucent Narga Razor",
+												"(A,W)"
+											],
+											[
+												"20",
+												"-",
+												"Cloudy Moonshard",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Lucent Narga Shard",
+												"entries": [
+													"{@i Handicraft+3.} For 24 hours, you gain proficiency with three artisan tools of your choice each dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Nargacuga Lash",
+												"entries": [
+													"While you are attuned to this armor, you have proficiency in {@skill Stealth}, if you are already proficient then you gain expertise in stealth. While in dim light or Darkness, you can take the {@action Hide} action as a Bonus Action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Tailspear",
+												"entries": [
+													"{@i Evade Window.} This armor has 3 runes, and it regains 1d3 expended runes daily at dawn. When you fail a Dexterity saving throw while wearing it, you can use your reaction to expend 1 of its runes to succeed on that saving throw instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Dapple",
+												"entries": [
+													"You are immune to radiant damage while you are attuned to this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Hardfang",
+												"entries": [
+													"While you are wearing this armor and you take damage, you can use your reaction to magically turn {@condition invisible} until the start of your next turn or until you attack, make a damage roll, or force someone to make a saving throw. You can use this property twice, regaining all expended uses when you finish a short or long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Razor",
+												"entries": [
+													"{@i Evade Extender (L).} You gain a +3 bonus to Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Cloudy Moonshard",
+												"entries": [
+													"This armor has 8 runes. While holding it, you can use an action to expend 1 or more of its runes to cast one of the following Spells from it, using your spell save DC: {@spell blur} (2 runes), {@spell moonbeam} at 4th-level (4 runes), or {@spell invisibility} (2 runes), {@spell greater invisibility} (4 runes). This weapon regains 1d6+2 expended runes daily at dawn. If you expend the last rune it can't regain any runes for one week."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Lucent Narga Shard",
+												"entries": [
+													"{@i (Ranged Weapon Only) Ammo Up.} Your bowgun's normal ammo capacity doubles while you are attuned to this weapon. Additionally when coating, you can coat up to 10 additional arrows."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Nargacuga Lash",
+												"entries": [
+													"{@i Adrenaline.} The first time you drop below half of your hit point maximum in combat, you gain a rush of adrenaline. On your next turn your movement speed doubles and you can take one extra action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Tailspear",
+												"entries": [
+													"{@i (Bowgun Only) Spread up+.} When you hit a creature with spread ammo and they are within half your normal bowgun range, increase the damage die size by 1. Additionally instead of splitting the damage, the target takes full damage from the spread ammo and each adjacent creature must succeed on a Dexterity saving throw equal to your ammo save DC. On a failed save, the target is dealt the same damage as the target. On a successful save, the target takes half as much damage as the target."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Dapple",
+												"entries": [
+													"{@i Critical Element (poison+).} When you critically hit with a weapon or spell that deals poison damage, you deal an extra {@damage 1d8} poison damage. Additionally if a creature fails its saving throw by 5 or more against a spell that deals poison damage, you deal an extra {@damage 1d8} poison damage to it."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Hardfang",
+												"entries": [
+													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra {@damage 1d6} weapon damage. (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")"
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lucent Narga Razor",
+												"entries": [
+													"{@i Critical Boost+.} You can roll two additional weapon damage dice when determining the extra damage for a critical hit with a weapon attack."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Cloudy Moonshard",
+												"entries": [
+													"{@i Sneak Attack.} When you force a creature to make a Dexterity saving throw while you are hidden or when an ally is within 5 feet of the creature, that creature has disadvantage on the save."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/mWs0N7h.png",
+			"damageTags": [
+				"P",
+				"S",
+				"B"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"RW",
+				"AOE"
+			],
+			"conditionInflict": [
+				"prone",
+				"poisoned"
+			]
+		},
+		{
 			"name": "Ludroth",
 			"size": [
 				"M"
@@ -42630,7 +46492,7 @@
 											[
 												"1-10",
 												"Hydro Hide",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"11-16",
@@ -42663,6 +46525,13 @@
 										"style": "list-hang",
 										"name": "WEAPON MATERIAL EFFECTS",
 										"items": [
+											{
+												"type": "entries",
+												"name": "Hydro Hide",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
+												]
+											},
 											{
 												"type": "entries",
 												"name": "Immature Sponge",
@@ -42702,6 +46571,448 @@
 			],
 			"conditionInflict": [
 				"poisoned",
+				"prone"
+			]
+		},
+		{
+			"name": "Lunagaron",
+			"size": [
+				"L"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"fanged"
+				]
+			},
+			"group": [
+				"Fanged Wyverns"
+			],
+			"environment": [
+				"coastal",
+				"desert",
+				"forest",
+				"hill",
+				"mountain",
+				"swamp",
+				"underdark"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				17,
+				{
+					"ac": 19,
+					"from": [
+						"with Ice Cloak or Werewolf active"
+					]
+				}
+			],
+			"hp": {
+				"average": 52,
+				"formula": "5d10 + 25 (242 hp with mythic traits)"
+			},
+			"speed": {
+				"walk": 50,
+				"climb": 30
+			},
+			"str": 23,
+			"dex": 16,
+			"con": 20,
+			"int": 8,
+			"wis": 15,
+			"cha": 10,
+			"save": {
+				"dex": "+9",
+				"con": "+11",
+				"wis": "+8"
+			},
+			"skill": {
+				"acrobatics": "+9",
+				"athletics": "+12",
+				"perception": "+8"
+			},
+			"resist": [
+				{
+					"resist": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical attacks",
+					"cond": true
+				}
+			],
+			"immune": [
+				"cold"
+			],
+			"passive": 18,
+			"cr": "19",
+			"page": 0,
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Ice Cloak (Mythic Trait; Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the lunagaron is reduced to 0 hit points while in its normal form, it doesn't die or fall {@condition unconscious}. Instead, its current hit point total instead resets to 84 (8d10 + 40 hit points, it regains one expended use of Legendary Resistance, and it coats its limbs and tail with ice for 1 minute. Additionally, the lunagaron can now use the ice cloak options in the \"Mythic Actions\" section for 1 minute."
+					]
+				},
+				{
+					"name": "Keen Hearing and Smell",
+					"entries": [
+						"The lunagaron has advantage on Wisdom ({@skill Perception}) checks that rely on hearing or smell."
+					]
+				},
+				{
+					"name": "Legendary Resistance (2/Day)",
+					"entries": [
+						"If the lunagaron fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Werewolf (Mythic Trait; Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the lunagaron is reduced to 0 hit points while ice cloak is active or needs to be recharged, it doesn't die or fall {@condition unconscious}. Instead, its current hit point total instead resets to 105 (10d10 + 50) hit points, it regains one expended use of Legendary Resistance, and it stands on its two hind legs, infusing ice around its claws and creates huge spikes on its back for 1 minute. Additionally, the lunagaron can now use the werewolf options in the \"Mythic Actions\" section for 1 minute."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The lunagaron makes one Bite attack and two Claw attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 5 ft., one target. {@h}15 ({@damage 2d8 + 6}) piercing damage."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 5 ft., one target. {@h}9 ({@damage 1d6 + 6}) slashing damage, or 9 ({@damage 1d6 + 6}) plus 7 ({@damage 2d6}) cold damage while ice cloak or werewolf is active. If the target is a creature and ice cloak or werewolf is active, the target must succeed on a {@dc 19} Constitution saving throw or be diseased with {@disease iceblight|MHMM} until the start of lunagaron's next turn."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 5 ft., one target. {@h}15 ({@damage 2d8 + 6}) bludgeoning damage, or 15 ({@damage 2d8 + 6}) plus 7 ({@damage 2d6}) cold damage while ice cloak or werewolf is active. If the target is a creature and ice cloak or werewolf is active, the target must succeed on a {@dc 19} Constitution saving throw or be diseased with {@disease iceblight|MHMM} until the start of lunagaron's next turn."
+					]
+				},
+				{
+					"name": "Furious Swipes {@recharge 5}",
+					"entries": [
+						"The lunagaron makes three Claw attacks that deal an extra 7 ({@damage 2d6}) slashing damage against the same target."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Uncanny Dodge",
+					"entries": [
+						"The lunagaron halves the damage that it takes from an attack that hits it. The lunagaron must be able to see the attacker."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The lunagaron makes one Tail attack."
+					]
+				},
+				{
+					"name": "Flash Freeze",
+					"entries": [
+						"The lunagaron freezes the air in a 5-foot radius around it. Each creature in that area must succeed on a {@dc 19} Constitution saving throw or be diseased with {@disease iceblight|MHMM} until the start of the lunagaron's next turn. If the saving throw fails by 9 or more, the target is instead diseased with {@disease iceblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Pounce (Costs 2 Actions)",
+					"entries": [
+						"The lunagaron moves up to its speed, then makes one Bite attack. If the attack hit, the target must succeed on a {@dc 20} Strength saving throw, or be knocked {@condition prone}."
+					]
+				}
+			],
+			"mythicHeader": [
+				"If the lunagaron's Ice Cloak trait has activated in the last minute, it can use the Ice Cloak options below as legendary actions. If the lunagaron's Werewolf trait has activated in the last minute, it can use the Werewolf options below as legendary actions."
+			],
+			"mythic": [
+				{
+					"name": "Ice Cloak",
+					"entries": [
+						{
+							"type": "list",
+							"style": "list-hang",
+							"items": [
+								{
+									"type": "item",
+									"name": "Cold Breath (Costs 2 Actions)",
+									"entries": [
+										"The lunagaron exhales an icy blast in a 30-foot line that is 10 feet wide. Each creature in that line must make a {@dc 19} Constitution saving throw, taking 31 ({@damage 9d6}) cold damage and be diseased with {@disease iceblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't diseased with {@disease iceblight|MHMM} on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Trample (Costs 2 Actions)",
+									"entries": [
+										"The lunagaron moves up to its speed, during this move it can move through other creatures without provoking opportunity attacks. Each creature the lunagaron moves through must succeed on a {@dc 20} Dexterity saving throw or take 28 ({@damage 4d10 + 6}) bludgeoning damage and and be knocked {@condition prone} and diseased with {@disease iceblight|MHMM} until the start of lunagaron's next turn."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Werewolf",
+					"entries": [
+						{
+							"type": "list",
+							"style": "list-hang",
+							"items": [
+								{
+									"type": "item",
+									"name": "Tail Flip",
+									"entries": [
+										"The lunagaron makes one Tail attack then leaps 10 feet backwards away from the target. Opportunity attacks against the lunagaron have disadvantage when it leaps away."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Leaping Wolf Slash (Costs 3 Actions; {@recharge 4})",
+									"entries": [
+										"The lunagaron lunges up to 15 feet and swipes with both claws at a creature within 5 feet of it. That creature must make a {@dc 20} Dexterity saving throw, taking 48 ({@damage 12d6 + 6}) slashing damage on a failed save, or half as much damage on a successful one."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Lunagaron is a large, wolf-like fanged wyvern similar in appearance to new World fanged wyverns such as {@creature odogaron|MHMM} and {@creature tobi-kadachi|MHMM}. Its body is covered in cobalt scales with white edges, with several ridges running down its back.",
+							"Like other fanged wyverns, it is very agile and can easily climb up and jump off walls and large rocks. It is agile enough to perform several attacks in a row using its front legs, as well as acrobatic movements. Although normally quadrupedal, lunagaron have a \"true-form\" in which it takes a bipedal stance. Additionally, lunagaron can chill the air it inhales with a special organ, which then circulates throughout its body as a unique form of thermoregulation. It can also use this ability to form ice armor on itself during combat and breath mist of frost.",
+							"Born hunter, Lunagaron feeds on smaller monsters, including some smaller size large monsters like {@creature Aknosom|MHMM}. It often competes with other dangerous monsters like {@creature Zinogre|MHMM}, {@creature Garangolm|MHMM} and {@creature Malzeno|MHMM}, often in Turf Wars around various locales, such as the Citadel.",
+							"Lunagaron is first encountered in the Shrine Ruins of Kamura; however, its main domain is the ice caverns of Elgado's Citadel. Due to its special thermoregulation skill, lunagaron has been seen living in non-cold areas such as the jungle.",
+							{
+								"type": "inset",
+								"name": "Lunagaron",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"19",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-4",
+												"1-4",
+												"Lunagaron Shard",
+												"(A,W)"
+											],
+											[
+												"5-9",
+												"5-9",
+												"Lunagaron Cortex",
+												"(A,W)"
+											],
+											[
+												"10-14",
+												"10-12",
+												"Luna Vermilion Hardclaw",
+												"(A,W)"
+											],
+											[
+												"-",
+												"13-15",
+												"Lunagaron Lash Shell",
+												"(W)"
+											],
+											[
+												"15-18",
+												"-",
+												"Frostborn Hardfang",
+												"(A,W)"
+											],
+											[
+												"19",
+												"16-18",
+												"Lunagaron Bluecore",
+												"(A)"
+											],
+											[
+												"20",
+												"19-20",
+												"Lunagaron Frost Jewel",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Lunagaron Shard",
+												"entries": [
+													"{@i (Druid Only)} While wearing this armor you can use your wild shape feature to transform into a {@creature winter wolf} or a {@creature werewolf} with white fur, but your bite doesn't pass on the curse."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Cortex",
+												"entries": [
+													"You have advantage on Wisdom ({@skill Perception}) checks that rely on hearing or smell."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Luna Vermilion Hardclaw",
+												"entries": [
+													"You have a climbing speed equal to your walking speed while you wear this armor. Your climb speed increases by an extra 10 feet for every lunagaron materials you have in your weapon, armor, or trinkets."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Lash Shell",
+												"entries": [
+													"{@i (Spellcaster Only)} This armor has two runes that it regains daily at dawn. As an action you can expend one of these runes to coat your armor in magical ice, gaining 20 temporary hit points. If a creature hits you with a melee attack while you have these hit points, the creature takes 20 cold damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Frostborn Hardfang",
+												"entries": [
+													"{@i Evasion.} You have advantage on Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Bluecore",
+												"entries": [
+													"You are immune to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Frost Jewel",
+												"entries": [
+													"{@i Redirection.} When you are the target of a melee attack, you can use your reaction to swap your position with another creature within 5 feet of you that is the same size or smaller than you. If the creature is unwilling, you must succeed on a Strength ({@skill Athletics}) or Dexterity ({@skill Acrobatics}) check contested by its Strength ({@skill Athletics}) or Dexterity ({@skill Acrobatics}) check or remain in your space. You can use this property a number of times equal to half of your proficiency bonus, regaining all expended uses when you finish a long rest."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Lunagaron Shard",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d8} cold damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Cortex",
+												"entries": [
+													"While you are attuned to this weapon, your cold spells bypass a creature's damage resistance."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Luna Vermilion Hardclaw",
+												"entries": [
+													"While you are holding this weapon, you can use an action to speak its command word to summon a {@creature winter wolf} for up to 8 hours. The wolf acts as your ally, and can telepathically communicate with you at any range if you and it are on the same plane of existence. Once this property has been used, it can't be used again until 2 days have passed."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Lash Shell",
+												"entries": [
+													"{@i Critical Eye+.} Your weapon attacks critical hit range is increased by 2.."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Frostborn Hardfang",
+												"entries": [
+													"{@i Latent Power +2.} When you are reduced to a half of your maximum hit points for the first time in combat or at the start of your turn on the 10th round of combat, whichever comes first, you gain the effects of the {@spell haste} spell for 1 minute. Once used, you must finish a short or long rest before you can use this property again."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunagaron Frost Jewel",
+												"entries": [
+													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra {@damage 1d6} weapon damage. (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"S",
+				"C",
+				"B"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			],
+			"conditionInflict": [
 				"prone"
 			]
 		},
@@ -42937,7 +47248,7 @@
 											[
 												"17-18",
 												"Lunastra Mane",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"19",
@@ -42982,6 +47293,13 @@
 												"name": "Lunastra Wing",
 												"entries": [
 													"{@i Evade Window.} This armor has 3 runes, and it regains 1d3 expended runes daily at dawn. When you fail a Dexterity saving throw while wearing it, you can use your reaction to expend 1 of its runes to succeed on that saving throw instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lunastra Mane",
+												"entries": [
+													"{@i Geologist+.} When you successfully gather a mining resource, you gather an extra 1d4 more."
 												]
 											},
 											{
@@ -43227,7 +47545,7 @@
 											[
 												"14-17",
 												"Maccao Scale",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"18-20",
@@ -43264,6 +47582,13 @@
 										"items": [
 											{
 												"type": "entries",
+												"name": "Maccao Scale",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
+												]
+											},
+											{
+												"type": "entries",
 												"name": "Bird Wyvern Fang",
 												"entries": [
 													"Your piercing weapon deals an extra 1 piercing damage."
@@ -43297,6 +47622,418 @@
 			],
 			"miscTags": [
 				"MW"
+			]
+		},
+		{
+			"name": "Magma Almudron",
+			"size": [
+				"G"
+			],
+			"type": "leviathan",
+			"group": [
+				"Leviathans"
+			],
+			"environment": [
+				"coastal",
+				"desert",
+				"hill",
+				"swamp",
+				"underwater"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 19,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 214,
+				"formula": "13d20 + 78"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 60,
+				"swim": 60
+			},
+			"str": 20,
+			"dex": 12,
+			"con": 22,
+			"int": 8,
+			"wis": 16,
+			"cha": 13,
+			"save": {
+				"dex": "+7",
+				"con": "+12",
+				"wis": "+9"
+			},
+			"immune": [
+				"acid",
+				"fire",
+				"necrotic"
+			],
+			"senses": [
+				"blindsight 60 ft.",
+				"darkvision 60 ft."
+			],
+			"passive": 17,
+			"cr": "13",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The almudron's long jump is up to 40 feet and its high jump is up to 20 feet, without a running start. In addition, the almudron does not incur attacks of opportunity while moving with a jump."
+					]
+				},
+				{
+					"name": "Softened Body",
+					"entries": [
+						"When the almudron emerges from underground, while in volcanic terrain, its AC is reduced by 2 until the end of its next turn."
+					]
+				},
+				{
+					"name": "Magma Boulder",
+					"entries": [
+						"When the almudron emerges from the ground roll a d6. On a 4-6, three magma boulders appear in random spaces within 20 feet of the almudron. On initiative count 20 (losing all ties) the rocks explode and each creature in a 10-foot radius around a rock must succeed on a {@dc 19} Dexterity saving throw or take 10 ({@damage 3d6}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The almudron two Claw attacks."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}15 ({@damage {@damage 2d6 + 5}}) slashing damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 15 ft., one target. {@h}18 ({@damage {@damage 3d8 + 5}}) bludgeoning damage or 32 ({@damage {@damage 6d8 + 5}}) bludgeoning damage plus 14 ({@damage 4d6}) fire damage while holding the magmaball. Once per turn, the almudron can cause one of the following additional effects (choose one or roll a d4):",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "1-2: Knockdown",
+									"entries": [
+										"If the target is a creature it must succeed on a {@dc 19} Strength saving throw or be pushed 10 feet away and knocked {@condition prone}."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "3-4: Magmawave",
+									"entries": [
+										"Magma pools form behind the target and flow across a 30-foot cone. Each creature in that area must make a {@dc 19} Dexterity saving throw, taking 14 ({@damage 4d6}) fire damage on a failed save, or half as much damage on a successful one."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Magma Tail Explosion {@recharge 5}",
+					"entries": [
+						"While underground the almudron moves up to its burrow speed and emerges from the ground and slams its tail creating an explosion under it. Each creature in a 15-foot-radius sphere of the almudron must make a {@dc 19} Dexterity saving throw, taking 38 ({@damage 7d10}) fire damage or 55 ({@damage 10d10}) fire damage if the almudron is holding a magmaball on a failed save, or half as much damage on a successful one. Additionally, if the almudron was holding a magmaball, it is destroyed."
+					]
+				},
+				{
+					"name": "Magma Drive (Recharges after a Short or Long Rest)",
+					"entries": [
+						"The almudron moves up to doubles its burrow speed along the surface, leaving a magma boulder in a space adjacent to it for every 10 feet it moves. On initiative 20 (losing all ties), the magma boulders explode as described in the Magma Boulder trait."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The almudron makes one Claw attack."
+					]
+				},
+				{
+					"name": "Jump",
+					"entries": [
+						"The almudron jumps up to 40 feet away."
+					]
+				},
+				{
+					"name": "Tail Slam (Costs 2 Actions)",
+					"entries": [
+						"Each creature in a 10-foot long line that is 15-feet wide adjacent to the almudron must make a {@dc 18} Strength saving throw, taking 18 ({@damage 3d8 + 5}) bludgeoning damage and be knocked prone on a failed save, or half as much on a successful one."
+					]
+				},
+				{
+					"name": "Mold Magma Ball (Costs 3 Actions)",
+					"entries": [
+						"The almudron molds a large magmaball that it holds in its tail. The magmaball can be attacked and destroyed AC 15; hp 40; vulnerability to cold damage; immunity to fire, poison, and psychic damage). While holding the magmaball, the almudron doubles its damage dice on its Tail attack (included in the attack). If the almduron lacks the magma to form the ball, it is able to super heat thee ground with its body to create the magma needed."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"B",
+				"D"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Magma Almudron are bluish gray and crimson in color, with a red glow that can be seen through the seams between its shell. It is noticeably smaller than a normal {@creature Almudron|MHMM}.",
+							"Magma Almudron skillfully uses its tail to spread magma along the ground. Magma Almudron can secrete a special liquid which allows it to melt the the ground itself. This allow it to dig into the hot volcanic ground, and by doing so, causes some of its body parts to heat up and soften. It can creates pillars of magma to stand on before it eventually explodes. It can also hold a magma-mud ball with its tail like how the normal Almudron holds a mud ball. It can use the magma bad like a bludgeon to hit its foes before it explodes the moment it hits the ground.",
+							{
+								"type": "inset",
+								"name": "Almudron",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"17",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-5",
+												"1-3",
+												"Magmadron Shard",
+												"(A,W)"
+											],
+											[
+												"6-9",
+												"4-8",
+												"Magmadron Cortex",
+												"(A,W)"
+											],
+											[
+												"10-13",
+												"-",
+												"Large Magmadron Fin",
+												"(A,W)"
+											],
+											[
+												"14-15",
+												"9-11",
+												"Magmadron Hardwhisker",
+												"(A,W)"
+											],
+											[
+												"-",
+												"12-16",
+												"Magmadron Tail",
+												"(A,W)"
+											],
+											[
+												"16-19",
+												"17-18",
+												"Inferno Lava Mud",
+												"(A,W)"
+											],
+											[
+												"20",
+												"19-20",
+												"Magmadron Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Magmadron Shard",
+												"entries": [
+													"While wearing this armor, veins of flowing lava cover your armor. When you take the armor off, the lava hardens into obsidian."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Cortex",
+												"entries": [
+													"While wearing this armor you ignore difficult terrain created volcanic terrain and you have a swim speed equal to your walking speed while in lava."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Large Magmadron Fin",
+												"entries": [
+													"You have resistance to fire damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Hardwhisker",
+												"entries": [
+													"{@i Pack Rat.} While you are attuned to this armor, your party can gather double the normal number of resources available on a hunt."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Tail",
+												"entries": [
+													"{@i Resuscitate.} You have advantage on Dexterity saving throws if you are suffering from a condition."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Inferno Lava Mud",
+												"entries": [
+													"{@i Heroics.} While below 25% of your maximum hit points your weapon attacks deal 1d4 extra damage and you have resistance to all damage except psychic damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Mantle",
+												"entries": [
+													"{@i Guard Up.} When you fail a Dexterity or Strength saving throw, you can use your reaction to use your AC in place of your roll. You can use this property a number of times equal to your Constitution modifier, regaining all expended uses when you finish a long rest."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Magmadron Shard",
+												"entries": [
+													"{@i Geologist+.} When you successfully gather a mining resource, you instead gather 1d4."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Cortex",
+												"entries": [
+													"While attuned this weapon, you can cast the {@spell mold earth|TCE} cantrip at will."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Large Magmadron Fin",
+												"entries": [
+													"{@i Blast Coat.} This material provides one of the following weapon properties depending on which weapon it is placed in:",
+													{
+														"type": "list",
+														"items": [
+															{
+																"type": "entries",
+																"name": "(Bow)",
+																"entries": [
+																	"Your blast coating deals an extra {@damage 1d6} fire damage."
+																]
+															},
+															{
+																"type": "entries",
+																"name": "(Dual Repeaters)",
+																"entries": [
+																	"When you hit a create with your empowered blaze ammo, it now ignites the terrain in a 5-foot line extending from you to the target. The terrain remains on fire until the start of your next turn. A creature that moves into the fire for the first time on a turn or ends it turn in the flames takes {@damage 1d6} fire damage."
+																]
+															},
+															{
+																"type": "entries",
+																"name": "(Heavy Bowgun)",
+																"entries": [
+																	"Your cluster ammo deals an extra {@damage 2d6} fire damage."
+																]
+															},
+															{
+																"type": "entries",
+																"name": "(Light Bowgun)",
+																"entries": [
+																	"Your flaming ammo now bypasses a creatures resistance to fire damage."
+																]
+															}
+														]
+													}
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Hardwhisker",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d8} fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Tail",
+												"entries": [
+													"{@i Crisis.} While suffering from an abnormal status effect, such as {@condition poisoned}, burning, {@spell slow}ed, {@condition blinded}, etc, all attacks and spells deal an extra {@damage 1d10} spell or weapon damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Inferno Lava Mud",
+												"entries": [
+													"{@i (Spellcaster Only)} Whenever you cast a spell of 1st-level or higher, lava erupts from the ground around you. any creature within 5 feet of you takes 9 ({@damage 2d8}) points of fire damage. Also when you cast a spell that deals fire damage, it deals extra damage equal to 2 times the spells level as fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magmadron Mantle",
+												"entries": [
+													"{@i Resentment.} Until the end of your turn, you gain a +1 bonus to attack and damage rolls against any creature that has damaged you since the end of your last turn."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"S",
+				"B"
+			],
+			"conditionInflict": [
+				"grappled",
+				"restrained",
+				"stunned"
 			]
 		},
 		{
@@ -44097,6 +48834,442 @@
 			],
 			"damageTags": [
 				"S"
+			]
+		},
+		{
+			"name": "Malzeno",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "undead",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Elder Dragons"
+			],
+			"environment": [
+				"desert",
+				"forest",
+				"hill",
+				"mountain",
+				"swamp",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 20,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"formula": "22d12 + 154",
+				"average": 297
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 24,
+			"dex": 24,
+			"con": 25,
+			"int": 16,
+			"wis": 15,
+			"cha": 19,
+			"passive": 18,
+			"cr": "20",
+			"page": 140,
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"senseTags": [
+				"SD"
+			],
+			"languages": [
+				"Draconic"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"save": {
+				"dex": "+13",
+				"con": "+13",
+				"wis": "+8",
+				"cha": "+10"
+			},
+			"skill": {
+				"perception": "+8",
+				"stealth": "+13"
+			},
+			"immune": [
+				"lightning",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"trait": [
+				{
+					"name": "Empowered (Mythic Trait; Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the malzeno would be reduced to 0 hit points, its current hit point total instead resets to 216 (16d12 + 112) hit points, it recharges its Explosive Breath, it regains all expended legendary resistances and it enters a empowered state for 1 minute, or until it uses Crimson Ire. While in this state, the malzeno can use its Bloodmist Blink and many of its actions are enhanced (included in the actions)."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/day)",
+					"entries": [
+						"If the malzeno fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Turn Resistance",
+					"entries": [
+						"The malzeno has advantage on saving throws against any effect that turns undead."
+					]
+				}
+			],
+			"damageTags": [
+				"P",
+				"N",
+				"B"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The malzeno makes one Claws attack and one Bite attack. Or it makes three Qurio Swarm attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 5 ft., one target. {@h}20 ({@damage 3d8 + 7}) piercing damage plus 10 ({@damage 3d6}) necrotic damage. The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the malzeno regains hit points equal to that amount. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}21 ({@damage 4d6 + 7}) piercing damage."
+					]
+				},
+				{
+					"name": "Qurio Swarm",
+					"entries": [
+						"{@atk rw} {@hit 13} to hit, range 80/320 ft., one target. {@h}14 ({@damage 4d6}) necrotic damage and the target must succeed on a {@dc 21} Constitution saving throw or be afflicted with {@condition bloodblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 15 ft., one target. {@h}18 ({@damage 2d10 + 7}) bludgeoning damage and the target must succeed on a {@dc 21} Constitution saving throw or be afflicted with {@condition bloodblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+						"Once per turn while empowered, the malzeno can cause one of the following additional effects (choose one or roll a d4):",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Pierce",
+									"entries": [
+										"The malzeno makes tail attack against each creature in a 10-foot line that is 5 feet wide behind the target."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Sweep",
+									"entries": [
+										"Each creature in a 15-foot-square centered on a space adjacent to the target must succeed on a {@dc 21} Strength saving throw or be knocked prone."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Explosive Breath {@recharge 5}",
+					"entries": [
+						"The malzeno fires its draconic energy into the ground causing multiple explosions in a 60-foot line that is 15 feet wide. Each creature in that line must make a {@dc 21} Dexterity saving throw, taking 42 ({@damage 12d6}) necrotic damage and afflicted with {@condition dragonblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with {@condition dragonblight|MHMM} on a successful one."
+					]
+				},
+				{
+					"name": "Crimson Ire (Empowered Only)",
+					"entries": [
+						"While on the ground, the malzeno flies 30 feet straight into the air without provoking opportunity attacks before firing a huge crimson orb at a point below it. Each creature in a 30-foot-radius sphere centered on that point must make a {@dc 21} Dexterity saving throw, taking 49 ({@damage 9d10}) necrotic damage and be afflicted with {@condition bloodblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with {@condition bloodblight|MHMM}. A creature can make a {@dc 21} Constitution saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Bloodmist Blink (Empowered Only)",
+					"entries": [
+						"The malzeno magically teleports, along with any equipment it is wearing or carrying, up to 120 feet to an unoccupied space it can see."
+					]
+				}
+			],
+			"miscTags": [
+				"RCH",
+				"AOE"
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The malzeno makes one Tail attack. While empowered, it can use Bloodmist Blink before making the attack."
+					]
+				},
+				{
+					"name": "Wind Blast (Costs 2 Actions)",
+					"entries": [
+						"While on the ground, the malzeno swings its wing creating a burst of ground-shattering air pressure in a 60-foot line that is 5 feet wide, or a 60-foot cone while empowered. While flying no more than 30 feet above the ground, the burst hits a 15-foot cube originating from a space below it.",
+						"Each creature in that line or area must make a {@dc 21} Dexterity saving throw, taking 18 ({@damage 4d8}) thunder damage or 27 ({@damage 6d8}) thunder damage while empowered, be pushed up to 10 feet away, and knocked prone on a failed save, or half as much damage, isn't pushed away or knocked {@condition prone} on a successful one."
+					]
+				},
+				{
+					"name": "Corkscrew (Costs 2 Actions)",
+					"entries": [
+						"The malzeno moves up to half its fly speed in a straight line while spinning. During this move it can move through the spaces of other creatures without provoking opportunity attacks. While empowered, the malzeno can use its Bloodmist Blink before it moves.",
+						"Each creature the malzeno moves through must make a {@dc 21} Dexterity saving throw, taking 16 ({@damage 2d8 + 7}) bludgeoning damage and be knocked {@condition prone} on a failed save, or half as much damage and is pushed 5-feet into an unoccupied space out of the way of the malzeno's path (PC choice). If there are no unoccupied spaces available, the creature automatically fails its saving throw."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					"Malzeno has a body shape reminiscent of a European dragon, similar to {@creature Velkhana|MHMM}, with dark scales covering its body along with swarms of small, flying leech-like creatures called {@creature Qurio|MHMM} on its neck, chest, and front legs. Its wings, while being dull grey when looked at from above, have a red underside. The wing membrane connects \"separately\" to the wing fingers, and each wing possesses a single, giant talon. There is also a pair of smaller fins, similar in coloration to the wings at the base of its tail. Three of the fingers on its front legs end in a curved, giant claw. It has two large, golden horns, as well as frills extending from both sides of its neck that resemble a cowl. Its tail ends in three large, movable prongs that can be used to grab small prey. It can cover its body with its wings like a cape.",
+					"It can command the Qurio that constantly follow it to syphon life force from enemies and prey, which it uses to strengthen itself further. Like the malzeno, these creatures can inflict bloodblight. The malzeno is bitter enemies with the elder dragon gaismagorm. Malzeno ensures there is not enough life force around the Yawning Abyss for it to absorb and by seizing control of the qurio and forcing them to provide it with stolen life force meant for gaismagorm.",
+					"Despite their lithe appearances, they are incredibly physically adept. In a base state, they rely primarily on fast and powerful physical blows with their limbs, especially their dexterous, claw-like tail and wings. Furthermore, their brute force is very easy to underestimate. Their physical attacks, while resemble those of other elder dragons (such as {@creature kushala daora|MHMM} and {@creature teostra|MHMM}), seem to have incredible force, as they commonly shatter the ground and send shockwaves, especially ones with the wings. They can also breath dragon energy into the ground, causing explosions, which also inflicts {@condition Dragonblight|MHMM}, while its tail stab attacks inflict {@condition Bloodblight|MHMM} on their targets. This energy also seems to transfer the targets' life-force to Malzeno, as landing enough of these allows it to change form.",
+					{
+						"type": "inset",
+						"name": "Malzeno",
+						"entries": [
+							{
+								"type": "table",
+								"colStyles": [
+									"col-1 bold",
+									"col-1",
+									"col-2 bold text-right",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"Challenge Rating",
+										"20",
+										"Carves",
+										"4 (or 8 as a mythic encounter)"
+									]
+								]
+							},
+							{
+								"type": "table",
+								"colLabels": [
+									"Carve Chance",
+									"Material",
+									"Slots"
+								],
+								"colStyles": [
+									"col-1 text-center",
+									"col-2 text-center",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"1-2",
+										"Elder Dragon Bone",
+										"(O)"
+									],
+									[
+										"3-4",
+										"Elder Dragon Blood",
+										"(O)"
+									],
+									[
+										"5-8",
+										"Malzeno Cortex",
+										"(A,W)"
+									],
+									[
+										"9-11",
+										"Malzeno Shard",
+										"(A,W)"
+									],
+									[
+										"12-13",
+										"Bloody Parasite",
+										"(A,W)"
+									],
+									[
+										"14",
+										"Malzeno Hardfang",
+										"(A,W)"
+									],
+									[
+										"15-16",
+										"Malzeno Fellwing",
+										"(A,W)"
+									],
+									[
+										"17-19",
+										"Malzeno Tail",
+										"(A,W)"
+									],
+									[
+										"20",
+										"Malzeno Bloodstone",
+										"(A,W)"
+									]
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "ARMOR MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Malzeno Cortex",
+										"entries": [
+											"While wearing this armor you have no reflection and your armor or clothing takes on a gothic appearance."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Shard",
+										"entries": [
+											"{@i Blightproof.} While wearing this armor you are immune to blight spells, spell like abilities, and conditions."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Bloody Parasite",
+										"entries": [
+											"You are immune to the {@condition bloodblight|MHMM} condition while you wear this armor."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Hardfang",
+										"entries": [
+											"{@i Recovery Up.} Whenever you regain hit points from any potion or plant, the first die is maximized."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Fellwing",
+										"entries": [
+											"While attuned to this weapon, you can use a bonus action to cast the {@spell misty step} spell from it. You can use this property three time, regaining all expended uses when you finish a long rest."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Tail",
+										"entries": [
+											"This armor has three runes. As a bonus action you can expend 1 or more runes to lose 1d8 hit points for each rune expended and heal another creature you can see within 30 feet of you for double the amount of hit points you lost. If this damage reduces you to 0 hit points, you're stable but unconscious. This armor regains 1 expended rune when you reduce a Medium or larger creature to 0 hit points."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Bloodstone",
+										"entries": [
+											"You are immune to necrotic damage while you wear this armor and your hit point maximum can't be reduced by the effects from a hostile creature."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "WEAPON MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Malzeno Cortex",
+										"entries": [
+											"Your weapon deals an extra {@damage 1d8} necrotic damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Shard",
+										"entries": [
+											"{@i Partbreaker+2.} You deal an extra {@damage 1d8} damage when you critically hit with this weapon."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Bloody Parasite",
+										"entries": [
+											"{@i Critical Status (Bloodblight).} Whenever you critically hit with this weapon, the target creature must make a {@dc 17} Constitution saving throw. On a failed save the target is afflicted with {@condition bloodblight|MHMM} for 1 minute."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Hardfang",
+										"entries": [
+											"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Fellwing",
+										"entries": [
+											"You gain a + 2 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +4 when the spell you are casting deals necrotic damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Tail",
+										"entries": [
+											"{@i Bloodrite.} When you attack a creature with this weapon and roll a 20 on the attack roll, that target takes an extra 10 necrotic damage if it isn't a construct or an undead. You also gain 10 temporary hit points."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Malzeno Bloodstone",
+										"entries": [
+											"This weapon has 4 runes. While holding it, you can use an action to expend 1 or more of its runes to cast the {@spell vampiric touch} spell (+11 to hit) from it. For 1 rune, you cast the 3rd-level version of the spell. You can increase the spell slot level by one for each additional rune you expend."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "OTHER MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Elder Dragon Blood",
+										"entries": [
+											"Any rarity weapon upgrade material."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Elder Dragon Bone",
+										"entries": [
+											"Any rarity armor upgrade material."
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"conditionInflict": [
+				"prone"
 			]
 		},
 		{
@@ -46692,13 +51865,13 @@
 												"8-11",
 												"5-11",
 												"Nargacuga Pelt",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"12-13",
 												"12-15",
 												"Nargacuga Fang",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"14-15",
@@ -46743,6 +51916,13 @@
 												"name": "Nargacuga Pelt",
 												"entries": [
 													"While you wear this armor, your eye's glow red at night, much like the nargacuga's. You gain {@sense darkvision} out to 60 feet. if you already have darkvision, it is increased by an additional 60 feet."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Lagombi Kit Claw",
+												"entries": [
+													"{@i Forager+.} When you harvest mushrooms, you instead gather 1d4."
 												]
 											},
 											{
@@ -46792,6 +51972,13 @@
 												"name": "Nargacuga Fang",
 												"entries": [
 													"While you are attuned to this weapon, your ammo pouch can hold double the amount of {@item pierce ammo (20)|AGMH|pierce ammo} and {@item cluster ammo (1)|AGMH|cluster ammo} it can normally hold."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Nargacuga Pelt",
+												"entries": [
+													"{@i (Bow Only) Bow Charge Plus+.} While attuned to this weapon, you can use your dragonpiercer two additional times between rests and it recharges after a Short or Long rest."
 												]
 											},
 											{
@@ -50326,7 +55513,7 @@
 											[
 												"9-11",
 												"Pumpkin.U Scale",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"12-14",
@@ -50372,6 +55559,13 @@
 												"name": "P.Firecell Stone",
 												"entries": [
 													"When you must succeed on a saving throw or be knocked {@condition prone}, you do so with advantage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Pumpkin.U Scute",
+												"entries": [
+													"{@i Entomologist+.} When you capture an insect with a bug net, you instead catch 1d4."
 												]
 											},
 											{
@@ -50510,6 +55704,674 @@
 			],
 			"conditionInflict": [
 				"prone"
+			]
+		},
+		{
+			"name": "Pyre Rakna-Kadaki",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"temnoceran"
+				]
+			},
+			"group": [
+				"Temnocerans"
+			],
+			"environment": [
+				"desert",
+				"mountain"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 20,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 162,
+				"formula": "13d12 + 78"
+			},
+			"speed": {
+				"walk": 30,
+				"climb": 30
+			},
+			"str": 15,
+			"dex": 22,
+			"con": 22,
+			"int": 8,
+			"wis": 15,
+			"cha": 10,
+			"save": {
+				"con": "+10",
+				"wis": "+8"
+			},
+			"skill": {
+				"perception": "+8"
+			},
+			"immune": [
+				"fire",
+				"lightning",
+				"necrotic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"passive": 18,
+			"cr": "19",
+			"trait": [
+				{
+					"name": "Damage Transfer (Requires Silk Gown)",
+					"entries": [
+						"While the rakna's body is covered by its silk gown, it takes only half the damage dealt to it, and the silk gown takes the other half."
+					]
+				},
+				{
+					"name": "Pyrantulas. (Requires Silk Gown)",
+					"entries": [
+						"While its body is covered by its silk gown, the rakna always has ten fiery {@creature rachnoid|MHMM}s on its abdomen. These rachnoids deal an extra 7 ({@damage 2d6}) fire damage with its Fire Breath, and gain a +3 bonus to hit with its Web attack. When the silk gown is destroyed, the rachnoids fall off the rakna and use their reactions to flee by burrowing underground."
+					]
+				},
+				{
+					"name": "Spider Climb",
+					"entries": [
+						"The rakna can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check."
+					]
+				},
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The rakna's long jump is up to 30 feet and its high jump is up to 15 feet, with or without a running start."
+					]
+				},
+				{
+					"name": "Web Sense",
+					"entries": [
+						"While in contact with a web, the rakna knows the exact location of any other creature in contact with the same web."
+					]
+				},
+				{
+					"name": "Web Walker",
+					"entries": [
+						"The rakna ignores movement restrictions caused by webbing."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The rakna uses its command rachnoid (if able). It then makes three attacks; two with its claws, and one with its abdomen."
+					]
+				},
+				{
+					"name": "Abdomen",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}33 ({@damage 6d8 + 6}) bludgeoning damage plus 14 ({@damage 4d6}) fire damage or 19 ({@damage 3d8 + 6}) bludgeoning damage when covered by its silk gown."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}16 ({@damage 3d6 + 6}) slashing damage."
+					]
+				},
+				{
+					"name": "Command Rachnoids (Requires Silk Gown)",
+					"entries": [
+						"The rakna uses one of the following actions:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Move",
+									"entries": [
+										"The rakna launches three rachnoids up to 30 feet away and pulls itself to that location. Two of the the rachnoids use its Fire Breath in the direction the rakna is moving."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Defend",
+									"entries": [
+										"The rachnoids on the rakna's body attempt to shove a creature off the rakna. Roll a contested Strength ({@skill Athletics}) check using the rachnoids strength modifier. The rachnoid gains a +4 bonus to its check."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Spread Rachnoids",
+									"entries": [
+										"The rakna launches all ten rachnoids off its abdomen, each landing at least 5 feet apart from each other and in a space within 20 feet of the rakna. Five of the rachnoid use its Fire Breath and the five other rachnoid use its Web, before being pulled back onto the rakna's abdomen."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"name": "Recharge Attack {@recharge 5}",
+					"entries": [
+						"The rakna uses one of the following actions.",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Fire Breath.",
+									"entry": "The rakna exhales fire in a 60-foot cone or spins in a circle and releases a gout of flame in a 30-foot radius around it. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 72 ({@damage 16d8}) fire damage on a failed save, or half as much damage on a successful one. If the rakna is on the ceiling of the area, the gout of flames is released in a 30-foot-radius, 40-foot-high cylinder centered on a point up to 30 feet directly below the rakna."
+								},
+								{
+									"type": "item",
+									"name": "Web Spray.",
+									"entry": "The rakna exhales webbing in a 60-foot cone in front of it. Each creature in that area must succeed on a {@dc 20} Dexterity saving throw or be {@condition restrained} by the webbing. As an action, the restrained target can make a {@dc 20} Strength check, bursting the webbing on a success. The webbing can be attacked and destroyed (AC 10; hp 30; vulnerability to slashing damage; immunity to bludgeoning, fire, poison, and psychic damage)."
+								}
+							]
+						}
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Blackened Silk Gown ({@recharge 6}, After the Gown is Destroyed)",
+					"entries": [
+						"The rakna covers its body in a silk webbing. The webbing can be attacked and destroyed (AC 19; hp 80; immunity to bludgeoning, fire, poison, and psychic damage). When a creature makes a melee weapon attack that fails to hit the rakna or silk gown by 5 or less its weapon becomes stuck to it, requiring an action and a successful {@dc 18} Strength check to pull free. If the attack is with a natural weapon, the creature is also {@condition grappled}. Until this grapple ends, the creature is {@condition restrained}."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Command",
+					"entries": [
+						"The rakna uses its command rachnoids action."
+					]
+				},
+				{
+					"name": "Flamethrower",
+					"entries": [
+						"The rakna moves up to half its speed in a straight line while releasing a gout of flame in a 15-foot line that is 10 feet wide in front of it. During this movement it can pass through a Medium or smaller creature's space. Each creature in fire's path must succeed on a {@dc 18} Dexterity saving throw, taking 14 ({@damage 4d6}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Explosive Slam (Costs 2 Actions)",
+					"entries": [
+						"The rakna slams its claws down creating a fiery explosion in a 15-foot-square area originating from it. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 28 ({@damage 8d6}) fire damage, be pushed 10 feet away and knocked {@condition prone} on a failed save, or half as much damage, isn't pushed away or knocked prone on a successful one."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					"{@creature Rakna-Kadaki|MHMM} are Temnocerans bristling with sharp curving spikes. Their body is covered in a purple carapace with several large spikes on the legs and the abdomen, which are used to hang their web. Unlike {@creature Nerscylla|MHMM}, Rakna-Kadaki have six legs, the first two pairs are walking legs and the last pair is held above the ground carrying the abdomen, and a pair of purplish-red, blunt pedipalps that can extend to over three times their length. The most peculiar trait of Rakna-Kadaki however is its \"neck\". Similar to pelican spiders, it has a long, extendable neck that can be \"retracted\" back on top of the thorax. Its head sports eight yellow eyes, as well as two pairs of chelicerae on its jaw.",
+					"Unlike most spiders, as well as Nerscylla, Rakna-Kadaki are capable of spitting silk from their mouth, and can spit several strands at the same time. They use this silk to bind their prey in web before finishing them off. They also capable spewing a stream of burning gas from its mouth, as well as expelling the same gas from the body.",
+					"Rakna-Kadaki are normally seen wearing their silk on the body, creating the appearance of a white gown. They also carry their {@creature rachnoid|MHMM|babies} around at all times, and can send them out to for coordinated attacks, such as spitting out globs of silk or pulling in their mother using their own silk.",
+					{
+						"type": "inset",
+						"name": "Pyre Rakna-Kadaki",
+						"entries": [
+							{
+								"type": "table",
+								"colStyles": [
+									"col-1 bold",
+									"col-1",
+									"col-2 bold text-right",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"Challenge Rating",
+										"19",
+										"Carves/Capture",
+										"3"
+									]
+								]
+							},
+							{
+								"type": "table",
+								"colLabels": [
+									"Carve Chance",
+									"Capture Chance",
+									"Material",
+									"Slots"
+								],
+								"colStyles": [
+									"col-1 text-center",
+									"col-1 text-center",
+									"col-2 text-center",
+									"col-1 text-center"
+								],
+								"rows": [
+									[
+										"1",
+										"1",
+										"Drone Substance",
+										"(W,O)"
+									],
+									[
+										"2-6",
+										"2-5",
+										"Pyre-Kadaki Carapace",
+										"(A,W)"
+									],
+									[
+										"7-8",
+										"6-8",
+										"Pyre-Kadaki Silk",
+										"(A,W,O)"
+									],
+									[
+										"9-11",
+										"9-11",
+										"Kadaki Queen Substance",
+										"(A,O)"
+									],
+									[
+										"12-13",
+										"-",
+										"Pyre-Kadaki Dull Glowgut",
+										"(A,W)"
+									],
+									[
+										"14-16",
+										"12-16",
+										"Pyre-Kadaki Hardclaw",
+										"(A,W)"
+									],
+									[
+										"17-18",
+										"17-19",
+										"Pyre-Kadaki Spike",
+										"(A,W)"
+									],
+									[
+										"19-20",
+										"20",
+										"Monster Broth",
+										"(O)"
+									]
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "ARMOR MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Carapace",
+										"entries": [
+											"{@i Constitution.} The duration from slowing effects, such as the {@spell slow} spell or a copper dragon's breath attack, are reduced by half while you wear this armor."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Silk",
+										"entries": [
+											"{@i Spider Climb.} While you wear this armor, you can move up, down, and across vertical surfaces and upside down along ceilings, while leaving your hands free. You have a climbing speed equal to your walking speed. However, the armor doesn't allow you to move this way on a slippery surface, such as one covered by ice or oil."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Kadaki Queen Substance",
+										"entries": [
+											"While you wear this armor small spiders emerge from it, like hatching from an egg sac. The spiders are friendly to you and crawl around your armor, but provide no other noticeable benefit."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Dull Glowgut",
+										"entries": [
+											"This armor has 4 runes. It regains 1d3+1 runes daily at dawn. As an action you can expend one or more runes to cast the {@spell web} spell (spell save {@dc 16}). For 1 rune, you cast the spell as normal. You can increase the size of the cubed area by 5 feet for each additional rune you expend."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Hardclaw",
+										"entries": [
+											"{@i Entomologist+.} When you capture an insect with a bug net, you instead gather 1d4."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Spike",
+										"entries": [
+											"You have resistance to fire and lightning damage while you wear this armor."
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "WEAPON MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Drone Substance",
+										"entries": [
+											"{@i Capture Novice.} While attuned to this weapon {@item tranq bomb|AGMH}s and {@item tranq ammo (1)|AGMH|tranq ammo} roll an extra 2d8 when they hit a creature."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Carapace",
+										"entries": [
+											"{@i Peak Performance.} When your hit points are full and you roll a 1 or 2 on a damage die for an attack you make with a melee weapon, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Silk",
+										"entries": [
+											"While attuned to this weapon you can use a bonus action to fire a strand of webbing at a creature, object, or terrain within 30 feet of you and pull yourself to the closest adjacent space to the target. If the target is a creature, they can make a {@dc 16} Dexterity saving throw. On a successful save, the creature avoids the webbing and you are unable to pull yourself to it. You can use this property a number of times equal to your proficiency modifier, regaining all expended uses when you finish a long rest."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Dull Glowgut",
+										"entries": [
+											"{@i Maximum Might.} While your hit points are full and you are not suffering from any levels of {@condition exhaustion}, you deal maximum weapon damage with your attacks."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Hardclaw",
+										"entries": [
+											"You gain a +2 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +3 when the spell you are casting is a fire spell."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Pyre-Kadaki Spike",
+										"entries": [
+											"{@i (Ranged Weapon Only) Tune-Up.} When this material is placed into a weapon choose one of the following effects to gain:",
+											{
+												"type": "list",
+												"items": [
+													"(Light Bowgun Only). If you miss an attack while hidden, your location is not revealed.",
+													"(Heavy Bowgun Only). You gain a +1 bonus to your AC while wielding this weapon. You gain a +2 bonus to your attack rolls with this weapon if the target is outside of your normal attack range."
+												]
+											}
+										]
+									}
+								]
+							},
+							{
+								"type": "list",
+								"style": "list-hang",
+								"name": "OTHER MATERIAL EFFECTS",
+								"items": [
+									{
+										"type": "entries",
+										"name": "Drone Substance",
+										"entries": [
+											"This oily like substance can be applied to the skin of a medium or smaller creature. Applying the substance takes 1 minute. The affected creature then has advantage on Charisma ({@skill Persuasion}) checks for 1 hour. During this time if they attempt to charm a creature with spells or spell-like abilities, the targeted creature has disadvantage on its saving throw.",
+											"{@i Cursed.} When applied to a creature, there is a 10% chance to attract nearby {@creature seltas|MHMM} while in urban areas. While in the wilds, there is a 50% chance to attract nearby seltas."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Rakna-Kadaki Silk",
+										"entries": [
+											"Can be used to craft {@item pitfall trap+|AGMH} (AGtMH p.63) by combining it with a {@item trap tool|AGMH} using {@item smith's tools|PHB} ({@dc 17}). (4 Uses)."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Kadaki Queen Substance",
+										"entries": [
+											"A potent pheromone sometimes released by the rakna-kadaki. It is highly valued by nobles (sell value 1,500 gp)."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Monster Broth",
+										"entries": [
+											"Material used to upgrade your Armor or Weapon to Legendary."
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"B",
+				"S",
+				"F"
+			],
+			"miscTags": [
+				"MW",
+				"RW",
+				"AOE"
+			],
+			"traitTags": [
+				"Spider Climb",
+				"Web Sense",
+				"Web Walker"
+			],
+			"conditionInflict": [
+				"restrained",
+				"grappled"
+			],
+			"actionTags": [
+				"Multiattack"
+			]
+		},
+		{
+			"name": "Qurio",
+			"size": [
+				"T"
+			],
+			"type": "monstrosity",
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 10,
+				"formula": "4d4"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": 60
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 10,
+			"int": 2,
+			"wis": 12,
+			"cha": 10,
+			"skill": {
+				"perception": "+3"
+			},
+			"passive": 13,
+			"cr": "1/8",
+			"page": 0,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"trait": [
+				{
+					"name": "Blood Sac",
+					"entries": [
+						"The qurio can store up to a maximum of 10 hit points in its blood sac. This maximum is reduced by 1 for every 1 hit point the qurio loses. The reduction lasts until the qurio finishes a short or long rest."
+					]
+				},
+				{
+					"name": "Tiny Critter",
+					"entries": [
+						"The qurio can occupy another creature's space and vice versa, and the qurio can move through any opening large enough for a Small moth."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 4} to hit, reach 0 ft., one target. {@h}2 ({@damage 1d4}) necrotic damage, or 1 necrotic damage if the qurio has half of its hit points or fewer. If the target is a creature it must succeed on a {@dc 10} Constitution saving throw or be afflicted with {@condition bloodblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+						"The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the qurio stores hit points equal to that amount in its blood sac. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Attach",
+					"entries": [
+						"The qurio attaches itself to a willing creature or when it hits a creature with a bite attack (escape {@dc 10}). While attached, the qurio does one of the following at the start of each of its turns:",
+						{
+							"type": "list",
+							"items": [
+								"It deals 2 ({@damage 1d4}) necrotic damage to the creature it is attached to and stores an amount of hit points equal to the necrotic damage done in its blood sac.",
+								"It expends up to 5 hit points in its blood sac and restores the same number of hit points to the creature it is attached to."
+							]
+						}
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"fluff": {
+				"entries": [
+					"The qurio is a parasitic creature that appears about the size of a small bird. It has a short tubular red body, with wings and a tail similar to a ryukin goldfish's tail. It has a round, sucking, radial mouth filled with rows of teeth around the interior, similar to that of a lamprey. There appear to be no eyes."
+				]
+			},
+			"damageTags": [
+				"N"
+			],
+			"miscTags": [
+				"MW"
+			]
+		},
+		{
+			"name": "Qurio Swarm",
+			"size": [
+				"M"
+			],
+			"type": {
+				"type": "monstrosity",
+				"swarmSize": "T"
+			},
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				12
+			],
+			"hp": {
+				"average": 31,
+				"formula": "7d8"
+			},
+			"speed": {
+				"walk": 10,
+				"fly": 60
+			},
+			"str": 10,
+			"dex": 14,
+			"con": 10,
+			"int": 3,
+			"wis": 12,
+			"cha": 10,
+			"skill": {
+				"perception": "+5"
+			},
+			"resist": [
+				"bludgeoning",
+				"piercing",
+				"slashing"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"grappled",
+				"paralyzed",
+				"petrified",
+				"prone",
+				"restrained",
+				"stunned"
+			],
+			"passive": 15,
+			"cr": "2",
+			"page": 0,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"trait": [
+				{
+					"name": "Blood Sac",
+					"entries": [
+						"The swarm can store up to a maximum of 64 hit points in its blood sac. This maximum is reduced by 2 for every 1 hit point the swarm loses. The reduction lasts until the swarm finishes a short or long rest."
+					]
+				},
+				{
+					"name": "Swarm",
+					"entries": [
+						"The swarm can occupy another creature's space and vice versa, and the swarm can move through any opening large enough for a Small moth. The swarm can't regain hit points or gain temporary hit points."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The swarm makes two Bite attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 4} to hit, reach 0 ft., one target. {@h}10 ({@damage 4d4}) necrotic damage, or 5 ({@damage 2d4}) necrotic damage if the qurio has half of its hit points or fewer. If the target is a creature it must succeed on a {@dc 10} Constitution saving throw or be afflicted with {@condition bloodblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+						"The target's hit point maximum is reduced by an amount equal to the necrotic damage taken, and the qurio stores hit points equal to that amount in its blood sac. The reduction lasts until the target finishes a long rest. The target dies if this effect reduces its hit point maximum to 0."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Attach",
+					"entries": [
+						"The swarm attaches itself to a willing creature or when it hits a creature with a bite attack (escape {@dc 10}). While attached, the swarm does one of the following at the start of each of its turns:",
+						{
+							"type": "list",
+							"items": [
+								"It deals 5 ({@damage 2d4}) necrotic damage to the creature it is attached to and stores an amount of hit points equal to the necrotic damage done in its blood sac.",
+								"It expends up to 10 hit points in its blood sac and restores the same number of hit points to the creature it is attached to."
+							]
+						}
+					]
+				}
+			],
+			"senseTags": [
+				"D"
+			],
+			"fluff": {
+				"entries": [
+					"The {@creature qurio|MHMM} is a parasitic creature that appears about the size of a small bird. It has a short tubular red body, with wings and a tail similar to a ryukin goldfish's tail. It has a round, sucking, radial mouth filled with rows of teeth around the interior, similar to that of a lamprey. There appear to be no eyes."
+				]
+			},
+			"damageTags": [
+				"N"
+			],
+			"miscTags": [
+				"MW"
 			]
 		},
 		{
@@ -52704,7 +58566,7 @@
 												"12-16",
 												"16-17",
 												"Rathalos Tail",
-												"(W,O)"
+												"(A,W,O)"
 											],
 											[
 												"17-18",
@@ -52765,6 +58627,13 @@
 												"name": "Rathalos Marrow",
 												"entries": [
 													"You suffer no harm from temperatures as warm as 120 degrees Fahrenheit while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Rathalos Tail",
+												"entries": [
+													"{@i Archaeologist+.} When you successfully gather a bone resource, you gather an extra 1d4 more."
 												]
 											},
 											{
@@ -53037,13 +58906,13 @@
 												"6-8",
 												"8-13",
 												"Rathian Carapace",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"9",
 												"14-15",
 												"Rathian Webbing",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"10",
@@ -53165,6 +59034,20 @@
 												"name": "Flame Sac",
 												"entries": [
 													"When you cast a spell that deals fire damage, it deals an extra 1d4 fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Rathian Carapace",
+												"entries": [
+													"{@i Entomologist.} When you capture an insect with a bug net, you instead catch two."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Rathian Webbing",
+												"entries": [
+													"{@i (Bow Only) Bow Charge Plus.} While attuned to this weapon, you can use your dragonpiercer one additional time between rests and it recharges after a Short or Long rest."
 												]
 											},
 											{
@@ -53609,6 +59492,1394 @@
 			]
 		},
 		{
+			"name": "Risen Chameleos",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Elder Dragons"
+			],
+			"environment": [
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"swamp",
+				"underdark",
+				"urban"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 18,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 200,
+				"formula": "16d12 + 96"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 21,
+			"dex": 14,
+			"con": 22,
+			"int": 17,
+			"wis": 16,
+			"cha": 15,
+			"save": {
+				"dex": "+8",
+				"con": "+12",
+				"wis": "+9",
+				"cha": "+8"
+			},
+			"skill": {
+				"perception": "+9",
+				"stealth": "+8"
+			},
+			"immune": [
+				"cold",
+				"poison"
+			],
+			"conditionImmune": [
+				"poisoned"
+			],
+			"passive": 19,
+			"languages": [
+				"Draconic"
+			],
+			"cr": "21",
+			"page": 0,
+			"senses": [
+				"blindsight 120 ft.",
+				"darkvision 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Blinding Panic",
+					"entries": [
+						"When the chameloes is {@condition invisible} and is {@condition blinded} by a {@item flash bomb|AGMH} or other effect, it panics and loses concentration. While the chameloes is blinded, it is unable to use its Invisible Passage."
+					]
+				},
+				{
+					"name": "Chameleon Skin",
+					"entries": [
+						"The chameleos has advantage on Dexterity ({@skill Stealth}) checks made to {@action hide}."
+					]
+				},
+				{
+					"name": "Deadly Poison",
+					"entries": [
+						"Poison damage dealt by the chameleos, including poison damage a creature takes at the start of its turn from the {@condition poisoned} condition, bypasses a creature's resistance to poison damage and deals half damage to creatures that are immune to poison damage."
+					]
+				},
+				{
+					"name": "Elder Dragon Sight",
+					"entries": [
+						"Magical Darkness doesn't impede the chameleos's darkvision."
+					]
+				},
+				{
+					"name": "Innate Spellcasting",
+					"entries": [
+						"The chameleos can innately cast the {@spell fog cloud} spell at 3rd-level at will. It doesn't need to concentrate on the spell, but when recast, the previous fog cloud dissipates."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the chameleos fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Risen State {@recharge 4}",
+					"entries": [
+						"At the start of its turn the chameleos enters a Risen State until the start of its next turn, if it is available. While in the Risen State, some of the chameleos's actions are enhanced (as described below) and it can use its Risen actions as an action or legendary action.",
+						"This Recharge trait, is immune to the effects of the Elderseal material.",
+						{
+							"type": "inset",
+							"name": "Enhanced Actions",
+							"entries": [
+								"{@b Multiattack.} The chameleos makes two Tongue attacks.",
+								"{@b Poison Fountain.} The chameleos exhales two extra poison balls into the air.",
+								"{@b Tongue.} A creature hit by this attack is pulled into an unoccupied space within 5 feet of the chameleos."
+							]
+						},
+						{
+							"type": "inset",
+							"name": "Risen Actions",
+							"entries": [
+								"{@b Poisonous Retreat (Costs 1 Action if used as a Legendary Action).} The chameleos spits poison at a creature, it can see, within 15 feet of it. That creature must make a {@dc 20} Constitution saving throw, taking 14 ({@damage 4d6}) poison damage and be poisoned for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. While poisoned in this way, the creature takes 17 ({@damage 5d6}) poison damage at the start of each of its turns. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. The chameleos then flies 15 feet into the air without provoking opportunity attacks.",
+								"{@b Poison Breath (Costs 2 Actions if used as a Legendary Action).} The chameleos exhales poison gas in a 60-foot cone or two lines in different directions that are 60-feet long and 5 feet wide. Each creature in that area must make a {@dc 20} Constitution saving throw, taking 14 ({@damage 4d6}) poison damage and be poisoned for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. While poisoned in this way, the creature takes 17 ({@damage 5d6}) poison damage at the start of each of its turns. The creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success.",
+								"{@b Toxic Explosion (Costs 3 Actions if used as a Legendary Action).} The chameleos exhales poison around it, before slaming its tail on the ground creating a large explosion. Each creature within 15-feet of the chameleos must succeed on a {@dc 20} Constitution saving throw or take 45 ({@damage 13d6}) poison damage."
+							]
+						}
+					]
+				},
+				{
+					"name": "Silent Step",
+					"entries": [
+						"While {@condition invisible}, as a bonus action, the chameleos teleports up to 30 feet to an unoccupied space."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The chameleos makes two attacks with its horn or two attacks with its claws."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}15 ({@damage 3d6 + 5}) slashing damage."
+					]
+				},
+				{
+					"name": "Horn",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 10 ft., one target. {@h}21 ({@damage 3d10 + 5}) piercing damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 10 ft., one target. {@h}21 ({@damage 3d10 + 5}) bludgeoning damage and the target and each Medium or smaller creature adjacent to the target must succeed on a {@dc 19} Strength saving throw, or be pushed 10 feet away from the chameleos and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tongue",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 15 ft., one target. {@h}15 ({@damage 3d6 + 5}) bludgeoning damage. On hit, if the target has an object in at least one hand, they must make a {@dc 15} Strength saving throw or have the object swallowed by the Chameleos. If the chameleos takes 30 damage in one turn, it regurgitates all swallowed objects in an 5 foot area adjacent to it."
+					]
+				},
+				{
+					"name": "Poison Fountain (Must be in fog)",
+					"entries": [
+						"The chameleos looks up and exhales three poison balls into the air, each of which can strike a target within the fog cloud. A target must make a {@dc 20} Constitution saving throw, or be {@condition poisoned} for 1 minute on a failed save, or half as much damage on a successful one. While poisoned in this way, the creature takes 17 ({@damage 5d6}) poison damage at the start of each of its turns. A creature may repeat its saving throw at the end of its turn, ending the poison on a success."
+					]
+				},
+				{
+					"name": "Poison Ring {@recharge 5}",
+					"entries": [
+						"The chameleos flies 15 feet into the air without provoking opportunity attacks and exhales poisonous gas that spreads across the ground in a 30-foot radius centered directly below the chameleos. Each creature in that area must make a {@dc 20} Constitution saving throw, taking 28 ({@damage 8d6}) poison damage and be {@condition poisoned} for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. While poisoned in this way, the creature takes 17 ({@damage 5d6}) poison damage at the start of each of its turns. A creature may repeat its saving throw at the end of its turn, ending the poison on a success."
+					]
+				},
+				{
+					"name": "Invisible Passage",
+					"entries": [
+						"The chameleos magically turns {@condition invisible} until it attacks or casts a spell, or until its concentration ends (as if concentrating on a spell). While {@condition invisible}, the chameleos leaves no physical evidence of its passage, so it can be tracked only by magic."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack (2/round)",
+					"entries": [
+						"The chameleos attacks with its tongue or tail."
+					]
+				},
+				{
+					"name": "Transparent",
+					"entries": [
+						"The chameleos uses its invisible passage."
+					]
+				},
+				{
+					"name": "Mist (Costs 2 Actions)",
+					"entries": [
+						"The chameleos casts the {@spell fog cloud} spell at 3rd-level."
+					]
+				},
+				{
+					"name": "Poison Breath (Costs 3 Actions)",
+					"entries": [
+						"The chameleos exhales poisonous gas in a 90-foot line that is 5-feet wide. Each creature in that area must succeed on a {@dc 20} Constitution saving throw, taking 14 ({@damage 4d6}) poison damage and be {@condition poisoned} for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. While poisoned in this way, the creature takes 17 ({@damage 5d6}) poison damage at the start of each of its turns. A creature may repeat its saving throw at the end of its turn, ending the poison on a success."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack",
+				"Swallow"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"A risen chameleos is a {@creature chameleos|MHMM} has overcome being afflicted by the {@creature qurio|MHMM} and has become more powerful as a result.",
+							{
+								"type": "inset",
+								"name": "Risen Chameleos",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"21",
+												"Carves",
+												"4"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-2",
+												"Elder Dragon Bone",
+												"(O)"
+											],
+											[
+												"3-4",
+												"Elder Dragon Blood",
+												"(O)"
+											],
+											[
+												"5-8",
+												"T.Chameleos Speckled Hide",
+												"(A,W)"
+											],
+											[
+												"9-11",
+												"T.Chameleos Wing",
+												"(A,W)"
+											],
+											[
+												"12-13",
+												"T.Chameleos Claw",
+												"(A,W)"
+											],
+											[
+												"14",
+												"TC.Deadly Poison Sac",
+												"(A,W)"
+											],
+											[
+												"15-16",
+												"T.Chameleos Tail",
+												"(A,W)"
+											],
+											[
+												"17-19",
+												"T.Chameleos Spike",
+												"(A,W)"
+											],
+											[
+												"20",
+												"T.Chameleos Gem",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "T.Chameleos Speckled Hide",
+												"entries": [
+													"While wearing this armor all creatures have disadvantage on skills checks when trying to track you. Additionally you leave no footprints while you are {@condition invisible}."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Wing",
+												"entries": [
+													"You have advantage on Dexterity ({@skill Stealth}) checks while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Claw",
+												"entries": [
+													"{@i Evade Window.} This armor has 3 runes, and it regains 1d3 expended runes daily at dawn. When you fail a Dexterity saving throw while wearing it, you can use your reaction to expend 1 of its runes to succeed on that saving throw instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "TC.Deadly Poison Sac",
+												"entries": [
+													"{@i Rock Steady.} While wearing this armor, you can't be unwillingly knocked {@condition prone} and you ignore effects like the kushala daora and amatsu's wind barrier."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Tail",
+												"entries": [
+													"You have immunity to cold damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Spike",
+												"entries": [
+													"While you are wearing this armor and you take damage, you can use your reaction to magically turn {@condition invisible} until the start of your next turn or until you attack, make a damage roll, or force someone to make a saving throw. You can use this property twice, regaining all expended uses when you finish a short or long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Gem",
+												"entries": [
+													"You are resistant to poison damage and immune to the {@condition poisoned} condition while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "T.Chameleos Speckled Hide",
+												"entries": [
+													"This weapon is transparent while sheathed or stowed on your body. If a creature uses its action to examine you, the creature can see the slight shimmer of the weapon with a successful {@dc 20} Wisdom ({@skill Perception})."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Wing",
+												"entries": [
+													"{@i Peak Performance.} When your hit points are full and you roll a 1 or 2 on a damage die for an attack you make with a melee weapon, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Claw",
+												"entries": [
+													"{@i (Ranged weapon only) Deadeye+.} Your weapon's normal attack range is doubled."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "TC.Deadly Poison Sac",
+												"entries": [
+													"{@i (Druid, Sorcerer, Warlock & Wizard only)} This weapon has 10 runes While holding this weapon, you can use an action to expend 1 or more of its runes to cast one of the following Spells from it, using your spell save DC: {@spell dragon's breath|XGE} (poison) (1 rune), {@spell fog cloud} (1 rune), {@spell darkvision} (2 runes), {@spell invisibility} (2 runes) or, {@spell stinking cloud} (3 rune). The weapon regains 1d4 + 1 expended runes daily at dawn. If you expend the last rune it cannot regain any runes for one week."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Tail",
+												"entries": [
+													"You gain a + 2 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +4 when the spell you are casting deals poison damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Spike",
+												"entries": [
+													"{@i Status Crit (Poison).} Whenever you critically hit with this weapon, the target creature must make a {@dc 17} Constitution saving throw. On a failed save the target is {@condition poisoned} for 1 minute."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Chameleos Gem",
+												"entries": [
+													"{@i Mind's Eye.} Your attacks with this weapon bypass the damage resistances of any creature."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "TC.Deadly Poison Sac",
+												"entries": [
+													"You can make a {@dc 17} Wisdom ({@item Poisoner's Kit|PHB}) check using this material as its ingredient plus a {@item vial|PHB}. On a success you create a vial of {@item midnight tears|DMG} (DMG p. 258). On a fail, the material is destroyed."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Elder Dragon Blood",
+												"entries": [
+													"Any rarity weapon upgrade material."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Elder Dragon Bone",
+												"entries": [
+													"Any rarity armor upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"type": "entries",
+						"name": "A Chameleos's Lair",
+						"entries": [
+							"The Forest-Dwelling Chameleos very rarely share their territory with other dragons. With its ability to become invisible at will, it steals the treasures from anything that attempts to invade and take over. A chameleos lair is sometimes confused with a green dragon's lair due to both of them having a perpetual fog hanging in the air, the chameleos carrying a sweeter whiff of its poison mist. Tiny mushrooms, known has toadstool, litter the ground releasing poisonous spores at the slightest touch. Growing bigger as you deeper into the forest.",
+							"At the center of the forest, the chameleos chooses a grove typically covered in mushrooms. The tree lining the grove are sparse, allowing the chameleos to move freely in and out. A hole has been dug out in the middle and has been filled with the treasures the chameleos has gathered from lost folk, adventurers, and anything else it has stolen in its travels."
+						]
+					}
+				]
+			},
+			"legendaryGroup": {
+				"name": "Chameleos",
+				"source": "MHMM"
+			},
+			"tokenUrl": "https://i.imgur.com/ubtVXsh.png",
+			"damageTags": [
+				"S",
+				"P",
+				"B",
+				"I"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			],
+			"spellcastingTags": [
+				"I"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"prone"
+			]
+		},
+		{
+			"name": "Risen Kushala Daora",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Elder Dragons"
+			],
+			"environment": [
+				"arctic",
+				"coastal",
+				"desert",
+				"forest",
+				"grassland",
+				"mountain"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 19,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 189,
+				"formula": "18d12 + 72"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 23,
+			"dex": 18,
+			"con": 19,
+			"int": 18,
+			"wis": 15,
+			"cha": 12,
+			"save": {
+				"str": "+11",
+				"dex": "+9",
+				"wis": "+7",
+				"cha": "+6"
+			},
+			"skill": {
+				"perception": "+7",
+				"stealth": "+9"
+			},
+			"vulnerable": [
+				"poison"
+			],
+			"passive": 17,
+			"languages": [
+				"Draconic"
+			],
+			"cr": "17",
+			"page": 0,
+			"senses": [
+				"blindsight 60 ft.",
+				"darkvision 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Wind Barrier",
+					"entries": [
+						"A barrier of strong wind surrounds the kushala daora in a 5-foot radius around it. The strong wind keeps fog, smoke, and other gases at bay. Small or smaller flying creatures or Objects can't pass through the wall. Loose, lightweight materials brought into the wall fly upward. Arrows, bolts, and other ordinary projectiles launched at the kushala daora are deflected upward and automatically miss. (Boulders hurled by Giants or siege engines, and similar projectiles, are unaffected.) Creatures in {@spell Gaseous Form} can't pass through the barrier. When a Medium sized creature enters the Wind Barrier's area for the first time on a turn or starts its turn there, they must make a {@dc 19} Strength saving throw or be pushed back 10 feet. If a creature fails the saving throw by more than 5 they are also knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Poison Susceptibility",
+					"entries": [
+						"While {@condition poisoned}, the kushala daora's Wind Barrier is deactivated, it must land on its next turn, and is unable to fly until the {@condition poisoned} is removed. Once the {@condition poisoned} condition is removed, the kushala daora's Wind Barrier once again takes effect."
+					]
+				},
+				{
+					"name": "Risen State {@recharge 4}",
+					"entries": [
+						"At the start of its turn (winning all ties) the kushala enters a Risen State until the start of its next turn, if available. While in the Risen State, the kushala's can use its Risen actions as an action or legendary action.",
+						"This Recharge trait, is immune to the effects of the Elderseal material.",
+						{
+							"type": "inset",
+							"name": "Risen Actions",
+							"entries": [
+								"{@b Multiattack (Cannot be used as a Legendary Action).} The kushala makes two Claw attacks.",
+								"{@b Claw (Costs 1 Action if used as a Legendary Action).} {@atk mw} {@hit 11} to hit, reach 10 ft., one target. {@h}13 ({@damage 2d6 + 6}) piercing damage plus 14 ({@damage 4d6}) thunder damage and each creature in a 30-foot line that is 5 feet wide behind the target must succeed on a {@dc 19} Dexterity saving throw or be dealt the same damage as the target.",
+								"{@b Aerial Dragon Slam (Costs 2 Actions if used as a Legendary Action).} While flying, the kushala daora moves up to its fly speed into a space on the ground that contains one or more other creatures. Each of those creatures must succeed on a {@dc 19} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone}, afflicted with {@condition dragonblight|MHMM} for 1 minute, and take 24 ({@damage 4d8 + 6}) bludgeoning damage plus 7 ({@damage 2d6}) necrotic damage. On a successful save, the creature takes only half the damage, isn't knocked prone or afflicted with dragonblight, and is pushed 5 feet out of the kushala's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the kushala's space.",
+								"{@b Eye of the Storm (1/Round; Costs 3 Actions if used as a Legendary Action).} The kushala spins 20 feet into the air without provoking opportunity attacks and each creature within 60-feet of the kushala is pulled 30 feet towards it, as the kushala forms a massive vortex. Each creature in a 30-foot radius, 40-foot-high cylinder centered on the kushala's original location must make a {@dc 17} Dexterity saving throw, taking 63 ({@damage 14d8}) thunder damage, and be knocked {@condition prone} on a failed save, or half as much damage and isn't knocked prone on a successful one.",
+								"{@b Vortex Burst (Costs 2 Actions if used as a Legendary Action).} The kushala takes a deep breath before exhaling a giant swirling ball of wind at a point within 120-feet of it. Each creature in a 10-foot radius sphere centered on that point must make a {@dc 17} Dexterity saving throw, taking 45 ({@damage 13d6}) thunder damage on a failed save, or half as much damage on a successful one."
+							]
+						}
+					]
+				},
+				{
+					"name": "Flyby",
+					"entries": [
+						"The kushala daora doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The kushala daora makes two bite attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 10 ft., one target. {@h}22 ({@damage 3d10 + 6}) piercing damage."
+					]
+				},
+				{
+					"name": "Barrage",
+					"entries": [
+						"The kushala daora rains the debris down to the ground in a 10-foot-radius, 20-foot-high cylinder centered on a point within 150 feet. Each creature in the cylinder must make a {@dc 16} Dexteriy saving throw. A creature takes 16 ({@damage 3d10}) bludgeoning damage and 16 ({@damage 3d10}) slashing damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Tornado (Recharges after a short or long rest)",
+					"entries": [
+						"The kushala daora conjures a tornado that lasts for 1 minute. The tornado is a 20-foot-radius, 60-foot-high spiraling cylinder of wind centered on a location within 100 feet of the kushala daora. This cylinder becomes difficult terrain for the duration, even for flying creatures. Unattended objects in this cylinder that are Large or smaller are pulled towards the center. When a creature enters the tornado's area for the first time on a turn or starts its turn there, it is struck by debris the tornado has picked up, and it must make a {@dc 19} Strength saving throw or taking 14 ({@damage 4d6}) bludgeoning damage plus 14 ({@damage 4d6}) slashing damage, they are pulled to the center of the cylinder, and are {@condition restrained} on a failed save. On a successful save the creature takes half as much damage and they are not pulling into the center or restrained.",
+						"On each of the kushala daoras turns, it must use its bonus action to move the tornado 30 feet in any direction."
+					]
+				},
+				{
+					"name": "Wind Tunnel {@recharge 5}",
+					"entries": [
+						"The kushala daora blast of strong wind in a 90 foot line that is 10 feet wide. Each creature in the line must succeed on a {@dc 19} Strength saving throw, taking 49 ({@damage 11d8}) thunder damage and be pushed 15 feet away in a direction following the line on a failed save or half as much on a successful one and pushed away. Any creature in the line must spend 2 feet of movement for every 1 foot it moves when moving closer to the kushala daora. The wind tunnel disperses gas or vapor, and it extinguishes candles, torches, and similar unprotected flames in the area. It causes protected flames, such as those of lanterns, to dance wildly and has a 50 percent chance to extinguish them."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Move",
+					"entries": [
+						"The kushala daora can move all dust devils up to 30 feet in any direction."
+					]
+				},
+				{
+					"name": "Bite Attack",
+					"entries": [
+						"The kushala daora makes a bite attack."
+					]
+				},
+				{
+					"name": "Dust Devils (Costs 2 Actions)",
+					"entries": [
+						"The kushala daora chooses 3 unoccupied 5-foot cube within 60 feet of it. An elemental force that resembles a dust devil appears in the cube and lasts for 1 minute. Any creature that ends its turn within 5 feet of the dust devil must make a {@dc 19} Strength saving throw. On a failed save, the creature takes 9 ({@damage 2d8}) bludgeoning damage and is pushed 10 feet away. On a successful save, the creature takes half as much damage and isn't pushed.",
+						"If the dust devil moves over sand, dust, loose dirt, or small gravel, it sucks up the material and forms a 10-foot-radius cloud of debris around itself that lasts until the start of your next turn. The cloud heavily obscures its area."
+					]
+				}
+			],
+			"traitTags": [
+				"Flyby"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"A risen kushala daora is a {@creature kushala daora|MHMM} that has overcome being afflicted by the {@creature qurio|MHMM} and has become more powerful as a result.",
+							{
+								"type": "inset",
+								"name": "Risen Kushala Daora",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"17",
+												"Carves",
+												"4"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-2",
+												"Elder Dragon Bone",
+												"(O)"
+											],
+											[
+												"3-4",
+												"Elder Dragon Blood",
+												"(O)"
+											],
+											[
+												"5-8",
+												"Daora Dragon Scale",
+												"(A,W)"
+											],
+											[
+												"9-11",
+												"Daora Carapace",
+												"(A,W)"
+											],
+											[
+												"12-14",
+												"Daora Claw",
+												"(A,W)"
+											],
+											[
+												"15",
+												"Daora Tail",
+												"(W)"
+											],
+											[
+												"16-17",
+												"Daora Webbing",
+												"(A,W)"
+											],
+											[
+												"18-19",
+												"Daora Horn",
+												"(A,W)"
+											],
+											[
+												"20",
+												"Daora Gem",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Daora Dragon Scale",
+												"entries": [
+													"{@i Handicraft+2.} For 24 hours, you gain proficiency with two artisan tools of your choice each dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Carapace",
+												"entries": [
+													"{@i Heat Guard.} While wearing this armor you are immune to damage from lava and you are unaffected by extreme heat."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Claw",
+												"entries": [
+													"{@i Evade Extender (M).} You gain a +2 bonus to Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Webbing",
+												"entries": [
+													"{@i Evade Window.} This armor has 3 runes, and it regains 1d3 expended runes daily at dawn. When you fail a Dexterity saving throw while wearing it, you can use your reaction to expend 1 of its runes to succeed on that saving throw instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Horn",
+												"entries": [
+													"{@i Wind Barrier.} While you are attuned to this armor, you can use an action to summon a wind barrier around you for 1 minute. While the barrier is active, you have half cover against range attacks, resistance to nonmagical ammunition, and disperse any fog like effect in a 5-foot radius around you. Once used, you can't use this property again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Gem",
+												"entries": [
+													"You have immunity to cold damage while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Daora Dragon Scale",
+												"entries": [
+													"While attuned to this weapon, you know the {@spell gust|XGE} cantrip. If you already know the cantrip you can cast it as a bonus action instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Carapace",
+												"entries": [
+													"{@i FastCharge+.} When you roll for initiative, your greatsword, longsword, charge blade, or tonfas gains 2 charge, spirit, or phial charge."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Claw",
+												"entries": [
+													"Your weapon deals an extra 1d8 cold damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Tail ",
+												"entries": [
+													"{@i Critical Element (cold).} When you critically hit with a weapon or spell that deals cold damage, you deal an extra {@damage 1d6} cold damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Webbing",
+												"entries": [
+													"{@i Elderseal.} A creature hit by this weapon cannot use an action that has a recharge until the start of your next turn. The creature can still roll to recharge its ability at the end of its turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Horn",
+												"entries": [
+													"As an action you can release a blast of strong wind in a 45-foot line that is 5 feet wide. Each creature in the line must succeed on a {@dc 17} Strength saving throw, taking {@damage 5d6} thunder damage and is pushed 15-feet back on a failed save or half as much on a successful one and is not pushed back. Once used, you can't use this property again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Daora Gem",
+												"entries": [
+													"{@i (Druid, Sorcerer, & Wizard only)} This weapon has 6 runes. While holding it, you can use an action to expend 1 or more of its runes to cast the {@spell dust devil|XGE} spell from it. For 1 rune, you cast the 2nd-level version of the spell. You can increase the spell slot level by one for each additional rune you expend.",
+													"The weapon regains 1d6 + 1 expended runes daily at dawn. If you expend the weapon's last rune, roll a d20. On a 1, you can't regain any runes on this weapon for 1 week."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Elder Dragon Blood",
+												"entries": [
+													"Any rarity weapon upgrade material."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Elder Dragon Bone",
+												"entries": [
+													"Any rarity armor upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"B",
+				"S",
+				"O"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			]
+		},
+		{
+			"name": "Risen Teostra",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "dragon",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Elder Dragons"
+			],
+			"environment": [
+				"desert",
+				"mountain",
+				"swamp",
+				"underdark"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 19,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"formula": "18d12 + 126",
+				"average": 243
+			},
+			"speed": {
+				"walk": 50,
+				"fly": 60
+			},
+			"str": 25,
+			"dex": 17,
+			"con": 24,
+			"int": 16,
+			"wis": 15,
+			"cha": 10,
+			"passive": 18,
+			"cr": "22",
+			"page": 126,
+			"senses": [
+				"blindsight 60 ft.",
+				"darkvision 120 ft."
+			],
+			"senseTags": [
+				"B",
+				"SD"
+			],
+			"languages": [
+				"Draconic"
+			],
+			"languageTags": [
+				"DR"
+			],
+			"save": {
+				"str": "+13",
+				"wis": "+8",
+				"cha": "+6",
+				"con": "+13"
+			},
+			"skill": {
+				"perception": "+8"
+			},
+			"resist": [
+				{
+					"resist": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "damage from nonmagical attacks",
+					"cond": true
+				}
+			],
+			"immune": [
+				"fire"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"poisoned"
+			],
+			"trait": [
+				{
+					"name": "Fire Aura",
+					"entries": [
+						"At the start of each of the teostra's turns, each creature within 5 feet of it takes 7 ({@damage 2d6}) fire damage, and flammable objects in the aura that aren't being worn or carried ignite. A creature that touches the teostra or hits it with a melee attack while within 5 feet of it takes 7 ({@damage 2d6}) fire damage."
+					]
+				},
+				{
+					"name": "Explosive Cloud",
+					"entries": [
+						"At the start of the teostra's turn, it beats its wings and four clouds of explosive powder appear in unoccupied 5-foot cubes of air within 60 feet of the teostra. Additionally every 15 feet the teostra moves, it leaves a cloud of explosive powder in a 5-foot cube. The clouds remain until detonation, until a wind of moderate or greater speed (at least 10 miles per hour) disperses it, or when the teostra dies.",
+						"As a Bonus action, the teostra can move up to three of these clouds 20 feet in any direction."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the teostra fails a saving throw, it can choose to succeed instead."
+					]
+				},
+				{
+					"name": "Risen State {@recharge 4}",
+					"entries": [
+						"At the start of its turn (winning all ties) the teostra enters a Risen State until the start of its next turn, if available. While in the Risen State, some of the teostra's actions and traits are enhanced (as described below) and it can use its Risen actions as an action or legendary action.",
+						"This Recharge trait, is immune to the effects of the Elderseal material.",
+						{
+							"type": "inset",
+							"name": "Enhanced Traits",
+							"entries": [
+								"{@b Explosive Cloud.} All explosive clouds detonate (as if by the Detonate legendary action) when the teostra enters the Risen State and immediately after it appears while it remains in the Risen State.",
+								"{@b Fire Aura.} The teostra's fire aura damage is increased by {@damage 2d6}."
+							]
+						},
+						{
+							"type": "inset",
+							"name": "Enhanced Actions",
+							"entries": [
+								"{@b Supernova.} This action now is a Recharge 5-6 instead of a 1/day, but you can only roll the recharge while in the Risen State. Its save DC increases by 2 ({@dc 23}) while in the Risen State."
+							]
+						},
+						{
+							"type": "inset",
+							"name": "Risen Actions",
+							"entries": [
+								"{@b Flame Thrower (Costs 1 Action if used as a Legendary Action).} The teostra uses its Fire Breath.",
+								"{@b Ignition (Costs 2 Actions if used as a Legendary Action).} The teostra recharges its Fire Breath, if available.",
+								"{@b Ground Explosion (Costs 2 Actions if used as a Legendary Action).} The teostra releases a gout of flames in a 15-foot-squared area originating from it. Each creature in that area must make a {@dc 21} Dexterity saving throw, taking 38 ({@damage 11d6}) fire damage on a failed save, or half as much damage on a successful one."
+							]
+						}
+					]
+				},
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The teostra's long jump is up to 30 feet and its high jump is up to 15 feet, with or without a running start."
+					]
+				}
+			],
+			"damageTags": [
+				"P",
+				"S",
+				"B",
+				"F"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The teostra makes three attacks: two with its claw and one with its bite or tail."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d8 + 7}) piercing damage."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 5 ft., one target. {@h}17 ({@damage 3d6 + 7}) slashing damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 13} to hit, reach 10 ft., one target. {@h}20 ({@damage 3d8 + 7}) bludgeoning damage. On hit, the target must make a {@dc 21} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Deadly Leap",
+					"entries": [
+						"If the teostra jumps at least 15 feet as part of its movement, it can then use this action to land on its feet in a space that contains one or more other creatures. Each of those creatures must succeed on a {@dc 21} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 33 ({@damage 6d8 + 6}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked {@condition prone}, and is pushed 5 feet out of the teostra's space into an unoccupied space of the creature's choice. If no unoccupied space is with in range, the creature instead falls {@condition prone} in the teostra's space."
+					]
+				},
+				{
+					"name": "Fire Breath {@recharge 5}",
+					"entries": [
+						"The teostra exhales fire in a 90-foot cone. Each creature in that area must make a {@dc 21} Dexterity saving throw, taking 38 ({@damage 11d6}) fire damage on a failed save, or half as much on a successful one."
+					]
+				},
+				{
+					"name": "Supernova (1/day)",
+					"entries": [
+						"The teostra beats its wings rising 20 feet into the air and releases a large burst of fire all around it. Each creature within a 40-foot-radius sphere of the teostra must succeed on a {@dc 21} Dexterity saving throw, taking 63 ({@damage 14d8}) fire damage and are pushed back 10 feet on a failed save, or half as much on a successful one and not pushed back."
+					]
+				}
+			],
+			"actionTags": [
+				"Breath Weapon",
+				"Multiattack"
+			],
+			"legendaryActions": 2,
+			"legendary": [
+				{
+					"name": "Move",
+					"entries": [
+						"The teostra moves up to its speed without provoking opportunity attacks."
+					]
+				},
+				{
+					"name": "Attack",
+					"entries": [
+						"The teostra makes a bite attack."
+					]
+				},
+				{
+					"name": "Detonate (Costs 2 Actions)",
+					"entries": [
+						"All Explosive Clouds detonate and burst into flames. Each creature within 10-feet of a explosive cloud must make a {@dc 21} Dexterity saving throw, taking 22 ({@damage 4d10}) fire damage on a failed save or half as much on a successful one. If a creature is within range of more than one explosive cloud, they take an additional 22 ({@damage 4d10}) fire damage for each additional cloud."
+					]
+				}
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"A risen teostra is a {@creature teostra|MHMM} that has overcome being afflicted by the {@creature qurio|MHMM} and has become more powerful as a result.",
+							{
+								"type": "inset",
+								"name": "Risen Teostra",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"22",
+												"Carves",
+												"4"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-2",
+												"Elder Dragon Bone",
+												"(O)"
+											],
+											[
+												"3-4",
+												"Elder Dragon Blood",
+												"(O)"
+											],
+											[
+												"5-7",
+												"T.Fire Dragon Scale",
+												"(A,W)"
+											],
+											[
+												"8-10",
+												"T.Teostra Carapace",
+												"(A,W)"
+											],
+											[
+												"11-12",
+												"T.Teostra Claw",
+												"(A,W)"
+											],
+											[
+												"13-14",
+												"Teostra Webbing",
+												"(A,W)"
+											],
+											[
+												"15-16",
+												"T.Teostra Tail",
+												"(W)"
+											],
+											[
+												"17-19",
+												"T.Teostra Mane",
+												"(W)"
+											],
+											[
+												"19",
+												"T.Teostra Horn",
+												"(A,W)"
+											],
+											[
+												"20",
+												"T.Teostra Gem",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "T.Fire Dragon Scale",
+												"entries": [
+													"{@i Biology.} You become proficient with {@item dung bomb|AGMH}s while you are wearing this armor, and you are immune to blight effects such as {@condition waterblight|MHMM}, {@condition iceblight|MHMM}, or the {@spell blight} spell."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Carapace",
+												"entries": [
+													"While wearing this armor you can use an action to cast the {@spell protection from energy} (fire) spell from it. This property can be used three times, regaining all expended uses daily at dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Claw",
+												"entries": [
+													"{@i Archaeologist+.} When you successfully gather a bone resource, you gather an extra 1d4 more."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Webbing",
+												"entries": [
+													"While wearing this armor you have immunity to fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Horn",
+												"entries": [
+													"{@i Wide-Range+.} When you use {@table plants|AGMH|Herbs}, {@item Antidote|AGMH}s, {@item Cool Drink|AGMH}s, {@item Hot Drink|AGMH}s, {@table plants|AGMH|Adamant Seeds, or Might Seeds}; all other creatures within a 20-foot radius of you gain its effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Gem",
+												"entries": [
+													"{@i (Spellcaster only)} While wearing this armor you can use an action to cast the {@spell fire shield} (warm shield) spell from it. This property can be used twice, regaining all expended uses daily at dawn."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "T.Fire Dragon Scale",
+												"entries": [
+													"{@i Quick Load.} You can reload as a free action while you are attuned to this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Carapace",
+												"entries": [
+													"{@i (Bow only) Special Ammo Boost+2.} Your coating now coats up to 30 arrows and your dragonpiercer deals an extra 3d6 piercing damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Claw",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d10} fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Webbing",
+												"entries": [
+													"While attuned to this weapon, your fire spells bypass a creatures resistance and deal half damage to a creature that is immune to fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Tail",
+												"entries": [
+													"Once per turn, when you hit a creature with a melee weapon attack using this Weapon, you can engulf the target in flames. At the start of each of the engulfed creature's turns, it takes {@damage 1d6} fire damage and it can then make a {@dc 15} Dexterity saving throw, putting out the flames on a successful save. Alternatively, the engulfed creature, or a creature within 5 feet of it, can use an action to smother the flames ending the effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Mane",
+												"entries": [
+													"{@i Critical Eye+.} Your weapon attacks critical hit range is increased by 2."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Horn",
+												"entries": [
+													"{@i Reckless Abandon.} When you make your first attack on your turn with this weapon, you can choose to without care or regard for consequences. Doing so gives you advantage on melee weapon attack rolls using Strength during this turn, but disadvantage on all saving throws and all attack rolls against you have advantage until the start of your next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Teostra Gem",
+												"entries": [
+													"{@i Latent Power +2.} When you are reduced to half of your maximum hit points for the first time in combat or at the start of your turn on the 10th round of combat, whichever comes first, you gain the effects of the {@spell haste} spell for 1 minute. Once used, you must finish a short or long rest before you can use this property again."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Elder Dragon Blood",
+												"entries": [
+													"Any rarity weapon upgrade material."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Elder Dragon Bone",
+												"entries": [
+													"Any rarity armor upgrade material."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"type": "entries",
+						"name": "A Teostra's Lair",
+						"entries": [
+							"Teostra's lair in high mountains or volcanoes, dwelling in caverns underground in the desert, or within the deep halls of abandoned mines and dwarven strongholds. Caves with volcanic or geothermal activity are the most highly prized teostra's lair, creating hazards that hinder intruders and letting searing heat and volcanic gases wash over a teostra as it sleeps. On rare occasions they can be seen living in more temperate areas such as a swamp or ancient forest, changing the area around it to suit its needs.",
+							"A teostra's lair is sometimes confused with a red dragon's lair due to both of them mainly preferring areas with intense heat. On many occasions a teostra will attempt to take a red dragon's lair for its own, either by killing the red dragon or causing it to flee while gravely injured, leaving its horde of treasure behind. The teostra will guard this horde, mainly because it now belongs to him, but will typically not add to its treasure, being more concerned with intruders than riches.",
+							"A teostra encountered in its lair has a challenge rating of 14 (11,500 XP). A tempered teostra's challenge rating remains the same."
+						]
+					}
+				]
+			},
+			"legendaryGroup": {
+				"name": "Teostra",
+				"source": "MHMM"
+			},
+			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
 			"name": "Royal Ludroth",
 			"size": [
 				"L"
@@ -53744,7 +61015,7 @@
 												"10-12",
 												"5-7",
 												"R.Ludroth Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"13-14",
@@ -53789,6 +61060,13 @@
 												"name": "R.Ludroth Scale",
 												"entries": [
 													"While wearing this armor, you gain +2 AC while completely submerged in water."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "R.Ludroth Claw",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
 												]
 											},
 											{
@@ -55519,6 +62797,443 @@
 			]
 		},
 		{
+			"name": "Scorned Magnamalo",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"fanged"
+				]
+			},
+			"group": [
+				"Fanged Wyverns"
+			],
+			"environment": [
+				"arctic",
+				"coastal",
+				"forest",
+				"grassland",
+				"mountain"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				{
+					"ac": 21,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 264,
+				"formula": "23d12 + 115"
+			},
+			"speed": {
+				"walk": 60
+			},
+			"str": 21,
+			"dex": 14,
+			"con": 21,
+			"int": 8,
+			"wis": 18,
+			"cha": 16,
+			"save": {
+				"str": "+12",
+				"dex": "+8",
+				"con": "+12"
+			},
+			"resist": [
+				{
+					"resist": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical attacks",
+					"cond": true
+				}
+			],
+			"immune": [
+				"fire",
+				"necrotic"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"petrified"
+			],
+			"passive": 14,
+			"cr": "21",
+			"page": 0,
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Hellfire",
+					"entries": [
+						"Fire damage dealt by the magnamalo bypasses fire resistance and deals half damage to creatures that are immune to fire damage."
+					]
+				},
+				{
+					"name": "Hellfire Dust",
+					"entries": [
+						"At the start of each of the magnamalo's turns, each creature within 5 feet of it takes 13 ({@damage 3d8}) fire damage, and flammable objects in the aura that aren't being worn or carried ignite."
+					]
+				},
+				{
+					"name": "Magic Resistance",
+					"entries": [
+						"The magnamalo has advantage on saving throws against spells and other magical effects."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The magnamalo can use its Frightful Presence. It then makes two Claw attacks, three Tail attack, or four Hellfire Orb attacks. It can replace one Claw attack with a use of Hellfire Wave if available."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 5 ft., one target. {@h}14 ({@damage 2d6 + 5}) piercing damage plus 7 ({@damage 2d6}) fire damage."
+					]
+				},
+				{
+					"name": "Claw",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 10 ft., one target. {@h}12 ({@damage 2d6 + 5}) slashing damage and each creature within 5 feet of the target (including the target) must succeed on a {@dc 20} Dexterity saving throw or take 9 ({@damage 2d8}) fire damage."
+					]
+				},
+				{
+					"name": "Hellfire Orbs",
+					"entries": [
+						"{@atk rw} {@hit 12} to hit, range 30/120 ft., up to three targets. {@h}18 ({@damage 4d8}) fire damage."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 15 ft., one target. {@h}23 ({@damage 4d8 + 5}) piercing damage and chose three 5-foot cubed areas adjacent to the magnamalo or the target. Hellfire dust fills those spaces.",
+						"At the start of the magnamalo's next turn the hellfire dust explodes. Each creature within 5 feet of the dust must succeed on a {@dc 20} Dexterity saving throw or take 9 ({@damage 2d8}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Apex Predator",
+					"entries": [
+						"The magnamalo feeds on the corpse of a creature that has a challenge rating equal to 1/2 or less than the magnamalo's challenge rating. A Medium or smaller creature is consumed whole, while the magnamalo can feed on a Large or bigger creature for up to 30 seconds. For each round the magnamalo feeds on a creature, it heals for an amount equal to the creature's challenge rating."
+					]
+				},
+				{
+					"name": "Frightful Presence",
+					"entries": [
+						"Each creature of the magnamalo's choice that is within 120 feet of the magnamalo and aware of it must succeed on a {@dc 18} Wisdom saving throw or become {@condition frightened} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. If a creature's saving throw is successful or the effect ends for it, the creature is immune to the magnamalo's Frightful Presence for the next 24 hours."
+					]
+				},
+				{
+					"name": "Hellfire Wave {@recharge 5}",
+					"entries": [
+						"The magnamalo releases a swirling wave of purple hellfire in a 90-foot line that is 5 feet wide. Each creature in that line must make a {@dc 20} Dexterity saving throw, taking 66 ({@damage 12d10}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				},
+				{
+					"name": "Red Hellfire Explosion (Recharges after a Short or Long Rest)",
+					"entries": [
+						"While below half of its maximum hit points, the magnamalo roars as it covers itself in red hellfire before creating a massive explosion in a 15-foot-radius sphere centered on it. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 49 ({@damage 9d10}) fire damage on a failed save, or half as much on a successful one. A creature is vulnerable to this actions damage if it does not have resistance or immunity to fire damage."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Hellfire Jump",
+					"entries": [
+						"The magnamalo can jump up to 120 feet into the air by jumping in 40-foot high increments in a zigzag pattern, using its hellfire to temporarily hover between jumps. During this jump, the magnamalo's horizontal movement can't exceed its speed and it takes no fall damage when it lands."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Bite Attack",
+					"entries": [
+						"The magnamalo makes a bite attack."
+					]
+				},
+				{
+					"name": "Hellfire Drill (Costs 2 Actions)",
+					"entries": [
+						"The magnamalo launches itself forward in a drill-like motion, moving up to half its speed. During this move, it can move through other creatures without provoking opportunity attacks. Each creature the magnamalo moves through or within 5 feet of the magnamalo when it stops moving must succeed on a {@dc 20} Dexterity saving throw or take 32 ({@damage 3d10 + 5}) bludgeoning damage plus 9 ({@damage 2d8}) fire damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Hellfire Barrage (Costs 3 Actions)",
+					"entries": [
+						"The magnamalo makes a Hellfire Orb attack against each creature in a 120-foot cone."
+					]
+				},
+				{
+					"name": "Hellfire Divebomb (Costs 3 Actions)",
+					"entries": [
+						"The magnamalo leaps into the air, without provoking opportunity attacks, and uses its hellfire to propel it forward at highspeeds, until it comes crashing down at a point within 60 feet of it. Each creature in a 30-foot-radius sphere centered on that point must make a {@dc 20} Dexterity saving throw, taking 22 ({@damage 5d8}) bludgeoning damage plus 22 ({@damage 5d8}) fire damage on a failed save, or half as much damage on a successful one."
+					]
+				}
+			],
+			"actionTags": [
+				"Frightful Presence",
+				"Multiattack"
+			],
+			"traitTags": [
+				"Magic Resistance"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Scorned Magnamalo's main visual differences from a standard {@creature Magnamalo|MHMM} are its elongated, oddly jagged arm-blades and fangs. Its body is now a dark purple with red scars all over its body, similar to the appearance of the apex monsters found in Kamura. Its body is shrouded in hellfire at all times.",
+							"Scorned Magnamalo are much more aggressive than their standard counterpart, and have a greater mastery over hellfire: they have been seen focusing and swinging it like a blade. It can now also shoot condensed hellfire beams from its tail very rapidly that covers a large area. Its hellfire also reaches a even higher state, normal Hellfire is pink in color instead of purple, and can sometimes turn into red color and inflict dragonblight.",
+							{
+								"type": "inset",
+								"name": "Scorned Magnamalo",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"21",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-5",
+												"1-3",
+												"Begrudged Rancorscale",
+												"(A,W)"
+											],
+											[
+												"6-8",
+												"4-9",
+												"Magna Armored Cortex",
+												"(A,W)"
+											],
+											[
+												"9-11",
+												"--",
+												"Surging Armblade",
+												"(A,W)"
+											],
+											[
+												"--",
+												"10-12",
+												"Moaning Bladeshell",
+												"(A,W)"
+											],
+											[
+												"12-14",
+												"13-14",
+												"Magnamalo Tail+",
+												"(A,W)"
+											],
+											[
+												"15-18",
+												"-",
+												"Magna Barrierprism",
+												"(A,W)"
+											],
+											[
+												"19",
+												"15-18",
+												"Horn of Malice",
+												"(A,W)"
+											],
+											[
+												"20",
+												"19-20",
+												"Magna Glare Eye",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Begrudged Rancorscale",
+												"entries": [
+													"{@i Handicraft+3.} For 24 hours, you gain proficiency with three artisan tools of your choice each dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magna Armored Cortex",
+												"entries": [
+													"When you jump while wearing this armor, you can use your bonus action to hover in the air. On subsequent turns you can use an action to remain hovering or jump again and hover in the new location."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Surging Armblade",
+												"entries": [
+													"{@i Speed Eating.} While you are attuned to this armor, you can use any consumable, such as a potion or food, as a bonus action; so long as you are the one consuming it."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Moaning Bladeshell",
+												"entries": [
+													"{@i Wide-Range+.} When you use {@table plants|AGMH|Herbs}, {@item Antidote|AGMH}s, {@item Cool Drink|AGMH}s, {@item Hot Drink|AGMH}s, {@table plants|AGMH|Adamant Seeds, or Might Seeds}, each creature within a 20-foot radius of you also gain its effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magnamalo Tail+",
+												"entries": [
+													"When you are attuned to this armor, you can speak the armor's command word to conjure a samurai mask resembling the face of the magnamalo. While wearing the mask you have advantage on Charisma ({@skill Intimidation}) checks. Additionally, this mask has 3 runes. You can use an action to expend 1 rune to release an aura of misery. Each creature within 30 feet of you that can see the mask must succeed on a {@dc 18} Wisdom saving throw or be {@condition incapacitated} until the end of your next turn. A creature that succeeds on its saving throw or is no longer incapacitated due to this masks effect is immune to the effect of this mask for 24 hours. This mask regains 1d3 expended runes daily at dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magna Barrierprism",
+												"entries": [
+													"{@i Flinch Free+.} When a creature you can see attacks or casts a spell at a target other than you, you can use your reaction to redirect it to you, provided you are within the attack or spell's range. You can use this property a number of times equal to your proficiency bonus, regaining all expended uses when you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Horn of Malice",
+												"entries": [
+													"You are immune to fire damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magna Glare Eye",
+												"entries": [
+													"{@i (This material must also follow weapon rules) Hellfire Cloak.} You have resistance to fire damage while you are wearing this armor. Additionally your armor has 3 runes that recharge daily at dawn. When you hit a creature with an melee weapon attack you can expend a rune to generate an explosion on impact. You can only expend one rune per round. The target and all creatures other than yourself within 5 feet of the target must make a {@dc 17} Constitution saving throw, taking {@damage 5d6} fire damage on a failed save or half as much on a successful one."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Begrudged Rancorscale",
+												"entries": [
+													"While attuned to this weapon you can use an action to speak its command word, causing magenta flames to envelope it. The flames shed bright magenta-colored light in a 5- to 20-foot radius and dim light for an additional number of feet equal to the chosen radius. You can alter the radius as a bonus action. Speaking the command word again snuffs out the flames."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magna Armored Cortex",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d10} fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Surging Armblade",
+												"entries": [
+													"{@i Coalescence+.} Whenever you succeed on a saving throw to end a condition, you gain a +2 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra 1d6 cold, fire, or lightning damage (your choice) until the end of your next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Moaning Bladeshell",
+												"entries": [
+													"{@i Hellfire Orbs.} While attuned to this weapon, you can use an action to cast the {@spell chromatic orb} spell (+11 to hit) three times. Each chromatic orb must target a different creature, and deals fire damage. Once you use this property, you can't use it again until you finish a short or long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magnamalo Tail+",
+												"entries": [
+													"You gain a +2 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +4 when the spell you are casting deals fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magna Barrierprism",
+												"entries": [
+													"{@i Hellfire.} While you are attuned to this weapon, your fire damage bypasses a creature resistance and deals half damage to a creature that is immune to fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Horn of Malice",
+												"entries": [
+													"{@i Resentment+.} Until the end of your turn, you gain a +2 bonus to attack and damage rolls against any creature that has damaged you since the end of your last turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Magna Glare Eye",
+												"entries": [
+													"{@i Mail of Hellfire.} When you make your first attack on your turn, you can decide to attack recklessly. Doing so gives you advantage on attack rolls during this turn, but attack rolls against you have advantage until your next turn. You can use this property a number of times equal to your Constitution modifier, regaining expended uses when you finish a long rest."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"S",
+				"F"
+			],
+			"conditionInflict": [
+				"prone",
+				"frightened"
+			],
+			"miscTags": [
+				"MW",
+				"RW",
+				"AOE",
+				"RCH"
+			]
+		},
+		{
 			"name": "Seething Bazelgeuse",
 			"size": [
 				"H"
@@ -56037,7 +63752,7 @@
 												"19-20",
 												"18-20",
 												"Seltas Horn",
-												"(W)"
+												"(A,W)"
 											]
 										]
 									},
@@ -56065,6 +63780,13 @@
 												"name": "Seltas Wing",
 												"entries": [
 													"While wearing this armor you can use an action to cast the {@spell feather fall} spell from it. Once used, you can't use this property again until the next dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seltas Horn",
+												"entries": [
+													"{@i Archaeologist.} When you successfully gather a bone resource, you gather an extra 2 more."
 												]
 											}
 										]
@@ -58000,7 +65722,7 @@
 											[
 												"16-20",
 												"Shamos Hide",
-												"(W)"
+												"(A,W)"
 											]
 										]
 									},
@@ -59855,7 +67577,7 @@
 										"9-12",
 										"10-12",
 										"Obsidian Icetalon",
-										"(W)"
+										"(A,W)"
 									],
 									[
 										"13-15",
@@ -59900,6 +67622,13 @@
 										"name": "Legiana Shard",
 										"entries": [
 											"{@i Marathon Runner+.} While wearing this armor, your walking speed increases by 10 feet and you ignore difficult terrain if it was not created by a magical effect."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "Obsidian Icetalon",
+										"entries": [
+											"{@i Geologist+.} When you successfully gather a {@table minerals|AGMH|mining} resource, you instead gather 1d4."
 										]
 									},
 									{
@@ -60490,6 +68219,20 @@
 												"name": "Slagtoth Hide",
 												"entries": [
 													"You reduce cold damage you take by 2 while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Slagtoth Hide",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
 												]
 											}
 										]
@@ -61761,6 +69504,399 @@
 			]
 		},
 		{
+			"name": "Tempered Astalos",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"flying"
+				]
+			},
+			"group": [
+				"Flying Wyverns"
+			],
+			"environment": [
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"swamp"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 18,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 189,
+				"formula": "14d12 + 98"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 21,
+			"dex": 15,
+			"con": 24,
+			"int": 11,
+			"wis": 14,
+			"cha": 16,
+			"save": {
+				"dex": "+7",
+				"con": "+12",
+				"wis": "+7",
+				"cha": "+8"
+			},
+			"immune": [
+				"lightning"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"paralyzed"
+			],
+			"passive": 12,
+			"cr": "16",
+			"page": 0,
+			"senses": [
+				"darkvision 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Charged State (Mythic Trait; Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the astalos would be reduced to 0 hit points, its current hit point total instead resets to 135 (10d12 + 70) hit points, it recharges its Lightning Bolt, it regains one expended legendary resistance and it enters a charged state for 1 minute, or until it uses Lightning Pulse. While in this state, the astalos' movement speed increases by 10 feet, it has advantage on Dexterity saving throws, and many of its actions are enhanced (included in the actions)."
+					]
+				},
+				{
+					"name": "Legendary Resistance (2/Day)",
+					"entries": [
+						"If the astalos fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The astalos makes one Horn attack and one Tail attack. It can replace its Tail attack with a use of Lightning Bolt if available. When Charged State is active, it can make two Winged Arm attacks."
+					]
+				},
+				{
+					"name": "Horn",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}12 ({@damage 2d6 + 5}) slashing damage plus 5 ({@damage 1d10}) lightning damage."
+					]
+				},
+				{
+					"name": "Winged Arm",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}18 ({@damage 3d8 + 5}) bludgeoning damage plus 5 ({@damage 1d10}) lightning damage, or 18 ({@damage 3d8 + 5}) bludgeoning damage plus 11 ({@damage 2d10}) lightning damage if its Charged State has been activated in the last minute."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 10 ft., one target. {@h}15 ({@damage 3d6 + 5}) piercing damage plus 5 ({@damage 1d10}) lightning damage, or 15 ({@damage 3d6 + 5}) piercing damage plus 16 ({@damage 3d10}) lightning damage if its Charged State has been activated in the last minute. If the target is afflicted with {@condition thunderblight|MHMM}, it must make a {@dc 20} Constitution saving throw or become {@condition paralyzed} for 1 minute. The target can repeat the saving throw at the end of each of its turns, ending the paralysis on itself on a success."
+					]
+				},
+				{
+					"name": "Lightning Bolt ({@recharge 5} or {@recharge 4} while Charged State is Active)",
+					"entries": [
+						"The astalos releases a bolt of lightning from its tail in a 60-foot line that is 5 feet wide. Each creature in that line must make a {@dc 20} Dexterity saving throw, taking 21 ({@damage 6d6}) lightning damage or 28 ({@damage 8d6}) lightning damage if the astalos' Charged State has activated in the last minute, and be afflicted with {@condition thunderblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with {@condition thunderblight|MHMM} on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Lightning Pulse (Charged State Only; Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the astalos flies at least 20 feet as part of its movement before landing, it can then use this action to create a burst of lightning in a 30-foot-radius sphere around it and ending its Charged State. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 49 ({@damage 9d10}) lightning damage and be afflicted with {@condition thunderblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The astalos makes one Winged Arm attack."
+					]
+				},
+				{
+					"name": "Lightning Blade",
+					"entries": [
+						"A blade of electricity extends out from the astalos' horn before striking the ground in a 30-foot line that is 5 feet wide. Each creature in that line must make a DC 18 Dexterity saving throw, taking 16 ({@damage 3d10}) lightning damage or 22 ({@damage 4d10}) lightning damage if the astalos' Charged State has activated in the last minute, and be afflicted with {@condition thunderblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with {@condition thunderblight|MHMM} on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Dash (Costs 2 Actions)",
+					"entries": [
+						"The astalos moves up to its speed. During this move it can move through the spaces of other creatures without provoking opportunity attacks. Each creature the astalos moves through must succeed on a {@dc 18} Dexterity saving throw or take 16 ({@damage 3d6 + 5}) bludgeoning damage plus 11 ({@damage 2d10}) lightning damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Lightning Stake (Costs 2 Actions)",
+					"entries": [
+						"The astalos stabs its tail into the ground causing lightning to strike in a 5-foot radius around it. Each creature in that area must make a {@dc 20} Dexterity saving throw, taking 22 ({@damage 5d8}) lightning damage or 36 ({@damage 8d8}) if the astalos' Charged State has activated in the last minute, and be afflicted with {@condition thunderblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with {@condition thunderblight|MHMM} on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Lightning Storm (Costs 3 Actions)",
+					"entries": [
+						"The astalos summons 15-foot high pillars of lightning that zigzag across a 45-foot cone. Each creature in that area must succeed on a {@dc 20} Dexterity saving throw, taking 38 ({@damage 11d6}) lightning damage or 56 ({@damage 16d6}) lightning damage if the astalos' Charged State has activated in the last minute, and be afflicted with {@condition thunderblight|MHMM} for 1 minute. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"SD"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Known as the \"Thunder Wyvern.\" {@creature Astalos|MHMM} body is almost entirely covered in sharp, dark green plating, although it has a more bright colored underside. Unlike any other Flying Wyvern, Astalos' wings resemble those of an insect, most precisely a glasswing butterfly's wings. Its thin legs have three toes. Its tail is long, making up almost half of the monster's length, and it has two pair of earwig-like pincers at the tip. It has a relatively small head, with a big horn on top of it. Its eyes are red.",
+							"Astalos are high up in the food chain. They are known to be predators and have been found to feed on Herbivore like {@creature Mosswine|MHMM} and {@creature Aptonoth|MHMM}. Astalos have also been observed eating Neopteron like {@creature Vespoid|MHMM} and lesser predators like {@creature Velocidrome|MHMM}. Despite being top predators, Astalos have to compete with other large predatory monsters like {@creature Rathalos|MHMM}, {@creature Najarala|MHMM}, {@creature Seregios|MHMM}, and {@creature Seltas Queen|MHMM}.",
+							"Astalos's whole body is an electrical organ. Astalos uses Piezoelectricity - as an Astalos fights and becomes more active, Its tail, wings, and crest will begin to charge up with electricity. This can easily be seen by looking for green surges of electricity on those parts of its body. Astalos's flying abilities are comparable to a Rathalos with the help of its powerful wings. Its wings are tough, covered in spikes, and are even used as weapons on the ground. The wings can also produce a special electrical charge used for capturing prey. Its pincer-like tail is used for capturing and paralyzing prey.",
+							"They've been seen attacking large Flying Wyverns, like Rathalos, even if those monsters are not interested in the Astalos's presence. Even if the enemy is losing the fight, Astalos will fight them relentlessly, even if they are trying to escape. If the enemy is killed, the Astalos may feed on the enemy's corpse, as it is sometimes known to do. Astalos will even sometimes cannibalize their own young by accident. This is due to the adults mistaking the young for Neopteron like Vespoid occasionally. To prevent this, Astalos guard their nest up until the eggs are ready to hatch before leaving the young to fend for themselves. Even while young, Astalos don't hesitate about anything, including cannibalism, and can be quite violent. When a town gets reports of this monster, they are known to send adventurers immediately to hunt it down. This is due to Astalos actually disrupting the ecological balance in an area.",
+							{
+								"type": "inset",
+								"name": "Tempered Astalos",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"16",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-5",
+												"1-3",
+												"Astalos Shard",
+												"(A,W)"
+											],
+											[
+												"6-8",
+												"4-7",
+												"Heavy Astalos Shell",
+												"(A,W)"
+											],
+											[
+												"9-10",
+												"8-11",
+												"Astalos Wingmembrane",
+												"(A,W)"
+											],
+											[
+												"11-12",
+												"12-13",
+												"Astalos Scissortailblade",
+												"(A,W)"
+											],
+											[
+												"15-17",
+												"16-17",
+												"Heavy Astalos Crest+",
+												"(A,W)"
+											],
+											[
+												"15-17",
+												"16-17",
+												"Astalos Wingripper",
+												"(A,W)"
+											],
+											[
+												"18-19",
+												"18-19",
+												"Boltscale",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"Astalos Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Astalos Shard",
+												"entries": [
+													"While you are attuned to this armor, lightning arcs across it, creating bright light in a 10-foot radius and dim light for an additional 5 feet."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Heavy Astalos Shell",
+												"entries": [
+													"You have advantage on {@skill Acrobatics} checks while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Wingmembrane",
+												"entries": [
+													"{@i Marathon Runner+.} While wearing this armor, your walking speed increases by 10 feet and you ignore difficult terrain if it was not created by a magical effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Scissortailblade",
+												"entries": [
+													"{@i Stam Recov+.} When you take a long rest, you reduce your {@condition exhaustion} by 3 levels instead of 1."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Heavy Astalos Crest+",
+												"entries": [
+													"{@i Stamina Surge+2.} While wearing this armor, you can use an action to cast the {@spell haste} spell from it once per day, but can target only yourself when you do so and you gain 1 level of {@condition exhaustion} when the spell ends."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Wingripper",
+												"entries": [
+													"{@i Adrenaline.} The first time you drop below half of your hit point maximum in combat, you gain a rush of adrenaline. On your next turn your movement speed doubles and you can take one extra action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Boltscale",
+												"entries": [
+													"You cannot be {@condition stunned} while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Mantle",
+												"entries": [
+													"You are immune to lightning damage while you wear this armor."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Astalos Shard",
+												"entries": [
+													"Your weapon looks to be made of lightning and sheds dim light in a 5-foot radius around you. When placed in a sword, the blade has the appearance of lightning. For hammers and others, its the head."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Heavy Astalos Shell",
+												"entries": [
+													"{@i (Druids Only)} While attuned to this weapon, you can use an action to cast the {@spell Call Lightning} spell from it twice per long rest, without expending a spell slot."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Wingmembrane",
+												"entries": [
+													"You gain a +2 bonus to your spell attack rolls and spell save DC while attuned to this weapon. This bonus increases to +4 when the spell you are casting deals lightning or thunder damage, such as {@spell lightning bolt} or {@spell thunderwave} spells."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Scissortailblade",
+												"entries": [
+													"{@i Offensive Guard.} Whenever you use a reaction that increases your AC, the next attack you make deals extra damage equal to the bonus AC the reaction provided."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Heavy Astalos Crest+",
+												"entries": [
+													"{@i (Ranged Weapon Only) Bonus Shot.} When you take the {@action attack} action, you can make one additional attack with this weapon as a bonus action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Wingripper",
+												"entries": [
+													"{@i (Bladed Weapon Only) Razor Sharp.} Once per turn, when you hit a creature with this weapon, anytime it would regain hit points before the end of its next turn, it regains half as many. Additionally, if the creature is afflicted with a wound, such as the odogaron's bloody wound, it can only be closed by magical healing for 1 minute."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Boltscale",
+												"entries": [
+													"While you are attuned to this weapon, your lightning spells bypass a creature's resistance."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Astalos Mantle",
+												"entries": [
+													"{@i Chain Crit.} Every consecutive hit on a creature increases your crit range by 1 until you score a critical hit, miss an attack, or hit a different creature."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/kr3nem9.png",
+			"damageTags": [
+				"P",
+				"L"
+			],
+			"conditionInflict": [
+				"paralyzed"
+			]
+		},
+		{
 			"name": "Tempered Chameleos",
 			"size": [
 				"H"
@@ -62239,6 +70375,382 @@
 			]
 		},
 		{
+			"name": "Tempered Daimyo Hermitaur",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "beast",
+				"tags": [
+					"carapaceon"
+				]
+			},
+			"group": [
+				"Carapaceons"
+			],
+			"environment": [
+				"coastal",
+				"desert",
+				"forest",
+				"mountain",
+				"swamp",
+				"underdark"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 22,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 189,
+				"formula": "18d12 + 72"
+			},
+			"speed": {
+				"walk": 30,
+				"burrow": 60
+			},
+			"str": 18,
+			"dex": 16,
+			"con": 18,
+			"int": 13,
+			"wis": 14,
+			"cha": 16,
+			"save": {
+				"con": "+10"
+			},
+			"resist": [
+				"piercing",
+				"slashing"
+			],
+			"passive": 12,
+			"cr": "18",
+			"page": 0,
+			"senses": [
+				"darkvision 60 ft.",
+				"tremorsense 60 ft."
+			],
+			"trait": [
+				{
+					"name": "Amphibious",
+					"entries": [
+						"The hermitaur can breathe air and water."
+					]
+				},
+				{
+					"name": "Monoblos Skull",
+					"entries": [
+						"The hermitaur protects its vulnerable back with the skull of a {@creature monoblos|MHMM} (AC 19, 50 HP; immunity to poison and psychic damage, resistances to piercing, and slashing from nonmagical weapons, vulnerable to bludgeoning damage). Damaging the shell deals no damage to the hermitaur. Once destroyed, the hermitaur's AC is reduced by 2 and it is vulnerable to bludgeoning, piercing, and slashing damage if at least two hostile creatures are within 5 feet of it."
+					]
+				},
+				{
+					"name": "Standing Leap",
+					"entries": [
+						"The hermitaur's long jump is up to 30 feet and its high jump is up to 15 feet, without a running start."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The hermitaur makes two Claw attacks."
+					]
+				},
+				{
+					"name": "Claws",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}20 ({@damage 3d10 + 4}) slashing damage."
+					]
+				},
+				{
+					"name": "Shell",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}20 ({@damage 3d10 + 4}) bludgeoning damage plus 11 ({@damage 2d10}) piercing damage, or 9 ({@damage 1d10 + 4}) bludgeoning damage if the shell is destroyed. If the hermitaur moved at least 20 feet straight toward the target immediately before the hit, the target takes an extra 16 ({@damage 3d10}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 18} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Burrowed Shell Strikes {@recharge 5}",
+					"entries": [
+						"The hermitaur burrows underground and moves up to 60 feet before emerging in an unoccupied space. Once underground, it doesn't provoke opportunity attacks and it can make three shell attacks, each against a different target on the ground above it."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Scuttle",
+					"entries": [
+						"The hermitaur moves up to its speed in a straight line."
+					]
+				}
+			],
+			"reaction": [
+				{
+					"name": "Claw Guard",
+					"entries": [
+						"After being hit by an attack, the hermitaur can take the {@action dodge} action until the start of its next turn. If a creature throws a {@item sonic bomb|AGMH} at the hermitaur or it is subjected to thunder damage, its dodge ends. While dodging, if a creature attacks the hermitaur while within 5 feet of it and misses, the hermitaur can make one Claw attack against it and the dodge ends."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Claw Flick",
+					"entries": [
+						"The hermitaur makes one Claw attack, but its damage is reduced by half and the target must succeed on a {@dc 18} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Waterbeam (Costs 2 Actions)",
+					"entries": [
+						"The hermitaur sprays a high-pressure beam of water in a 60-foot line that is 5 feet wide, or a 30-foot line that is 5-feet wide. If the line is 30-foot long, it can move up to its speed in a straight line perpendicular to the beam, striking each creature in the beams path. Each creature in the line or a space the beam passes through must make a {@dc 18} Dexterity saving throw, taking 18 ({@damage 4d8}) acid damage and be afflicted with {@condition waterblight|MHMM} for 1 minute on a failed save, or half as much damage and isn't afflicted with waterblight on a successful one. A creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				},
+				{
+					"name": "Crush (Costs 3 Actions)",
+					"entries": [
+						"The hermitaur jumps into a space that contains one or more other creatures within 30 feet of it. Each of those creatures must succeed on a {@dc 18} Strength or Dexterity saving throw (target's choice) or be knocked {@condition prone} and take 22 ({@damage 4d8 + 4}) bludgeoning damage. On a successful save, the creature takes only half the damage, isn't knocked prone, and is pushed 5 feet out of the hermitaur's space into an unoccupied space of the creature's choice. If no unoccupied space is within range, the creature instead falls prone in the hermitaur's space."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"D",
+				"T"
+			],
+			"traitTags": [
+				"Amphibious"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"{@creature Daimyo Hermitaur|MHMM} has a large, crab-like body. It is covered in a red and white carapace and wears the skull of a {@creature Monoblos|MHMM} as a protective shell. They have huge, thick claws capable of holding prey as well as shielding the giant crab from most any attacks. Daimyo Hermitaur's shell is also very tough, able to deflect the blows of most weapons. The one chink in the creature's armor is its soft hindquarters, where many of the creature's major organs are stored. To fix this problem, Daimyo Hermitaur will wear the skulls of dead wyverns on their backs. Acquiring the right size shell is a chore though, and occasionally Daimyo Hermitaur can be spotted with shells too large, or small for their bodies. Almost all of Daimyo Hermitaur's shells come from members of the larger species like Monoblos. Daimyo Hermitaur also possess surprisingly strong legs, able to move the creature with great speed if necessary. The legs assist the creature in digging holes and they are able to launch themselves many feet into the air, causing them to land vigorously on top of hunters who don't react fast enough.",
+							"Some unusual rare Daimyo Hermitaur have a dark reddish color on their claws, darker legs and more shiny eyes. Along with this their shells are unusually covered in moss or algae. They also have the ability to spit long streams of water. They use new attack techniques as their claws are much stronger than average, they use their claws in a shielded position much like a human boxing while walking at a target, these claws are reported to be so strong in this position that ranged projectiles fired from guns ricochet, along with this new smarter advancing technique they perform a very aggressive non stop side to side claw snapping attack behavior that out-speeds most attackers.",
+							"Despite their size, Daimyo Hermitaur are fairly calm, when undisturbed. However, Daimyo Hermitaur will turn aggressive if they feel threatened or attacked. Most of time, they can be seen foraging for food as they roam around their environment.",
+							{
+								"type": "inset",
+								"name": "Tempered Daimyo Hermitaur",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"15",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-4",
+												"1-3",
+												"Crab Pearl+ x2",
+												"(O)"
+											],
+											[
+												"5-8",
+												"4-6",
+												"Hermitaur Cortex",
+												"(A)"
+											],
+											[
+												"9-12",
+												"7-10",
+												"Hermitaur Leg",
+												"(A,W)"
+											],
+											[
+												"13-15",
+												"11-14",
+												"Fine Black Pearl x2",
+												"(O)"
+											],
+											[
+												"16-17",
+												"15-17",
+												"Monster Toughbone",
+												"(O)"
+											],
+											[
+												"18",
+												"18-19",
+												"Hermitaur Hardclaw",
+												"(A,W)"
+											],
+											[
+												"19-20",
+												"20",
+												"Twisted Crimson Horn",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Hermitaur Cortex",
+												"entries": [
+													"{@i Tremor-Proof.} You cannot be knocked {@condition prone} while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Hermitaur Leg",
+												"entries": [
+													"{@i Handicraft+2.} For 24 hours, you gain proficiency with two artisan tools of your choice each dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Hermitaur Hardclaw",
+												"entries": [
+													"{@i (Shield Required) Claw Guard+.} When you take the {@action Dodge} action while you are attuned to this armor, you gain a +1 bonus to your AC until the start of your next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Twisted Crimson Horn",
+												"entries": [
+													"{@i Guard Up.} When you fail a Dexterity or Strength saving throw, you can use your reaction to use your AC in place of your roll. You can use this property a number of times equal to your Constitution modifier, regaining all expended uses when you finish a long rest."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Hermitaur Cortex",
+												"entries": [
+													"{@i (Bowgun Only) Load Up+.} While attuned to this weapon, you increase the maximum capacity for all your ammo by 2."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Hermitaur Leg",
+												"entries": [
+													"When you hit a creature with this weapon, it must make a {@dc 14} Constitution saving throw or be afflicted with {@condition waterblight|MHMM} until the end of its next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Hermitaur Hardclaw",
+												"entries": [
+													"{@i Ammo Saver+.} When you make a ranged weapon attack and roll a 15 or higher on the attack die, the ammunition returns to you unbroken after hitting the target(s)."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Twisted Crimson Horn",
+												"entries": [
+													"{@i (Ranged Weapon Only) Tune-Up.} When this material is placed into a weapon choose one of the following effects to gain:",
+													{
+														"type": "list",
+														"items": [
+															{
+																"type": "item",
+																"entry": "{@i (Light Bowgun Only)}. If you miss an attack while hidden, your location is not revealed."
+															},
+															{
+																"type": "item",
+																"entry": "{@i (Heavy Bowgun Only)}. You gain a +1 bonus to your AC while wielding this weapon."
+															},
+															{
+																"type": "item",
+																"entry": "You gain a +2 bonus to your attack rolls with this weapon if the target is outside of your normal attack range."
+															}
+														]
+													}
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Crab Pearl+",
+												"entries": [
+													"A fine specimen that has been forming for a long time. Valued at 200 gp."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Monster Toughbone",
+												"entries": [
+													"Very rare weapon upgrade material."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Fine Black Pearl",
+												"entries": [
+													"Largest and most beautiful of all black pearls. Very valuable and hard to find. Valued at 750 gp."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"S",
+				"C",
+				"B"
+			],
+			"miscTags": [
+				"MW"
+			],
+			"conditionInflict": [
+				"poisoned",
+				"prone"
+			]
+		},
+		{
 			"name": "Tempered Dire Miralis",
 			"size": [
 				"G"
@@ -62467,7 +70979,7 @@
 									[
 										"10",
 										"T.Gushing Magma",
-										"(A)"
+										"(A,W)"
 									],
 									[
 										"11-13",
@@ -62477,7 +70989,7 @@
 									[
 										"14-15",
 										"T.Miralis Smelter",
-										"(W)"
+										"(A,W)"
 									],
 									[
 										"16-17",
@@ -62531,6 +71043,13 @@
 									},
 									{
 										"type": "entries",
+										"name": "T.Miralis Smelter",
+										"entries": [
+											"{@i Geologist+.} When you successfully gather a mining resource, you gather an extra 1d4 more."
+										]
+									},
+									{
+										"type": "entries",
 										"name": "T.Miralis Hellwing",
 										"entries": [
 											"You have immunity to fire damage while you wear this armor."
@@ -62562,6 +71081,13 @@
 										"name": "T.Miralis Fireclaw",
 										"entries": [
 											"Your weapon deals an extra 1d8 fire damage."
+										]
+									},
+									{
+										"type": "entries",
+										"name": "T.Gushing Magma",
+										"entries": [
+											"{@i Bow Charge Plus+.} While attuned to this weapon, you can use your dragonpiercer two additional times between rests and it recharges after a Short or Long rest."
 										]
 									},
 									{
@@ -62607,6 +71133,410 @@
 				]
 			},
 			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
+			"name": "Tempered Espinas",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"flying"
+				]
+			},
+			"group": [
+				"Flying Wyverns"
+			],
+			"environment": [
+				"coastal",
+				"desert",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 22,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 203,
+				"formula": "14d12 + 112"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 23,
+			"dex": 12,
+			"con": 27,
+			"int": 10,
+			"wis": 16,
+			"cha": 19,
+			"save": {
+				"dex": "+7",
+				"con": "+14",
+				"cha": "+10"
+			},
+			"skill": {
+				"perception": "+9"
+			},
+			"resist": [
+				"lightning"
+			],
+			"immune": [
+				"fire",
+				"poison"
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"paralyzed",
+				"poisoned"
+			],
+			"passive": 19,
+			"cr": "18",
+			"page": 0,
+			"trait": [
+				{
+					"name": "Barbed Hide",
+					"entries": [
+						"At the start of each of its turns, the espinas deals 16 ({@damage 3d10}) poison damage to any creature grappling it."
+					]
+				},
+				{
+					"name": "Enrage (Recharges After a Short or Long Rest)",
+					"entries": [
+						"When the espinas hit points drop below half of its maximum, it enrages for 1 minute. While enraged, the espinas AC is reduced by 2, its movement is increased by 10 feet, and it has advantage on melee attack rolls."
+					]
+				},
+				{
+					"name": "Heavy Sleeper+",
+					"entries": [
+						"The espinas gains a +5 bonus to its AC, while it is {@condition unconscious}. Additionally, if the espinas is subjected to an effect that allows it to make a Strength or Dexterity saving throw to take only half damage, the espinas instead makes a Constitution saving throw and takes no damage if it succeeds on the saving throw and only half damage if it fails, provided the espinas is unconscious or it is the round immediately after it woke up."
+					]
+				},
+				{
+					"name": "Legendary Resistance (2/Day)",
+					"entries": [
+						"If the espinas fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The espinas makes one Tail attack and one Bite attack."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 5 ft., one target. {@h}16 ({@damage 3d6 + 6}) piercing damage."
+					]
+				},
+				{
+					"name": "Horn",
+					"entries": [
+						"{@atk mw} {@hit 12} to hit, reach 5 ft., one target. {@h}16 ({@damage 3d6 + 6}) piercing damage. If the espinas moved at least 20 feet straight toward the target immediately before the hit, the target takes an extra 28 ({@damage 8d6}) piercing damage. If the target is a creature, it must succeed on a {@dc 20} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 9} to hit, reach 10 ft., one target. {@h}21 ({@damage 3d10 + 6}) piercing damage. If the target is a creature, it must succeed on a {@dc 20} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Blight Breath {@recharge 5}",
+					"entries": [
+						"The expinas use one of the following breaths attacks:",
+						{
+							"type": "list",
+							"items": [
+								{
+									"type": "entries",
+									"name": "Giant Fireball",
+									"entries": [
+										"The espinas spews a large blighted fireball at a point within 150 feet of it. Each creature in a 20-foot-radius sphere centered on that point must make a {@dc 22} Dexterity or Constitution saving throw, taking 27 ({@damage 5d10}) fire damage plus 14 ({@damage 4d6}) poison damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't {@condition poisoned} on a successful one.",
+										"If the saving throw fails by 5 or more, the target is {@condition paralyzed} while {@condition poisoned} in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Triple Fireball",
+									"entries": [
+										"The expinas spews out three blighted fireballs in a 20-foot line that is 60-feet wide and 20-feet tall. Each creature in that area must make a {@dc 22} Dexterity or Constitution saving throw, taking 16 ({@damage 3d10}) fire damage plus 10 ({@damage 3d6}) poison damage, be {@condition poisoned} for 1 minute, and ignites on a failed save, or half as much damage, doesn't burst into flames and isn't {@condition poisoned} on a successful one. A creature in the radius of more than one fireball, makes its saving throw at disadvantage, but does not take any additional damage.",
+										"If the saving throw fails by 5 or more, the target is {@condition paralyzed} while {@condition poisoned} in this way. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+									]
+								}
+							]
+						}
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Body Slam",
+					"entries": [
+						"The espinas leaps up and slams its body onto the ground. Each creature in a 5-foot radius around it must succeed on a {@dc 20} Strength saving throw or saving throw or be pushed 5 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Swerving Chomp",
+					"entries": [
+						"The espinas moves up to 10 feet in a straight line. It can then makes one Bite attack."
+					]
+				},
+				{
+					"name": "Tackle (Costs 2 Actions)",
+					"entries": [
+						"The espinas moves up to its speed. During this move it can move through the spaces of other creatures without provoking opportunity attacks. Each creature the espinas moves through must succeed on a {@dc 20} Dexterity saving throw or take 20 ({@damage 4d6 + 6}) bludgeoning damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Flying Blight Breath (Costs 2 Actions)",
+					"entries": [
+						"The espinas spews a fireball at a point within 10-feet of it. Each creature in a 5-foot-radius sphere centered on that point must make a {@dc 22} Dexterity saving throw, taking 16 ({@damage 3d10}) fire damage plus 10 ({@damage 3d6}) poison damage. The espinas can then fly up to half its flying speed.",
+						"If the saving throw fails by 5 or more, the target is {@condition poisoned} for 1 minute and ignites. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. A {@condition poisoned} creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"{@creature Espinas|MHMM} are physically similar to {@creature rathian|MHMM}s, but alongside scales its body is covered in hot pink spikes full of venom and rough green armor plating. A long, pink, venom-filled horn protrudes from the front of its head, in a similar fashion to {@creature monoblos|MHMM}. Venomous thorns also protrude from its body, wings, tail, feet, and head. Its body, tail, and feet are bigger and more muscular than those of other flying wyverns. It has four pink claws upon its feet. Red-orange veins will appear when it is in its enraged state, similar to {@creature tigrex|MHMM}.",
+							"Espinas is an unusually passive flying wyvern. In the wild, it can almost always be found sleeping. Even when disturbed and woken up, it still responds disinterestedly to any attacks, casually walking back and forth whilst relying on its thick hide to protect itself.",
+							"However, if injured, it will become enraged. When this occurs, it becomes much faster and more brutal, charging aggressors down, ramming them with its horn, and shooting toxic fireballs.",
+							"Espinas can usually be fought in flora filled places like the great forest, although there have been much rarer sightings in areas like fortress ruins, as well as swamps.",
+							{
+								"type": "inset",
+								"name": "Tempered Espinas",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"18",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-3",
+												"1-4",
+												"T.Espinas Shard",
+												"(A,W)"
+											],
+											[
+												"4-7",
+												"5-7",
+												"T.Espinas Cortex",
+												"(A,W)"
+											],
+											[
+												"-",
+												"8-13",
+												"T.Espinas Hardhorn",
+												"(A,W)"
+											],
+											[
+												"6-9",
+												"14-15",
+												"T.Espinas Toxic Blood",
+												"(A,W)"
+											],
+											[
+												"10-14",
+												"16-19",
+												"T.Espinas Lash",
+												"(A,W)"
+											],
+											[
+												"15-18",
+												"-",
+												"T.Espinas Surspike",
+												"(A,W)"
+											],
+											[
+												"19-20",
+												"20",
+												"T.Espinas Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "T.Espinas Shard",
+												"entries": [
+													"While attuned to this armor, it grows numerous dull tip spines which rise and move when agitated or in danger."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Cortex",
+												"entries": [
+													"{@i Heavy Sleeper+.} While attuned to this armor, you don't suffer any ill effects from sleeping in your armor. Additionally, when you are subjected to an effect that allows you to make a Strength or Dexterity saving throw to take only half damage, you can choose to make a Constitution saving throw and takes no damage if you succeed on the saving throw and only half damage if you fail, provided you are {@condition unconscious} or it is the round immediately after you woke up."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Hardhorn",
+												"entries": [
+													"While wearing this armor you are immune to fire damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Toxic Blood",
+												"entries": [
+													"{@i Wellness.} While wearing this armor, you cannot be unwillingly put to sleep, {@condition poisoned}, {@condition paralyzed}, or {@condition stunned}."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Lash",
+												"entries": [
+													"{@i Adrenaline.} The first time you drop below half of your hit point maximum in combat, you gain a rush of adrenaline. On your next turn your movement speed doubles and you can take one extra action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Surspike",
+												"entries": [
+													"While you wear this armor, any creature that hits you with a melee attack takes {@damage 1d8} poison damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Mantle",
+												"entries": [
+													"While wearing this armor you are immune to poison damage and you cannot be {@condition poisoned}."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "T.Espinas Shard",
+												"entries": [
+													"{@i Protective Polish+.} This weapon is so finely constructed it never needs maintenance, cannot rust or tarnish, and deals an extra {@damage 1d8} weapon damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Cortex",
+												"entries": [
+													"While you are attuned to this weapon, you can use a bonus action to speak its command word and exhale a blighted fireball at a point within 30 feet of you. Each creature in a 5-foot-radius sphere of that point must make a {@dc 16} Dexterity saving throw, taking {@damage 4d6} fire damage and be {@condition poisoned} for 1 minute on a failed save, or half as much damage and isn't poisoned on a successful one. If the creature rolled a 1 on the saving throw, it is also {@condition paralyzed} until the end of its next turn. A poisoned creature can repeat the saving throw at the end of each of its turns, ending the effect on itself on a success. Once used, this property cannot be used again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Hardhorn",
+												"entries": [
+													"{@i (Ranged Weapon Only) Bonus Shot.} When you take the {@action attack} action, you can make one additional attack with this weapon as a bonus action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Toxic Blood",
+												"entries": [
+													"When you inflict the {@condition poisoned} condition on a creature that has a duration of 1 minute or more, it must succeed on their Constitution saving throw one additional time to end the effect."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Lash",
+												"entries": [
+													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra {@damage 1d6} weapon damage. {@i (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")}"
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Surspike",
+												"entries": [
+													"When a creature fails its saving throw against being {@condition poisoned} by you by 5 or more it is {@condition paralyzed} until the end of its next turn. When the effect ends for it, the creature is immune to this property for the next 24 hours."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "T.Espinas Mantle",
+												"entries": [
+													"{@i Foray+.} If the target is afflicted with a blight, is {@condition poisoned}, or {@condition paralyzed} your critical hit range is increased by 1 and you deal an extra {@damage 2d6} poison damage."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"P",
+				"F",
+				"I"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"AOE"
+			],
+			"conditionInflict": [
+				"paralyzed",
+				"poisoned",
 				"prone"
 			]
 		},
@@ -63219,6 +72149,237 @@
 			]
 		},
 		{
+			"name": "Tempered Gore Magala",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"unknown"
+				]
+			},
+			"group": [
+				"Unknown"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				{
+					"ac": 21,
+					"from": [
+						"22 in Frenized State"
+					]
+				}
+			],
+			"hp": {
+				"average": 270,
+				"formula": "20d12 + 140"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 120
+			},
+			"str": 27,
+			"dex": 18,
+			"con": 25,
+			"int": 12,
+			"wis": 15,
+			"cha": 19,
+			"save": {
+				"str": "+15",
+				"wis": "+9",
+				"cha": "+11"
+			},
+			"skill": {
+				"perception": "+9",
+				"stealth": "+11"
+			},
+			"immune": [
+				"poison",
+				{
+					"immune": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical weapons",
+					"cond": true
+				}
+			],
+			"conditionImmune": [
+				"blind",
+				"charmed",
+				"frightened",
+				"stunned"
+			],
+			"passive": 19,
+			"cr": "21",
+			"page": 0,
+			"senses": [
+				"blindsight 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Frenzied State (Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the gore magala would be reduced to 0 hit points, its current hit point total instead resets to 202 (15d12 + 105) hit points, it gains a +2 bonus to its AC, it recharges its Breath Weapon, and it regains any expended uses of Legendary Resistance. Additionally, the gore magala can now use the options in the \"Mythic Actions\" section for 1 hour."
+					]
+				},
+				{
+					"name": "Frenzy",
+					"entries": [
+						"When a creature has 3 Frenzy Charges, they must makes a {@dc 22} Constitution saving throw. On a fail, the target is afflicted with the {@disease Frenzy Virus|MHMM} until dispelled by a {@spell Greater Restoration} spell. On a success, the frenzy charges reset to 0."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the gore magala fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The gore magala makes one Bite attack and one Tail attack. It can use Frenzy Pool after its Tail attack."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 15} to hit, reach 10 ft., one target. {@h}21 ({@damage 3d8 + 8}) piercing damage and the target gains 1 frenzy charge."
+					]
+				},
+				{
+					"name": "Body Slam",
+					"entries": [
+						"{@atk mw} {@hit 15} to hit, reach 5 ft., one target. {@h}24 ({@damage 3d10 + 8}) bludgeoning damage. If the gore magala moved at least 10 feet straight toward the target immediately before the hit, the target takes an extra 16 ({@damage 3d10}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 23} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Frenzy Burst",
+					"entries": [
+						"{@atk rw} {@hit 11} to hit, reach 80/320 ft., one target. {@h}17 ({@damage 5d6}) necrotic damage and the target gains 1 frenzy charge.",
+						"If the gore magala's frenzied state has activated in the last hour, it instead creates multiple frenzy explosions in a 25-foot line that is 5 feet wide centered on the target and perpendicular to the gore magala. Each creature in that line, takes 24 ({@damage 7d6}) necrotic damage and gain one frenzy charge."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 15} to hit, reach 15 ft., one target. {@h}21 ({@damage 3d10 + 8}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Winged Arm (Frenzied State Only)",
+					"entries": [
+						"{@atk mw} {@hit 15} to hit, reach 15 ft., one target. {@h}15 ({@damage 2d6 + 8}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Frenzy Breath {@recharge 5}",
+					"entries": [
+						"The gore magala exhales projectiles of concentrated frenzy virus in a 90-foot cone. Each creature in that area must make a {@dc 22} Dexterity saving throw, taking 63 ({@damage 14d8}) necrotic damage and gain 1 frenzy charge on a failed save. On a successful save, a target takes half as much damage, and does not gain a frenzy charge.",
+						"If the gore magala's frenzied state has activated in the last hour, it deals an extra 18 ({@damage 4d8}) necrotic damage and a creature gains two frenzy charges on a failed save."
+					]
+				}
+			],
+			"bonus": [
+				{
+					"name": "Frenzy Pool",
+					"entries": [
+						"Immediately after the gore magala makes a tail attack, a pool of purple mist fills the area in a 5-foot radius underneath the gore magala until the start of its next turn. A creature that enters the mist for the first time on a turn or ends its turn in the mist takes 17 ({@damage 5d6}) necrotic damage and gains 1 frenzy charge."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Detect",
+					"entries": [
+						"The gore magala makes a Wisdom ({@skill Perception}) Check."
+					]
+				},
+				{
+					"name": "Viral Discharge",
+					"entries": [
+						"{@atk rw} {@hit 11} to hit, reach 80/320 ft., one target. {@h}17 ({@damage 5d6}) necrotic damage or 24 ({@damage 7d6}) if the gore magala's Frenzied State has activated in the last hour, and the target gains 1 frenzy charge."
+					]
+				},
+				{
+					"name": "Close Range Frenzy Burst (Costs 2 Actions)",
+					"entries": [
+						"The gore magala releases three explosions of the frenzy virus in a 5-foot long line that is 15-feet wide centered on a point in front of it. Each creature in that area must make a {@dc 22} Dexterity saving throw, taking 17 ({@damage 5d6}) necrotic damage and gain one frenzy charge on a failed save, or half as much damage and doesn't gain a frenzy charge on a successful one.",
+						"If the gore magala's frenzied state has activated in the last hour, it instead creates five explosions in a 5-foot long line that is 25-feet wide centered on a point in front of it."
+					]
+				}
+			],
+			"mythicHeader": [
+				"If the gore magala's Frenzied State trait has activated in the last hour, it can use the options below as legendary actions."
+			],
+			"mythic": [
+				{
+					"name": "Winged Arms",
+					"entries": [
+						"The gore magala makes two Winged Arm attacks."
+					]
+				},
+				{
+					"name": "Ground Slam (Costs 2 Actions)",
+					"entries": [
+						"The gore magala rises up and slams its winged arms down on the ground beneath it. Each creature in a 15-foot square originating from the gore magala must make a {@dc 23} Dexterity saving throw, taking 30 ({@damage 4d10 + 8}) bludgeoning damage and be pushed up to 10 feet away and knocked {@condition prone} on a failed save, or half as much damage, isn't pushed away, or knocked prone on a successful one."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"B"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"{@creature Gore Magala|MHMM} is unlike anything anyone has ever seen before. In light of the discovery that it is the juvenile form of the {@creature Shagaru Magala|MHMM}, some scholars have proposed that it be classified as an Elder Dragon, but until a consensus is reached it has been given the placeholder classification of Unknown.",
+							"Gore Magala is a very unique wyvern, sharing traits and similarities to that of the Elder Dragons, possessing six limbs, including the clawed wings on its back. Though, its overall appearance and stance resembles a quadrupedal wyvern like the {@creature Nargacuga|MHMM}. Its body is covered in dark exoskeleton plates, with notable features including the hidden feelers that are folded alongside its face, the lack of visible eyes and fanged jaws that are actually parts of its external armor plates. The other unique part is its wings, which are covered in jet-black fur that resemble a tattered and ragged cape. The claws on its wings are extremely prehensile, and even seem to possess opposable thumbs. They are used for grabbing, help at running and maintaining stability. When not engaged in combat, Gore Magala tends to cloak its body with its wings by latching them onto its back.",
+							"Gore Magala has an unusually high metabolism but rarely feeds on much prey. Due to this metabolism, its hairs on its wings are constantly left behind and flying in the air. These hairs are used to understand their environment and leave behind a trail that Gore Magala uses to see both predators and prey by heat. Once it smells something in the area, it will begin to spread around its hairs around the area in order to find the target and these hairs will attach onto the target, allowing the Gore Magala to see them with heat. As Gore Magala's senses increase and become better from these hairs, its color under its wings will slowly change and get brighter. When its sense are at their highest peak, two antennae will appear from its head and it will release a large amounts of hairs into the air. The hairs in the sky will darken the sky as if an eclipse was in the area and it will begin to walk on all six. This is its Frenzy State. When it enters this state, it will begin to use its wing claws to allow it to walk and attack better using them. These claws can leave deep gouges in prey that are said to never heal.",
+							"Gore Magala's most infamous feature is the {@disease Frenzy Virus|MHMM}. This virus is spread from Gore Magala's scales and hairs while its breath has similar properties to them. When in its Frenzy State, Gore Magala is able to make explosions in the area by combining the hairs in the atmosphere around it with a spark from its mouth. The Frenzy Virus causes some abnormalities in the nervous system, increased physical strength, and a decrease in the body's resistance. This virus makes all monsters extremely violent and eventually kills most of them. Some may overcome the effects of the Frenzy Virus and actually develop a relationship with it, becoming physically stronger from the virus while also spreading the virus like Gore Magala in order to get rid of competition from their own species. These rare individuals are known as Apex Monsters.",
+							"Gore Magalas are highly aggressive, elusive monsters. These monsters show great amounts of aggression and have shown great amounts of intelligence. Some have even been shown to play dead before slipping away when given an opportunity too. Despite competing with other powerful predators, Gore Magalas have rarely been seen with any wounds or scars on their body. Though these monsters are aggressive, they are more aggressive when its time for them to return to the Heaven's Mount and go to the Sanctuary. The reason for this is for the Gore Magala to molt into a legendary Shagaru Magala that once nearly wiped out every living thing in the mountains.",
+							"Interestingly, Gore Magala have been known to attack seafaring ships during their voyages across the great seas.",
+							{
+								"type": "homebrew",
+								"entries": [
+									"No loot table is printed for Tempered Gore Magala. When a variant lacks fluff I usually leave up the base fluff because it has no mechanical impact and looks nicer, but inserting the base monster's loot table here would feel like an extra editorial step."
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"S",
+				"P",
+				"N",
+				"B"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"RW"
+			],
+			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
 			"name": "Tempered Kirin",
 			"size": [
 				"L"
@@ -63700,8 +72861,8 @@
 				"cha": "+3"
 			},
 			"skill": {
-				"perception": "+2",
-				"investigation": "+1"
+				"investigation": "+3",
+				"perception": "+4"
 			},
 			"passive": 14,
 			"cr": "7",
@@ -63945,6 +73106,10 @@
 				"MW",
 				"RW"
 			],
+			"skill": {
+				"perception": "+2",
+				"investigation": "+1"
+			},
 			"conditionInflict": [
 				"prone"
 			]
@@ -64784,6 +73949,781 @@
 					}
 				]
 			}
+		},
+		{
+			"name": "Tempered Seregios",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "wyvern",
+				"tags": [
+					"flying"
+				]
+			},
+			"group": [
+				"Flying Wyverns"
+			],
+			"environment": [
+				"arctic",
+				"coastal",
+				"desert",
+				"forest",
+				"grassland",
+				"hill",
+				"mountain",
+				"underdark"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 18,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 189,
+				"formula": "18d12 + 72"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 80
+			},
+			"str": 21,
+			"dex": 20,
+			"con": 18,
+			"int": 8,
+			"wis": 12,
+			"cha": 15,
+			"save": {
+				"dex": "+10",
+				"wis": "+6",
+				"cha": "+7"
+			},
+			"skill": {
+				"acrobatics": "+10",
+				"perception": "+6"
+			},
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"fire"
+			],
+			"passive": 16,
+			"cr": "15",
+			"page": 0,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"trait": [
+				{
+					"name": "Flyby",
+					"entries": [
+						"The seregios doesn't provoke opportunity attacks when it flies out of an enemy's reach."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The seregios makes two Talon attacks, or three with its Bladescale attacks."
+					]
+				},
+				{
+					"name": "Talon",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, reach 5 ft., one target. {@h}18 ({@damage 3d8 + 5}) slashing damage. If the seregios is flying and dives at least 30 feet straight toward a target toward the target immediately before the hit, the target takes an extra 13 ({@damage 3d8}) slashing damage. If the target is a creature, it must succeed on a {@dc 18} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 10} to hit, 10 ft., one target. {@h}16 ({@damage 2d10 + 5}) bludgeoning damage plus 4 ({@damage 1d8}) piercing damage."
+					]
+				},
+				{
+					"name": "Bladescale",
+					"entries": [
+						"{@atk rw} {@hit 10} to hit, range 60/240 ft., one target. {@h}14 ({@damage 2d8 + 5}) piercing damage and it must succeed on a {@dc 18} Constitution saving throw or lose 5 ({@damage 2d4}) hit points at the start of each of its turns due to an open wound. Each time the seregios hits the wounded target with an attack, the damage dealt by the wound increases by 5 ({@damage 2d4}). Any creature can take an action to stanch the wound with a successful {@dc 15} Wisdom ({@skill Medicine}) check. The wound also closes if the target receives magical healing."
+					]
+				},
+				{
+					"name": "Bladescale Barrage {@recharge 5}",
+					"entries": [
+						"If the seregios flies at least 30 feet as part of its movement, it can then use this action make one Talon attack against a creature. It then flies up to 20 feet away, or to its remaining fly speed (whichever is lower) before releasing a hailstorm of bladescales centered the target of the talon attack. Each creature in a 15-foot radius of the target (including the target) must make a {@dc 18} Dexterity saving throw, taking 40 ({@damage 9d8}) piercing damage and suffer from an open wound as if by the seregios's Bladescale attack on a failed save, or half as much damage and doesn't suffer from an open wound on a successful one."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The seregios makes one Tail attack or one Bladescale attack."
+					]
+				},
+				{
+					"name": "Fly (Costs 2 Actions)",
+					"entries": [
+						"The seregios flies up to half its flying speed."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"D"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"{@creature Seregios|MHMM} are powerful, territorial and highly aggressive predators. With their razor sharp weapons a Seregios can make short work of their unfortunate victims. Larger Seregios have been seen flying with smaller Flying Wyverns clutched in their talons, including other Seregios. Reports like this confirm that the wyverns will cannibalize each other. Due to their capability of living in a number of different environments, Seregios compete with a large number of other large predators. Seregios have also been witnessed aggressively attacking {@creature Rathalos|MHMM} and {@creature Rathian|MHMM} (including their subspecies) and are said to be serious rivals toward them.",
+							"The Seregios is covered in extremely sharp Blade Scales. These scales are capable of cutting through the armor of certain prey and flinging them at a distance with good aim. On impact the scales will embed themselves in the victim like shrapnel and can leave complicated gouges in prey and even rocks. The wounds the scales leave behind are extremely painful for the victim and said pain can last for long periods of time, possibly causing infections as well. The most defining trait that this species is that they have Zygodactyly feet like roadrunners and other birds. Seregios are the only species in the Flying Wyvern class that possess them. The feet of these creatures can be used as devastating weapons against prey and enemies alike. A hunting Seregios use their feet to grasp their prey in a vice-like grip giving their victims little hope for escape. When in flight the claws on their wings are utilized for control and to allow them to shift their weight more easily. A Seregios is one of a few wyverns whose flight mobility and control is comparable to a Rathalos. Seregios will also utilize the thick, sturdy blade-like horns on their heads along with their blade-scaled covered tails in combat.",
+							"Seregios are hostile usurpers of the land. They are violent fighters and will battle other monsters in order to kick them out of their territory claim it as their own, this includes their own kind in their land. In most cases, the monster they are fighting will end up dead after the battle and while some live on. The bigger the Seregios, the larger amount of territory it needs. Once a territory is gained by a Seregios, it will mark its territory with its own Blade Scales.",
+							{
+								"type": "inset",
+								"name": "Tempered Seregios",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"7",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-6",
+												"1-2",
+												"Seregios Slavescale+",
+												"(A,W)"
+											],
+											[
+												"7-10",
+												"3-9",
+												"Seregios Airblade+",
+												"(A,W)"
+											],
+											[
+												"11",
+												"10-11",
+												"Seregios Carver+",
+												"(A,W)"
+											],
+											[
+												"12-13",
+												"12-14",
+												"Seregios Breacher+",
+												"(A,W)"
+											],
+											[
+												"14-17",
+												"15-17",
+												"Seregios Scraper+",
+												"(W)"
+											],
+											[
+												"18-19",
+												"18-19",
+												"Seregios Impaler+",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"Seregios Lens",
+												"(W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Seregios Slavescale+",
+												"entries": [
+													"{@i Handicraft+2.} For 24 hours, you gain proficiency with two artisan tools of your choice each dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Airblade+",
+												"entries": [
+													"{@i Wall Runner.} You have a climbing speed equal to your walking speed while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Carver+",
+												"entries": [
+													"{@i Constitution.} The duration from slowing effects, such as the {@spell slow} spell or a copper dragon's breath attack, are reduced by half while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Breacher+",
+												"entries": [
+													"{@i Evade Window.} This armor has 3 runes, and it regains 1d3 expended runes daily at dawn. When you fail a Dexterity saving throw while wearing it, you can use your reaction to expend 1 of its runes to succeed on that saving throw instead."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Impaler+",
+												"entries": [
+													"While you wear this armor, any creature that hits you with a melee attack takes {@damage 1d6} slashing damage."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Seregios Slavescale+",
+												"entries": [
+													"When you jump or fly 20 feet towards a creature in a straight line without taking damage, your first attack against it deals an extra {@damage 1d6} damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Airblade+",
+												"entries": [
+													"{@i Carver.} You have advantage on your first carve attempt on a creature while you are attuned to this weapon."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Carver+",
+												"entries": [
+													"While you are attuned to this armor, you can cast the {@spell blade barrier} spell from it. Once you use this property, you can't use it again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Breacher+",
+												"entries": [
+													"{@i (Ranged Weapon Only)} While you are attuned to this weapon you can speak its command word as a bonus action causing bladescales to magically appear and circle around the weapon. The next time you hit a creature with a ranged weapon attack in the next minute, the target of the attack and each creature within 5 feet of it must make a {@dc 16} Dexterity saving throw, taking {@damage 3d10} piercing damage on a failed save, or half as much damage on a successful one. You can use this property twice, regaining all expended uses when you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Scraper+",
+												"entries": [
+													"Your weapon deals an extra {@damage 1d8} slashing damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Impaler+",
+												"entries": [
+													"When you hit a creature with this weapon, it must succeed on a {@dc 16} Constitution saving throw or lose {@damage 1d4} hit points at the start of each of its turns due to an open wound. Any creature can take an action to stanch the wound with a successful {@dc 12} Wisdom ({@skill Medicine}) check. The wound also closes if the target receives magical healing."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Seregios Lens",
+												"entries": [
+													"{@i Bladescale Hone.} When you take the {@action Dodge} action and a creature misses you before the start of your next turn or when you succeed on a Dexterity saving throw to take only half damage, the next attack roll you make before the end of your next turn has advantage."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/UMbe72T.png",
+			"damageTags": [
+				"P"
+			],
+			"miscTags": [
+				"MW",
+				"RW"
+			],
+			"conditionInflict": [
+				"prone"
+			]
+		},
+		{
+			"name": "Tempered Shagaru Magala",
+			"size": [
+				"H"
+			],
+			"type": {
+				"type": "monstrosity",
+				"tags": [
+					"elder"
+				]
+			},
+			"group": [
+				"Unknown"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"C",
+				"E"
+			],
+			"ac": [
+				{
+					"ac": 25,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 580,
+				"formula": "40d12 + 320"
+			},
+			"speed": {
+				"walk": 40,
+				"fly": 120
+			},
+			"str": 29,
+			"dex": 20,
+			"con": 27,
+			"int": 15,
+			"wis": 16,
+			"cha": 20,
+			"save": {
+				"str": "+18",
+				"con": "+14",
+				"wis": "+12",
+				"cha": "+14"
+			},
+			"skill": {
+				"perception": "+12"
+			},
+			"immune": [
+				"poison",
+				{
+					"immune": [
+						"bludgeoning",
+						"piercing",
+						"slashing"
+					],
+					"note": "from nonmagical weapons",
+					"cond": true
+				}
+			],
+			"conditionImmune": [
+				"charmed",
+				"frightened",
+				"prone",
+				"stunned"
+			],
+			"passive": 22,
+			"cr": "30",
+			"page": 0,
+			"senses": [
+				"truesight 120 ft."
+			],
+			"trait": [
+				{
+					"name": "Ultra Frenzied State (Recharges after a Short or Long Rest)",
+					"entries": [
+						"If the magala would be reduced to 0 hit points, its current hit point total instead resets to 348 (24d12 + 192) hit points, it recharges its Breath Weapon, it regains any expended uses of Legendary Resistance, and flies 60 feet straight up into the air without provoking opportunity attacks."
+					]
+				},
+				{
+					"name": "Frenzy",
+					"entries": [
+						"When a creature has 3 Frenzy Charges, they must makes a {@dc 25} Constitution saving throw. On a fail, the target is afflicted with the {@disease Frenzy Virus|MHMM} until dispelled by a {@spell Greater Restoration} spell. On a success, the frenzy charges reset to 0."
+					]
+				},
+				{
+					"name": "Frenzy Geysers (Ultra Frenzied State Only)",
+					"entries": [
+						"At the start of each of the magala's turns, choose three creatures within 300-feet of it. Each creature must succeed on a {@dc 25} Dexterity saving throw or take 42 ({@damage 12d6}) necrotic damage and gain one frenzy charge on a failed save, or half as much damage and doesn't gain a charge on a successful one."
+					]
+				},
+				{
+					"name": "Legendary Resistance (3/Day)",
+					"entries": [
+						"If the magala fails a saving throw, it can choose to succeed instead."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The magala makes four Winged Arm attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 18} to hit, reach 10 ft., one target. {@h}36 ({@damage 6d8 + 9}) piercing damage and the target gains 1 frenzy charge."
+					]
+				},
+				{
+					"name": "Body Slam",
+					"entries": [
+						"{@atk mw} {@hit 18} to hit, reach 5 ft., one target. {@h}42 ({@damage 6d10 + 9}) bludgeoning damage. If the magala moved at least 10 feet straight toward the target immediately before the hit, the target takes an extra 16 ({@damage 3d10}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 26} Strength saving throw or be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Winged Arm",
+					"entries": [
+						"{@atk mw} {@hit 18} to hit, reach 15 ft., one target. {@h}23 ({@damage 4d6 + 9}) bludgeoning. If the target is Huge or smaller, it is {@condition grappled} (escape {@dc 19}). If the magala's Ultra Frenzied State has activated in the last hour, it also creates explosions of the frenzy virus (on a hit or miss) in a 20-foot long line that is 5-feet wide originating in the target's space. Each creature in that line must make a {@dc 25} Dexterity saving throw, taking 21 ({@damage 6d6}) necrotic damage and gain one frenzy charge on a failed save, or half as much damage and doesn't gain a charge on a successful one."
+					]
+				},
+				{
+					"name": "Frenzy Burst",
+					"entries": [
+						"The magala's fires an orb of concentrated frenzy virus at a space within 320 feet of it. Each creature in a 25-foot line that is 5 feet wide centered on the space and perpendicular to the magala must make a {@dc 25} Dexterity saving throw, taking 42 ({@damage 12d6}) necrotic damage and gain one frenzy charge on a failed save, or half as much damage and doesn't gain a charge on a successful one."
+					]
+				},
+				{
+					"name": "Breath Weapon {@recharge 5}",
+					"entries": [
+						"The magala uses one of the following breath weapons that is available to it:",
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Cone (Ultra Frenzied State Only)",
+									"entry": "The magala fires a frenzied beam across a 45-foot cone. Each creature in that area must make a {@dc 25} Constitution saving throw, taking 110 ({@damage 17d12}) necrotic damage on a failed save, or half as much damage on a successful one."
+								},
+								{
+									"type": "item",
+									"name": "Line",
+									"entry": "The magala fires a frenzied beam in a 120-foot line that is 10 feet wide. Each creature in that line must make a {@dc 25} Dexterity saving throw, taking 84 ({@damage 13d12}) necrotic damage on a failed save, or half as much damage on a successful one."
+								},
+								{
+									"type": "item",
+									"name": "Projectile",
+									"entry": "The magala fires orbs of concentrated frenzy virus at up to three creatures in a 120-foot cone, forming a line 5 feet wide that extends out from the magala to a target. Each creature in a line must make a {@dc 25} Dexterity saving throw, taking 39 ({@damage 6d12}) necrotic damage and gain two frenzy charges on a failed save. On a successful save, a target takes half as much damage, and does not gain a frenzy charge."
+								}
+							]
+						}
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The magala makes one Bite attack."
+					]
+				},
+				{
+					"name": "Fling",
+					"entries": [
+						"One Large or smaller object held, or creature grappled by the magala is thrown up to 60 feet in a random direction and knocked {@condition prone}. If a thrown target strikes a solid surface, the target takes 3 ({@damage 1d6}) bludgeoning damage for every 10 feet it was thrown. If the target is thrown at another creature, that creature must succeed on a {@dc 26} Dexterity saving throw or take the same damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Aerial Charge (Costs 2 Actions)",
+					"entries": [
+						"While flying, the magala flies up to half its speed. During this move it can move through a creature's space without provoking opportunity attacks. Each creature the magala moves through must succeed on a {@dc 26} Dexterity saving throw or take 42 ({@damage 6d10 + 9}) bludgeoning damage and be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Ground Slam (Costs 2 Actions)",
+					"entries": [
+						"The magala rises up and slams its winged arms down on the ground beneath it. Each creature in a 15-foot square originating from the magala must make a {@dc 26} Dexterity saving throw, taking 23 ({@damage 4d6 + 9}) bludgeoning damage and be pushed up to 10 feet away and knocked {@condition prone} on a failed save, or half as much damage, isn't pushed away, or knocked {@condition prone} on a successful one."
+					]
+				}
+			],
+			"traitTags": [
+				"Legendary Resistances"
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"U"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"{@creature Shagaru Magala|MHMM} is the \"adult\" form of {@creature Gore Magala|MHMM}, which transforms by shedding its black skin. Following the skin-shedding, its body is now covered in glittering golden scales, as well as its horns, claws and other spiky protrusions, which changed colors from crimson red / purple to dark brown. The once hidden eyes underneath the horns are also now fully opened. Its ragged-tattered wings also became golden scaly sheets that when fully expanded, resembles a star shape (more specifically, when both wings are expanded.)",
+							"Having reached adulthood, Shagaru Magala's physical abilities are greatly enhanced; they are much stronger, more agile, and most of all, more ferocious. Apart from more aggressive melee attacks like the clawed wings-pounce and a grab attack that involves crushing and then hurling hunters around like a ragdoll, their virus breath attacks are also enhanced; with the range of the explosion being larger and dealing more damage.",
+							"Like its \"juvenile\" form these drakes have highly specialized wings ending with four large talons at the end that can act as an extra pair of arms. This is very useful when climbing up cliff faces or gripping struggling prey. When exposed to bright sunlight its wings will also refract light into multicolored rays. In their juvenile form as a Gore Magala it lacks eyes, but upon metamorphosing it loses its heat sensors and gains useable eyes. Unlike a Gore Magala it lacks the virus carrying hairs on its wings and instead uses a currently unknown mechanism to spread the {@disease Frenzy Virus|MHMM}. A Shagaru Magala is capable of making the Frenzy Virus cover a much greater range than that of its \"juvenile\" form and has the potential of killing every animal in a single area. The virus strain also seems to be more intense, easily corrupting a mighty beast like {@creature Zinogre|MHMM} and turning pack-monsters like the {@creature Great Baggi|MHMM} and {@creature Baggi|MHMM} against each other. The dark virus aura that envelops a Shagaru Magala is so intense that it's said to dissipate only once the progenitor monster is dead.",
+							"These dragons are highly aggressive and territorial predators that won't hesitate in attacking hunters if spotted. Like elder dragons, Shagaru Magala are very rare and are considered myths in some lands. Part of this due to the fact that it takes years for a Gore Magala to molt. Many believe that when the molting process is about to begin said creature will travel to the Heaven's Mount to complete the process. In legend Shagaru Magala is known as \"The Punishing God of the Mountains\" due to its role of nearly wiping out all life in the mountains. The reason for this is to claim territory for themselves, prevent rivals from molting properly, and to release the next generation of Gore Magala into their territory. Their infected mist not only contains a stronger version of the Frenzy Virus but also their parasitic offspring. Their offspring live in an infected host, whether it is dead or alive, and their host acts as nursery for the young. They get their nutrition and everything they need from their host before eventually bursting out of their host's body. Once Shagaru Magala is finished breeding in a territory, it'll leave the area for its next generation and begin to wander around the world randomly. They don't reproduce again for quite awhile due to trying to prevent future monster generations from gaining a resistance against their virus while reproducing. Thus far, only three Shagaru Magala have been sighted, two of which have been killed. Many people believe that the Shagaru Magala and Gore Magala represent light and darkness.",
+							{
+								"type": "inset",
+								"name": "Tempered Shagaru Magala",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"30",
+												"Carves",
+												"4 (or 8 as a mythic encounter)"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1",
+												"Vile Frenzy Crystal",
+												"(O)"
+											],
+											[
+												"2",
+												"Pure Frenzy Crystal",
+												"(O)"
+											],
+											[
+												"3-4",
+												"S.Magala Shard",
+												"(A,W)"
+											],
+											[
+												"5-6",
+												"S.Magala Cortex",
+												"(A,W)"
+											],
+											[
+												"7-9",
+												"S.Magala Purifier",
+												"(A,W)"
+											],
+											[
+												"10-13",
+												"S.Magala Lightwing",
+												"(A,W)"
+											],
+											[
+												"14-16",
+												"S.Magala Lash",
+												"(A)"
+											],
+											[
+												"17-19",
+												"S.Magala Hardhorn",
+												"(A,W)"
+											],
+											[
+												"20",
+												"S.Magala Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "S.Magala Shard",
+												"entries": [
+													"You can't be {@condition charmed} or {@condition frightened} while attuned to this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Cortex",
+												"entries": [
+													"{@i Resuscitate+.} You have advantage on Dexterity and Constitution saving throws if you are suffering from a condition."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Purifier",
+												"entries": [
+													"While you are wearing this armor, you cannot be knocked {@condition prone}. In addition, when your AC would increase from the effect of a reaction, it lasts until the end of your next turn. If the reaction would normally last until the end of your next turn, it instead lasts for one additional round."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Lightwing",
+												"entries": [
+													"While wearing this armor, you can use an action to speak its command word to grow wings that look like the Shagaru Magala's. You gain a flying speed of 80 feet for 24 hours or until you end the effect as an action. Once used, this property can't be used again for 3 days."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Lash",
+												"entries": [
+													"You are immune to cold damage and have resistance to lightning damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Hardhorn",
+												"entries": [
+													"{@i Stellar Hunter.} You have advantage on Dexterity ({@skill Stealth}), Intelligence ({@skill Investigation}), Strength ({@skill Athletics}), Wisdom ({@skill Insight}), and Wisdom ({@skill Survival}) checks."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Mantle",
+												"entries": [
+													"While attuned to this armor, you have {@sense truesight} out to a range of 60 feet."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "S.Magala Shard",
+												"entries": [
+													"{@i Razor Sharp.} Once per turn, when you hit a creature with this weapon, anytime it would regain hit points before the end of its next turn, it regains half as many. Additionally, if the creature is afflicted with a wound, such as the odogaron's bloody wound, it can only be closed by magical healing for 1 minute."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Cortex",
+												"entries": [
+													"{@i Ammo Saver+.} When you make a ranged weapon attack and roll a 15 or higher on the attack die, the ammunition returns to you unbroken after hitting the target(s)."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Purifier",
+												"entries": [
+													"{@i Critical Element.} When you critically hit with a weapon or spell that deals cold, fire, lightning, necrotic, or thunder damage, you deal an extra {@damage 1d10} damage of that type."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Lightwing",
+												"entries": [
+													"{@i Coalescence.} Whenever you succeed on a saving throw to end a condition, you gain a +1 bonus to your attack rolls and spell save DC, and your weapon or spell attacks deal an extra {@damage 1d4} cold, fire, or lightning damage (your choice) until the end of your next turn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Lash",
+												"entries": [
+													"{@i (Bow Only) Bow Charge Plus++.} While attuned to this weapon, you can use your dragonpiercer three additional times between rests and it recharges after a Short or Long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Hardhorn",
+												"entries": [
+													"Your weapon deals an extra {@damage 2d6} radiant damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "S.Magala Mantle",
+												"entries": [
+													"{@i Bloodlust.} While you are attuned to this weapon and fall below half of your maximum hit points you are infected with the {@condition frenzy virus|MHMM} (even if you are normally immune to disease for 1 minute. Once you use this property, you can't use it again until you finish a long rest.",
+													"In addition whenever you are infected with the frenzy virus, you ignore the negative effects of the frenzy virus (Impaired Healing, Suppressed Immunities, Vulnerability), but you lose {@damage 1d6} hit points at the end of each of your turns, if you did not attack a creature since the end of your last turn."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "OTHER MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Pure Frenzy Crystal",
+												"entries": [
+													"A crystal so pure it hardly belongs in this world. Sows destructive impulses."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Vile Frenzy Crystal",
+												"entries": [
+													"A sanity-robbing crystal. The Guild demands these be turned in immediately."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"damageTags": [
+				"S",
+				"P",
+				"N",
+				"B"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"RW"
+			],
+			"conditionInflict": [
+				"grappled",
+				"prone"
+			]
 		},
 		{
 			"name": "Tempered Shogun Ceanataur",
@@ -66243,7 +76183,7 @@
 											[
 												"11-12",
 												"Teostra Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"13-14",
@@ -66289,6 +76229,13 @@
 												"name": "Teostra Carapace",
 												"entries": [
 													"While wearing this armor you can use an action to cast the {@spell protection from energy} (fire) spell from it. This property can be used twice, regaining all expended uses daily at dawn."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Teostra Claw",
+												"entries": [
+													"{@i Archaeologist+.} When you successfully gather a bone resource, you gather an extra 1d4 more."
 												]
 											},
 											{
@@ -66979,7 +76926,7 @@
 												"10-11",
 												"10-13",
 												"Tetsucabra Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"12-13",
@@ -67018,6 +76965,13 @@
 												"name": "Tetsucabra Shell",
 												"entries": [
 													"Whenever you must succeed on a saving throw or be knocked {@condition prone}, you do so with a +2 bonus."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Tetsucabra Claw",
+												"entries": [
+													"{@i Expert Fisherman.} When you catch fish, you instead catch two."
 												]
 											},
 											{
@@ -68153,7 +78107,7 @@
 												"20",
 												"20",
 												"Kadachi Gem",
-												"(A)"
+												"(A,W)"
 											]
 										]
 									},
@@ -68230,6 +78184,13 @@
 												"name": "Tobi Electro Sac",
 												"entries": [
 													"Your weapon deals an extra {@damage 1d4} lightning damage."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Kadachi Gem",
+												"entries": [
+													"{@i Entomologist+.} When you capture an insect with a bug net, you instead catch 1d4."
 												]
 											}
 										]
@@ -69994,7 +79955,7 @@
 											[
 												"19",
 												"Vaal Hazak Tail",
-												"(A)"
+												"(A,W)"
 											],
 											[
 												"20",
@@ -70099,6 +80060,13 @@
 													"{@i (Bow only & Requires 3 sockets)} When you nock an arrow on this bow, it whispers in Elvish, \"Return to that which spawned you\" When you use this weapon to make a ranged attack, you can, as a command phrase, say \"To one with life\" The target of your attack becomes your sworn enemy until it dies or until dawn seven days later. You can have only one such sworn enemy at a time. When your sworn enemy dies, you can choose a new one after the next dawn.",
 													"When you make a ranged attack roll with this weapon against your sworn enemy, you have advantage on the roll. In addition, your target gains no benefit from cover, other than total cover, and you suffer no disadvantage due to long range. If the attack hits, your sworn enemy takes an extra 3d6 piercing damage.",
 													"While your sworn enemy lives, you have disadvantage on attack rolls with all other weapons."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Vaal Hazak Tail",
+												"entries": [
+													"{@i (Bow Only) Bow Charge Plus++.} While attuned to this weapon, you can use your dragonpiercer three additional times between rests and it recharges after a Short or Long rest."
 												]
 											},
 											{
@@ -72064,6 +82032,384 @@
 			]
 		},
 		{
+			"name": "Violet Mizutsune",
+			"size": [
+				"H"
+			],
+			"type": "leviathan",
+			"group": [
+				"Leviathans"
+			],
+			"source": "MHMM",
+			"alignment": [
+				"U"
+			],
+			"ac": [
+				{
+					"ac": 17,
+					"from": [
+						"natural armor"
+					]
+				}
+			],
+			"hp": {
+				"average": 195,
+				"formula": "17d12 + 85"
+			},
+			"speed": {
+				"walk": 50,
+				"swim": 40
+			},
+			"str": 17,
+			"dex": 23,
+			"con": 21,
+			"int": 12,
+			"wis": 15,
+			"cha": 10,
+			"save": {
+				"dex": "+11",
+				"con": "+10",
+				"wis": "+7"
+			},
+			"skill": {
+				"acrobatics": "+11",
+				"perception": "+1"
+			},
+			"resist": [
+				"necrotic"
+			],
+			"immune": [
+				"fire"
+			],
+			"passive": 17,
+			"cr": "15",
+			"page": 0,
+			"senses": [
+				"darkvision 60 ft."
+			],
+			"trait": [
+				{
+					"name": "Oiled Body",
+					"entries": [
+						"The mizutsune has advantage on Dexterity ({@skill Acrobatics}) checks and Dexterity saving throws."
+					]
+				}
+			],
+			"action": [
+				{
+					"name": "Multiattack",
+					"entries": [
+						"The mizutsune makes one Bite attack and two Tail attacks."
+					]
+				},
+				{
+					"name": "Bite",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 5 ft., one target. {@h}19 ({@damage 3d8 + 6}) piercing damage. If the target is a Large or smaller creature, it is {@condition grappled} (escape {@dc 13}). Until this grapple ends, the mizutsune can't use its bite on another target."
+					]
+				},
+				{
+					"name": "Bubble Prison",
+					"entries": [
+						"{@atk rw} {@hit 11} to hit, range 80/320 ft., one Large or smaller creature. {@h}The creature is {@condition slick|MHMM} and enclosed in a bubble of shimmering force for 1 minute or until the bubble is destroyed. Nothing, not physical objects, energy, or other spell effects, can pass through the bubble, in or out, though a creature in the sphere can breathe. A creature inside of the bubble has disadvantage on attacks due to its slippery nature and takes 5 ({@damage 1d10}) fire damage at the start of each of its turns. The bubble can be attacked and destroyed (AC 15; hp 40; resistance to bludgeoning damage; immunity to poison and psychic damage; vulnerability to piercing damage). At the end of the mizutsune's turn all bubbles rise 15 feet higher into the air."
+					]
+				},
+				{
+					"name": "Slam",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 10 ft., one target. {@h}22 ({@damage 3d10 + 6}) bludgeoning damage. If the mizutsune moved at least 10 feet straight toward the target immediately before the hit, the target takes an extra 16 ({@damage 3d10}) bludgeoning damage. If the target is a creature, it must succeed on a {@dc 19} Strength saving throw or be knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"{@atk mw} {@hit 11} to hit, reach 10 ft., one target. {@h}25 ({@damage 3d12 + 6}) bludgeoning damage."
+					]
+				},
+				{
+					"name": "Bubble Barrage",
+					"entries": [
+						"The mizutsune creates five bubbles around it. When it uses this action, and as a bonus action on subsequent turns, the mizutsune can hurl one bubble at a point within 120 feet of it. Each creature within 5 feet of the point must make a {@dc 18} Dexterity saving throw, taking 11 ({@damage 2d10}) fire damage and ignites on a failed save, or half as much damage and doesn't burst into flames on a successful one. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+					]
+				},
+				{
+					"name": "Scaling Stream {@recharge 5}",
+					"entries": [
+						"The mizutsune releases a high pressure stream of water in a 90-foot line that is 5 feet wide or in a 60-foot cone. Each creature in that area must make a {@dc 18} Dexterity saving throw, taking 55 ({@damage 10d10}) fire damage on a failed save, or half as much damage and doesn't burst into flames on a successful one. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+					]
+				},
+				{
+					"name": "Bath Bomb (Recharges after a Short or Long Rest)",
+					"entries": [
+						"The mizutsune forms a Huge bubble that hovers 30-feet above it, and moves with it. On its subsequent turn, the mizutsune an use an action to perform a dance, that creates a vortex around, before the bubble impacts the ground and explodes. Each creature in a 60-foot-radius, 60-foot-high cyclinder centered on the bubble must succeed on a {@dc 18} Strength saving throw or be pulled 30 feet towards the bubble and automatically fails its saving throw against the explosion. Each creature within 30 feet of the bubble when it explodes must make a {@dc 18} Dexterity saving throw, taking 90 ({@damage 20d8}) fire damage on a failed save, or half as much damage and doesn't burst into flames on a successful one. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns.",
+						"The mizutsune must concentrate on the bubble (as if concentrating on a spell) while it remains in the air above it. If it fails its Constitution saving throw to maintain concentration on the bubble, it explodes, dousing any flames within 60 feet of the bubble."
+					]
+				}
+			],
+			"legendary": [
+				{
+					"name": "Attack",
+					"entries": [
+						"The mizutsune makes a Bite attack."
+					]
+				},
+				{
+					"name": "Encapsulate",
+					"entries": [
+						"The mizutsune uses Bubble Prison."
+					]
+				},
+				{
+					"name": "Bubbles (Costs 2 Actions)",
+					"entries": [
+						"The mizutsune uses Bubble Barrage."
+					]
+				},
+				{
+					"name": "Slide (Costs 2 Actions)",
+					"entries": [
+						"The mizutsune moves up to its speed, during this move it can move through other creatures without provoking opportunity attacks. Each creature the mizutsune moves through must succeed on a {@dc 19} Dexterity saving throw or take 20 ({@damage 4d6 + 6}) bludgeoning damage, be pushed up to 10 feet away and knocked {@condition prone}."
+					]
+				},
+				{
+					"name": "Spray Burst (Costs 2 Actions)",
+					"entries": [
+						"The mizutsune spurts out liquid that instantly explodes. Each creature in a 15-foot square originating from the mizutsune must make a {@dc 18} Dexterity saving throw, taking 16 ({@damage 3d10}) fire damage on a failed save, or half as much damage and doesn't burst into flames on a successful one. Until a creature takes an action to douse the fire, the target takes 5 ({@damage 1d10}) fire damage at the start of each of its turns."
+					]
+				}
+			],
+			"actionTags": [
+				"Multiattack"
+			],
+			"senseTags": [
+				"D"
+			],
+			"fluff": {
+				"entries": [
+					{
+						"type": "entries",
+						"entries": [
+							"Violet mizutsune has whitish-lilac scales with light streaks of indigo running down its body, as well as indigo fins and black fur. During its empowered state, its fur glows faint-blue. Like many rare species, the violet mizutsune is slightly larger than a regular {@creature mizutsune|MHMM}.",
+							"On top of the graceful agility of mizutsune, sliding around the battlefield with its secretion, the violet mizutsune's body produces a type of secretion, with properties akin to oil, that it leaves on the battlefield and utilizes in the same manner as the bubblefoam. Additionally, it can also wrap itself in flames, bathing the surrounding in a beautiful but deadly white-hot inferno.",
+							"By temporarily increases the secretion rate of this gas to perform a powerful and explosive claw slam. The violet mizutsune will create a massive bubble that will float above it and it will then perform a dance drawing hunters towards it before the bubble falls to the ground creating a massive explosion. However if the violet mizutsune is interupted before the bubble falls, the bubble will turn orange and douse the flames in the nearby area. Its bubbles, once time has passed after being releases will home onto a hunter.",
+							"Like its counterpart, the violet mizutsune likes to sleep when not fighting and will react with violence should an intruder appear. It can easily defeat monsters like the {@creature tigrex|MHMM} with ease. However it must contend with dangerous monsters such as apex monsters, equally powerful rare species, and elder dragons for territory.",
+							{
+								"type": "inset",
+								"name": "Violet Mizutsune",
+								"entries": [
+									{
+										"type": "table",
+										"colStyles": [
+											"col-1 bold",
+											"col-1",
+											"col-2 bold text-right",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"Challenge Rating",
+												"15",
+												"Carves/Capture",
+												"3"
+											]
+										]
+									},
+									{
+										"type": "table",
+										"colLabels": [
+											"Carve Chance",
+											"Capture Chance",
+											"Material",
+											"Slots"
+										],
+										"colStyles": [
+											"col-1 text-center",
+											"col-1 text-center",
+											"col-2 text-center",
+											"col-1 text-center"
+										],
+										"rows": [
+											[
+												"1-6",
+												"1",
+												"Violet Mizu Shard",
+												"(A)"
+											],
+											[
+												"7-9",
+												"2-4",
+												"Violet Mizu Hardclaw",
+												"(A,W)"
+											],
+											[
+												"10-11",
+												"5-8",
+												"White Synovial Fluid",
+												"(A,W)"
+											],
+											[
+												"12-15",
+												"9-13",
+												"Violet Mizu Whitefell",
+												"(A,W)"
+											],
+											[
+												"16-17",
+												"14-18",
+												"Violet Mizu Tail",
+												"(A,W)"
+											],
+											[
+												"18-19",
+												"19",
+												"Violet Mizu Fin",
+												"(A,W)"
+											],
+											[
+												"20",
+												"20",
+												"Violet Mizu Mantle",
+												"(A,W)"
+											]
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "ARMOR MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Violet Mizu Shard",
+												"entries": [
+													"While attuned to this armor, you have little bits of violet fire streaking through it, and harmless fiery bubbles emerge from your armor and pop creating small sparks around you. These effects are suppressed when near anything flammable or when sneaking."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Hardclaw",
+												"entries": [
+													"{@i Flinch Free.} While wearing this armor you cannot be knocked {@condition prone}, or unwillingly moved from your current location by any means."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "White Synovial Fluid",
+												"entries": [
+													"{@i Diversion.} While attuned to this armor you can use an action to speak this armor's command word, causing a large red X to appear across your chest for 1 minute. When a hostile creature attempts to attack a target within 15 feet of you while this X is visible, it must succeed on a {@dc 15} Wisdom saving throw or redirect its attack towards you. If the attacker's is unable to reach you with its remaining movement it succeeds on its saving throw, but has disadvantage on attack rolls against other target other than you, until the end of the turn. Once you use this property, you can't use it again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Whitefell",
+												"entries": [
+													"You have resistance to fire damage while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Tail",
+												"entries": [
+													"{@i Stamina Surge+2.} While wearing this armor, you can use an action to cast the {@spell haste} spell from it once per day, but can target only yourself when you do so and you gain 1 level of {@condition exhaustion} when the spell ends."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Fin",
+												"entries": [
+													"{@i Evade Extender (M).} You gain a +2 bonus to Dexterity saving throws while you wear this armor."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Mantle",
+												"entries": [
+													"{@i Embolden.} You have a +1 bonus to your AC and you can't be knocked {@condition prone} while you wear this armor. In addition, when you take the {@action Dodge} action, you gain a +2 bonus to Dexterity saving throws."
+												]
+											}
+										]
+									},
+									{
+										"type": "list",
+										"style": "list-hang",
+										"name": "WEAPON MATERIAL EFFECTS",
+										"items": [
+											{
+												"type": "entries",
+												"name": "Violet Mizu Shard",
+												"entries": [
+													"Your weapon is constantly covered in a thin liquid with a rainbow sheen. When the weapon is subjected to fire, it ignites for 1 hour or until it is sheathed. While lit, it provides bright light in a 20-foot radius and dim light for an additional 20 feet."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Hardclaw",
+												"entries": [
+													"While holding this weapon, you gain a +1 bonus to spell attack rolls and you ignore half cover when making a spell attack."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "White Synovial Fluid",
+												"entries": [
+													"While attuned to this weapon you can use an action to speak its command word to create five fiery bubbles. The bubbles float in the air and orbit you for the 1 minute. When you use this action—and as a bonus action on each of your turns thereafter you can expend one bubble, and make one ranged spell attack against a target within 60 feet of you (+9 to hit or your own spell attack bonus). On a hit, the target takes {@damage 2d6} fire damage. Once you use this property, you can't use it again until you finish a long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Whitefell",
+												"entries": [
+													"{@i Adrenaline.} The first time you drop below half of your hit point maximum in combat, you gain a rush of adrenaline. On your next turn your movement speed doubles and you can take one extra action."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Tail",
+												"entries": [
+													"{@i Offensive Guard.} Whenever you use a reaction that increases your AC, the next attack you make deals extra damage equal to the bonus AC the reaction provided."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Fin",
+												"entries": [
+													"{@i Weakness Exploit+.} When you have advantage on an attack roll with this weapon and you hit the target, you can have your weapon deal its maximum damage if the lower of the two d20 rolls would also hit the target (all extra damage dice must still be rolled). You can use this property a number of times equal to your Strength or Dexterity modifier (your choice), regaining all expended uses when you finish a short or long rest."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Violet Mizu Fin",
+												"entries": [
+													"{@i Agitator.} Your weapon attacks critical hit range is increased by 1 and your weapon deals an extra {@damage 1d6} weapon damage. {@i (This material counts as both a critical eye material and a \"your weapon deals an extra damage material\")}"
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					}
+				]
+			},
+			"tokenUrl": "https://i.imgur.com/HaDilg0.png",
+			"damageTags": [
+				"B",
+				"P",
+				"F"
+			],
+			"miscTags": [
+				"MW",
+				"RCH",
+				"RW",
+				"AOE"
+			],
+			"conditionInflict": [
+				"Slick|MHMM",
+				"grappled",
+				"prone"
+			]
+		},
+		{
 			"name": "Viper Tobi-Kadachi",
 			"size": [
 				"L"
@@ -73087,7 +83433,7 @@
 											[
 												"12-16",
 												"11-17",
-												"Volvidon Pup Talon",
+												"Volvi Pup Talon",
 												"(A)"
 											],
 											[
@@ -73119,7 +83465,7 @@
 											},
 											{
 												"type": "entries",
-												"name": "Volvidon Pup Talon",
+												"name": "Volvi Pup Talon",
 												"entries": [
 													"{@i Botanist.} When you successfully gather a {@table plants|AGMH|plant} resource, you instead gather 2."
 												]
@@ -75022,7 +85368,7 @@
 											[
 												"12-13",
 												"Xeno'jiiva Claw",
-												"(W)"
+												"(A,W)"
 											],
 											[
 												"14-15",
@@ -75063,6 +85409,13 @@
 												"name": "Xeno'jiiva Soulscale",
 												"entries": [
 													"Your Constitution score is 19 while you wear this armor. It has no effect on you if your Constitution is already 19 or higher."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Xeno'jiiva Claw",
+												"entries": [
+													"{@i Archaeologist+.} When you successfully gather a bone resource, you gather an extra 1d4 more."
 												]
 											},
 											{
@@ -75501,7 +85854,7 @@
 											[
 												"10-14",
 												"Dragonwood",
-												"(O)"
+												"(A,O)"
 											],
 											[
 												"15-16",
@@ -75532,6 +85885,13 @@
 												"name": "Tsukami Hide",
 												"entries": [
 													"{@i Speed Eating.} While you are attuned to this armor, you can use any consumable, such as a potion or food, as a bonus action; so long as you are the one consuming it."
+												]
+											},
+											{
+												"type": "entries",
+												"name": "Dragonwood",
+												"entries": [
+													"{@i Forager+.} When you harvest mushrooms, you harvest an extra 1d4 more."
 												]
 											},
 											{
@@ -76423,7 +86783,7 @@
 											],
 											[
 												"11-19",
-												"Azure Jumbo Bone",
+												"Arzuros Cub Shell",
 												"(A,O)"
 											],
 											[

--- a/collection/Amellwind; Monster Hunter Monster Manual.json
+++ b/collection/Amellwind; Monster Hunter Monster Manual.json
@@ -33451,7 +33451,13 @@
 				{
 					"name": "Move",
 					"entries": [
-						"The gravios moves up to half its speed Tail. The gravios makes a Tail attack."
+						"The gravios moves up to half its speed."
+					]
+				},
+				{
+					"name": "Tail",
+					"entries": [
+						"The gravios makes a Tail attack."
 					]
 				},
 				{


### PR DESCRIPTION
Adds in remaining monsters from Sunbreak updates, along with changes to gathering and Bow Charge materials as specifically mentioned [here](https://www.reddit.com/r/dndnext/comments/10a0o8s/monster_hunter_monster_manual_and_guide_to/). While this document could still use a slow and thorough re-check - Amellwind's patch notes are never comprehensive, especially in regards to small rewordings - I think this update brings everything important up to speed.

Detailed list of changes:
```
Monsters
Tempered Shogun		
Tempered Daimyo		
Risen Cham			
Gaismagorm			
Risen Kush			
Malzeno				
Risen Toaster		
Blood Orange Bish	
Garangolm			
Lunagaron			
Scorned Magna		
Tempered Astalos	
Espinas				
Tempered Espinas	
Flaming Espi		
Lucent Narga		
Tempered Seregi		
Magma Almu			
Violet Mizu			
Aurora Somnacanth	
Pyre Rakna			
Boggi				
Tempered Gore		
Chaotic Gore		
Tempered Shagaru	
Qurio				
Qurio Swarm			
Gowngoat			

Materials
Bow Charge (Plus, ++, +++)
Archaeologist, 
Botanist, 
Entomologist, 
Expert Fisherman, 
Forager, 
Geologist 
```
