### PR TITLE
Subclasses from Crown of the Oathbreaker

### DIFF
--- a/subclass/Elderbrain; Crown of the Oathbreaker Subclass Compendium.json
+++ b/subclass/Elderbrain; Crown of the Oathbreaker Subclass Compendium.json
@@ -1,0 +1,3719 @@
+{
+		"_meta": {
+		"sources": [
+			{
+				"json": "EBCotOSCC",
+				"abbreviation": "EBCotOSCC",
+				"full": "ElderBrain Crown of the Oathbreaker Subclass Compendium",
+				"url": "https://elderbrain.com/products/crown-of-the-oathbreaker-pdf",
+				"authors": [
+					"Gabor Dan David Feher Tamas Marton"
+				],
+				"convertedBy": [
+					"cardboardvinyl 20230213"
+				],
+				"version": "0.1"
+			}
+		],
+		"dateAdded": 1676156472,
+		"dateLastModified": 1676156483,
+		"status": "ready"
+	},
+	"subclass": [
+		{
+			"name": "Path of the Umbral Stalker",
+			"source": "EBCotOSCC",
+			"shortName": "Umbral Stalker",
+			"className": "Rogue",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Eye of Darkness|Rogue||Umbral Stalker|EBCotOSCC|3",
+				"One with the Shadows|Rogue||Umbral Stalker|EBCotOSCC|9",
+				"Shadow Step|Rogue||Umbral Stalker|EBCotOSCC|13",
+				"Shadow Rift|Rogue||Umbral Stalker|EBCotOSCC|13",
+				"Umbral Strike|Rogue||Umbral Stalker|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Fear Rager",
+			"source": "EBCotOSCC",
+			"className": "Barbarian",
+			"classSource": "PHB",
+			"shortName": "Fear Rager",
+			"subclassFeatures": [
+				"Demoralizing Blow|Barbarian||Fear Rager|EBCotOSCC|3",
+				"Terrifying Onslaught|Barbarian||Fear Rager|EBCotOSCC|6",
+				"Culling the Weak|Barbarian||Fear Rager|EBCotOSCC|10",
+				"Intimidating Slaughter|Barbarian||Fear Rager|EBCotOSCC|14"
+			]
+		},
+        {
+			"name": "Frenzied Mutant",
+			"source": "EBCotOSCC",
+			"className": "Barbarian",
+			"classSource": "PHB",
+			"shortName": "Frenzied Mutant",
+			"subclassFeatures": [
+				"Grafted Appendages|Barbarian||Frenzied Mutant|EBCotOSCC|3",
+				"Bone Claw|Barbarian||Frenzied Mutant|EBCotOSCC|3",
+				"Telepathic Terror|Barbarian||Frenzied Mutant|EBCotOSCC|6",
+				"Aberrant Anatomy|Barbarian||Frenzied Mutant|EBCotOSCC|10",
+                "Agile Tentacles|Barbarian||Frenzied Mutant|EBCotOSCC|14"
+			]
+		},
+        {
+			"name": "Spelleater",
+			"source": "EBCotOSCC",
+			"className": "Barbarian",
+			"classSource": "PHB",
+			"shortName": "Spelleater",
+			"subclassFeatures": [
+				"Raging Defiance|Barbarian||Spelleater|EBCotOSCC|3",
+				"Absorb Magic|Barbarian||Spelleater|EBCotOSCC|6",
+				"Brawn Over Magic|Barbarian||Spelleater|EBCotOSCC|10",
+				"Magic Resistance|Barbarian||Spelleater|EBCotOSCC|14"
+			]
+		},
+        {
+			"name": "College of Dirge Singers",
+			"source": "EBCotOSCC",
+			"className": "Bard",
+			"classSource": "PHB",
+			"shortName": "Dirge Singers",
+			"subclassFeatures": [
+				"Lament of Melancholy|Bard||Dirge Singers|EBCotOSCC|3",
+				"Dirge of Grief|Bard||Dirge Singers|EBCotOSCC|3",
+				"Elegy of Hopelessness|Bard||Dirge Singers|EBCotOSCC|6",
+				"Threnody of Death|Bard||Dirge Singers|EBCotOSCC|14"
+			]
+		},
+        {
+			"name": "College of High Speaker",
+			"source": "EBCotOSCC",
+			"className": "Bard",
+			"classSource": "PHB",
+			"shortName": "High Speaker",
+			"subclassFeatures": [
+				"Accentuated Tone|Bard||High Speaker|EBCotOSCC|3",
+				"Commanding Voice|Bard||High Speaker|EBCotOSCC|3",
+				"Universal Language|Bard||High Speaker|EBCotOSCC|6",
+				"Word of Creation|Bard||High Speaker|EBCotOSCC|14"
+			]
+		},
+        {
+			"name": "College of Pretender",
+			"source": "EBCotOSCC",
+			"className": "Bard",
+			"classSource": "PHB",
+			"shortName": "Pretender",
+			"subclassFeatures": [
+				"Battle Feint|Bard||Pretender|EBCotOSCC|3",
+				"Captivating Monologue|Bard||Pretender|EBCotOSCC|3",
+				"Elusive Target|Bard||Pretender|EBCotOSCC|6",
+				"The Great Pretender|Bard||Pretender|EBCotOSCC|14"
+			]
+		},
+        {
+			"name": "Congregation Domain",
+			"source": "EBCotOSCC",
+			"className": "Cleric",
+			"classSource": "PHB",
+			"shortName": "Congregation",
+            "subclassSpells": [
+                "bless",
+                "protection from evil and good",
+                "aid",
+                "calm emotions",
+                "beacon of hope",
+                "mass healing word",
+                "compulsion",
+                "private sanctum",
+                "mass cure wounds",
+                "telepathic bond"
+                    ],
+                    "additionalSpells": [
+                        {
+                        "prepared": {
+                                        "1": [
+                                            "bless",
+                                            "protection from evil and good"
+                                        ],
+                                        "3": [
+                                            "aid",
+                                            "calm emotions"
+                                        ],
+                                        "5": [
+                                            "beacon of hope",
+                                            "mass healing word"
+                                        ],
+                                        "7": [
+                                            "compulsion",
+                                            "private sanctum"
+                                        ],
+                                        "9": [
+                                            "mass cure wounds",
+                                            "telepathic bond"
+                                        ]
+                                    }
+                                }
+                            ],
+            "subclassFeatures": [
+				"Congregation Domain|Cleric||Congregation|EBCotOSCC|1",
+				"Bonus Cantrip|Cleric||Congregation|EBCotOSCC|1",
+				"Bonus Proficiency|Cleric||Congregation|EBCotOSCC|1",
+				"Communal Prayer|Cleric||Congregation|EBCotOSCC|1",
+                "Channel Divinity: Mass Aid|Cleric||Congregation|EBCotOSCC|2",
+                "Channel Divinity: Heighten Spells|Cleric||Congregation|EBCotOSCC|6",
+                "Helping Hand|Cleric||Congregation|EBCotOSCC|8",
+                "Forceful Communal Prayers|Cleric||Congregation|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Darkness Domain",
+			"source": "EBCotOSCC",
+			"className": "Cleric",
+			"classSource": "PHB",
+			"shortName": "Darkness",
+            "subclassSpells": [
+                "fog cloud",
+                "sleep",
+                "darkness",
+                "darkvision",
+                "fear",
+                "nondetection",
+                "greater invisibility",
+                "phantasmal killer",
+                "dream",
+                "mislead"
+                    ],
+                    "additionalSpells": [
+                        {
+                        "prepared": {
+                                        "1": [
+                                            "fog cloud",
+                                            "sleep"
+                                        ],
+                                        "3": [
+                                            "darkness",
+                                            "darkvision"
+                                        ],
+                                        "5": [
+                                            "fear",
+                                            "nondetection"
+                                        ],
+                                        "7": [
+                                            "greater invisibility",
+                "phantasmal killer"
+                                        ],
+                                        "9": [
+                                            "dream",
+                                            "mislead"
+                                        ]
+                                    }
+                                }
+                            ],
+            "subclassFeatures": [
+				"Darkness Domain|Cleric||Darkness|EBCotOSCC|1",
+				"Cloak of Darkness|Cleric||Darkness|EBCotOSCC|1",
+                "Channel Divinity: Darkness Descends|Cleric||Darkness|EBCotOSCC|2",
+                "Channel Divinity: Conjure Shadows|Cleric||Darkness|EBCotOSCC|6",
+                "Void Eye|Cleric||Darkness|EBCotOSCC|8",
+                "Shadowform|Cleric||Darkness|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Ooze Domain",
+			"source": "EBCotOSCC",
+			"className": "Cleric",
+			"classSource": "PHB",
+			"shortName": "Ooze",
+            "subclassSpells": [
+                "create or destroy water",
+                "false life",
+                "acid arrow",
+                "blindness/deafness",
+                "meld into stone",
+                "protection from energy",
+                "black tentacles",
+                "freedom of movement",
+                "contagion",
+                "hold monster"
+                    ],
+                    "additionalSpells": [
+                        {
+                        "prepared": {
+                                        "1": [
+                                            "create or destroy water",
+                                            "false life"
+                                        ],
+                                        "3": [
+                                            "acid arrow",
+                                            "blindness/deafness"
+                                        ],
+                                        "5": [
+                                            "meld into stone",
+                                            "protection from energy"
+                                        ],
+                                        "7": [
+                                            "black tentacles",
+                                            "freedom of movement"
+                                        ],
+                                        "9": [
+                                            "contagion",
+                                            "hold monster"
+                                        ]
+                                    }
+                                }
+                            ],
+            "subclassFeatures": [
+				"Ooze Domain|Cleric||Ooze|EBCotOSCC|1",
+                "Bonus Cantrip|Cleric||Pretender|EBCotOSCC|1",
+				"Bonus Proficiency|Cleric||Pretender|EBCotOSCC|1",
+				"Sense of the Ooze|Cleric||Ooze|EBCotOSCC|1",
+                "Channel Divinity: Charm Oozes|Cleric||Ooze|EBCotOSCC|2",
+                "Acid Resistance|Cleric||Ooze|EBCotOSCC|6",
+                "Gelatinous Form|Cleric||Ooze|EBCotOSCC|8",
+                "Ooze Form|Cleric||Ooze|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Circle of the Bloom",
+			"source": "EBCotOSCC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Bloom",
+            "subclassSpells": [
+                "barkskin",
+                "locate aminals or plants",
+                "daylight",
+                "plant growth",
+                "control water",
+                "freedom of movement",
+                "commune with nature",
+                "tree stride"
+                    ],
+            "additionalSpells": [
+                        {
+                        "prepared": {
+                                        "3": [
+                                            "barkskin",
+                                            "locate aminals or plants"
+                                        ],
+                                        "5": [
+                                            "daylight",
+                                            "plant growth"
+                                        ],
+                                        "7": [
+                                            "control water",
+                                            "freedom of movement"
+                                        ],
+                                        "9": [
+                                            "commune with nature",
+                                            "tree stride"
+                                        ]
+                                    }
+                                }
+                            ],
+            "subclassFeatures": [
+				"Plant Form|Druid||Bloom|EBCotOSCC|2,6",
+                "Circle Spells|Druid||Bloom|EBCotOSCC|3,5,7,9",
+				"Speak with Plants|Druid||Bloom|EBCotOSCC|2",
+				"Land's Stride|Druid||Bloom|EBCotOSCC|6",
+                "Blessings of Bloom|Druid||Bloom|EBCotOSCC|10",
+                "Treant Form|Druid||Bloom|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Circle of the Savage Blood",
+			"source": "EBCotOSCC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Savage Blood",
+            "subclassSpells": [
+                "enhance ability",
+                "enlarge/reduce",
+                "blink",
+                "fly",
+                "dominate beast",
+                "polymorph",
+                "antilife shell",
+                "hold monster"
+                    ],
+            "additionalSpells": [
+                        {
+                        "prepared": {
+                                        "3": [
+                                            "enhance ability",
+                                            "enlarge/reduce"
+                                        ],
+                                        "5": [
+                                            "blink",
+                                            "fly"
+                                        ],
+                                        "7": [
+                                            "dominate beast",
+                                            "polymorph"
+                                        ],
+                                        "9": [
+                                            "antilife shell",
+                                            "hold monster"
+                                        ]
+                                    }
+                                }
+                            ],        
+            "subclassFeatures": [
+				"Monstrous Form|Druid||Savage Blood|EBCotOSCC|2",
+                "Bonus Cantrip|Druid||Savage Blood|EBCotOSCC|2",
+                "Circle Spells|Druid||Savage Blood|EBCotOSCC|3,5,7,9",
+				"Monstrous Aspect|Druid||Savage Blood|EBCotOSCC|2",
+				"Monstrous Caller|Druid||Savage Blood|EBCotOSCC|6",
+                "Master of Monsters|Druid||Savage Blood|EBCotOSCC|10",
+                "Monster Friend|Druid||Savage Blood|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Inheritor of the Unbegotten",
+			"source": "EBCotOSCC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Unbegotten",
+            "subclassSpells": [
+                "blur",
+                "detect thoughts",
+                "gaseous form",
+                "spirit guardians",
+                "banishment",
+                "black tentacles",
+                "contact other plane",
+                "hallow"
+                    ],
+            "additionalSpells": [
+                        {
+                        "prepared": {
+                                        "3": [
+                                            "blur",
+                "detect thoughts"
+                                        ],
+                                        "5": [
+                                            "gaseous form",
+                "spirit guardians"
+                                        ],
+                                        "7": [
+                                            "banishment",
+                                            "black tentacles"
+                                        ],
+                                        "9": [
+                                            "contact other plane",
+                                            "hallow"
+                                        ]
+                                    }
+                                }
+                            ],
+            "subclassFeatures": [
+                "Bonus Cantrip|Druid||Unbegotten|EBCotOSCC|2",
+                "Circle Spells|Druid||Unbegotten|EBCotOSCC|3,5,7,9",
+				"Voice of the Void|Druid||Unbegotten|EBCotOSCC|2",
+                "Incomprehensible Intellect|Druid||Unbegotten|EBCotOSCC|2",
+				"Manifest Aberrant Trait|Druid||Unbegotten|EBCotOSCC|6",
+                "Enslave|Druid||Unbegotten|EBCotOSCC|10",
+                "Conjure Abomination|Druid||Unbegotten|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Commander",
+			"source": "EBCotOSCC",
+			"className": "Fighter",
+			"classSource": "PHB",
+			"shortName": "Commander",
+            "subclassFeatures": [
+                "Commander's Orders|Fighter||Commander|EBCotOSCC|3,5,10,15",
+                "Order of Charge|Fighter||Commander|EBCotOSCC|7",
+				"Order of Defense|Fighter||Commander|EBCotOSCC|10",
+                "Order of Attack|Fighter||Commander|EBCotOSCC|15",
+				"Legendary Commander|Fighter||Commander|EBCotOSCC|18"
+			]
+        },
+        {
+			"name": "Mercenary",
+			"source": "EBCotOSCC",
+			"className": "Fighter",
+			"classSource": "PHB",
+			"shortName": "Mercenary",
+            "subclassFeatures": [
+                "Iron Will|Fighter||Mercenary|EBCotOSCC|3",
+                "Ready for Anything|Fighter||Mercenary|EBCotOSCC|7",
+				"Versatile Fighting Style|Fighter||Mercenary|EBCotOSCC|10",
+                "Mettle|Fighter||Mercenary|EBCotOSCC|15",
+				"Get the Job Done|Fighter||Mercenary|EBCotOSCC|18"
+			]
+        },
+        {
+			"name": "Royal Guard",
+			"source": "EBCotOSCC",
+			"className": "Fighter",
+			"classSource": "PHB",
+			"shortName": "Royal Guard",
+            "subclassFeatures": [
+                "Alert of Duty|Fighter||Royal Guard|EBCotOSCC|3",
+                "Coordinated Strike|Fighter||Royal Guard|EBCotOSCC|7",
+				"Coordinated Shot|Fighter||Royal Guard|EBCotOSCC|10",
+                "Swift Strike|Fighter||Royal Guard|EBCotOSCC|15",
+				"Divert Strike|Fighter||Royal Guard|EBCotOSCC|18"
+			]
+        },
+        {
+			"name": "Way of the Stonefist",
+			"source": "EBCotOSCC",
+			"className": "Monk",
+			"classSource": "PHB",
+			"shortName": "Stonefist",
+            "subclassFeatures": [
+                "Resist Strikes|Monk||Stonefist|EBCotOSCC|3",
+                "Mountain Stance|Monk||Stonefist|EBCotOSCC|6",
+				"Stone Body|Monk||Stonefist|EBCotOSCC|11",
+                "Elemental Transformation|Monk||Stonefist|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Way of the Nine Seals",
+			"source": "EBCotOSCC",
+			"className": "Monk",
+			"classSource": "PHB",
+			"shortName": "Nine Seals",
+            "subclassFeatures": [
+                "Hellfire Fist|Monk||Nine Seals|EBCotOSCC|3",
+                "Deny Advantage|Monk||Nine Seals|EBCotOSCC|6",
+				"Pierce Deception|Monk||Nine Seals|EBCotOSCC|11",
+                "Contractual Fate|Monk||Nine Seals|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Way of the Tentacle",
+			"source": "EBCotOSCC",
+			"className": "Monk",
+			"classSource": "PHB",
+			"shortName": "Tentacle",
+            "subclassFeatures": [
+                "Tentacle Limb|Monk||Tentacle|EBCotOSCC|3",
+                "Nerve-Wracking Strike|Monk||Tentacle|EBCotOSCC|6",
+				"Psychic Barrage|Monk||Tentacle|EBCotOSCC|11",
+                "Suffocating Strike|Monk||Tentacle|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Inquisitor",
+			"source": "EBCotOSCC",
+			"className": "Paladin",
+			"classSource": "PHB",
+			"shortName": "Inquisitor",
+            "subclassSpells": [
+                "comprehend languages",
+                "detect evil and good",
+                "detect thoughts",
+                "zone of truth",
+                "clairvoyance",
+                "speak with dead",
+                "banishment",
+                "locate creature",
+                "dispel evil and good",
+                "legend lore"
+                    ],
+            "additionalSpells": [
+                {
+                "prepared": {
+                                "3": [
+                                    "comprehend languages",
+                                    "detect evil and good"
+                                ],
+                                "5": [
+                                    "detect thoughts",
+                                    "zone of truth"
+                                ],
+                                "9": [
+                                    "clairvoyance",
+                                    "speak with dead"
+                                ],
+                                "13": [
+                                    "banishment",
+                                    "locate creature"
+                                ],
+                                "17": [
+                                    "dispel evil and good",
+                                    "legend lore"
+                                ]
+                            }
+                        }
+                    ],
+            "subclassFeatures": [
+				"Tenets of Inquisition|Paladin||Inquisitor|EBCotOSCC|3",
+                "Oath Spells|Paladin||Inquisitor|EBCotOSCC|3,5,9,13,17",
+				"Channel Divinity: Pierce Illusion|Paladin||Inquisitor|EBCotOSCC|3",
+                "Channel Divinity: Denounce Shapeshifter|Paladin||Inquisitor|EBCotOSCC|3",
+				"Discern Falsehood|Paladin||Inquisitor|EBCotOSCC|7",
+                "Prevent Escape|Paladin||Inquisitor|EBCotOSCC|15",
+                "Ultimate Conviction|Paladin||Inquisitor|EBCotOSCC|20"
+			]
+        },
+        {
+			"name": "Oath of Cleansing",
+			"source": "EBCotOSCC",
+			"className": "Paladin",
+			"classSource": "PHB",
+			"shortName": "Cleansing",
+            "subclassSpells": [
+                "protection from evil and good",
+                "purify food and drink",
+                "lesser restoration",
+                "protection from poison",
+                "protection from energy",
+                "remove curse",
+                "death ward",
+                "freedom of movement",
+                "dispel evil and good",
+                "greater restoration"
+                    ],
+            "additionalSpells": [
+                {
+                "prepared": {
+                                "3": [
+                                    "protection from evil and good",
+                                    "purify food and drink"
+                                ],
+                                "5": [
+                                    "lesser restoration",
+                                    "protection from poison"
+                                ],
+                                "9": [
+                                    "protection from energy",
+                                    "remove curse"
+                                ],
+                                "13": [
+                                    "death ward",
+                                    "freedom of movement"
+                                ],
+                                "17": [
+                                    "dispel evil and good",
+                                    "greater restoration"
+                                ]
+                            }
+                        }
+                    ],
+            "subclassFeatures": [
+				"Tenets of Cleansing|Paladin||Cleansing|EBCotOSCC|3",
+                "Oath Spells|Paladin||Cleansing|EBCotOSCC|3,5,9,13,17",
+				"Channel Divinity: Hallow|Paladin||Cleansing|EBCotOSCC|3",
+                "Channel Divinity: Cleansing Lay on Hands|Paladin||Cleansing|EBCotOSCC|3",
+				"Exorcist|Paladin||Cleansing|EBCotOSCC|7",
+                "Purify|Paladin||Cleansing|EBCotOSCC|15",
+                "Greater Purify|Paladin||Cleansing|EBCotOSCC|20"
+			]
+        },
+        {
+			"name": "Oath of Protection",
+			"source": "EBCotOSCC",
+			"className": "Paladin",
+			"classSource": "PHB",
+			"shortName": "Protection",
+            "subclassSpells": [
+                "protection from evil and good",
+                "shield of faith",
+                "warding bond",
+                "protection from poison",
+                "protection from energy",
+                "magic circle",
+                "death ward",
+                "guardian of faith",
+                "dispel evil and good",
+                "raise dead"
+                    ],
+            "additionalSpells": [
+                {
+                "prepared": {
+                                "3": [
+                                    "protection from evil and good",
+                                    "shield of faith"
+                                ],
+                                "5": [
+                                    "warding bond",
+                                    "protection from poison"
+                                ],
+                                "9": [
+                                    "protection from energy",
+                                    "magic circle"
+                                ],
+                                "13": [
+                                    "death ward",
+                                    "guardian of faith"
+                                ],
+                                "17": [
+                                    "dispel evil and good",
+                                    "raise dead"
+                                ]
+                            }
+                        }
+                    ],
+            "subclassFeatures": [
+				"Tenets of Protection|Paladin||Protection|EBCotOSCC|3",
+                "Oath Spells|Paladin||Protection|EBCotOSCC|3,5,9,13,17",
+				"Channel Divinity: Vow of Protection|Paladin||Protection|EBCotOSCC|3",
+                "Channel Divinity: Divine Ward|Paladin||Protection|EBCotOSCC|3",
+				"Dedicated Defender|Paladin||Protection|EBCotOSCC|7",
+                "Bastion of Self|Paladin||Protection|EBCotOSCC|15",
+                "Divine Protector|Paladin||Protection|EBCotOSCC|20"
+			]
+        },
+        {
+			"name": "Feyfriend",
+			"source": "EBCotOSCC",
+			"className": "Ranger",
+			"classSource": "PHB",
+			"shortName": "Feyfriend",
+            "subclassFeatures": [
+                "Resist Lure|Ranger||Feyfriend|EBCotOSCC|3",
+                "Fey Armament|Ranger||Feyfriend|EBCotOSCC|3",
+                "Speak with Beasts and Plants|Ranger||Feyfriend|EBCotOSCC|3",
+				"Sprite Companion|Ranger||Feyfriend|EBCotOSCC|7",
+                "Fey Reinforcements|Ranger||Feyfriend|EBCotOSCC|11",
+                "Sanctuary of the Fey Court|Ranger||Feyfriend|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Monster Tamer",
+			"source": "EBCotOSCC",
+			"className": "Ranger",
+			"classSource": "PHB",
+			"shortName": "Tamer",
+            "subclassSpells": [
+                "speak with animals",
+                "locate animals and plants",
+                "conjure animals",
+                "dominate beast",
+                "hold monster"
+                    ],
+            "subclassFeatures": [
+                "Monster Tamer Magic|Ranger||Tamer|EBCotOSCC|3,5,9,13,17",
+                "Bestial Affinity|Ranger||Tamer|EBCotOSCC|3",
+                "Sense Beasts|Ranger||Tamer|EBCotOSCC|3",
+				"Master of Monsters|Ranger||Tamer|EBCotOSCC|7",
+                "Call of the Beasts|Ranger||Tamer|EBCotOSCC|11",
+                "Protection of the Pack|Ranger||Tamer|EBCotOSCC|15"
+			]
+        },
+        {
+			"name": "Seige Beast Master",
+			"source": "EBCotOSCC",
+			"className": "Ranger",
+			"classSource": "PHB",
+			"shortName": "SBM",
+            "subclassFeatures": [
+                "Beast Companion|Ranger||SBM|EBCotOSCC|3",
+                "Seige Beast Companion|Ranger||SBM|EBCotOSCC|7",
+                "Magical Seige Beast Companion|Ranger||SBM|EBCotOSCC|11",
+                "Greater Magical Seige Beast Companion|Ranger||SBM|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Path of the Spellthief",
+			"source": "EBCotOSCC",
+			"shortName": "Spellthief",
+			"className": "Rogue",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Sneaky Interrupt|Rogue||Spellthief|EBCotOSCC|3",
+				"Steal Spell|Rogue||Spellthief|EBCotOSCC|9",
+				"Unhook Spell|Rogue||Spellthief|EBCotOSCC|13",
+				"Reflect Spell|Rogue||Spellthief|EBCotOSCC|17"
+			]
+        },
+        {
+			"name": "Path of the Spy",
+			"source": "EBCotOSCC",
+			"shortName": "Spy",
+			"className": "Rogue",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Spycraft|Rogue||Spy|EBCotOSCC|3",
+				"Photographic Memory|Rogue||Spy|EBCotOSCC|3",
+                "Second Chance|Rogue||Spy|EBCotOSCC|9",
+				"Read Thoughts|Rogue||Spy|EBCotOSCC|13",
+				"Master Spy|Rogue||Spy|EBCotOSCC|17"
+			]
+        },        {
+			"name": "Entropist Bloodline",
+			"source": "EBCotOSCC",
+			"shortName": "Entropist Bloodline",
+			"className": "Sorcerer",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Touch of Entropy|Sorcerer||Entropist Bloodline|EBCotOSCC|1,5,9,13,17",
+				"Aura of Entropy|Sorcerer||Entropist Bloodline|EBCotOSCC|1,6,11,20",
+                "Entropic Damage|Sorcerer||Entropist Bloodline|EBCotOSCC|6",
+				"Resistances to Natural Law|Sorcerer||Entropist Bloodline|EBCotOSCC|14",
+				"Sphere of Entropy|Sorcerer||Entropist Bloodline|EBCotOSCC|18"
+			]
+        },        
+        {
+			"name": "Lycanthropic Bloodline",
+			"source": "EBCotOSCC",
+			"shortName": "Lycanthropic Bloodline",
+			"className": "Sorcerer",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Keen Senses|Sorcerer||Lycanthropic Bloodline|EBCotOSCC|1",
+				"Predator's Knowledge|Sorcerer||Lycanthropic Bloodline|EBCotOSCC|1",
+                "Hybrid Form|Sorcerer||Lycanthropic Bloodline|EBCotOSCC|6",
+				"Curse of Silver|Sorcerer||Lycanthropic Bloodline|EBCotOSCC|14",
+				"Apex Predator|Sorcerer||Lycanthropic Bloodline|EBCotOSCC|18"
+			]
+        },
+        {
+			"name": "Primordial Energy Savant",
+			"source": "EBCotOSCC",
+			"shortName": "PES",
+			"className": "Sorcerer",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Voice of the Elements|Sorcerer||PES|EBCotOSCC|1",
+				"Primordial Physiology|Sorcerer||PES|EBCotOSCC|1",
+                "Energy Admixture|Sorcerer||PES|EBCotOSCC|6",
+				"Heightened Primordial Magic|Sorcerer||PES|EBCotOSCC|14",
+				"Elemental Gate|Sorcerer||PES|EBCotOSCC|18"
+			]
+        },
+        {
+			"name": "Chaos Wielder",
+			"source": "EBCotOSCC",
+			"shortName": "CW",
+			"className": "Warlock",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Expanded Spell List|Warlock||CW|EBCotOSCC|1",
+				"Wild Magic|Warlock||CW|EBCotOSCC|1",
+                "Flows of Chaos|Warlock||CW|EBCotOSCC|6",
+				"Order in Chaos|Warlock||CW|EBCotOSCC|10",
+				"Twisted Fate|Warlock||CW|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Dragon Patron",
+			"source": "EBCotOSCC",
+			"shortName": "DP",
+			"className": "Warlock",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Expanded Spell List|Warlock||DP|EBCotOSCC|1",
+				"Dragon's Tongue|Warlock||DP|EBCotOSCC|1",
+                "Dragon's Claws|Warlock||DP|EBCotOSCC|1",
+                "Dragon Ancestry|Warlock||DP|EBCotOSCC|6",
+				"Dragon Senses|Warlock||DP|EBCotOSCC|10",
+				"Dragon Wings|Warlock||DP|EBCotOSCC|14",
+                "Frightful Presence|Warlock||DP|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Witchservant",
+			"source": "EBCotOSCC",
+			"shortName": "Witchservant",
+			"className": "Warlock",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Expanded Spell List|Warlock||Witchservant|EBCotOSCC|1",
+				"Hag's Form|Warlock||Witchservant|EBCotOSCC|1",
+                "Dark Devotion|Warlock||Witchservant|EBCotOSCC|1",
+                "Painful Incantation|Warlock||Witchservant|EBCotOSCC|6",
+				"Malediction|Warlock||Witchservant|EBCotOSCC|10",
+				"Ethereal Passage|Warlock||Witchservant|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Academic Wizard",
+			"source": "EBCotOSCC",
+			"shortName": "Academic",
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Efficient Spell Recovery|Wizard||Academic|EBCotOSCC|2",
+				"Simplified Spell Rituals|Wizard||Academic|EBCotOSCC|2",
+                "Expedient Spell Preparation|Wizard||Academic|EBCotOSCC|6",
+                "Elevated Spell Power|Wizard||Academic|EBCotOSCC|10",
+				"Combined Spell Effects|Wizard||Academic|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "Arcane Sentinel",
+			"source": "EBCotOSCC",
+			"shortName": "Arcane Sentinel",
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Practiced Abjurer|Wizard||Arcane Sentinel|EBCotOSCC|2",
+				"Advanced Alarm|Wizard||Arcane Sentinel|EBCotOSCC|2",
+                "Empowered Glyph|Wizard||Arcane Sentinel|EBCotOSCC|6",
+                "Tenacious Abjurations|Wizard||Arcane Sentinel|EBCotOSCC|10",
+				"Logical Defense|Wizard||Arcane Sentinel|EBCotOSCC|14"
+			]
+        },
+        {
+			"name": "School of Shadow",
+			"source": "EBCotOSCC",
+			"shortName": "SoS",
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassFeatures": [
+				"Darksight|Wizard||SoS|EBCotOSCC|2",
+				"Shadow Shield|Wizard||SoS|EBCotOSCC|2",
+                "Pseudo Reality|Wizard||SoS|EBCotOSCC|6",
+                "Shadow Evocation|Wizard||SoS|EBCotOSCC|10",
+				"Shadow Conjuration|Wizard||SoS|EBCotOSCC|14"
+			]
+        }
+    ],
+            "subclassFeature": [
+                {
+                    "name": "Demoralizing Blow",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Fear Rager",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you can break the ferocity of those whom you attack. As a bonus action, you can choose a creature that you have dealt damage to with a melee weapon during your turn. If the creature can see or hear you, it must succeed on a Wisdom saving throw (DC equals 8 + your Proficiency Bonus + your Charisma modifier) or have disadvantage on its melee attack rolls against you until the end of your next turn."
+                    ]
+                },
+                {
+                    "name": "Terrifying Onslaught",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Fear Rager",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 6,
+                    "entries": [
+                        "Starting at 6th level, you can instill fear in the hearts of those you attack. As a bonus action, you can choose a creature that you have dealt damage to with a melee weapon during your turn. If the creature can see or hear you, it must succeed on a Wisdom saving throw (DC equals 8 + your Proficiency Bonus + your Charisma modifier) or become frightened until the end of your next turn."
+                    ]
+                },
+                {
+                    "name": "Culling the Weak",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Fear Rager",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 10,
+                    "entries": [
+                        "Starting at 10th level, you can take advantage of those who fear you. You gain advantage on melee attack rolls against frightened creatures and your melee weapon attacks score a critical hit against them on a roll of 19 or 20."
+                    ]
+                },
+                {
+                    "name": "Intimidating Slaughter",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Fear Rager",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 14,
+                    "entries": [
+                        "Starting at 14th level, the fear in the eyes of your enemies intensifies your combat prowess. As a bonus action, you can make a melee weapon attack against a frightened creature and your melee weapon attacks score a critical hit against them on a roll of 18, 19 or 20. On a critical hit, all hostile creatures within 30 feet who saw your critical hit must succeed on a Wisdom saving throw (DC equals 8 + your Proficiency Bonus + your Charisma modifier) or become frightened until the end of your next turn."
+                    ]
+                },
+                {
+                    "name": "Grafted Appendages",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Frenzied Mutant",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you learn how to graft aberrant appendages into your body and use them to soak up damage from attacks. You gain 10 temporary hit points and +1 bonus to AC while you have these hit points. You regain these temporary hit points after a long rest."
+                    ]
+                },
+                {
+                    "name": "Bone Claw",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Frenzied Mutant",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, sharp, curved bone appendages grow out of both of your forearms that you can use to make attacks. The bone claws have a reach of 5 feet, can be used as part of an unarmed attack, and deal 1d8 + Strength modifier slashing damage on a hit."
+                    ]
+                },
+                {
+                    "name": "Telepathic Terror",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Frenzied Mutant",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 6,
+                    "entries": [
+                        "Starting at 6th level, you can telepathically project your rage into the mind of your enemies, causing them spasms that shake their will. As a bonus action, you can expend one use of your Rage feature to assault the mind of a target creature. The target creature must succeed on a Wisdom saving throw (DC equals 8 + your Proficiency Bonus + your Constitution modifier) or become charmed. A creature charmed this way has disadvantage on attack rolls, ability checks, and saving throws for 1 minute. At the end of each of its turns, the target can make another Wisdom saving throw. On a success, the effect ends on the target."
+                    ]
+                },
+                {
+                    "name": "Aberrant Anatomy",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Frenzied Mutant",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 10,
+                    "entries": [
+                        "Starting at 10th level, your bodily mutations become so severe and bizarre that your physiology is no longer similar to that of your original race. You become immune to critical hits and diseases. Extra eyes give you advantage on Wisdom (Perception) skill checks that rely on sight, and you gain darkvision to a range of 120 feet. You are also considered an aberration type creature for the purposes of determining effects but you otherwise retain your original creature type."
+                    ]
+                },               
+                {
+                    "name": "Agile Tentacles",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Frenzied Mutant",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 14,
+                    "entries": [
+                        "Starting at 14th level, you sprout appendages in the form of two fully functional alien tentacles that spread disease. You gain additional tentacle limbs that you can use to manipulate objects within a reach of 5 feet. You are considered to be proficient with these tentacles when making unarmed attacks with them. You can attack with both tentacles as a bonus action. Each hit with a tentacle causes 1d6 points of bludgeoning damage + your Strength modifier. A creature hit by a tentacle must make a Constitution saving throw (DC equals 8 + your Proficiency Bonus + your Constitution modifier) or become diseased. A creature diseased this way gains disadvantage on its attack rolls and ability checks for 1 minute."
+                    ]
+                }, 
+                {
+                    "name": "Raging Defiance",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Spelleater",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you can shake off and overcome magical effects with ease. While raging, you have advantage on saving throws against spells and magical effects."
+                    ]
+                },    
+                {
+                    "name": "Absorb Magic",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Spelleater",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 6,
+                    "entries": [
+                        "Starting at 6th level, you can soak up harmful magic while raging and revitalize yourself from its energies. When you succeed on a save against a spell or magical effect while raging, you regain 1d6 hit points for each level of the spell affecting you or 2d6 hit points if the magical effect has no spell levels associated with it."
+                    ]
+                }, 
+                {
+                    "name": "Brawn Over Magic",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Spelleater",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 10,
+                    "entries": [
+                        "Starting at 10th level, you can tense your muscles and stiffen your body to withstand the effects of magic. When you become the target of a spell or magical effect that requires a saving throw, you may choose to make a Strength saving throw instead of the original required save. In addition, if the spell or magical effect would allow you to make a saving throw to take only half damage, you instead take no damage if you succeed on the saving throw and only half damage if you fail. Once you use this feature, you cannot use it until you finish a short or long rest."
+                    ]
+                }, 
+                {
+                    "name": "Magic Resistance",
+                    "source": "EBCotOSCC",
+                    "className": "Barbarian",
+                    "classSource": "PHB",
+                    "subclassShortName": "Spelleater",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 14,
+                    "entries": [
+                        "Starting at 14th level, you become naturally resilient towards harmful magic. You gain advantage on all saving throws against spells and magical effects. You also gain the effects of a {@spell haste spell} for three rounds when you successfully save against a harmful spell or magical effect."
+                    ]
+                },
+                {
+                    "name": "Lament of Melancholy",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Dirge Singers",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you can sing a woeful lament that causes creatures to fall into a state of depression. As an action, you can expend one use of your Bardic Inspiration on your turn to choose a number of creatures that you can see within 60 feet equal to your Charisma modifier (a minimum of one). Those creatures must make a Charisma saving throw against your spell DC or become charmed. While charmed, the creature has disadvantage on ability checks for one minute but can make a Charisma saving throw at the end of each of its turns to end the effect."
+                    ]
+                }, 
+                {
+                    "name": "Dirge of Grief",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Dirge Singers",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you can sing a song that causes a creature to fall into a state of intense grief, washing away its hostility. As an action, you can target a creature that you can see within 60 feet. That creature must make a Charisma saving throw against your spell DC or become charmed. While charmed, the target becomes indifferent about creatures of your choice towards which it is hostile. This indifference ends if the target is attacked or harmed by a spell or if it witnesses any of its allies being harmed. The effect ends after one minute and the creature can become hostile again. Once you use this feature, you cannot use it again until you finish a short or long rest."
+                    ]
+                },
+                {
+                    "name": "Elegy of Hopelessness",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Dirge Singers",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 6,
+                    "entries": [
+                        "Starting at 6th level, you can recite a poem about death and passing that causes creatures to lose their motivation. As an action, you can expend one use of your Bardic Inspiration on your turn to choose a number of creatures that you can see within 60 feet equal to your Charisma modifier (minimum of one). Those creatures must make a Charisma saving throw against your spell DC or become charmed. While charmed, the creature has disadvantage on attack rolls and saving throws for one minute but can make a Charisma saving throw at the end of each of its turns to end the effect."
+                    ]
+                }, 
+                {
+                    "name": "Threnody of Death",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Dirge Singers",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 14,
+                    "entries": [
+                        "Starting at 14th level, you can sing a song of death that creates harmful necrotic energies. As an action, you can target a creature that you can see within 60 feet. That creature must make a Constitution saving throw against your spell DC. On a failed save, the creature takes 49 (14d6) necrotic damage, or half as much damage on a successful one. Once you use this feature, you cannot use it again until you finish a short or long rest."
+                    ]
+                },
+                {
+                    "name": "Accentuated Tone",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "High Speaker",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you learn how to add weight to your voice-based spells. As a bonus action, you can expend one use of your Bardic Inspiration to force your target to make a saving throw against your spell with disadvantage if that spell requires your target to hear you."
+                    ]
+                }, 
+                {
+                    "name": "Commanding Voice",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "High Speaker",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you learn how to force your will on other creatures by the sheer force of your voice. As a bonus action, you can expend one use of your Bardic Inspiration to cast the {@spell command} spell without expending a spell slot or material components. The {@spell command} spell is added to the bard spell list when you learn more bard spells of your choice."
+                    ]
+                }, 
+                {
+                    "name": "Universal Language",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "High Speaker",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 6,
+                    "entries": [
+                        "Starting at 6th level, you become able to converse with anyone alive or dead. You are constantly under the effect of a {@spell tongues} spell and you can cast the {@spell speak with dead}, {@spell speak with animals}, {@spell speak with plants} spells each a number of times per day equal to your Charisma modifier (minimum of once) without using spell slots or material components. Your spells that require your target to hear you can affect any creature type that has an Intelligence ability score of 3 or higher even if that creature is immune to being {@condition charmed} or {@condition frightened}."
+                    ]
+                },
+                {
+                    "name": "Word of Creation",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "High Speaker",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 14,
+                    "entries": [
+                        "Starting at 14th level, you learn to voice the word that shaped the world. As a bonus action, you can cast the {@spell divine word) spell without using a spell slot or material components. Once you use this feature, you cannot use it again until you finish a long rest."
+                    ]
+                },  
+                {
+                    "name": "Battle Feint",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Pretender",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, you can fool your enemies with your sudden swordplay and movement, placing them in a precarious combat situation. As a bonus action, you can expend one use of your Bardic Inspiration on your turn to feint, choosing one creature within 5 feet of you as your target. Your target must succeed on a Wisdom (Insight) skill check against your Charisma (Deception) skill check. If you win the contest, you have advantage on your melee attack rolls against that creature and the creature has disadvantage on attack rolls until the start of your next turn."
+                    ]
+                }, 
+                {
+                    "name": "Captivating Monologue",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Pretender",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 3,
+                    "entries": [
+                        "Starting at 3rd level, if you speak to an audience for at least 1 minute, you can attempt to captivate them with your style and colorful phrases. At the end of the performance, choose a number of humanoids within 60 feet of you who watched and listened to all of it, up to a number equal to your Charisma modifier (minimum of one). Each target must succeed on a Wisdom saving throw against your spell save DC or be charmed by you. While charmed in this way, the target has disadvantage on all Wisdom (Insight) skill checks against you. This effect ends on the target after 1 hour, if it takes any damage, if you attack it, or if it witnesses you attacking or damaging any of its allies. If a target succeeds on its saving throw, the target has no hint that you tried to charm it. Once you use this feature, you cannot use it again until you finish a short or long rest."
+                    ]
+                },
+                {
+                    "name": "Elusive Target",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Pretender",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 6,
+                    "entries": [
+                        "Starting at 6th level, you can avoid the melee attacks of your enemies with an unexpected move. As a reaction, you can expend one use of your Bardic Inspiration to negate a melee attack that would otherwise hit you."
+                    ]
+                },
+                {
+                    "name": "The Great Pretender",
+                    "source": "EBCotOSCC",
+                    "className": "Bard",
+                    "classSource": "PHB",
+                    "subclassShortName": "Pretender",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 14,
+                    "entries": [
+                        "Starting at 14th level, you can pretend to be someone else by projecting a visage of your pure imagination, while you remain invisible. As an action, you can expend one use of your Bardic Inspiration to cast {@spell mislead} without using a spell slot or material components."
+                    ]
+                },                                                                    
+                {
+                    "name": "Congregation Domain",
+                    "source": "EBCotOSCC",
+                    "className": "Cleric",
+                    "classSource": "PHB",
+                    "subclassShortName": "Congregation",
+                    "subclassSource": "EBCotOSCC",
+                    "level": 1,
+                    "entries": [
+                        "Shepherds of their flocks and great orators, these clerics can heighten the potency of their prayers when others of their faith reinforce them. The congregation's strength is in numbers, and clerics who follow this domain almost never serve alone and are almost always found in at least pairs. Priests of the congregation can favor war or competence over battle might, but all are dedicated to leading large groups of worshippers, sharing faith, and lending a hand to their co-religionists.",
+                        {
+                            "type": "table",
+                            "caption": "Congregation Domain Spells",
+                            "colLabels": [
+                                "Cleric Level",
+                                "Spells"
+                            ],
+                            "colStyles": [
+                                "col-3 text-center",
+                                "col-9"
+                            ],
+                            "rows": [
+                                [
+                                    "1st",
+                                    "{@spell bless}, {@spell protection from evil and good}"
+                                ],
+                                [
+                                    "3rd",
+                                    "{@spell aid}, {@spell calm emotions}"
+                                ],
+                                [
+                                    "5th",
+                                    "{@spell beacon of hope}, {@spell mass healing word}"
+                                ],
+                                [
+                                    "7th",
+                                    "{@spell compulsion}, {@spell private sanctum}"
+                                ],
+                                [
+                                    "9th",
+                                    "{@spell mass cure wounds}, {@spell telepathic bond}"
+                                ]
+                            ]
+		}
+        ]
+    },
+    {
+        "name": "Bonus Cantrip",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "When you choose this domain at 1st level, you gain the {@spell guidance} cantrip, which does not count against the number of cleric cantrips you now."
+        ]
+    },
+    {
+        "name": "Bonus Proficiency",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you become proficient in the Persuasion skill."
+        ]
+    },
+    {
+        "name": "Communal Prayers",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you can make your spells more potent if others cast the same spell as you. When another friendly creature casts the same spell in the same round as you, but before your spell takes effect, creatures targeted by your spell have disadvantage on saving throws against your spell."
+        ]
+    },
+    {
+        "name": "Channel Divinity: Mass Aid",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you can use your Channel Divinity to bolster your allies with toughness and resolve. As an action, you present your holy symbol and evoke healing energy that increases the hit point maximums and current hit points by your proficiency bonus x 5 for eight hours for all creatures you choose within 30 feet of you. This trait has no effect on undead or constructs."
+        ]
+    },
+    {
+        "name": "Channel Divinity: Heighten Spells",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can heighten your spells more effectively. If you cast a spell at a higher level that allows for additional creatures to be affected by your spell, you can use your Channel Divinity to make your spell affect two additional creatures per spell level instead of just one creature."
+        ]
+    },
+    {
+        "name": "Helping Hand",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 8,
+        "entries": [
+            "Starting at 8th level, you can aid multiple creatures in the completion of a task or allow a creature to make multiple attacks. When you take the Help action, an additional friendly creature within 5 feet of you gains advantage on the next ability check made to perform the task you are helping with, provided that the check is made before the start of your next turn. Alternatively, you can use your Help action to aid up to two friendly creatures in attacking a creature within 5 feet of you and if your allies attack the target before your next turn, all of their first attack rolls are made with advantage."
+        ]
+    },
+    {
+        "name": "Forceful Communal Prayers",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Congregation",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, you can make spells more potent if you or others ast the same spell in your presence. After you or an ally casts a spell, creatures targeted by the same spell cast by you or an ally gain disadvantage on the saving throw until the end of the turn. Additionally, if the spell requires a dice roll, you or allies can reroll 1s and 2s and must use the new roll, even if the new roll is a 1 or a 2."
+        ]
+    },
+    {
+        "name": "Darkness Domain",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "The clerics of the Darkness Within are secretive individuals who detach themselves from society and keep to the shadows. They accommodate themselves to darkness and operate unseen, focusing on hiding what they deem significant from the eyes of those who seek them. The imprint of the Dark Star’s reign still resonates with the populace of Aglarion, manifesting in the subconscious memory of the society as a whole. Those who follow the Darkness Within keep their faith to themselves even if they are not devoted to the ideology of the dark solar avatar of their dualistic god. They pray at midnight and venerate the new moon as the absolute peak of their god’s power.",
+            {
+                "type": "table",
+                "caption": "Darkness Domain Spells",
+                "colLabels": [
+                    "Cleric Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "1st",
+                        "{@spell fog cloud}, {@spell sleep}"
+                    ],
+                    [
+                        "3rd",
+                        "{@spell darkness}, {@spell darkvision}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell fear}, {@spell nondetection}"
+                    ],
+                    [
+                        "7th",
+                        "{@spell greater invisibility}, {@spell phantasmal killer}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell dream}, {@spell mislead}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Dark Sight",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you gain darkvision 60 ft. and magical darkness does not impede your sight. If you already have darkvision, its range increases by 60 ft."
+        ]
+    },
+    {
+        "name": "Cloak of Darkness",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, as a bonus action, you can weave shadows around you into a magical cloak that hides your form and protects you from attacks. For 1 minute, creatures have disadvantage on attack rolls against you. An attacker is immune to this effect if it does not rely on sight, as with blindsight or tremorsense, or can see through illusions, as with truesight. Once you use this feature, you cannot use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Channel Divinity: Darkness Descends",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, as an action, you can use your Channel Divinity to harness darkness, summoning darkness and banishing light. As an action, you present your holy symbol and summon a 30 foot radius globe of darkness that functions as the {@spell darkness} spell that lasts for 1 minute. The globe appears in a space that you can see within 30 feet of you. Any magical light effect within the globe is dispelled. Additionally, each hostile creature within the globe must make a Constitution saving throw against your spell save DC when the globe of darkness appears. A creature takes necrotic damage equal to 2d6 + your cleric level on a failed saving throw, and half as much damage on a successful one. A creature that has total cover from you is unaffected."
+        ]
+    },
+    {
+        "name": "Channel Divinity: Conjure Shadows",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can spend two uses of your Channel Divinity as an action to summon living shadows from darkness. This ability functions as a {@spell conjure animals} spell, however it summons a single shadow, which speaks Common and does your bidding for one hour."
+        ]
+    },
+    {
+        "name": "Void Eye",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 8,
+        "entries": [
+            "Starting at 8th level, you gain blindsight 30 ft. and become immune to the blinded condition."
+        ]
+    },
+    {
+        "name": "Shadowform",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Darkness",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, as an action you can transform yourself into the form of a shadow. You and your possessions become incorporeal for one hour. Once you use this feature you cannot use it until you finish a long rest. You gain the following benefits:",
+        {"type": "list",
+        "items":[
+        "You gain a fly speed equal to your walking speed.",
+        "You can move through a space as narrow as 1 inch wide without squeezing.",
+        "You can take the Hide action as a bonus action while in dim light or darkness.",
+        "You have advantage on Dexterity (Stealth) skill checks",
+        "You gain damage resistance to acid, cold, fire, lightning, thunder and bludgeoning, piercing, and slashing from nonmagical attacks.",
+        "You gain damage immunity to poison.",
+        "You are immune to the exhaustion, grappled, paralyzed, petrified, poisoned, prone, and restrained condition."
+        ]
+    }
+        ]
+    },
+    {
+        "name": "Ooze Domain",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Clerics of the Ooze Domain believe in a higher level of physical existence that is represented by oozes. They serve their formless god to learn to be free from physical bounds. They believe that in the end, all organic materials will be wholly absorbed by oozes and are ready to sacrifice even themselves towards the fulfillment of this eventuality. In Aglarion, clerics of the ooze domain usually serve the Blind God, a minor entity that has only a few fanatic believers.",
+            {
+                "type": "table",
+                "caption": "Ooze Domain Spells",
+                "colLabels": [
+                    "Cleric Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "1st",
+                        "{@spell create or destroy water}, {@spell false life}"
+                    ],
+                    [
+                        "3rd",
+                        "{@spell acid arrow}, {@spell blindness/deafness}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell meld into stone}, {@spell protection from energy}"
+                    ],
+                    [
+                        "7th",
+                        "{@spell black tentacles}, {@spell freedom of movement}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell contagion}, {@spell hold monster}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Bonus Cantrip",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "When you choose this domain at 1st level, you gain the {@spell acid splash} cantrip, which does not count against the number of cleric cantrips you know."
+        ]
+    },
+    {
+        "name": "Bonus Proficiency",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you gain proficiency with martial weapons."
+        ]
+    },
+    {
+        "name": "Sense of the Ooze",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you can gain the senses of an ooze as a bonus action. You gain blindsight to 5 ft. for a number of rounds equal to your Wisdom modifier. The range of this blindsight increases by 5 feet at 5th, 9th, 13th and 17th level. You can use this feature a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest."
+        ]
+    },
+    {
+        "name": "Channel Divinity: Charm Oozes",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you can use your Channel Divinity to charm oozes. As an action, you present your holy symbol and invoke the name of your deity. Each ooze that can sense you must make a Wisdom saving throw. If the creature fails its saving throw it is charmed by you for 1 minute or until it takes damage. While it is charmed by you, it is friendly to you and other creatures you designate."
+        ]
+    },
+    {
+        "name": "Acid Resistance",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you gain resistance to acid damage."
+        ]
+    },
+    {
+        "name": "Gelatinous Form",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 8,
+        "entries": [
+            "Starting at 8th level, you can become as transparent as a gelatinous cube. As an action, you can become transparent, even when you are in plain sight. Your gear also becomes transparent with you. It requires a DC 15 Wisdom (Perception) skill check to spot you if you have not moved nor attacked during your turn. A creature that tries to enter your space while unaware of you is surprised by you."
+        ]
+    },
+    {
+        "name": "Ooze Form",
+        "source": "EBCotOSCC",
+        "className": "Cleric",
+        "classSource": "PHB",
+        "subclassShortName": "Ooze",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, as an action you can assume the form of an ooze for 1 hour. You gain a speed of 20 ft. and climb 20 ft. You gain damage immunity to acid, cold, lightning and slashing damage. You become immune to the blinded, charmed, deafened, frightened and prone conditions as well as exhaustion. In addition, you gain blindsight 60 ft., but become blind beyond the range of your blindsight. Once you use this feature, you cannot use it again until you finish along rest. You gain the following abilities:",
+        {"type": "list",
+        "items":[
+        "You can move through a space as narrow as 1 inch wide without squeezing.",
+        "A creature that touches you or hits you with a melee attack while within 5 feet of you takes 13 (3d8) acid damage. Any nonmagical weapon made of metal or wood that hits you corrodes. After dealing damage, the weapon takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. Nonmagical ammunition made of metal or wood that hits you is destroyed after dealing damage. You can eat through 2-inch thick, nonmagical wood or metal in 1 round.",
+        "You can climb difficult surfaces, including upside down on ceilings, without needing to make an ability check.",
+        "You can make a melee attack with a reach of 5 ft. that deals 1d6 + your Strength modifier bludgeoning damage plus 18 (4d8) acid damage. In addition, nonmagical armor worn by the target is partly dissolved and takes a permanent and cumulative -1 penalty to the AC it offers. The armor is destroyed if the penalty reduces its AC to 10."
+        ]
+    }
+        ]
+    },
+    {
+        "name": "Plant Form",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Bloom",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, your strong connection to plant life allows you to transform into monstrous forms. You can use your Wild Shape to transform into a plant instead of a beast.",
+            "Starting at 6th level, your attacks in plant form count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage."
+        ]
+    },
+    {
+        "name": "Circle Spells",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Bloom",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Your mystical connection to plant life infuses you with the ability to cast certain spells. At 3rd, 5th, 7th, and 9th level you gain access to circle spells Once you gain access to a circle spell, you always have it prepared, and it does not count against the number of spells you can prepare each day. If you gain access to a spell that does not appear on the druid spell list, the spell is nonetheless a druid spell for you.",
+            {
+                "type": "table",
+                "caption": "Circle of the Bloom Spells",
+                "colLabels": [
+                    "Druid Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell barkskin}, {@spell locate animals or plants}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell daylight}, {@spell plant growth}"
+                    ],
+                    [
+                        "7th",
+                        "{@spell control water}, {@spell freedom of movement}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell commune with nature}, {@spell tree stride}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Speak with Plants",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Bloom",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you gain the ability to converse with plants. You can cast the {@spell speak with plants} spell without expending a spell slot or material components. Once you use this feature, you cannot use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Land's Stride",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Bloom",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, moving through nonmagical difficult terrain costs you no extra movement. You can also pass through nonmagical plants without being slowed by them and without taking damage from them if they have thorns, spines, or a similar hazard.",
+            "In addition, you gain advantage on saving throws against plants that are magically created or manipulated to impede movement, such as those created by the entangle spell."
+        ]
+    },
+    {
+        "name": "Blessings of Bloom",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Bloom",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, your magic becomes attuned to the flora and your plant magic is stronger than usual. You gain the following benefits:",
+        {"type": "list",
+        "items":[
+        "When you cast the {@spell entangle} spell, the area of the spell is increased to a 40-foot square. Whenever a creature uses a Strength check to free itself, the thorns on the plants deal 2 (1d4) piercing damage.",
+        "When you cast {@spell barkskin}, the target’s AC can’t be less than 18, regardless of what kind of armor it is wearing.",
+        "When you cast the {@spell locate animals or plants} spell and you describe a specific kind of plant, the area of the spell increases to a range of 50 miles.",
+        "When you cast {@spell plant growth}, the radius of the area covered by plants is 500 feet.",
+        "When you cast the {@spell commune with nature} spell, the area of the effect is doubled. You also gain an understanding of all plant creatures in the area, as well as all plant-based hazards and poisons."
+        ]
+    }
+        ]
+    },
+    {
+        "name": "Treant Form",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Bloom",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you can take on the form of the grandest creature of the forest, the treant. You can use your Wild Shape to transform into a treant, but must follow all other limitations presented under Wild Shape. You cannot use the Animate Trees ability of the treant."
+        ]
+    },
+    {
+        "name": "Bonus Cantrip",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you gain access to the {@spell true strike} cantrip"
+        ]
+    },
+    {
+        "name": "Circle Spells",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you gain access to the following circle spells, which are always prepared and don’t count towards the number of spells you can prepare each day.",
+            {
+                "type": "table",
+                "caption": "Circle of the Savage Blood Spells",
+                "colLabels": [
+                    "Druid Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell enhance ability}, {@spell enlarge/reduce}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell blink}, {@spell fly}"
+                    ],
+                    [
+                        "7th",
+                        "{@spell dominate beast}, {@spell polymorph}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell antilife shell}, {@spell hold monster}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Monstrous Form",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you acquire the ability to transform into monstrous forms. You can use your Wild Shape to transform into a monstrosity instead of a beast."
+        ]
+    },
+    {
+        "name": "Monstrous Aspect",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you can transform your body to manifest the feature of a monstrosity. This manifestation persists for 1 minute or until you're incapacitated. Once you use this feature, you can't use it again until you finish a short or long rest.As a bonus action, you can apply one of the features to your body from the options below",
+            {"type": "list",
+            "items":[
+            "{@bold Gallop of the Centaur.} Your two legs turn into those of a centaur and become powerful. Your speed increases to 50 feet.",
+            "{@bold Wings of the Cockatrice.} You sprout two feathery wings that allow you to fly. You gain a fly speed of 40 feet.",
+            "{@bold Claws of the Griffon.} Your hands turn into savage claws like those of a griffon. You can use your attack action to make a claw attack that deals 2d4 slashing damage plus your Strength modifier.",
+            "{@bold Horns of the Minotaur.} Horns grow from your forehead. You can use your attack action to make a gore attack that deals 1d8 bludgeoning damage plus your Strength modifier. If the target is a creature, it must succeed on a Strength saving throw (DC equals 8 + your Proficiency Bonus + your Strength modifier) or be pushed up to 10 ft. away and knocked prone."
+            ]
+        }
+            ]
+    },
+    {
+        "name": "Monster Caller",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can summon monstrous creatures that obey your commands. Your conjuration spells can summon monstrosities instead of beasts."
+        ]
+    },
+    {
+        "name": "Master of Monsters",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Staring at 10th level, you can affect monstrosities with your spells that would otherwise affect beasts. You can target monstrosities with spells that normally affect beasts."
+        ]
+    },
+    {
+        "name": "Monster Friend",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Savage Blood",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, monstrosities sense your connection to their kind and become hesitant to attack you. When a monstrosity wants to attack you, that creature must make a Wisdom saving throw against your druid spell save DC. On a failed save, the creature must choose a different target, or the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours. The creature is aware of this effect before it makes its attack against you."
+        ]
+    },
+    {
+        "name": "Bonus Cantrip",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you gain access to the {@spell eldritch blast} cantrip"
+        ]
+    },
+    {
+        "name": "Circle Spells",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you gain access to the following circle spells, which are always prepared and don’t count towards the number of spells you can prepare each day.",
+            {
+                "type": "table",
+                "caption": "Inheritor of the Unbegotten Spells",
+                "colLabels": [
+                    "Druid Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell blur}, {@spell detect thoughts}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell gaseous form}, {@spell spirit guardians}"
+                    ],
+                    [
+                        "7th",
+                        "{@spell banishment}, {@spell black tentacles}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell contact other plane}, {@spell hallow}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Voice of the Void",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you learn how to converse with aberrations. You learn how to speak, read, and write Deep Speech. You can also make yourself understood by aberrations that don’t speak Dark Speech or are not capable of speech."
+        ]
+    },
+    {
+        "name": "Incomprehensible Intellect",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, your mind becomes as obscure and alien as the beings you venerate. Your thoughts cannot be read by magical means and you become immune to being charmed."
+        ]
+    },
+    {
+        "name": "Manifest Aberrant Trait",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can call forth specific powers of your revered entities. As an action, you can expend one use of your Wild Shape feature to emulate one special trait of any aberration type creature of CR 3 or lower for one minute. If there is a saving throw associated with the special trait then the DC equals 8 + your Proficiency Bonus + your Wisdom modifier."
+        ]
+    },
+    {
+        "name": "Enslave",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Staring at 10th level, you can manifest your dominance over humanoids. As an action, you can cast the {@spell dominate person} spell without expending a spell slot or material components. Once you use this feature, you cannot use it until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Conjure Abomination",
+        "source": "EBCotOSCC",
+        "className": "Druid",
+        "classSource": "PHB",
+        "subclassShortName": "Unbegotten",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, the otherworldly beings you venerate allow you to summon their more powerful servants. As an action, you can cast the {@spell conjure celestial} spell without expending aspell slot or material components, but instead of a celestial creature, you conjure an aberration type creature of your choice within the limits of the spell. The spell lasts 1 hour and does not require you to concentrate on it. Once you use this feature, you cannotuse it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Commander's Orders",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Commander",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can inspire others through the power of your commands. To do so, you use a bonus action on your turn to choose any number of creatures other than yourself within 60 feet of you who can hear you. Those creatures gain one Command die, a d6.",
+            "Once within the next 10 minutes, the creature can roll the die and add the number rolled to one ability check. The creature can wait until after it rolls the d20 before deciding to use the Command die, but must decide before the DM says whether the roll succeeds or fails. Once the Command die is rolled, it is lost. A creature can have only one Command die at a time. You can use this feature a number of times equal to your Charisma modifier (a minimum of once). You regain any expended uses when you finish a long rest.",
+            "Your Command die changes when you reach certain levels in this class. The dice becomes a d8 at 5th level, a d10 at 10th level, and a d12 at 15th level."
+        ]
+    },
+    {
+        "name": "Order of Charge",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Commander",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, you can expend one use of your Commander's Order ability to double the movement speed of the creatures you choose until the end of their next turn."
+        ]
+    },
+    {
+        "name": "Order of Defense",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Commander",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you can expend one use of your Commander's Order ability to allow the creatures you choose to gain and roll the Command die and add the number rolled to one saving throw."
+        ]
+    },
+    {
+        "name": "Order of Attack",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Commander",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, you can expend one use of your Commander's Orders ability to allow the creatures you choose to gain and roll the Command die and add the number rolled to one attack roll."
+        ]
+    },
+    {
+        "name": "Legendary Command",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Commander",
+        "subclassSource": "EBCotOSCC",
+        "level": 18,
+        "entries": [
+            "Starting at 18th level, your Commander's Order can influence every friendly creature within 80 feet of you who can hear you, as well as yourself. Additionally, you can cast the command spell a number of times per day equal to your proficiency bonus (DC equals 8 + your Proficiency Bonus + your Charisma modifier) without expending a spell slot or material components."
+        ]
+    },
+    {
+        "name": "Iron Will",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Mercenary",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you become focused and confident. You gain advantage on saving throws against being charmed and frightened."
+        ]
+    },
+    {
+        "name": "Ready for Anything",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Mercenary",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, you learn to be prepared for the unexpected. When targeted by a spell or effect, you can take a reaction to gain advantage on the saving throw."
+        ]
+    },
+    {
+        "name": "Versatile Fighting",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Mercenary",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you become experienced with all kinds of weapons and fighting styles. You can swiftly change your style of fighting to fit the challenge temporarily. You can't benefit from the same Fighting Style option more than once. Choose one of the following options at the beginning of your turn:",
+            {"type": "list",
+            "items":[
+            "{@bold Archery.} You gain a +2 bonus to attack rolls you make with ranged weapons.",
+            "{@bold Defense.} While you are wearing armor, you gain a +1 bonus to AC.",
+            "{@bold Dueling.} When you are wielding a melee weapon in one hand and no other weapons, you gain a +2 bonus to damage rolls with that weapon.",
+            "{@bold Great Weapon Fighting.} When you roll a 1 or 2 on a damage die for an attack you make with a melee weapon that you are wielding with two hands, you can reroll the die and must use the new roll, even if the new roll is a 1 or a 2. The weapon must have the two-handed or versatile property for you to gain this benefit."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Mettle",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Mercenary",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, you have become skilled in resisting several types of threats. Choose two abilities in which you don't have a saving throw proficiency. You gain proficiency in saving throws made with the chosen abilities."
+        ]
+    },
+    {
+        "name": "Get the Job Done",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Mercenary",
+        "subclassSource": "EBCotOSCC",
+        "level": 18,
+        "entries": [
+            "Starting at 18th level, you can overcome threats with ease. Instead of rolling, you can choose to succeed on a saving throw automatically. Once you use this feature, you can't use it until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Alert on Duty",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Royal Guard",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can focus your attention to notice movement. Designate a 10 square foot area. If you stay in this area for 10 minutes, you can double your proficiency bonus and gain advantage on Wisdom (Perception) skill checks made to notice creatures."
+        ]
+    },
+    {
+        "name": "Coordinated Strike",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Royal Guard",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, you can use your combat training to coordinate your attacks with your allies. Once per turn, you gain advantage on your first melee attack roll against a creature if at least one of your allies is within 5 ft. of the creature and the ally isn't Incapacitated."
+        ]
+    },
+    {
+        "name": "Coordinated Shot",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Royal Guard",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you can spot the exact moment to release a shot while your ally occupies your target. Once per turn, you gain advantage on your first ranged attack roll against a creature if at least one of your allies is within 5 ft. of the creature and the ally isn't Incapacitated."
+        ]
+    },
+    {
+        "name": "Swift Strike",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Royal Guard",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, your combat reactions become effortless. You gain an extra reaction that doesn't count towards your single use in the turn and that you can use only to make an attack roll, but only when your reaction is triggered."
+        ]
+    },
+    {
+        "name": "Divert Strike",
+        "source": "EBCotOSCC",
+        "className": "Fighter",
+        "classSource": "PHB",
+        "subclassShortName": "Royal Guard",
+        "subclassSource": "EBCotOSCC",
+        "level": 18,
+        "entries": [
+            "Starting at 18th level, you become one with your weapon, being able to deflect melee attacks. As a reaction, when targeted by a melee ttack made by a creature within 5 feet of you that you can see, you can try to negate the attack. You must make a melee attack roll contest against the melee attack roll of the creature. On a success, you negate all damage from the creature's attack."
+        ]
+    },
+    {
+        "name": "Resist Strikes",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Stonefish",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can channel your ki into resisting damage from a blow. As a reaction, you can spend 1 ki point to reduce the damage you take from an attack by 1d10 + your Strength modifier + your monk level."
+        ]
+    },
+    {
+        "name": "Mountain Stance",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Stonefish",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can tighten your muscles to enter a steady stance making you immovable and hard to grapple with. As a bonus action, you can spend 1 ki point to gain advantage on contests involving Strength (Athletics) ability checks made against you and on Strength saving throws for 1 minute. If you move, you lose this advantage until the start of your next turn."
+        ]
+    },
+    {
+        "name": "Stone Body",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Stonefish",
+        "subclassSource": "EBCotOSCC",
+        "level": 11,
+        "entries": [
+            "Starting at 11th level, you can evoke a protective layer of stony skin over your entire body. As a bonus action, you can spend 3 ki points to gain damage resistance from bludgeoning, piercing, and slashing damage for 1 minute."
+        ]
+    },
+    {
+        "name": "Elemental Transformation",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Stonefish",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, you can become one of the elemental creatures you learned to imitate your whole life. As a bonus action, you can spend 6 ki points to transform into an earth elemental for 1 minute as if you were using the Wild Shape ability of the druid class. You can use all of your monk abilities in this new form. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Hellfire Fist",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Nine Seals",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can spend 1 ki point as an action to inflame a melee weapon you touch or your fists with hellish fire for 1 minute. Your unarmed or melee attacks deal an extra 1d4 fire damage."
+        ]
+    },
+    {
+        "name": "Deny Advantage",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Nine Seals",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can demand equal chances from your enemies. As a bonus action, you can spend 1 ki point to have one creature of your choice within 30 feet lose its advantage on all ability checks, saving throws, skill checks, and attack rolls until the start of your next turn."
+        ]
+    },
+    {
+        "name": "Pierce Deception",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Nine Seals",
+        "subclassSource": "EBCotOSCC",
+        "level": 11,
+        "entries": [
+            "Starting at 11th level, the powers of Hell grant you the ability to see reality as it is for a short period of time. As a bonus action, you can spend 3 ki points to gain the benefits of  a true seeing spell for 1 minute."
+        ]
+    },
+    {
+        "name": "Contractual Fate",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Nine Seals",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, you can benefit from your hellish contract that has promised to protect you from unwanted outcomes of your fate in return for your service. As a reaction, you can automatically succeed on one ability check, saving throw, or skill check instead of rolling. Once you use this feature, you can't use it again until you finish a short or long rest, unless you spend 5 ki points."
+        ]
+    },
+    {
+        "name": "Tentacle Limb",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Tentacle",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can turn your body into the form of an aberrant creature. As a bonus action, you can spend 1 ki point to transform your arm into a 10-foot long tentacle for 1 minute. The tentacle has reach and can be used as part of an unarmed strike. The tentacle deals bludgeoning damage equal to your Martial Arts die + your Strength or Dexterity modifier. You gain advantage on Strength (Athletics) skill checks to grapple an opponent with the tentacle. At 11th level, you can transform both of your arms into tentacle limbs."
+        ]
+    },
+    {
+        "name": "Nerve-Wracking Strike",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Tentacle",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can channel psychic energies into your tentacle strikes. Your unarmed strikes with your tentacle limb count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage. You can spend 1 ki point to deal additional psychic damage with one unarmed strike of your tentacle limb equal to one roll of your Martial Arts die + your Wisdom modifier."
+        ]
+    },
+    {
+        "name": "Psychic Barrage",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Tentacle",
+        "subclassSource": "EBCotOSCC",
+        "level": 11,
+        "entries": [
+            "Starting at 11th level, your ability to channel harmful psychic powers intensifies. When you use Flurry of Blows after an attack made with Nerve-wracking Strike, you can replace each of the unarmed strikes with a use of your Nerve-wracking Strike without spending additional ki points."
+        ]
+    },
+    {
+        "name": "Suffocating Strike",
+        "source": "EBCotOSCC",
+        "className": "Monk",
+        "classSource": "PHB",
+        "subclassShortName": "Tentacle",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, you learn how to force your tentacle limb into the throat of your enemies to kill them. The reach of your tentacle limb becomes 15 feet. As an action, you can attempt to grapple your opponent with your tentacle limb. A successfully grappled target becomes unable to speak and if you choose, it starts to suffocate while being grappled by you."
+        ]
+    },
+    {
+        "name": "Tenets of Inquisition",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Inquisitor",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "The tenets of the Oath of the Inquisitor drive a paladin to seek the truth and to eliminate the hidden enemies of its faith.",
+            "{@italic Draw out the truth.} The truth is not always visible. Finding it is sometimes hard, but the effort must be made. Once found, it must be announced so that others can learn it as well.",
+            "{@italic Facts only.} Facts are the only truths on which you can rely. Anything else is mere speculation. One can only make a decision based on facts. Without firm evidence, even truth cannot be proven.",
+            "{@italic Oppose heresy.} Seeking those who work to ruin and undermine the church’s integrity is the holiest service one can do for one’s faith. Therefore, one must always stay vigilant and be on the lookout for corruption and those who spread falsehoods.",
+            "{@italic Live by the law.} Law provides safety and justice to all. Order is the only truth on which one can build. Those who break the law must pay the price. Therefore, one must live by the law and keep it at all costs."
+        ]
+    },
+    {
+        "name": "Oath Spells",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Inquisitor",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, You gain oath spells at the paladin levels listed.",
+            {
+                "type": "table",
+                "caption": "Inquisitor Spells",
+                "colLabels": [
+                    "Paladin Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell comprehend languages}, {@spell detect evil and good}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell detect thoughts}, {@spell zone of truth}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell clairvoyance}, {@spell speak with dead}"
+                    ],
+                    [
+                        "13th",
+                        "{@spell banishment}, {@spell locate creature}"
+                    ],
+                    [
+                        "17th",
+                        "{@spell dispel evil and good}, {@spell legend lore}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Channel Divinity",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Inquisitor",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "When you take this oath at 3rd level, you gain the following two Channel Divinity options.",
+            {"type": "list",
+            "items":[
+            "{@bold Pierce Illusion.} As a bonus action, you can use your Channel Divinity to augment your senses to overcome illusions. For the next 10 minutes, you can automatically see through 2nd level or lower illusion spells, you can automatically make an Intelligence (Investigation) skill check to discern 3rd or higher level illusion spells that allow such checks by merely looking at them, and you gain advantage on Intelligence (Investigation) skill checks.",
+            "{@bold Denounce Shapeshifter.} You can use your Channel Divinity to force a shapeshifting creature back into its natural form. As an action, you can target one creature within 30 feet. The target creature must make a Charisma saving throw. On a failed save, the target reverts to its natural form and can't change its form for 1 minute."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Discern Falsehood",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Inquisitor",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, you can focus your senses to detect deliberate lies. As an action, you can target one creature within 30 feet. The target creature must make a Charisma saving throw (DC equals 8 + your Proficiency Bonus + your Charisma modifier). On a failed save, you know if the target creature deliberately and knowingly speaks a lie. This ability does not reveal the truth. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Prevent Escape",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Inquisitor",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, you are able to prevent your enemies from escaping. As an action, you can target one creature within 30 feet. The target creature must make a Charisma saving throw (DC equals 8 + your Proficiency Bonus + your Charisma modifier). On a failed save, the target creature becomes restrained by an invisible force and is prevented from using any form of teleportation, dimensional, or planar travel for one minute. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Ultimate Conviction",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Inquisitor",
+        "subclassSource": "EBCotOSCC",
+        "level": 20,
+        "entries": [
+            "Starting at 20th level, you can imprison, interrogate, and punish those you find guilty. As an action, you can create a cage made out of energy similar to a {@spell forcecage} spell. Any creature within the cage must make a Charisma saving throw (DC equals 8 + your Proficiency Bonus + your Charisma modifier). On a failed save, the creature is charmed. Creatures charmed this way must answer your questions truthfully until they are imprisoned this way. You can choose to release the target from the cage at any time, or target one of the creatures within the cage with an {@spell imprisonment} or {@spell power word kill} spell as if you have cast it requiring no material components. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Tenets of Cleansing",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Cleansing",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "The tenets of the Oath of Cleansing offer a framework for paladins of this order to keep all aspects of their lives and those of others pristine and devoid of harmful effects.",
+            "{@italic Cleanse the domain.} Your surroundings reflect upon your person. Keep them spotless so that you may benefit from their immaculate nature and the purity they provide.",
+            "{@italic Cleanse the body.} Your body is the shrine of your being. A healthy body is the first step to a healthy mind and soul.",
+            "{@italic Cleanse the mind.} Keep your mind sharp and without filthy thoughts. Avoid substances that cloud your intellect and strive to keep it sharp.",
+            "{@italic Cleanse the soul.} The soul is divine and must be protected from external influences. By righteous actions, you can fortify it and keep it unsullied."
+        ]
+    },
+    {
+        "name": "Oath Spells",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Cleansing",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, You gain oath spells at the paladin levels listed.",
+            {
+                "type": "table",
+                "caption": "Oath of Cleansing Spells",
+                "colLabels": [
+                    "Paladin Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell protection from evil and good}, {@spell purify food and drink}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell lesser restoration}, {@spell protection from poison}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell protection from energy}, {@spell remove curse}"
+                    ],
+                    [
+                        "13th",
+                        "{@spell death ward}, {@spell freedom of movement}"
+                    ],
+                    [
+                        "17th",
+                        "{@spell dispel evil and good}, {@spell greater restoration}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Channel Divinity",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Cleansing",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "When you take this oath at 3rd level, you gain the following two Channel Divinity options.",
+            {"type": "list",
+            "items":[
+            "{@bold Hallow.} You can use your Channel Divinity to infuse an area as sacred ground. As an action, you present your holy symbol and speak a prayer. The effect functions as a hallow spell with a radius of up to 30 feet and lasts for 1 minute. When you use this feature, you can only choose the Courage or Energy Protection features of the spell.",
+            "{@bold Cleansing Lay on Hands.} You can use your Channel Divinity to empower your Lay on Hands ability. By extending one use of your Channel Divinity, you can cure multiple diseases and neutralize multiple poisons with a single use of Lay on Hands without expending hit points separately for each affliction. This use of your Lay on Hands also functions against negative influences that include being charmed, cursed, or frightened."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Exorcist",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Cleansing",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, you can exorcise evil spirits from others. As an action, you can end possession on a creature, forcing the possessing spirit out of the target with a touch. You can use this feature a number of times equal to your Charisma modifier (a minimum of once), and you regain all expended uses when you finish a long rest."
+        ]
+    },
+    {
+        "name": "Purify",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Cleansing",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, you can remove any negative condition from yourself or a willing creature you touch as an action. This ability also includes madness, petrification, and polymorph effects in addition to diseases and poisons, as well as being charmed, cursed, frightened. You can use this feature a number of times equal to your Charisma modifier (a minimum of once). You regain any expended uses when you finish a long rest."
+        ]
+    },
+    {
+        "name": "Greater Purify",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Cleansing",
+        "subclassSource": "EBCotOSCC",
+        "level": 20,
+        "entries": [
+            "At 20th level, your faith gives you and your allies immunity to all negative influences that you can cleanse in your surroundings. As an action, you can remove all effects listed under your Purify ability from yourself and friendly creatures within 30 feet of you."
+        ]
+    },
+    {
+        "name": "Tenets of Protection",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Protection",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "The first monarchs of Aglarion laid down the tenets of the Oath of Protection to protect their royal personages and the realm. However the oath has been shared widely by many faiths since then. Adherents to this oath hold the protection of people, places, and beliefs above all else and usually share these basic principles.",
+            "{@italic Protect those who protect us.} Show respect to and safeguard those that are deserving and to whom you are sworn. Your word is your bond. Knights of the Crown take a special oath in Aglarion that stands above all other tenets: “Protect the Realm, your Sovereign, and the Crown.”",
+            "{@italic Protect your allies.} Keep those who depend on you from harm if threatened by forces greater than themselves. Shield those who are in allegiance with you as a bastion against harm. Join forces with your allies to overcome threats.",
+            "{@italic Protect those who stand behind you.} Lead by example to become a beacon of inspiration to those around you, especially against seemingly insurmountable odds.",
+            "{@italic Protect yourself if there is nothing left to protect.} Fortify your faith so that you may stand firm against that which makes you vulnerable. Be willing to sacrifice even your own life before all others. Tend to your own well-being, so that you may safeguard your charge until the very last."
+        ]
+    },
+    {
+        "name": "Oath Spells",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Protection",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, You gain oath spells at the paladin levels listed.",
+            {
+                "type": "table",
+                "caption": "Oath of Protection Spells",
+                "colLabels": [
+                    "Paladin Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell protection from evil and good}, {@spell shield of faith}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell warding bond}, {@spell protection from poison}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell protection from energy}, {@spell magic circle}"
+                    ],
+                    [
+                        "13th",
+                        "{@spell death ward}, {@spell guardian of faith}"
+                    ],
+                    [
+                        "17th",
+                        "{@spell dispel evil and good}, {@spell raise dead}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Channel Divinity",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Protection",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "When you take this oath at 3rd level, you gain the following two Channel Divinity options.",
+            {"type": "list",
+            "items":[
+            "{@bold Vow of Protection.} You can use your Channel Divinity to bolster your defenses. As a bonus action, you can utter a vow of protection from a creature you can see within 30 feet of you, using your Channel Divinity. That creature gains disadvantage on attack rolls against you for 1 minute or until you drop to 0 hit points or fall unconscious.",
+            "{@bold Divine Ward.} You can use your Channel Divinity to offer protection to those around you. As an action, you present your holy symbol and each creature of your choice that you can see within 30 feet of you becomes warded for 1 minute. Any creature who targets a warded creature with an attack or a harmful spell must first make a Wisdom saving throw. On a failed save, the creature must choose a new target or lose the attack or spell. This effect doesn't protect the warded creature from area effects, such as the explosion of a fireball. If the warded creature makes an attack or casts a spell that affects an enemy creature, this effect ends. This effect ends on the creature if you are incapacitated or die or if the warded creature is more than 30 feet away from you."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Dedicated Defender",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Protection",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, you can deflect attacks against those whom you protect. When another creature damages you or your ally within 5 feet with a melee attack, you can use your reaction to reduce the damage you take from the attack by 1d6 + your Charisma modifier. This reduction increases to 1d8 + your Charisma modifier at 13th level, and 1d10 + your Charisma modifier at 17th level."
+        ]
+    },
+    {
+        "name": "Bastion of Self",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Protection",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, your faith makes you protected against your foes. Any creature who targets you with an attack or a harmful spell must first make a Wisdom saving throw against your spell save DC. On a failed save, the creature must choose a new target or lose the attack or spell. Any creature that succeeds on the saving throw is immune to Bastion of Self for 24 hours. This effect doesn't protect you from area effects, such as the explosion of a fireball. This effect also ends if you are incapacitated or die."
+        ]
+    },
+    {
+        "name": "Divine Protector",
+        "source": "EBCotOSCC",
+        "className": "Paladin",
+        "classSource": "PHB",
+        "subclassShortName": "Protection",
+        "subclassSource": "EBCotOSCC",
+        "level": 20,
+        "entries": [
+            "At 20th level, your dedication to become a paragon of protection makes you a bulwark against the enemies of your cause and a symbol to those around you. This effect ends early if you are incapacitated or die. Once you use this feature, you can't use it again until you finish a long rest.As an action, you recount the Tenets of Protection and gain the following benefits for 1 minute:",
+            {"type": "list",
+            "items": [
+            "You gain the benefits of a shimmering field of protection, granting you a +2 bonus to AC.",
+            "You have resistance to bludgeoning, piercing, and slashing damage from non-magical weapons.",
+            "Whenever you or any ally within 30 feet fails a saving throw, you can use your reaction to force the creature to reroll it. You must use this new roll."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Resist Lure",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Feyfriend",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you learn how to resist enchantments. You gain advantage on saving throws against being charmed."
+        ]
+    },
+    {
+        "name": "Fey Armament",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Feyfriend",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, the fey lords grant you the armament of a sprite. These weapons count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage. The weapon disappears after 1 minute, if it is more than 5 feet away from you for 1 round, if you dismiss the weapon (no action required), or if you die. Once you use this feature, you can't use it again until you finish a long rest.As an action, you can create one of the following weapons in your empty hand:",
+            {"type": "list",
+            "items": [
+            "{@b Shortbow of the Sprite.} A creature hit by this shortbow must succeed on a DC 10 Constitution saving throw or become poisoned for 1 minute. If its saving throw result is 5 or lower, the poisoned target falls unconscious for the same duration, or until it takes damage or another creature takes an action to shake it awake.",
+            "{@b Sword of the Elves.} This extremely sharp longsword deals an extra 1d6 slashing damage."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Speak with Beasts and Plants",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Feyfriend",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can communicate with beasts and plants as if they shared a language with you. You learn how to read, write, and speak Sylvan."
+        ]
+    },
+    {
+        "name": "Sprite Companion",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Feyfriend",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, the Feyrealm blesses you with a faithful sprite companion. The sprite acts on its own and has its own will, but it is always loyal to you. It disappears if it reaches 0 hit points but a new sprite arrives the next dawn to replace the previous one."
+        ]
+    },
+    {
+        "name": "Fey Reinforcements",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Feyfriend",
+        "subclassSource": "EBCotOSCC",
+        "level": 11,
+        "entries": [
+            "Starting at 11th level, you can call fey creatures to help you. You can cast the conjure fey spell without expending a spell slot or material components. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Sanctuary of the Fey Court",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Feyfriend",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            "Starting at 15th level, fey creatures and creatures of the natural world sense your connection to their kind and become hesitant to attack you. When a fey, beast or plant creature attacks you, that creature must make a Wisdom saving throw against your ranger spell save DC. On a failed save, the creature must choose a different target, or the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours. The creature is aware of this effect before it makes its attack against you."
+        ]
+    },
+    {
+        "name": "Ranger Spells",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Tamer",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "You learn an additional spell of 1st level or higher when you reach certain levels in this class, as shown in the Monster Tamer Spell List table. Each spell counts as a ranger spell for you, but it doesn't count against the number of ranger spells you know.",
+            {
+                "type": "table",
+                "caption": "Monster Tamer Spell List",
+                "colLabels": [
+                    "Ranger Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "3rd",
+                        "{@spell speak with animals}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell locate animals or plants}"
+                    ],
+                    [
+                        "9th",
+                        "{@spell conjure animals}"
+                    ],
+                    [
+                        "13th",
+                        "{@spell dominate beast}"
+                    ],
+                    [
+                        "17th",
+                        "{@spell hold monster}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Bestial Affinity",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Tamer",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can use your body language and soothing sounds to calm animals and monsters. You gain advantage on Wisdom (Animal Handling) skill checks made to calm beats and monstrosities with an Intelligence score of 3 or lower."
+        ]
+    },
+    {
+        "name": "Sense Beast",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Tamer",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you can detect hostile animals and monsters. As an action, you sense the direction to the location of the beast or monstrosity with the highest challenge rating, and you can tell its distance from you as long as the creature is within 1,000 feet of you. If the creature is moving,you know the direction of its movement. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Master of Monsters",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Tamer",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, your spells can affect monstrosities the same way they affect beasts. You can substitute the beast creature type with the monstrosity creature type in any of your spells."
+        ]
+    },
+    {
+        "name": "Call of the Beasts",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Tamer",
+        "subclassSource": "EBCotOSCC",
+        "level": 11,
+        "entries": [
+            "Starting at 11th level, you can conjure beasts and monsters to do your bidding.  You can cast the {@spell conjure animals} spell without expending a spell slot or material components and use it to summon a monstrosity with a challenge rating of 2 or lower and with an Intelligence score of 3 or lower. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Protection of the Pack",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "Tamer",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            " Starting at 15th level, when you surround yourself with allied beasts or monstrosities, the pack grants you benefits. You gain the following benefits if an allied beast or monstrosity is within 5 ft. of you or if you are mounted on such a creature.",
+            {"type": "list",
+            "items": [
+            "You gain +2 to your AC",
+            "Whenever you are the target of a melee attack, the beast or monstrosity can make a melee attack against the attacking opponent as a reaction.",
+            "When an attacker that you can see hits you with a melee attack, you can use your reaction to halve the attack's damage against you. However your beast or monstrosity ally takes the other half of the damage."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Beast Companion",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "SBM",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you gain a beast companion that fights beside you. Choose a beast that is no larger than Large size and that has a challenge rating of 1 or lower. The beast obeys your commands and takes its turn on your initiative. On your turn, you can command the beast where to move or what actions to take, which require no actions on your part. If you are incapacitated or absent, the beast has free will and protects you and itself. If the beast dies, you can obtain another one by spending 8 hours to befriend another non-hostile beast."
+        ]
+    },
+    {
+        "name": "Seige Beast Companion",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "SBM",
+        "subclassSource": "EBCotOSCC",
+        "level": 7,
+        "entries": [
+            "Starting at 7th level, the maximum challenge rating of the beast that you can have as your companion increases to 2.",
+            "Your beast companion also gains the {@i Siege Monster} trait, allowing it to deal double damage to objects and structures."
+        ]
+    },
+    {
+        "name": "Magical Siege Beast Companion",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "SBM",
+        "subclassSource": "EBCotOSCC",
+        "level": 11,
+        "entries": [
+            "Starting at 11th level, the maximum challenge rating of the beast that you can have as your companion increases to 3 and can be of Huge size.",
+            "Your beast companion's natural attacks count as magical for the purposes of overcoming damage resistance."
+        ]
+    },
+    {
+        "name": "Greater Magical Seige Companion",
+        "source": "EBCotOSCC",
+        "className": "Ranger",
+        "classSource": "PHB",
+        "subclassShortName": "SBM",
+        "subclassSource": "EBCotOSCC",
+        "level": 15,
+        "entries": [
+            " Starting at 15th level, the maximum challenge rating of the beast that you can have as your companion increases to 4.",
+            "When you are mounted on your beast companion or within 5 feet of it, any creature that attacks you provokes an opportunity attack from your beast companion."
+        ]
+    },
+    {
+        "name": "Sneaky Interrupt",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spellthief",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, your understanding of magic theories equals that of a trained wizard and as such, you know when it's best to strike at them. You gain proficiency in the Arcana skill if you aren't already proficient in it and gain an advantage on your attack rolls against targets maintaining concentration on a spell."
+        ]
+    },
+    {
+        "name": "Steal Spell",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spellthief",
+        "subclassSource": "EBCotOSCC",
+        "level": 9,
+        "entries": [
+            "Starting at 9th level, you can siphon a single spell from a spellcaster with a precise strike. As a bonus action, after you hit a creature with a melee weapon, you can force the creature to make a saving throw with its spellcasting ability modifier. The DC is 8 + proficiency bonus + your Dexterity modifier.",
+            "On a failed save or when you touch a willing creature, you gain a 1st level spell slot and a prepared 1st level spell chosen by you from the creature's known or prepared 1st level spells. At 13th level, the spell level you can steal increases to 2nd level spells, and at 17th level to 3rd level spells. The creature loses a 1st level spell slot, but still knows the spell and can use it normally. For the next 8 hours, you have the spell prepared and can cast it using your spell slots. If the creature is not a spellcaster you don't gain any benefits from this feature. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Unhook Spell",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spellthief",
+        "subclassSource": "EBCotOSCC",
+        "level": 13,
+        "entries": [
+            "Starting at 13th level, you can untie the fabric of magic and take it over from your opponent spellcaster, keeping it maintained for your own benefit. As a bonus action, after you hit a creature who is the target of an active spell with a melee weapon, you can choose not to deal extra damage from your Sneak Attack. Instead, you force the creature to make a saving throw with its spellcasting ability modifier. The DC is 8 + proficiency bonus + your Dexterity modifier. On a failed save, the maintained spell ends on the creature and you gain the spell's benefits for 1 minute. Once you successfully use this feature to unhook a spell, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Reflect Spell",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spellthief",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, you know exactly how to deflect and divert a ranged magical attack. As a reaction, you can reflect a magical ranged attack made against you back at any target you can see within the spell's range. The range and DC of the spell is the original caster's range and spell save DC. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Spycraft",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spy",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you become a master of spycraft. You gain proficiency with the Dexterity (Stealth), Dexterity (Sleight of Hand), and Charisma (Deception) skills if you are not already proficient in them or double your proficiency bonus if you are already proficient in them."
+        ]
+    },
+    {
+        "name": "Photographic Memory",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spy",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, you gain photographic memory and can recall the most minute details of what you've seen. You can recall every detail of a single image or a single page of script that you've studied for one round. You can recall a number of images or pages up to your Intelligence ability modifier. You can memorize new images or pages, but you will lose the memory of an image or page that you have previously memorized."
+        ]
+    },
+    {
+        "name": "Second Chance",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spy",
+        "subclassSource": "EBCotOSCC",
+        "level": 9,
+        "entries": [
+            "Starting at 9th level, whenever you fail a Dexterity (Stealth), Dexterity (Sleight of Hand), or Charisma (Deception) skill check, you can reroll the check as a bonus action. You must use the new result, even if it's lower than the original roll. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Read Thoughts",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spy",
+        "subclassSource": "EBCotOSCC",
+        "level": 13,
+        "entries": [
+            "Starting at 13th level, as an action you can read the surface thoughts of one creature within 60 feet of you. The effect can penetrate barriers, but 3 feet of wood or dirt, 2 feet of stone, 2 inches of metal, or a thin sheet of lead blocks it. While the target is in range, you can continue reading its thoughts, as long as your concentration isn't broken (as if concentrating on a spell). While reading the target's mind, you have advantage on Wisdom (Insight) and Charisma (Deception, Intimidation, and Persuasion) skill checks against the target."
+        ]
+    },
+    {
+        "name": "Master Spy",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Spy",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "entries": [
+            "Starting at 17th level, instead of rolling, you can choose to automatically succeed on a Dexterity (Stealth), Dexterity (Sleight of Hand), or Charisma (Deception) skill check. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Eye of Darkness",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Umbral Stalker",
+        "subclassSource": "EBCotOSCC",
+        "level": 3,
+        "entries": [
+            "Starting at 3rd level, your eyes become adapted to even the deepest darkness. You gain {@sense darkvision} in a 60-foot radius and can see through even magical darkness."
+        ]
+    },
+    {
+        "name": "One with the Shadows",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Umbral Stalker",
+        "subclassSource": "EBCotOSCC",
+        "level": 9,
+        "header": 2,
+        "entries": [
+            "Starting at 9th level, you can blend into darkness, making your movement almost undetectable. While under the cover of darness, you can use your Sneak Attack feature regardless of other requirements and have advantage on Dexterity {@skill Stealth} skill checks."
+        ]
+    },
+    {
+        "name": "Shadow Step",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Umbral Stalker",
+        "subclassSource": "EBCotOSCC",
+        "level": 13,
+        "header": 2,
+        "entries": [
+            "Starting at 13th level, you become able to move through the shadowrealm to reach your destination. While in darkness, you can use your movement to teleport to a location within the range of your movement as long as it is also in darkness."
+        ]
+    },
+    {
+        "name": "Shadow Rift",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Umbral Stalker",
+        "subclassSource": "EBCotOSCC",
+        "level": 13,
+        "header": 2,
+        "entries": [
+            "From 13th level, you become able to open a narrow rift in the fabric of the planes and transpose yourself to the Shadowrealm and back to the plane from whence you came. As an action, you can travel to the Shadowrealm or return to the plane you came from as if you have cast the {@spell plane shift} spell. You can use this feature if you are on the Ethereal Plane, the Feyrealm, the Material Plane, or the Shadowrealm. No magical or physical restrictions can prevent you from accomplishing the planar travel made possible by this feature. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Umbral Strike",
+        "source": "EBCotOSCC",
+        "className": "Rogue",
+        "classSource": "PHB",
+        "subclassShortName": "Umbral Stalker",
+        "subclassSource": "EBCotOSCC",
+        "level": 17,
+        "header": 2,
+        "entries": [
+            "Starting at 17th level, you can attack a creature's life force through its shadow. When you are able to use your Sneak Attack, your target's AC against your attack becomes 10 + the creature's Dexterity modifier. You can use this feature only if your target is in darkness."
+        ]
+    },
+    {
+        "name": "Touch of Entropy",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Entropist Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your touch destroys non-organic matter. If the nonmagical object isn't being worn or carried, you can choose to cause your touch to destroy a Tiny object at 1st level, a Small object at 5th level, a Medium object at 9th level, a Large object at 13th level, and a Huge object at 17th level. If the object is being worn or carried by a creature, the creature can make a Dexterity saving throw against your spell save DC to avoid your touch. If the object touched is a non-magical weapon being carried, it takes a permanent and cumulative -1 penalty to damage rolls. If its penalty drops to -5, the weapon is destroyed. If the object touched is either a nonmagical armor or a nonmagical shield being worn or carried, it takes a permanent and cumulative -1 penalty to the AC it offers. Armor reduced to an AC of 10 or a shield that drops to a +0 bonus is destroyed."
+        ]
+    },
+    {
+        "name": "Aura of Entropy",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Entropist Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you emanate an aura of entropy that interferes with the natural order of reality. The radius of your aura is 5 feet at 1st level, but increases to 10 feet at 6th level, 15 feet at 11th level, and 20 feet at 16th level. Within your aura, objects cannot be repaired (ex.: by mending spell). Additionally, all healing effects are hampered by your aura and require a DC 10 Constitution saving throw to function."
+        ]
+    },
+    {
+        "name": "Entropic Damage",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Entropist Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, your aura of entropy also dissolves organic flesh. Each creature you choose in your Aura of Entropy must succeed on a Constitution saving throw against your spell save DC or lose a number of hit points equal to 1d4 + your spellcasting ability modifier at the start of each of its turns. While the creature remains in your aura, its body continues to dissolve, and the creature continues to lose hit points at the start of its turns unless it succeeds on the Constitution saving throw. On a successful save, the creature is immune to this effect for 24 hours."
+        ]
+    },
+    {
+        "name": "Resistance to Natural Law",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Entropist Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you are partially protected against the flow of entropy. You gain resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks not made with adamantine weapons. You also gain advantage on saving throws against any spell cast or effects created by lawful creatures.",
+            "Additionally, you gain advantage against petrification and any other transmutation effect that would change the composition of your body or physical form, like polymorph."
+        ]
+    },
+    {
+        "name": "Sphere of Entropy",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Entropist Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 18,
+        "entries": [
+            "Starting at 18th level, as an action you can rip the fabric of space and create a swirling void in the multiverse, summoning a sphere of annihilation out of raw entropy. The sphere remains in existence for 1 minute, and you have advantage on rolls to control the sphere. You can't use this feature again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Keen Senses",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Lycanthropic Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your senses become sharper, similar to that of a predator. You gain advantage on Wisdom (Perception) skill checks that rely on hearing or smell."
+        ]
+    },
+    {
+        "name": "Predator's Knowledge",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Lycanthropic Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your bestial side awakens, giving you the skills of predators. You gain proficiency in the Dexterity (Stealth), Wisdom (Perception), and Wisdom (Survival) skills if you are not already proficient in them."
+        ]
+    },
+    {
+        "name": "Hybrid Form",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Lycanthropic Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can assume the form of a lycanthrope hybrid. As an action, you can spend 1 sorcery point to transform into a hybrid form for 1 minute and gain the following benefits:",
+            {"type": "list",
+            "items": [
+            "When you aren't wearing armor, your AC equals 12 + your Dexterity modifier.",
+            "You gain damage resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks not made with silvered weapons.",
+            "You become proficient with natural weapons.",
+            "Your hands transform into claws that deal 1d6 + Strength modifier points of slashing damage. You can attack twice with your claws, instead of once, whenever you take the attack action on your turn.",
+            "As a bonus action, you can make a bite attack that deals 1d8 + Strength modifier points of piercing damage."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Curse of Silver",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Lycanthropic Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, the curse coursing in your veins manifests, giving you enhanced invulnerability. You gain damage resistance to bludgeoning, piercing, and slashing damage from nonmagical attacks not made with silvered weapons."
+        ]
+    },
+    {
+        "name": "Apex Predator",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "Lycanthropic Bloodline",
+        "subclassSource": "EBCotOSCC",
+        "level": 18,
+        "entries": [
+            "Starting at 18th level, you become an apex lycanthropic predator infused with magic. When using your Hybrid Form class feature, you gain the following additional benefits:",
+            {"type": "list",
+            "items": [
+            "When you aren't wearing armor, your AC equals 13 + your Dexterity modifier.",
+            "Your claw damage increases to 2d4 + Strength modifier points of slashing damage.",
+            "Your bite damage increases to 2d6 + Strength modifier points of piercing damage.",
+            "You gain an additional attack action on each of your turns."
+            ]
+        }
+        ]
+    },
+    {
+        "name": "Voice of the Elements",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "PES",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you innately become able to converse with those who speak the language of the elements. You can understand and speak Auran, Aquan, Ignan, and Terran."
+        ]
+    },
+    {
+        "name": "Primordial Physiology",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "PES",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your anatomy resembles that of an elemental, making you less vulnerable to elements and certain conditions that affect the body. You gain advantage on saving throws against being petrified or poisoned. You also gain a damage threshold of 2 against acid, cold, fire, lightning, and thunder damage."
+        ]
+    },
+    {
+        "name": "Energy admixture",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "PES",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you become able to choose the element you wish to create with your spells. You can spend 1 sorcery point to change the damage type of a spell that causes acid, cold, fire, lightning, or thunder damage to any of the damage types that you can change."
+        ]
+    },
+    {
+        "name": "Heightened Primordial Magic",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "PES",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, your element-based spells become harder to resist. When you cast a spell that deals acid, cold, fire, lightning, radiant, or thunder damage and forces a creature to make a saving throw to resist the effects of the spell, you can spend 3 sorcery points to give all targets of the spell disadvantage on their first saving throw made against the spell."
+        ]
+    },
+    {
+        "name": "Elemental Gate",
+        "source": "EBCotOSCC",
+        "className": "Sorcerer",
+        "classSource": "PHB",
+        "subclassShortName": "PES",
+        "subclassSource": "EBCotOSCC",
+        "level": 18,
+        "entries": [
+            "Starting at 18th level, you can open a portal to any of the elemental planes. You can cast the {@spell gate} spell to open a portal to an Elemental Plane. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Expanded Spell List",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "CW",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "At 1st level, the Elemental Chaos lets you choose from an expanded list of spells when you learn a warlock spell. The following spells are added to the warlock spell list for you:",
+            {
+                "type": "table",
+                "caption": "Chaos Wielder Expanded Spells",
+                "colLabels": [
+                    "Spell Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "1st",
+                        "{@spell bane}, {@spell bless}" 
+                    ],
+                    [
+                        "2nd",
+                        "{@spell flaming sphere}, {@spell spiritual weapon}"
+                    ],
+                    [
+                        "3rd",
+                        "{@spell blink}, {@spell call lightning}"
+                    ],
+                    [
+                        "4th",
+                        "{@spell confusion}, {@spell polymorph}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell flame strike}, {@spell reincarnate}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Wild Magic",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "CW",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your spells can have unforeseen consequences. You can choose to apply a Wild Magic Surge effect immediately after you cast the spell. Roll for a random effect on the Wild Magic Surge table on page 104 of the Player's Handbook. You can use this feature a number of times equal to half your warlock levels rounded down, and you regain all expended uses when you finish a long rest."
+        ]
+    },
+    {
+        "name": "Flows of Chaos",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "CW",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can manipulate fate using the power of chaos. When any creature makes an attack roll, ability check, or saving throw, you can use your reaction to roll 1d4 and apply the number rolled as a bonus or penalty to the creature's roll. You can do so after the creature rolls but before any effects of the roll occur. At 10th level, this dice increases to 1d6, and at 14th level this dice increases to 1d8. You can use this feature a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+        ]
+    },
+    {
+        "name": "Order in Chaos",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "CW",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you can manipulate the energies of your spells for optimal effect. For any spell that requires a dice roll, you can roll twice and take the desired roll. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Twisted Fate",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "CW",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you can manipulate your fate and those of others. When any creature makes an attack roll, ability check, or saving throw, you can use your reaction to give advantage or disadvantage to the creature's roll. You can do so after the creature rolls but before any effects of the roll occur. You can use this feature a number of times equal to your proficiency bonus, and you regain all expended uses when you finish a long rest."
+        ]
+    },
+    {
+        "name": "Expanded Spell List",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "At 1st level, your Great Wyrm patron lets you choose from an expanded list of spells when you learn a warlock spell. The following spells are added to the warlock spell list for you:",
+            {
+                "type": "table",
+                "caption": "Dragon Patron Expanded Spells",
+                "colLabels": [
+                    "Spell Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "1st",
+                        "{@spell feather fall}, {@spell hunter's mark}" 
+                    ],
+                    [
+                        "2nd",
+                        "{@spell darkvision}, {@spell enhance ability}"
+                    ],
+                    [
+                        "3rd",
+                        "{@spell clairvoyance}, {@spell haste}"
+                    ],
+                    [
+                        "4th",
+                        "{@spell freedom of movement}, {@spell stoneskin}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell geas}, {@spell legend lore}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Dragon's Tongue",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, you can speak, read, and write Draconic. Additionally, whenever you make a Charisma ability check when interacting with dragons, your proficiency bonus is doubled if it applies to the check."
+        ]
+    },
+    {
+        "name": "Dragon's Claws",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your hands become clawlike that you can use to make attacks. The claws have a reach of 5 feet, can be used as an unarmed strike, and deal 1d6 + Strength modifier slashing damage on a hit."
+        ]
+    },
+    {
+        "name": "Dragon Ancestry",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you become dragonlike in your nature. You gain the Draconic Ancestry, and associated Breath Weapon and Damage Resistance traits of the Dragonborn race."
+        ]
+    },
+    {
+        "name": "Dragon's Senses",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you gain blindsight 30 ft. Additionally, you sense the presence of any treasure worth over 100 gold pieces within 120 feet of you. This ability merely reveals that treasure is present. You don't learn the location of the treasure, but you do learn its general value. This ability can't locate treasure if any thickness of lead, even a thin sheet, blocks a direct path between you and the object."
+        ]
+    },
+    {
+        "name": "Dragon Wings",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you gain the ability to sprout a pair of dragon wings from your back, gaining a fly speed equal to your walking speed. You can create these wings as a bonus action on your turn. They last until you dismiss them as a bonus action on your turn. You can't manifest your wings while wearing armor unless the armor is made to accommodate them, and clothing not made to accommodate your wings might be destroyed when you manifest them."
+        ]
+    },
+    {
+        "name": "Frightful Presence",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "DP",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you can channel the dread presence of your dragon ancestor, causing those around you to become frightened. As an action, you can draw on this power and exude an aura of fear to a distance of 60 feet. For 1 minute or until you lose your concentration (as if you were concentrating on a spell), each hostile creature that starts its turn in this aura must succeed on a Wisdom saving throw against your spell save DC or be frightened until the aura ends. A creature that succeeds on this saving throw is immune to your aura for 24 hours. Once you use this feature, you can't use it again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Expanded Spell List",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "Witchservant",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "At 1st level, your hag patron lets you choose from an expanded list of spells when you learn a warlock spell. The following spells are added to the warlock spell list for you:",
+            {
+                "type": "table",
+                "caption": "Witchservant Expanded Spells",
+                "colLabels": [
+                    "Spell Level",
+                    "Spells"
+                ],
+                "colStyles": [
+                    "col-3 text-center",
+                    "col-9"
+                ],
+                "rows": [
+                    [
+                        "1st",
+                        "{@spell bane}, {@spell hideous laughter}" 
+                    ],
+                    [
+                        "2nd",
+                        "{@spell blindness/darkness}, {@spell darkvision}"
+                    ],
+                    [
+                        "3rd",
+                        "{@spell bestow curse}, {@spell tiny hut}"
+                    ],
+                    [
+                        "4th",
+                        "{@spell divination}, {@spell polymorph}"
+                    ],
+                    [
+                        "5th",
+                        "{@spell commune}, {@spell contagion}"
+                    ]
+                ]
+            }
+        ]
+    },
+    {
+        "name": "Hag's Form",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "Witchservant",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            " Starting at 1st level, you can mimic the shape-changing ability of your hag patron. As a bonus action, you can magically polymorph into a Small or Medium humanoid for one hour. Your statistics are the same in each form. Any equipment you are wearing or carrying isn't transformed. You revert to your true form if you die. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Dark Devotion",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "Witchservant",
+        "subclassSource": "EBCotOSCC",
+        "level": 1,
+        "entries": [
+            "Starting at 1st level, your hag patron bolsters your determination. You have advantage on saving throws against being charmed."
+        ]
+    },
+    {
+        "name": "Painful Incantation",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "Witchservant",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can cause intense pain with your damaging spells. As a bonus action, you can choose to use painful incantation when you roll damage for a spell and force the damaged creature to make a Constitution saving throw (DC 8 + proficiency bonus + Charisma modifier). On a failed save, the target creature's speed is halved, it has disadvantage on attacks, skill checks, Strength and Dexterity saving throws for 1 minute, and if the target tries to cast a spell during this time, it must first succeed on a Constitution saving throw or the casting fails and the spell is wasted. A target suffering from this pain can make a Constitution saving throw at the end of each of its turns. On a successful save, the pain ends. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Malediction",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "Witchservant",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you can channel the vile energies of your hag patron to curse your enemies. As a bonus action, you can force one creature of your choice within 30 feet to make a Charisma saving throw (DC 8 + proficiency bonus + Charisma modifier). On a failed save, the target creature is cursed and must roll 1d6 and subtract the number rolled from its attack rolls or saving throws whenever it makes one within the next 1 minute. For the duration, the target creature also gains vulnerability to all damage dealt by you. A remove curse spell ends this effect. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Ethereal Passage",
+        "source": "EBCotOSCC",
+        "className": "Warlock",
+        "classSource": "PHB",
+        "subclassShortName": "Witchservant",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you gain the ability to traverse the Ethereal plane. You can cast {@spell etherealness} without consuming a spell slot. Once you use this feature, you can't use it again until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Efficient Spell Recovery",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Academic",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you have learned to recall spells more efficiently by remembering their key variables. You can recover an additional spell slot when using your arcane recovery class ability."
+        ]
+    },
+    {
+        "name": "Simplified Spell Ritual",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Academic",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you have mastered conducting rituals by focusing on their most fundamental structures. Instead of the usual 10 minutes required to cast ritual spells, you can cast the ritual version of a spell in 1 minute."
+        ]
+    },
+    {
+        "name": "Expedient Spell Preparation",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Academic",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can prepare spells faster than usual. Preparing a new spell takes 1 round per spell level for you instead of the usual 1 minute per spell level."
+        ]
+    },
+    {
+        "name": "Elevated Spell Power",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Academic",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you attain an optimized form of spellcasting methodology, which makes your spells more powerful. Spells you cast are considered to be one spell slot level higher than their actual spell slot level."
+        ]
+    },
+    {
+        "name": "Combined Spell Effects",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Academic",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you learn how to apply spells so that their effects are combined. You can apply and stack the same magical effect of a spell to a target one additional time. Once you use this feature, you can't use it until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Practiced Abjurer",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Arcane Sentinel",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you become practiced at learning abjuration spells. The gold and time you must spend to copy an abjuration spell into your spellbook is halved."
+        ]
+    },
+    {
+        "name": "Advanced Alarm",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Arcane Sentinel",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you gain deeper insight into the working of the {@spell alarm} spell. Add the alarm spell to your spellbook. The duration of an alarm spell cast by you becomes 24 hours, and it can be both mental and audible. You can also designate other willing creatures to be alerted by your alarm spell's mental alert."
+        ]
+    },
+    {
+        "name": "Empowered Glyph",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Arcane Sentinel",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            "Starting at 6th level, you can inscribe the {@spell glyph of warding) spell in an instant and make it more potent. Add the glyph of warding spell to your spellbook. You can cast the glyph of warding spell as an action without using a spell slot and reroll a number of the damage dice equal to your Intelligence modifier (minimum 1) when using the spell's explosive runes option. You must use the new rolls. Once you use this feature, you can't use it until you finish a long rest."
+        ]
+    },
+    {
+        "name": "Tenacious Abjurations",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Arcane Sentinel",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, your abjuration spells become hard to dispel. An attempt to use the spells counterspell or dispel magic against your 3rd or lower level abjuration spells requires an ability check. All ability checks made to dispel an abjuration spell cast by you have disadvantage."
+        ]
+    },
+    {
+        "name": "Logical Defense",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "Arcane Sentinel",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you can deduct the outcome of a threat directed at you. As a reaction, you can add your Intelligence modifier (minimum 1) as a bonus to your AC or a saving throw made against a spell."
+        ]
+    },
+    {
+        "name": "Darksight",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "SoS",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, your eyes have adapted to darkness. You gain darkvision with a 60- foot radius, or your darkvision's radius improves by 60 feet if you already have darkvision."
+        ]
+    },
+    {
+        "name": "Shadow Shield",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "SoS",
+        "subclassSource": "EBCotOSCC",
+        "level": 2,
+        "entries": [
+            "Starting at 2nd level, you can instantly create a tangled mass of shadows that make you harder to hit. You can use your reaction to conjure a shadowy aura that negates one hit by an attack that targets you. Once you use this feature, you can't do so again until you finish a short or long rest."
+        ]
+    },
+    {
+        "name": "Pseudo Reality",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "SoS",
+        "subclassSource": "EBCotOSCC",
+        "level": 6,
+        "entries": [
+            " Starting at 6th level, you can empower your illusions with quasi-real shadows that deal damage. When you cast a 1st or higher level spell to create the image of an object, creature, or visible phenomenon, you can choose to cast your spell to deal 1d6 psychic damage per spell level at the beginning of every turn of each affected creature. Affected creatures can make an Intelligence saving throw to halve the damage. Physical interaction with the image does not reveal it to be an illusion. A creature that successfully disbelieves the image by taking an action to make a successful Intelligence (Investigation) skill check becomes immune to the damage dealt by the spell."
+        ]
+    },
+    {
+        "name": "Shadow Evocation",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "SoS",
+        "subclassSource": "EBCotOSCC",
+        "level": 10,
+        "entries": [
+            "Starting at 10th level, you can create a barrage of illusory damaging spells formed out of semi-real shadowstuff. As an action, you can choose an evocation spell that deals damage. You cast this spell as an illusion spell using a spell slot equal to the spell level of the chosen spell. Otherwise, the spell works exactly like the original spell. The affected creature must make the saving throws as described in the spell's description. However, a creature affected by a shadow evocation spell must first make an Intelligence saving throw. On a failed save, the creature believes the spell to be real and takes damage from the spell as normal. On a successful save, the creature takes only half damage."
+        ]
+    },
+    {
+        "name": "Shadow Conjuration",
+        "source": "EBCotOSCC",
+        "className": "Wizard",
+        "classSource": "PHB",
+        "subclassShortName": "SoS",
+        "subclassSource": "EBCotOSCC",
+        "level": 14,
+        "entries": [
+            "Starting at 14th level, you can create a quasi-real creature made out of shadows. As an action, you can cast the conjure elemental spell without expending a spell slot or material components, but instead of conjuring an elemental, you can create an illusory creature of challenge rating 6 or lower of any type. A creature that uses its action to examine the illusory creature can determine that it is an illusion with a successful Intelligence (Investigation) skill check against your spell save DC. If a creature discerns the illusory creature for what it is, the creature can see through the image and takes only half damage from the illusory creature, and has advantage on saving throws and ability checks made against the illusory creature. Once you use this feature, you can't use it until you finish a long rest."
+        ]
+    }
+]
+}


### PR DESCRIPTION
36 subclasses (3 for each class of the SRD) from Elderbrain's Crown of the Oathbreaker campaign.