### PR TITLE
Add LaserLlama; Druid Circles

### DIFF
--- a/subclass/LaserLlama; Druid Circles.json
+++ b/subclass/LaserLlama; Druid Circles.json
@@ -1,0 +1,1780 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "LL:DC",
+				"abbreviation": "LL:DC",
+				"full": "Druid Circles",
+				"authors": [
+					"LaserLlama"
+				],
+				"convertedBy": [
+					"Korvinagor"
+				],
+				"version": "1.0",
+				"url": "https://www.gmbinder.com/share/-M0iZqG1CjdCXsEKFKnc"
+			}
+		],
+		"dateAdded": 1676753660,
+		"dateLastModified": 1676753660
+	},
+	"subclass": [
+		{
+			"name": "Circle of the Ancients",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Ancients",
+			"subclassFeatures": [
+				"Circle of the Ancients|Druid||Ancients|LL:DC|2",
+				"Primal Strikes|Druid||Ancients|LL:DC|6",
+				"Dreadful Wild Shape|Druid||Ancients|LL:DC|10",
+				"Monstrous Form|Druid||Ancients|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Primal Savagery|xge",
+				"Alter Self",
+				"Enlarge/Reduce",
+				"Fear",
+				"Haste",
+				"Dominate Beast",
+				"Freedom of Movement",
+				"Commune with Nature",
+				"Insect Plague"
+			]
+		},
+		{
+			"name": "Circle of the Depths",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Depths",
+			"subclassFeatures": [
+				"Circle of the Depths|Druid||Depths|LL:DC|2",
+				"Alien Strikes|Druid||Depths|LL:DC|6",
+				"Abhorrent Wild Shape|Druid||Depths|LL:DC|10",
+				"Aberrant Evolution|Druid||Depths|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Mind Sliver|tce",
+				"Crown of Madness",
+				"Tasha's Mind Whip|tce",
+				"Enemies Abound|xge",
+				"Hunger of Hadar",
+				"Evard's Black Tentacles",
+				"Summon Aberration|tce",
+				"Rary's Telepathic Bond",
+				"Telekinesis"
+			]
+		},
+		{
+			"name": "Circle of the Guardian",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Guardian",
+			"subclassFeatures": [
+				"Circle of the Guardian|Druid||Guardian|LL:DC|2",
+				"Arboreal Strikes|Druid||Guardian|LL:DC|6",
+				"Grasp of the Forest|Druid||Guardian|LL:DC|10",
+				"Verdant Mastery|Druid||Guardian|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Compelled Duel",
+				"Ensnaring Strike",
+				"Earthbind|xge",
+				"Warding Bond",
+				"Erupting Earth|xge",
+				"Plant Growth",
+				"Aura of Life",
+				"Grasping Vine",
+				"Tree Stride",
+				"Wrath of Nature|xge"
+			]
+		},
+		{
+			"name": "Circle of the Harvest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Harvest",
+			"subclassFeatures": [
+				"Circle of the Harvest|Druid||Harvest|LL:DC|2",
+				"Extra Attack|Druid||Harvest|LL:DC|6",
+				"Mantle of Defense|Druid||Harvest|LL:DC|10",
+				"Cull the Unnatural|Druid||Harvest|LL:DC|14"
+			]
+		},
+		{
+			"name": "Circle of Scales",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Scales",
+			"subclassFeatures": [
+				"Circle of Scales|Druid||Scales|LL:DC|2",
+				"Infused Strikes|Druid||Scales|LL:DC|6",
+				"Terrifying Wild Shape|Druid||Scales|LL:DC|10",
+				"Elder Power|Druid||Scales|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Thaumaturgy",
+				"Dragon's Breath|xge",
+				"Fear",
+				"Elemental Bane|xge",
+				"Dominate Person"
+			]
+		},
+		{
+			"name": "Circle of the Sower",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Sower",
+			"subclassFeatures": [
+				"Circle of the Sower|Druid||Sower|LL:DC|2",
+				"Wild Growth|Druid||Sower|LL:DC|6",
+				"Abundant Harvest|Druid||Sower|LL:DC|10",
+				"Verdant Grasp|Druid||Sower|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Entangle",
+				"Goodberry",
+				"Lesser Restoration",
+				"Spike Growth",
+				"Create Food and Water",
+				"Plant Growth",
+				"Aura of Life",
+				"Grasping Vine",
+				"Greater Restoration",
+				"Tree Stride"
+			]
+		},
+		{
+			"name": "Circle of the Tides",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Tides",
+			"subclassFeatures": [
+				"Circle of the Tides|Druid||Tides|LL:DC|2",
+				"Undertow|Druid||Tides|LL:DC|6",
+				"Waters of Life|Druid||Tides|LL:DC|10",
+				"Master of the Waves|Druid||Tides|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Fog Cloud",
+				"Healing Word",
+				"Misty Step",
+				"Prayer of Healing",
+				"Mass Healing Word",
+				"Tidal Wave|xge",
+				"Control Water",
+				"Watery Sphere|xge",
+				"Maelstrom|xge",
+				"Raise Dead"
+			]
+		},
+		{
+			"name": "Alternate Circle of the Land",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Land (LL)",
+			"subclassFeatures": [
+				"Alternate Circle of the Land|Druid||Land (LL)|LL:DC|2",
+				"Land's Stride|Druid||Land (LL)|LL:DC|6",
+				"Nature's Ward|Druid||Land (LL)|LL:DC|10",
+				"Nature's Sanctuary|Druid||Land (LL)|LL:DC|14"
+			],
+			"subSubclassSpells": {
+				"Arctic": [
+					"Armor of Agathys",
+					"Ice Knife|xge",
+					"Hold Person",
+					"Spike Growth",
+					"Slow",
+					"Ice Storm",
+					"Cone of Cold"
+				],
+				"Cave": [
+					"Cause Fear|xge",
+					"Faerie Fire",
+					"Darkvision",
+					"Web",
+					"Fear",
+					"Giant Insect",
+					"Passwall"
+				],
+				"Coast": [
+					"Cure Wounds",
+					"Fog Cloud",
+					"Gust of Wind",
+					"Misty Step",
+					"Tidal Wave|xge",
+					"Watery Sphere|xge",
+					"Maelstrom|xge"
+				],
+				"Desert": [
+					"Silent Image",
+					"Sleep",
+					"Blur",
+					"Dust Devil|xge",
+					"Daylight",
+					"Hallucinatory Terrain",
+					"Seeming"
+				],
+				"Forest": [
+					"Entangle",
+					"Goodberry",
+					"Barkskin",
+					"Spider Climb",
+					"Plant Growth",
+					"Guardian of Nature|xge",
+					"Tree Stride"
+				],
+				"Grassland": [
+					"Jump",
+					"Longstrider",
+					"Pass Without Trace",
+					"Sleep",
+					"Haste",
+					"Freedom of Movement",
+					"Far Step|xge"
+				],
+				"Mountain": [
+					"Earth Tremor|xge",
+					"Feather Fall",
+					"Maximilian's Earthen Grasp|xge",
+					"Spike Growth",
+					"Call Lightning",
+					"Stone Shape",
+					"Wall of Stone"
+				],
+				"Swamp": [
+					"Tasha's Caustic Brew|tce",
+					"Ray of Sickness",
+					"Melf's Acid Arrow",
+					"Spider Climb",
+					"Stinking Cloud",
+					"Blight",
+					"Insect Plague"
+				]
+			}
+		}
+	],
+	"subclassFeature": [
+		{
+			"name": "Circle of the Ancients",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"Deep in the unexplored jungles of the world, lizardfolk tribes are led by a fearsome Circle of druids that worship ancient reptiles known as Dinosaurs. Members of this Circle draw upon the memory of these ancient beasts that flows within their own blood to strike fear into the hearts of their foes.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Ancients|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Ancient Forms|Druid||Ancients|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Primitive Adaptation|Druid||Ancients|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your link with ancient dinosaurs grants you access to certain spells. At 2nd level, you learn the {@spell primal savagery|xge} cantrip.",
+				"When you reach certain Druid levels, you gain access to the spells below. These spells count as druid spells for you and you always have them prepared, but they don't count against the number of spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Ancients Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell primal savagery|xge}"
+						],
+						[
+							"3rd",
+							"{@spell alter self}, {@spell enlarge/reduce}"
+						],
+						[
+							"5th",
+							"{@spell fear}, {@spell haste}"
+						],
+						[
+							"7th",
+							"{@spell dominate beast}, {@spell freedom of movement}"
+						],
+						[
+							"9th",
+							"{@spell commune with nature}, {@spell insect plague}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Ancient Forms",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"When you adopt this Circle at 2nd level, your blood, whether by heritage or ceremony, now bears the memory of ancient dinosaurs. As a bonus action, you can expend a use of Wild Shape to take the form of a {@filter reptilian beast or dinosaur with a CR as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the max CR column of the Beast Shapes table, but must abide by all other limitations.",
+				"You don't need to have seen a dinosaur before to Wild Shape into it. However, you can are limited to Wild Shaping only into dinosaurs and their descendants: birds and reptiles. Examples include velociraptors, crocodiles, and vultures.",
+				"At 6th level, you can Wild Shape into an Ancient Form with a CR as high as your druid level divided by 3, rounded down."
+			]
+		},
+		{
+			"name": "Primal Strikes",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your unique Wild Shapes have grown in power. Starting at 6th level, your attacks while in Wild Shape count as magical for the sake of overcoming resistances and immunities."
+			]
+		},
+		{
+			"name": "Dreadful Wild Shape",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Your connection with ancient dinosaurs increases. Starting at 10th level, you can expend two uses of Wild Shape as a bonus action to transform into an Ancient Form with a CR equal to your druid level divided by 2, rounded down."
+			]
+		},
+		{
+			"name": "Monstrous Form",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Beginning at 14th level, you can enhance your Ancient Form with druidic power. While in Ancient Form, you can cast the enlarge portion of {@spell enlarge/reduce}, targeting only yourself, without expending a spell slot or material components.",
+				"You can cast enlarge/reduce in this way a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"name": "Primitive Adaptation",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"You are enhanced by the ancient power in your blood. When you join this Circle at 2nd level, you gain a climbing speed and a swimming speed equal to your movement speed."
+			]
+		},
+		{
+			"name": "Circle of the Depths",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"From the highest mountain peaks, to ancient forest groves, to blistering deserts, Circles of Druids can be found in every environment. The strangest of these druidic Circles is found in the darkest depths, where blind things gnaw at the roots of the world. Druids of the Depths spend their lives monitoring the strange ecosystems that exist in the deep, and wield the aberrant powers that develop in the never ending darkness.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Depths|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Aberrant Form|Druid||Depths|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your time in the endless dark grants you access to certain spells. At 2nd level, you learn the {@spell mind sliver|tce} cantrip.",
+				"When you reach certain Druid levels, you gain access to the Circle of the Depths Spells. They count as druid spells for you and you always have them prepared, but they don't count against the total number of spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Depths Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell mind sliver|tce}"
+						],
+						[
+							"3rd",
+							"{@spell crown of madness}, {@spell tasha's mind whip|tce}"
+						],
+						[
+							"5th",
+							"{@spell enemies abound|xge}, {@spell hunger of hadar}"
+						],
+						[
+							"7th",
+							"{@spell evard's black tentacles}, {@spell summon aberration|tce}"
+						],
+						[
+							"9th",
+							"{@spell rary's telepathic bond}, {@spell telekinesis}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Aberrant Form",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"The strange power of your Circle allows you to adopt more powerful beast forms. Starting at 2nd level, you can use your Wild Shape to transform into a {@filter beast with a challenge rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max CR column of the Beast Shapes table, but must abide by the other limitations there.",
+				"In addition, when you use your Wild Shape feature you can choose to transform into the Aberrant Form of a beast you could normally take the shape of. When you do, you use the normal statistics of the beast, but it gains sunlight sensitivity trait, and a number of traits of your choice from this list below equal to half your proficiency bonus, rounded up.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "options",
+							"entries": [
+								{
+									"type": "entries",
+									"name": "Sunlight Sensitivity",
+									"entries": [
+										"You have disadvantage on attack rolls and Perception checks relying on sight when you, your target, or whatever you are perceiving is in direct sunlight."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Amphibious Skin",
+									"entries": [
+										"The beast's skin becomes completely translucent. The beast can breathe both air and water."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Arachnoid Grip",
+									"entries": [
+										"The beast sprouts multiple extra legs. The beast gains a 30 foot climbing speed, and it can climb difficult surfaces without needing to make an ability check."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Gnawing Hunger",
+									"entries": [
+										"The beast grows serrated mouths at the end of each limb. When the beast deals damage with a melee attack, it gains temporary hit points equal to half the damage."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Insectile Carapace",
+									"entries": [
+										"The beast grows a chitinous shell in place of fur or scales. The beast gains a bonus to its Armor Class equal to half your proficiency bonus, rounded up."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Psionic Awakening",
+									"entries": [
+										"The beast appears emaciated and its eyes become milky and white. You can cast any of your Circle of the Depths Spells as normal while in this form."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Quivering Flesh",
+									"entries": [
+										"The beast's flesh quivers as if it is made of slime or viscous ooze. The beast can move through spaces as narrow as 1 inch wide without needing to squeeze."
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Alien Strikes",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Starting at 6th level, while you are in an Aberrant Form, your attacks count as magical for the purpose of overcoming resistances and immunities to nonmagical attacks.",
+				"In addition, you can now Wild Shape into a beast with a CR as high as your druid level divided by 3, rounded down."
+			]
+		},
+		{
+			"name": "Abhorrent Wild Shape",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You have forged a strange connection with the unnatural and alien creatures of the darkness. Starting at 10th level, you can expend two uses of Wild Shape at the same time to take the form of an {@filter aberration with a CR of 5 or lower|bestiary|challenge rating=[&0;&5]|type=aberration|miscellaneous=!swarm}."
+			]
+		},
+		{
+			"name": "Aberrant Evolution",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"You have adapted your Aberrant Forms to thrive in sunlight as well as darkness. Upon reaching 14th level, you no longer gain the sunlight sensitivity trait in your Aberrant Forms."
+			]
+		},
+		{
+			"name": "Circle of the Guardian",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"While all druids forge a relationship with the natural world, those who join the Circle of the Guardian dedicate their lives to protecting the elder and sacred places of the wild. Known as Guardians, these druids draw their magic from the ancient forests they protect. These elder groves are places of sources of great druidic power, often with links to the plane of Fey.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Guardian|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Elder Limbs|Druid||Guardian|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Guardian Form|Druid||Guardian|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your link with your primal grove grants you access to certain spells. At 2nd level, and again when you reach certain Druid levels, you gain access to the spells listed in the table below. These spells count as druid spells for you and you always have them prepared, but they don't count against the total number of druid spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Guardian Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell compelled duel}, {@spell ensnaring strike}"
+						],
+						[
+							"3rd",
+							"{@spell earthbind|xge}, {@spell warding bond}"
+						],
+						[
+							"5th",
+							"{@spell erupting earth|xge}, {@spell plant growth}"
+						],
+						[
+							"7th",
+							"{@spell aura of life}, {@spell grasping vine}"
+						],
+						[
+							"9th",
+							"{@spell tree stride}, {@spell wrath of nature|xge}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Elder Limbs",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"When you adopt this Circle at 2nd level, your limbs become tough and knotted like the eldest trees of the wood. When you hit a creature with an unarmed strike, they take bludgeoning damage equal to 1d8 + your Strength modifier.",
+				"Also, when you hit a creature with an unarmed strike, you can expend a spell slot as part of that attack to cast {@spell ensnaring strike} on your target, in addition to the damage of the attack."
+			]
+		},
+		{
+			"name": "Guardian Form",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"The primordial forests you protect can lend you their power. Beginning at 2nd level, you can use an action to expend a use of your Wild Shape and take the form of a druidic Guardian. When you assume this Guardian form, you retain your game statistics, but you take on tree-like appearance. While in your Guardian form you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Your skin becomes rough and bark-like in appearance, and your Armor Class cannot be lower then 16.",
+						"As a bonus action, you can grant yourself temporary hit points equal to your Wisdom modifier (minimum of 1).",
+						"The reach of your unarmed strikes increases by 5 feet.",
+						"You can use your Wisdom, in place of Strength, for the attack and damage rolls for your unarmed strikes."
+					]
+				},
+				"Your Guardian form lasts for 10 minutes. It ends early if you are reduced to 0 hit points, or you end it as an action."
+			]
+		},
+		{
+			"name": "Arboreal Strikes",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"At 6th level, the primordial grove you guard enhances your abilities. You can attack twice, instead of once, when you take the Attack action on your turn. Moreover, you can cast one of your druid cantrips in place of one of those attacks.",
+				"Also, your unarmed strikes count as magical for the sake of overcoming resistance and immunity to nonmagical attacks."
+			]
+		},
+		{
+			"name": "Grasp of the Forest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Your very presence stimulates wild plant growth. Starting at 10th level, you can expend a use of your Wild Shape as an action to cast {@spell plant growth}. When cast in this way, you can choose a number of creatures equal to your Wisdom modifier (minimum of 1) who can ignore the difficult terrain effects of the spell as the plants move aside to avoid hindering them."
+			]
+		},
+		{
+			"name": "Verdant Mastery",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardian",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Your body is suffused with the druidic magic of the ageless trees that you defend. Beginning at 14th level, during each long rest, you automatically cast the 8 hour version of {@spell plant growth}, unless you choose not to. When cast in this way, the spell does not consume a spell slot or a use of Wild Shape.",
+				"In addition, while you are in your Guardian form you are resistant to all bludgeoning, piercing, and slashing damage."
+			]
+		},
+		{
+			"name": "Circle of the Harvest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Harvest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"The cyclical nature of life is a central belief of every druid, no matter their Circle. However, to members of the Circle of the Harvest this cycle of life is of the utmost importance. Known as Avengers, these druids spent their lives enforcing this life cycle. They are protectors of nature and wrathful warriors who cut down any who abuse natural law. They are mortal enemies of necromancers and undead of all kinds. Rigid in their beliefs, Druidic Avengers ruthlessly hunt down and destroy anything that violates the natural laws of the world.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Druidic Avenger|Druid||Harvest|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Harvest Scythe|Druid||Harvest|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Druidic Avenger",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Harvest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Starting at 2nd level, you can assume the ancient mantle of an Avenger. As a bonus action, you can expend a use of your Wild Shape to take on your Avenger form. While in this form, you retain your game statistics, but your body is covered in a billowing cowl of darkness that obscures your features. While in your Avenger form you gain the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"Your base movement speed increases by 10 feet.",
+						"So long as you are not wearing medium or heavy armor or wielding a shield, you gain a bonus to your Armor Class equal to your Wisdom modifier (minimum of +1).",
+						"When you make a Constitution saving throw to maintain concentration on a spell, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
+					]
+				},
+				"Your Avenger form lasts for 1 minute. It ends early if you are incapacitated or you choose to end it as a bonus action."
+			]
+		},
+		{
+			"name": "Harvest Scythe",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Harvest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Starting at 2nd level, when you finish a short or long rest, you can perform a short ritual to conjure a harvest scythe. This scythe is a magic weapon with both the finesse and versatile properties, and it deals 1d8 (1d10) slashing damage on hit. This scythe can be used as a spellcasting focus by you, and you gain the following benefits while you wield it:",
+				{
+					"type": "list",
+					"items": [
+						"You know {@spell chill touch}. It counts as a druid spell for you, but it doesn't count against your number of Cantrips Known.",
+						"You always have {@spell inflict wounds} prepared. It counts as a druid spell for you, but it doesn't count against the total number of druid spells you can prepare each day.",
+						"You can cast {@spell inflict wounds} at 1st-level spell, without expending a spell slot a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest."
+					]
+				},
+				"If you lose your harvest scythe, you can perform a 1-hour ritual to conjure another. This ritual can be performed during a short or long rest, and the previous scythe turns to ash."
+			]
+		},
+		{
+			"name": "Extra Attack",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Harvest",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Starting at 6th level, you can attack twice, instead of once, when you take the Attack action on your turn. Moreover, you can cast one of your cantrips in place of one of those attacks."
+			]
+		},
+		{
+			"name": "Mantle of Defense",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Harvest",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You can use your druidic magic to absorb incoming blows while in your Avenger form. Starting at 10th level, when you take damage, you can use your reaction to expend a spell slot. The incoming damage is reduced by an amount equal to five times the level of the spell slot you expended."
+			]
+		},
+		{
+			"name": "Cull the Unnatural",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Harvest",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Upon reaching 14th level, your desire to destroy the enemies of nature empowers your attacks. You can add your Wisdom modifier (minimum of +1) to the damage of any attacks you make with your harvest scythe."
+			]
+		},
+		{
+			"name": "Circle of Scales",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"While most druids protect places of natural power or wield the forces of nature, some form their Druidic Circles in the service of powerful dragons. In an effort to defend their lair, elder dragons will bestow some of their power upon druids who maintain the surrounding environment. The older the dragon, the greater its influence, and the larger its Circle.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Scales|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Gift of the Elder Dragon|Druid||Scales|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Draconic Wild Shape|Druid||Scales|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your elder dragon grants you access to certain spells. At 2nd level, and again when you reach certain Druid levels, you gain access to the spells in the table below. They count as druid spells for you and you always have them prepared, but they don't count against the number of spells you can prepare.",
+				{
+					"type": "table",
+					"caption": "Circle of Scales Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell thaumaturgy}"
+						],
+						[
+							"3rd",
+							"{@spell dragon's breath|xge}"
+						],
+						[
+							"5th",
+							"{@spell fear}"
+						],
+						[
+							"7th",
+							"{@spell elemental bane|xge}"
+						],
+						[
+							"9th",
+							"{@spell dominate person}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Gift of the Elder Dragon",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"When you join this Circle at 2nd level, you pledge yourself in service to a great dragon. Choose the scale color of dragon you serve from the table below. You gain resistance to the damage type associated with your elder dragon's Element.",
+				{
+					"type": "table",
+					"caption": "Circle of Scales Spells",
+					"colLabels": [
+						"Color",
+						"Element"
+					],
+					"colStyles": [
+						"col-2",
+						"col-10"
+					],
+					"rows": [
+						[
+							"Amethyst",
+							"Force"
+						],
+						[
+							"Black",
+							"Acid"
+						],
+						[
+							"Blue",
+							"Lightning"
+						],
+						[
+							"Brass",
+							"Fire"
+						],
+						[
+							"Bronze",
+							"Lightning"
+						],
+						[
+							"Copper",
+							"Acid"
+						],
+						[
+							"Crystal",
+							"Radiant"
+						],
+						[
+							"Emerald",
+							"Psychic"
+						],
+						[
+							"Gold",
+							"Fire"
+						],
+						[
+							"Green",
+							"Poison"
+						],
+						[
+							"Red",
+							"Fire"
+						],
+						[
+							"Sapphire",
+							"Thunder"
+						],
+						[
+							"Silver",
+							"Cold"
+						],
+						[
+							"Steel",
+							"Acid"
+						],
+						[
+							"Topaz",
+							"Necrotic"
+						],
+						[
+							"White",
+							"Cold"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Draconic Wild Shape",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"The draconic power you have been gifted allows you to adopt more powerful beast forms. Starting at 2nd level, you can use your Wild Shape to transform into a {@filter beast with a challenge rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max CR column of the Beast Shapes table, but must abide by the other limitations.",
+				"Also, when you Wild Shape you can expend a druid spell slot of 1st-level or higher to empower your beast form with draconic magic, granting you the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"The beast is covered in a thin sheen of draconic scales that resemble those of the dragon you serve. Your beast form's Armor Class is equal to 13 + its Dexterity modifier.",
+						"The beast gains resistance to the damage type associated with the Element of the elder dragon you serve.",
+						"The beast gains temporary hit points equal to five times the level of the spell slot you used to empower this form.",
+						"As a bonus action, you can expend a druid spell slot to grant your beast form temporary hit points equal to five times the level of the spell slot you expend."
+					]
+				}
+			]
+		},
+		{
+			"name": "Infused Strikes",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Beginning at 6th level, when you empower your beast form with draconic magic, you can choose for its natural weapon attacks to deal the damage type of your dragon's Element.",
+				"In addition, you can now Wild Shape into a beast with a CR as high as your druid level divided by 3, rounded down."
+			]
+		},
+		{
+			"name": "Terrifying Wild Shape",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Your body has been suffused with draconic magic, allowing you to take on the forms of true dragon. Starting at 10th level, you can expend two uses of Wild Shape at the same time to take the form of a {@filter dragon with a CR of 5 or lower|bestiary|challenge rating=[&0;&5]|type=dragon|miscellaneous=!swarm}.",
+				"If you Wild Shape into a dragon with a breath weapon, you can choose for its breath weapon to deal the damage type of your elder dragon's Element in place of the normal damage."
+			]
+		},
+		{
+			"name": "Elder Power",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Scales",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"You have become valued as one of your elder dragon's most loyal servants and are given increased power. Beginning at 14th level, when you empower your beast form with draconic magic, the beast sprouts a leathery pair of draconic wings and gains a 40 foot flying or swimming speed (your choice)."
+			]
+		},
+		{
+			"name": "Circle of the Sower",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"The Druid Circle that is most revered by civilized peoples is that of the Sowers. Folktales tell of an ancient druidic sage that guided mortals to the discovery of agriculture. Drawing on their mystical knowledge of the natural world, this druid led ancient peoples to establish the first farms and towns.",
+				"Those who join the Circle of the Sower follow the example of that ancient sage. They wander the countryside and offer magical aid to farmers, gardeners, and all who till the soil.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Sower|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mystic Fruit|Druid||Sower|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Wandering Sage|Druid||Sower|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your understanding of the natural world grants you access to certain spells. At 2nd level, and again when you reach certain Druid levels, you gain access to the spells listed in the table below. These spells count as druid spells for you and you always have them prepared, but they don't count against the total number of druid spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Sower Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell entangle}, {@spell goodberry}"
+						],
+						[
+							"3rd",
+							"{@spell lesser restoration}, {@spell spike growth}"
+						],
+						[
+							"5th",
+							"{@spell create food and water}, {@spell plant growth}"
+						],
+						[
+							"7th",
+							"{@spell aura of life}, {@spell grasping vine}"
+						],
+						[
+							"9th",
+							"{@spell greater restoration}, {@spell tree stride}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Mystic Fruit",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"When you join this Circle at 2nd level, you learn to use your druidic magic to produce wondrous fruits. As a bonus action, you can expend a use of Wild Shape to produce a mystical fruit from the list below in your empty hand. The fruit can be eaten as an action. Any uneaten fruit spoils after 1 minute.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "options",
+							"entries": [
+								{
+									"type": "entries",
+									"name": "Invigorating Fruit",
+									"entries": [
+										"The creature regains hit points equal to your Wisdom modifier + your druid level. Any hit points over their hit point maximum become temporary hit points."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Mystical Fruit",
+									"entries": [
+										"The creature regains one expended spell slot of a level equal to your proficiency bonus or lower."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Revitalizing Fruit",
+									"entries": [
+										"The creature is immediately cured of one of the following conditions: {@condition blinded}, {@condition deafened}, {@condition paralyzed}, {@condition petrified}, {@condition poisoned}, a reduction to an ability score or their hit point maximum, or their exhaustion level is reduced by 1."
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Wandering Sage",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"At 2nd level, you gain a mystical understanding of the natural cycles of life and growth. You gain proficiency in the Nature skill, and whenever you make an Intelligence (Nature) check related to agriculture, animal husbandry, the weather, or the growing and harvesting of plants you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
+			]
+		},
+		{
+			"name": "Wild Growth",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Beginning at 6th level, you cause plants to blossom and grow wherever you set foot. When you take a short or long rest, the effects of the 8 hour casting of {@spell plant growth} immediately take effect in the area around you, unless you withhold them.",
+				"Your connection with plant life also grants you immunity to poison damage, the {@condition poisoned} condition, and natural poisons."
+			]
+		},
+		{
+			"name": "Abundant Harvest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Starting at 10th level, you can use your Wild Shape to grow more potent produce. When you produce a Mystic Fruit you can choose from the following additional options:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "options",
+							"entries": [
+								{
+									"type": "entries",
+									"name": "Emboldening Fruit",
+									"entries": [
+										"If the d20 roll for the first attack roll, ability check, or saving throw the creature makes after eating this fruit is lower then your Wisdom score, the creature can choose to substitute their d20 roll with your Wisdom score."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Primal Fruit",
+									"entries": [
+										"The creature is resistant to all bludgeoning, piercing, and slashing damage for the next minute."
+									]
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Verdant Grasp",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Starting when you reach 14th level, you can cast {@spell grasping vine} without expending a spell slot a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest.",
+				"When you cast {@spell grasping vine}, you can conjure two vines at once in separate locations within range of the spell. You can direct both vines at once with the same bonus action."
+			]
+		},
+		{
+			"name": "Circle of the Tides",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"Few natural forces exert as much influence over mortals as the waters of the world. Rain for crops, raging storms, and winding rivers all influence mortal folk throughout their lives. Tidal druids monitor the relationship between civilization and the waters of oceans, rivers, and lakes. They are often found using the innate magic of the waters to heal the sick, provide rest to the weary, and nurture the crops of common folk.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Disciple of the Sea|Druid||Tides|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Tides|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Tidal Aura|Druid||Tides|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Disciple of the Sea",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your dedication and service to the life giving primal waters has changed you. When you join this Circle at 2nd level, you gain the ability to breathe both air and water, and you gain a swimming speed equal to your movement speed."
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your connection with the primal waters grants you access to certain spells. At 2nd level, you learn the shape water cantrip.",
+				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as druid spells for you and you always have them prepared, but they don't count against the total number of spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Tides Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell fog cloud}, {@spell healing word}"
+						],
+						[
+							"3rd",
+							"{@spell misty step}, {@spell prayer of healing}"
+						],
+						[
+							"5th",
+							"{@spell mass healing word}, {@spell tidal wave|xge}"
+						],
+						[
+							"7th",
+							"{@spell control water}, {@spell watery sphere|xge}"
+						],
+						[
+							"9th",
+							"{@spell maelstrom|xge}, {@spell raise dead}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Tidal Aura",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"At 2nd level, you learn to channel the mystical power of the Tides, even when you are away from bodies of water. As a bonus action, you can expend a use of Wild Shape to exude a mystical watery force in a 15-foot radius. Creatures of your choice within your Tidal Aura treat it as {@quickref difficult terrain||3}. If a creature has a swimming speed it can ignore this effect.",
+				"Your Tidal Aura also enhances your healing powers. When you cast a spell of 1st-level or higher that restores hit points to a creature within your Tidal Aura, one target of the spell within your Tidal Aura regains additional hit points equal to your Wisdom modifier (minimum of 1 additional hit point).",
+				"Your Tidal Aura lasts for 1 minute. The effects end early if you end it as a bonus action, or if you are incapacitated."
+			]
+		},
+		{
+			"name": "Undertow",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your Tidal magic has grown in power. Starting at 6th level, when you cast a spell of 1st-level or higher that forces a creature in your Tidal Aura to make a Strength, Dexterity, or Constitution saving throw, you can choose to empower the spell. Any creature within your Tidal Aura makes their initial saving throw against the empowered spell at disadvantage.",
+				"You can empower a spell in this way a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest."
+			]
+		},
+		{
+			"name": "Waters of Life",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Upon reaching 10th level, you can wield the magic of primal water to rejuvenate your allies as you hinder your foes. When you activate your Tidal Aura you gain a pool of temporary hit points equal to your druid level + your Wisdom modifier. While that Tidal Aura is active, you can use a bonus action to distribute any amount of temporary hit points from that pool to any creature that is within your Tidal Aura, including you.",
+				"When your Tidal Aura ends, any unused temporary hit points from your pool immediately disappear."
+			]
+		},
+		{
+			"name": "Master of the Waves",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tides",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Your bond with the mystical waters of the world has reached its apex. Starting at 14th level, you can cast {@spell control water} at will, without expending a spell slot, so long as you can target a body of water of sufficient size for you to manipulate.",
+				"Also, the radius of your Tidal Aura increases to 30 feet, and creatures of your choice treat the area of your Tidal Aura as difficult terrain even if they have a swimming speed."
+			]
+		},
+		{
+			"name": "Alternate Circle of the Land",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"Druids of the Circle of the Land are the most common sort of druid, if druids can be considered common at all. These sages of the natural world are able to attune themselves to almost any environment, giving them an increased ability to draw out the natural magic of the flora and fauna that surround them.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Bonus Cantrip|Druid||Land (LL)|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Environmental Attunement|Druid||Land (LL)|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Natural Recovery|Druid||Land (LL)|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Bonus Cantrip",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"At 2nd level you learn one additional cantrip of your choice from the {@filter druid spell list|spells|level=0|class=druid}. This cantrip doesn't count against your total number of Cantrips Known."
+			]
+		},
+		{
+			"name": "Environmental Attunement",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Your connection to the natural world grants you increased druidic power. At 2nd level, you are infused with the ability to cast certain spells based on your environment. These spells are listed in the Environment Spells table below. When you finish a long rest, you can attune to the environment around you, choosing from one of the following options: arctic, cave, coast, desert, forest, grassland, mountain, or swamp.",
+				"While you are attuned to that environment you gain access to the spells in the corresponding column of the Environment Spells table below. They count as druid spells for you and you always have them prepared, but they don't count against the total number of druid spells you can prepare each day.",
+				{
+					"type": "table",
+					"caption": "Arctic",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell armor of agathys}, {@spell ice knife|xge}"
+						],
+						[
+							"3rd",
+							"{@spell hold person}, {@spell spike growth}"
+						],
+						[
+							"5th",
+							"{@spell slow}"
+						],
+						[
+							"7th",
+							"{@spell ice storm}"
+						],
+						[
+							"9th",
+							"{@spell cone of cold}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Cave",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell cause fear|xge}, {@spell faerie fire}"
+						],
+						[
+							"3rd",
+							"{@spell darkvision}, {@spell web}"
+						],
+						[
+							"5th",
+							"{@spell fear}"
+						],
+						[
+							"7th",
+							"{@spell giant insect}"
+						],
+						[
+							"9th",
+							"{@spell passwall}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Coast",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell cure wounds}, {@spell fog cloud}"
+						],
+						[
+							"3rd",
+							"{@spell gust of wind}, {@spell misty step}"
+						],
+						[
+							"5th",
+							"{@spell tidal wave|xge}"
+						],
+						[
+							"7th",
+							"{@spell watery sphere|xge}"
+						],
+						[
+							"9th",
+							"{@spell maelstrom|xge}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Desert",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell silent image}, {@spell sleep}"
+						],
+						[
+							"3rd",
+							"{@spell blur}, {@spell dust devil|xge}"
+						],
+						[
+							"5th",
+							"{@spell daylight}"
+						],
+						[
+							"7th",
+							"{@spell hallucinatory terrain}"
+						],
+						[
+							"9th",
+							"{@spell seeming}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Forest",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell entangle}, {@spell goodberry}"
+						],
+						[
+							"3rd",
+							"{@spell barkskin}, {@spell spider climb}"
+						],
+						[
+							"5th",
+							"{@spell plant growth}"
+						],
+						[
+							"7th",
+							"{@spell guardian of nature|xge}"
+						],
+						[
+							"9th",
+							"{@spell tree stride}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Grassland",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell jump}, {@spell longstrider}"
+						],
+						[
+							"3rd",
+							"{@spell pass without trace}, {@spell sleep}"
+						],
+						[
+							"5th",
+							"{@spell haste}"
+						],
+						[
+							"7th",
+							"{@spell freedom of movement}"
+						],
+						[
+							"9th",
+							"{@spell far step|xge}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Mountain",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell earth tremor|xge}, {@spell feather fall}"
+						],
+						[
+							"3rd",
+							"{@spell maximilian's earthen grasp|xge}, {@spell spike growth}"
+						],
+						[
+							"5th",
+							"{@spell call lightning}"
+						],
+						[
+							"7th",
+							"{@spell stone shape}"
+						],
+						[
+							"9th",
+							"{@spell wall of stone}"
+						]
+					]
+				},
+				{
+					"type": "table",
+					"caption": "Swamp",
+					"colLabels": [
+						"Druid Level",
+						"Environment Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell ray of sickness}, {@spell tasha's caustic brew|tce}"
+						],
+						[
+							"3rd",
+							"{@spell melf's acid arrow}, {@spell spider climb}"
+						],
+						[
+							"5th",
+							"{@spell stinking cloud}"
+						],
+						[
+							"7th",
+							"{@spell blight}"
+						],
+						[
+							"9th",
+							"{@spell insect plague}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Natural Recovery",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"Starting at 2nd level, you can regain some of your druidic magic by communing with nature. During a short rest, you choose expended spell slots to recover. The spell slots can have a combined level that is equal to or less than half your druid level (rounded up), and none can be 6th-level or higher. You can't use this feature again until you finish a long rest."
+			]
+		},
+		{
+			"name": "Land's Stride",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Starting at 6th level, you move effortlessly through the native obstacles of your attuned environment. You ignore the effects of natural {@quickref difficult terrain||3} in your attuned environment.",
+				"In addition, you have advantage on saving throws to resist the harmful effects of your attuned environment. Examples include resisting extreme temperatures, magically created or manipulated plants, or other magical environmental effects."
+			]
+		},
+		{
+			"name": "Nature's Ward",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You are able to adapt to the hostile effects of nearly any wild place. Beginning at 10th level, when you finish a short or long rest, choose one of the following damage types: acid, cold, fire, lightning, poison, or thunder. You gain resistance to that type of damage until the end of your next short or long rest."
+			]
+		},
+		{
+			"name": "Nature's Sanctuary",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Land (LL)",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"When you reach 14th level, creatures of the natural world sense your connection to nature and become hesitant to attack you. When a beast or plant attacks you, you can force the creature to make a Wisdom saving throw. On a failed save, the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours.",
+				"Beasts and plants with a Wisdom of 4 or higher are aware of this effect before they make their attack against you."
+			]
+		}
+	]
+}

--- a/subclass/LaserLlama; Druid Circles.json
+++ b/subclass/LaserLlama; Druid Circles.json
@@ -32,15 +32,11 @@
 				"Monstrous Form|Druid||Ancients|LL:DC|14"
 			],
 			"subclassSpells": [
-				"Primal Savagery|xge",
-				"Alter Self",
+				"Cause Fear|xge",
 				"Enlarge/Reduce",
 				"Fear",
-				"Haste",
 				"Dominate Beast",
-				"Freedom of Movement",
-				"Commune with Nature",
-				"Insect Plague"
+				"Commune with Nature"
 			]
 		},
 		{
@@ -57,27 +53,23 @@
 			],
 			"subclassSpells": [
 				"Mind Sliver|tce",
-				"Crown of Madness",
 				"Tasha's Mind Whip|tce",
-				"Enemies Abound|xge",
 				"Hunger of Hadar",
 				"Evard's Black Tentacles",
-				"Summon Aberration|tce",
-				"Rary's Telepathic Bond",
 				"Telekinesis"
 			]
 		},
 		{
-			"name": "Circle of the Guardian",
+			"name": "Circle of the Guardians",
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"shortName": "Guardian",
+			"shortName": "Guardians",
 			"subclassFeatures": [
-				"Circle of the Guardian|Druid||Guardian|LL:DC|2",
-				"Arboreal Strikes|Druid||Guardian|LL:DC|6",
-				"Grasp of the Forest|Druid||Guardian|LL:DC|10",
-				"Verdant Mastery|Druid||Guardian|LL:DC|14"
+				"Circle of the Guardians|Druid||Guardians|LL:DC|2",
+				"Arboreal Strikes|Druid||Guardians|LL:DC|6",
+				"Grasp of the Forest|Druid||Guardians|LL:DC|10",
+				"Verdant Mastery|Druid||Guardians|LL:DC|14"
 			],
 			"subclassSpells": [
 				"Compelled Duel",
@@ -155,6 +147,57 @@
 			]
 		},
 		{
+			"name": "Circle of the Swarm",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Swarm",
+			"subclassFeatures": [
+				"Circle of the Swarm|Druid||Swarm|LL:DC|2",
+				"Greater Swarm|Druid||Swarm|LL:DC|6",
+				"Eyes of the Swarm|Druid||Swarm|LL:DC|10",
+				"From Many, One|Druid||Swarm|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Infestation|xge",
+				"Faerie Fire",
+				"Ray of Sickness",
+				"Blur",
+				"Web",
+				"Gaseous Form",
+				"Slow",
+				"Arcane Eye",
+				"Giant Insect",
+				"Commune with Nature",
+				"Insect Plague"
+			]
+		},
+		{
+			"name": "Circle of the Tempest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"shortName": "Tempest",
+			"subclassFeatures": [
+				"Circle of the Tempest|Druid||Tempest|LL:DC|2",
+				"Thunderous Strike|Druid||Tempest|LL:DC|6",
+				"Tempestuous Form|Druid||Tempest|LL:DC|10",
+				"One with the Storm|Druid||Tempest|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Fog Cloud",
+				"Thunderwave",
+				"Shatter",
+				"Warding Wind|xge",
+				"Lightning Bolt",
+				"Thunder Step|xge",
+				"Ice Storm",
+				"Storm Sphere|xge",
+				"Control Winds|xge",
+				"Maelstrom|xge"
+			]
+		},
+		{
 			"name": "Circle of the Tides",
 			"source": "LL:DC",
 			"className": "Druid",
@@ -187,33 +230,27 @@
 			"shortName": "Land (LL)",
 			"subclassFeatures": [
 				"Alternate Circle of the Land|Druid||Land (LL)|LL:DC|2",
-				"Land's Stride|Druid||Land (LL)|LL:DC|6",
+				"Acolyte of Nature|Druid||Land (LL)|LL:DC|6",
 				"Nature's Ward|Druid||Land (LL)|LL:DC|10",
 				"Nature's Sanctuary|Druid||Land (LL)|LL:DC|14"
 			],
 			"subSubclassSpells": {
 				"Arctic": [
 					"Armor of Agathys",
-					"Ice Knife|xge",
 					"Hold Person",
-					"Spike Growth",
 					"Slow",
 					"Ice Storm",
 					"Cone of Cold"
 				],
 				"Cave": [
 					"Cause Fear|xge",
-					"Faerie Fire",
-					"Darkvision",
 					"Web",
 					"Fear",
 					"Giant Insect",
 					"Passwall"
 				],
 				"Coast": [
-					"Cure Wounds",
 					"Fog Cloud",
-					"Gust of Wind",
 					"Misty Step",
 					"Tidal Wave|xge",
 					"Watery Sphere|xge",
@@ -221,8 +258,6 @@
 				],
 				"Desert": [
 					"Silent Image",
-					"Sleep",
-					"Blur",
 					"Dust Devil|xge",
 					"Daylight",
 					"Hallucinatory Terrain",
@@ -230,36 +265,28 @@
 				],
 				"Forest": [
 					"Entangle",
-					"Goodberry",
-					"Barkskin",
 					"Spider Climb",
 					"Plant Growth",
 					"Guardian of Nature|xge",
 					"Tree Stride"
 				],
 				"Grassland": [
-					"Jump",
 					"Longstrider",
 					"Pass Without Trace",
-					"Sleep",
 					"Haste",
 					"Freedom of Movement",
 					"Far Step|xge"
 				],
 				"Mountain": [
 					"Earth Tremor|xge",
-					"Feather Fall",
 					"Maximilian's Earthen Grasp|xge",
-					"Spike Growth",
 					"Call Lightning",
 					"Stone Shape",
 					"Wall of Stone"
 				],
 				"Swamp": [
 					"Tasha's Caustic Brew|tce",
-					"Ray of Sickness",
 					"Melf's Acid Arrow",
-					"Spider Climb",
 					"Stinking Cloud",
 					"Blight",
 					"Insect Plague"
@@ -277,7 +304,11 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"Deep in the unexplored jungles of the world, lizardfolk tribes are led by a fearsome Circle of druids that worship ancient reptiles known as Dinosaurs. Members of this Circle draw upon the memory of these ancient beasts that flows within their own blood to strike fear into the hearts of their foes.",
+				"Deep in the unexplored jungles of the world, lizardfolk tribes are led by a fearsome Circle of Druids that worship ancient reptiles known as dinosaurs. Members of this Circle draw upon the memory of these ancient beasts that flows within their own blood to strike fear into the hearts of their foes.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Optional Rule: Reptilians Only|Druid||Ancients|LL:DC|2"
+				},
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Circle Spells|Druid||Ancients|LL:DC|2"
@@ -293,6 +324,21 @@
 			]
 		},
 		{
+			"name": "Optional Rule: Reptilians Only",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"type": "inset",
+			"entries": [
+				"In many worlds, Druids who join the Circle of the Ancients are required to be of reptilian heritage. This would include the lizardfolk, tortles, saurians, some dragonborn, aaracokra, and other avians.",
+				"Talk to your DM about lifting this restriction for your world, or come up with a ritual or reason for your Druid to be considered of reptilian heritage."
+			]
+		},
+		{
 			"name": "Circle Spells",
 			"source": "LL:DC",
 			"className": "Druid",
@@ -302,8 +348,8 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your link with ancient dinosaurs grants you access to certain spells. At 2nd level, you learn the {@spell primal savagery|xge} cantrip.",
-				"When you reach certain Druid levels, you gain access to the spells below. These spells count as druid spells for you and you always have them prepared, but they don't count against the number of spells you prepare each day.",
+				"{@i 2nd-level Circle of the Ancients feature}",
+				"When you reach certain Druid levels, you gain access to the spells listed below. They count as Druid spells for you, and you always have them prepared, but they don't count against the number of spells you prepare each day.",
 				{
 					"type": "table",
 					"caption": "Circle of the Ancients Spells",
@@ -318,23 +364,23 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell primal savagery|xge}"
+							"{@spell cause fear|xge}"
 						],
 						[
 							"3rd",
-							"{@spell alter self}, {@spell enlarge/reduce}"
+							"{@spell enlarge/reduce}"
 						],
 						[
 							"5th",
-							"{@spell fear}, {@spell haste}"
+							"{@spell fear}"
 						],
 						[
 							"7th",
-							"{@spell dominate beast}, {@spell freedom of movement}"
+							"{@spell dominate beast}"
 						],
 						[
 							"9th",
-							"{@spell commune with nature}, {@spell insect plague}"
+							"{@spell commune with nature}"
 						]
 					]
 				}
@@ -350,49 +396,10 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"When you adopt this Circle at 2nd level, your blood, whether by heritage or ceremony, now bears the memory of ancient dinosaurs. As a bonus action, you can expend a use of Wild Shape to take the form of a {@filter reptilian beast or dinosaur with a CR as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the max CR column of the Beast Shapes table, but must abide by all other limitations.",
-				"You don't need to have seen a dinosaur before to Wild Shape into it. However, you can are limited to Wild Shaping only into dinosaurs and their descendants: birds and reptiles. Examples include velociraptors, crocodiles, and vultures.",
-				"At 6th level, you can Wild Shape into an Ancient Form with a CR as high as your druid level divided by 3, rounded down."
-			]
-		},
-		{
-			"name": "Primal Strikes",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Ancients",
-			"subclassSource": "LL:DC",
-			"level": 6,
-			"header": 2,
-			"entries": [
-				"Your unique Wild Shapes have grown in power. Starting at 6th level, your attacks while in Wild Shape count as magical for the sake of overcoming resistances and immunities."
-			]
-		},
-		{
-			"name": "Dreadful Wild Shape",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Ancients",
-			"subclassSource": "LL:DC",
-			"level": 10,
-			"header": 2,
-			"entries": [
-				"Your connection with ancient dinosaurs increases. Starting at 10th level, you can expend two uses of Wild Shape as a bonus action to transform into an Ancient Form with a CR equal to your druid level divided by 2, rounded down."
-			]
-		},
-		{
-			"name": "Monstrous Form",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Ancients",
-			"subclassSource": "LL:DC",
-			"level": 14,
-			"header": 2,
-			"entries": [
-				"Beginning at 14th level, you can enhance your Ancient Form with druidic power. While in Ancient Form, you can cast the enlarge portion of {@spell enlarge/reduce}, targeting only yourself, without expending a spell slot or material components.",
-				"You can cast enlarge/reduce in this way a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest."
+				"{@i 2nd-level Circle of the Ancients feature}",
+				"Whether by heritage or ceremony, your bloodline now bears the memory of ancient dinosaurs. As a bonus action, you can expend a use of Wild Shape to take the form of a {@filter dinosaur or another reptilian beast with a Challenge Rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max. CR column of the Beast Shapes table, but you must abide by all other limitations.",
+				"You do not need to have seen a dinosaur before to Wild Shape into it. However, you are limited to Wild Shaping only into dinosaurs and their descendants: birds and reptiles. Examples include velociraptors, crocodiles, and vultures.",
+				"At 6th level, you can Wild Shape into an Ancient Form with a CR as high as your Druid level divided by 3, rounded down."
 			]
 		},
 		{
@@ -405,7 +412,51 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"You are enhanced by the ancient power in your blood. When you join this Circle at 2nd level, you gain a climbing speed and a swimming speed equal to your movement speed."
+				"{@i 2nd-level Circle of the Ancients feature}",
+				"Your fingers elongate into savage claws which count as natural weapons and deal 1d6 slashing damage on hit. You also gain a climbing speed equal to your walking speed."
+			]
+		},
+		{
+			"name": "Primal Strikes",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"{@i 6th-level Circle of the Ancients feature}",
+				"You have learned to draw forth more of the ancient power in your blood. Your natural weapon attacks in your normal form and Ancient Form attacks count as magical for the sake of overcoming resistance and immunity to nonmagical attacks."
+			]
+		},
+		{
+			"name": "Dreadful Wild Shape",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"{@i 10th-level Circle of the Ancients feature}",
+				"Your connection with the great reptiles of ancient days grows stronger. As a bonus action, you can expend two uses of Wild Shape to transform into an Ancient Form with a Challenge Rating equal to your Druid level divided by 2 (rounded down)."
+			]
+		},
+		{
+			"name": "Monstrous Form",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Ancients",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"{@i 14th-level Circle of the Ancients feature}",
+				"Beginning at 14th level, you can enhance your Ancient Form with druidic power. While in Ancient Form, you can cast the enlarge portion of {@spell enlarge/reduce}, targeting only yourself, without expending a spell slot or material components.",
+				"You can cast {@spell enlarge/reduce} in this way a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest."
 			]
 		},
 		{
@@ -417,14 +468,95 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"From the highest mountain peaks, to ancient forest groves, to blistering deserts, Circles of Druids can be found in every environment. The strangest of these druidic Circles is found in the darkest depths, where blind things gnaw at the roots of the world. Druids of the Depths spend their lives monitoring the strange ecosystems that exist in the deep, and wield the aberrant powers that develop in the never ending darkness.",
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Circle Spells|Druid||Depths|LL:DC|2"
-				},
+				"From the high mountain peaks to ancient forest groves, and to blistering deserts, Circles of Druids can be found in every environment. The strangest of these Druidic Circles is found in the darkest depths, where blind things gnaw at the roots of the world. Druids of the Depths spend their lives monitoring the strange ecosystems that exist in the deep and wield the aberrant powers that develop in the never-ending darkness.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Aberrant Form|Druid||Depths|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Depths|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Aberrant Form",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Depths",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Depths feature}",
+				"The dark power of your Circle allows you to adopt aberrant beast forms. As a bonus action, you can expend a use of Wild Shape to transform into a {@filter beast with a Challenge Rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max CR column of the Beast Shapes table, but you must abide by all other limitations there.",
+				"When you use Wild Shape in this way, you transform into the Aberrant Form of that beast. You use the beast's normal stat block, but it gains the {@i sunlight sensitivity} trait (as below), and one additional trait of your choice from the following list:",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "options",
+							"entries": [
+								{
+									"type": "entries",
+									"name": "Sunlight Sensitivity",
+									"entries": [
+										"The beast has disadvantage on Wisdom (Perception) checks and attack rolls that rely on sight when the beast, its target, or whatever it is attempting to perceive is in direct sunlight."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Amphibious Skin",
+									"entries": [
+										"The beast's skin becomes completely translucent. It gains a swimming speed of 10 feet, and it can breathe air and water."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Arachnoid Grip",
+									"entries": [
+										"The beast sprouts additional insectoid legs. It gains a 30 foot climbing speed, and it can climb difficult surfaces, including upside down, without needing to make an ability check."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Gnawing Hunger",
+									"entries": [
+										"The beast grows serrated mouths at the end of each of its limbs. When it deals damage with a natural weapon attack, it gains temporary hit points equal to half the damage dealt."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Insectile Carapace",
+									"entries": [
+										"The beast grows a chitinous shell or plates in place of its fur or scales. It gains a +2 bonus to its natural Armor Class."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Psionic Awakening",
+									"entries": [
+										"The beast appears emaciated and its eyes become milky and white. You can cast your Circle of the Depths Spells as normal while in this form."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Quivering Flesh",
+									"entries": [
+										"The beast's flesh quivers as if it is made of slime or viscous ooze. It can move through gaps as narrow as 1-inch wide without having to squeeze, without expending extra movement."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Unnatural Sight",
+									"entries": [
+										"The beast has only empty sockets where its eyes would be. It cannot see normally or perceive things normally, but it gains blindsight out to a 10-foot radius."
+									]
+								}
+							]
+						}
+					]
 				}
 			]
 		},
@@ -438,8 +570,9 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your time in the endless dark grants you access to certain spells. At 2nd level, you learn the {@spell mind sliver|tce} cantrip.",
-				"When you reach certain Druid levels, you gain access to the Circle of the Depths Spells. They count as druid spells for you and you always have them prepared, but they don't count against the total number of spells you prepare each day.",
+				"{@i 2nd-level Circle of the Depths feature}",
+				"Your time in the endless dark grants you deep magics. You learn {@spell mind sliver|tce}. It counts as a Druid cantrip for you, but doesn't count against your number of Cantrips Known.",
+				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they don't count against the number of spells you prepare each day.",
 				{
 					"type": "table",
 					"caption": "Circle of the Depths Spells",
@@ -458,93 +591,20 @@
 						],
 						[
 							"3rd",
-							"{@spell crown of madness}, {@spell tasha's mind whip|tce}"
+							"{@spell tasha's mind whip|tce}"
 						],
 						[
 							"5th",
-							"{@spell enemies abound|xge}, {@spell hunger of hadar}"
+							"{@spell hunger of hadar}"
 						],
 						[
 							"7th",
-							"{@spell evard's black tentacles}, {@spell summon aberration|tce}"
+							"{@spell evard's black tentacles}"
 						],
 						[
 							"9th",
-							"{@spell rary's telepathic bond}, {@spell telekinesis}"
+							"{@spell telekinesis}"
 						]
-					]
-				}
-			]
-		},
-		{
-			"name": "Aberrant Form",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Depths",
-			"subclassSource": "LL:DC",
-			"level": 2,
-			"header": 1,
-			"entries": [
-				"The strange power of your Circle allows you to adopt more powerful beast forms. Starting at 2nd level, you can use your Wild Shape to transform into a {@filter beast with a challenge rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max CR column of the Beast Shapes table, but must abide by the other limitations there.",
-				"In addition, when you use your Wild Shape feature you can choose to transform into the Aberrant Form of a beast you could normally take the shape of. When you do, you use the normal statistics of the beast, but it gains sunlight sensitivity trait, and a number of traits of your choice from this list below equal to half your proficiency bonus, rounded up.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "options",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Sunlight Sensitivity",
-									"entries": [
-										"You have disadvantage on attack rolls and Perception checks relying on sight when you, your target, or whatever you are perceiving is in direct sunlight."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Amphibious Skin",
-									"entries": [
-										"The beast's skin becomes completely translucent. The beast can breathe both air and water."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Arachnoid Grip",
-									"entries": [
-										"The beast sprouts multiple extra legs. The beast gains a 30 foot climbing speed, and it can climb difficult surfaces without needing to make an ability check."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Gnawing Hunger",
-									"entries": [
-										"The beast grows serrated mouths at the end of each limb. When the beast deals damage with a melee attack, it gains temporary hit points equal to half the damage."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Insectile Carapace",
-									"entries": [
-										"The beast grows a chitinous shell in place of fur or scales. The beast gains a bonus to its Armor Class equal to half your proficiency bonus, rounded up."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Psionic Awakening",
-									"entries": [
-										"The beast appears emaciated and its eyes become milky and white. You can cast any of your Circle of the Depths Spells as normal while in this form."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Quivering Flesh",
-									"entries": [
-										"The beast's flesh quivers as if it is made of slime or viscous ooze. The beast can move through spaces as narrow as 1 inch wide without needing to squeeze."
-									]
-								}
-							]
-						}
 					]
 				}
 			]
@@ -559,8 +619,9 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Starting at 6th level, while you are in an Aberrant Form, your attacks count as magical for the purpose of overcoming resistances and immunities to nonmagical attacks.",
-				"In addition, you can now Wild Shape into a beast with a CR as high as your druid level divided by 3, rounded down."
+				"{@i 6th-level Circle of the Depths feature}",
+				"Eldritch energies empower your aberrant transformations. The natural weapon attacks of your Aberrant Forms count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks.",
+				"In addition, you can Wild Shape into the Aberrant Form of any beast you have seen before with a Challenge Rating as high as your Druid level divided by 3 (rounded down)."
 			]
 		},
 		{
@@ -573,7 +634,9 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"You have forged a strange connection with the unnatural and alien creatures of the darkness. Starting at 10th level, you can expend two uses of Wild Shape at the same time to take the form of an {@filter aberration with a CR of 5 or lower|bestiary|challenge rating=[&0;&5]|type=aberration|miscellaneous=!swarm}."
+				"{@i 10th-level Circle of the Depths feature}",
+				"You have forged a strange connection with the unnatural and alien creatures of the depths. As a bonus action, you can expend two uses of Wild Shape at the same time to take the form of an {@filter aberration you have seen with a CR of 5 or lower|bestiary|challenge rating=[&0;&5]|type=aberration|miscellaneous=!swarm}.",
+				"Moreover, when you use Aberrant Form to Wild Shape into the Aberrant Form of a beast, it gains two Aberrant Form traits of your choice (in addition to sunlight sensitivity)."
 			]
 		},
 		{
@@ -586,31 +649,47 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"You have adapted your Aberrant Forms to thrive in sunlight as well as darkness. Upon reaching 14th level, you no longer gain the sunlight sensitivity trait in your Aberrant Forms."
+				"{@i 14th-level Circle of the Depths feature}",
+				"Your Aberrant Forms have evolved to thrive in sunlight as well as darkness. When you Wild Shape into the Aberrant Form of a beast, it no longer gains the sunlight sensitivity feature, and it instead gains an additional Aberrant trait of your choice from the list (for a total of three traits)."
 			]
 		},
 		{
-			"name": "Circle of the Guardian",
+			"name": "Circle of the Guardians",
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"subclassShortName": "Guardian",
+			"subclassShortName": "Guardians",
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"While all druids forge a relationship with the natural world, those who join the Circle of the Guardian dedicate their lives to protecting the elder and sacred places of the wild. Known as Guardians, these druids draw their magic from the ancient forests they protect. These elder groves are places of sources of great druidic power, often with links to the plane of Fey.",
+				"While all Druids forge a relationship with the natural world, those who join the Circle of Guardians dedicate their lives to protecting the elder forests and sacred groves that serve as sources of druidic magic. Known simply as Guardians, these Druids are as stalwart and resilient as the trees they defend.",
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Circle Spells|Druid||Guardian|LL:DC|2"
+					"subclassFeature": "Elder Limbs|Druid||Guardians|LL:DC|2"
 				},
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Elder Limbs|Druid||Guardian|LL:DC|2"
+					"subclassFeature": "Circle Spells|Druid||Guardians|LL:DC|2"
 				},
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Guardian Form|Druid||Guardian|LL:DC|2"
+					"subclassFeature": "Guardian Form|Druid||Guardians|LL:DC|2"
 				}
+			]
+		},
+		{
+			"name": "Elder Limbs",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Guardians",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Guardians feature}",
+				"The magic of the elder forest you guard empowers your body with primeval power. Your unarmed strikes deal bludgeoning damage equal to 1d8 + your Strength modifier on hit.",
+				"Moreover, when you hit a creature with an unarmed strike, you can expend a spell slot to cast {@spell ensnaring strike} on your target as part of your unarmed strike attack."
 			]
 		},
 		{
@@ -618,15 +697,16 @@
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"subclassShortName": "Guardian",
+			"subclassShortName": "Guardians",
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your link with your primal grove grants you access to certain spells. At 2nd level, and again when you reach certain Druid levels, you gain access to the spells listed in the table below. These spells count as druid spells for you and you always have them prepared, but they don't count against the total number of druid spells you prepare each day.",
+				"{@i 2nd-level Circle of the Guardians feature}",
+				"Your link with your primal grove grants you access to certain spells. When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they don't count against the total number of spells you prepare each day.",
 				{
 					"type": "table",
-					"caption": "Circle of the Guardian Spells",
+					"caption": "Circle of the Guardians Spells",
 					"colLabels": [
 						"Druid Level",
 						"Spells"
@@ -661,40 +741,27 @@
 			]
 		},
 		{
-			"name": "Elder Limbs",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Guardian",
-			"subclassSource": "LL:DC",
-			"level": 2,
-			"header": 1,
-			"entries": [
-				"When you adopt this Circle at 2nd level, your limbs become tough and knotted like the eldest trees of the wood. When you hit a creature with an unarmed strike, they take bludgeoning damage equal to 1d8 + your Strength modifier.",
-				"Also, when you hit a creature with an unarmed strike, you can expend a spell slot as part of that attack to cast {@spell ensnaring strike} on your target, in addition to the damage of the attack."
-			]
-		},
-		{
 			"name": "Guardian Form",
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"subclassShortName": "Guardian",
+			"subclassShortName": "Guardians",
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"The primordial forests you protect can lend you their power. Beginning at 2nd level, you can use an action to expend a use of your Wild Shape and take the form of a druidic Guardian. When you assume this Guardian form, you retain your game statistics, but you take on tree-like appearance. While in your Guardian form you gain the following benefits:",
+				"{@i 2nd-level Circle of the Guardians feature}",
+				"The primordial forests you protect can lend you their elder powers. As a bonus action, you can expend a use of Wild Shape and transform into a treelike Guardian Form, which grants you the following benefits for 10 minutes:",
 				{
 					"type": "list",
 					"items": [
-						"Your skin becomes rough and bark-like in appearance, and your Armor Class cannot be lower then 16.",
+						"Your flesh is covered in bark. Your Armor Class equals 10 + your Constitution modifier + your Wisdom modifier.",
 						"As a bonus action, you can grant yourself temporary hit points equal to your Wisdom modifier (minimum of 1).",
 						"The reach of your unarmed strikes increases by 5 feet.",
 						"You can use your Wisdom, in place of Strength, for the attack and damage rolls for your unarmed strikes."
 					]
 				},
-				"Your Guardian form lasts for 10 minutes. It ends early if you are reduced to 0 hit points, or you end it as an action."
+				"Your Guardian Form transformation ends early if you are reduced to 0 hit points, or you use a bonus action on your turn to revert to your normal form."
 			]
 		},
 		{
@@ -702,13 +769,14 @@
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"subclassShortName": "Guardian",
+			"subclassShortName": "Guardians",
 			"subclassSource": "LL:DC",
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"At 6th level, the primordial grove you guard enhances your abilities. You can attack twice, instead of once, when you take the Attack action on your turn. Moreover, you can cast one of your druid cantrips in place of one of those attacks.",
-				"Also, your unarmed strikes count as magical for the sake of overcoming resistance and immunity to nonmagical attacks."
+				"{@i 6th-level Circle of the Guardians feature}",
+				"The elder grove you defend enhances your combat abilities. You can attack twice, instead of once, whenever you take the Attack action on your turn. Moreover, you can cast one of your Druid cantrips in place of one of those attacks.",
+				"Also, your unarmed strikes count as magic for the sake of overcoming resistance and immunity to nonmagical attacks."
 			]
 		},
 		{
@@ -716,12 +784,13 @@
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"subclassShortName": "Guardian",
+			"subclassShortName": "Guardians",
 			"subclassSource": "LL:DC",
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"Your very presence stimulates wild plant growth. Starting at 10th level, you can expend a use of your Wild Shape as an action to cast {@spell plant growth}. When cast in this way, you can choose a number of creatures equal to your Wisdom modifier (minimum of 1) who can ignore the difficult terrain effects of the spell as the plants move aside to avoid hindering them."
+				"{@i 10th-level Circle of the Guardians feature}",
+				"Your elder magic stimulates wild growth. As an action, you can expend a use of Wild Shape to cast {@spell plant growth}. When you do, you can choose a number of creatures equal to your Wisdom modifier (minimum of 1) that can ignore the difficult terrain created, as the plants move and allow them to pass by."
 			]
 		},
 		{
@@ -729,13 +798,14 @@
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
-			"subclassShortName": "Guardian",
+			"subclassShortName": "Guardians",
 			"subclassSource": "LL:DC",
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"Your body is suffused with the druidic magic of the ageless trees that you defend. Beginning at 14th level, during each long rest, you automatically cast the 8 hour version of {@spell plant growth}, unless you choose not to. When cast in this way, the spell does not consume a spell slot or a use of Wild Shape.",
-				"In addition, while you are in your Guardian form you are resistant to all bludgeoning, piercing, and slashing damage."
+				"{@i 14th-level Circle of the Guardians feature}",
+				"Your body is completely suffused with elder druidic magic. When you transform into Guardian Form, you grow by one size category, for example from Medium to Large, and you resemble an ancient treant. You also gain resistance to all bludgeoning, piercing, poison, and slashing damage.",
+				"Finally, the duration of your Guardian Form transformation increases to 1 hour, and while you are in Guardian Form, you can speak to plants as if you were under the effects of the {@spell speak with plants} spell, so long as you speak in Druidic."
 			]
 		},
 		{
@@ -747,7 +817,7 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"The cyclical nature of life is a central belief of every druid, no matter their Circle. However, to members of the Circle of the Harvest this cycle of life is of the utmost importance. Known as Avengers, these druids spent their lives enforcing this life cycle. They are protectors of nature and wrathful warriors who cut down any who abuse natural law. They are mortal enemies of necromancers and undead of all kinds. Rigid in their beliefs, Druidic Avengers ruthlessly hunt down and destroy anything that violates the natural laws of the world.",
+				"The cyclical nature of life is a central belief of every Druid, no matter their Circle. However, to members of the Circle of the Harvest, this cycle is of utmost importance. They stand as the protectors of natural law and look to destroy any who would violate the cycle of life with necromancy or other dark magic.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Druidic Avenger|Druid||Harvest|LL:DC|2"
@@ -768,16 +838,17 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Starting at 2nd level, you can assume the ancient mantle of an Avenger. As a bonus action, you can expend a use of your Wild Shape to take on your Avenger form. While in this form, you retain your game statistics, but your body is covered in a billowing cowl of darkness that obscures your features. While in your Avenger form you gain the following benefits:",
+				"{@i 2nd-level Circle of the Harvest feature}",
+				"You have taken up the ancient mantle of the Druidic Avenger. As a bonus action, you can expend a use of your Wild Shape to transform into your Avenger Form. While in this Form, you retain your game statistics, but you gain the benefits below:",
 				{
 					"type": "list",
 					"items": [
-						"Your base movement speed increases by 10 feet.",
+						"Your walking speed increases by 10 feet.",
 						"So long as you are not wearing medium or heavy armor or wielding a shield, you gain a bonus to your Armor Class equal to your Wisdom modifier (minimum of +1).",
-						"When you make a Constitution saving throw to maintain concentration on a spell, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
+						"When you make a Constitution saving throw to maintain your concentration, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
 					]
 				},
-				"Your Avenger form lasts for 1 minute. It ends early if you are {@condition incapacitated} or you choose to end it as a bonus action."
+				"Your Avenger form lasts for 1 minute. It ends early if you are {@condition incapacitated} or you end it as a bonus action."
 			]
 		},
 		{
@@ -790,16 +861,17 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Starting at 2nd level, when you finish a short or long rest, you can perform a short ritual to conjure a harvest scythe. This scythe is a magic weapon with both the finesse and versatile properties, and it deals 1d8 (1d10) slashing damage on hit. This scythe can be used as a spellcasting focus by you, and you gain the following benefits while you wield it:",
+				"{@i 2nd-level Circle of the Harvest feature}",
+				"Over the course of 1 hour, which can be during a short or long rest, you can perform an ancient ritual to conjure a Harvest Scythe. It is a magic weapon with the finesse and versatile properties and deals 1d8 (1d10) slashing damage on hit. This Scythe can be used as a spellcasting focus by you, and you gain the following benefits while you wield it:",
 				{
 					"type": "list",
 					"items": [
-						"You know {@spell chill touch}. It counts as a druid spell for you, but it doesn't count against your number of Cantrips Known.",
-						"You always have {@spell inflict wounds} prepared. It counts as a druid spell for you, but it doesn't count against the total number of druid spells you can prepare each day.",
-						"You can cast {@spell inflict wounds} at 1st-level spell, without expending a spell slot a number of times equal to your Wisdom modifier (minimum of once). You regain all expended uses when you finish a long rest."
+						"You know {@spell chill touch}. It counts as a Druid spell for you, but it doesn't count against your Cantrips Known.",
+						"You always have {@spell inflict wounds} prepared. It counts as a Druid spell for you, but it doesn't count against the total number of Druid spells you can prepare each day.",
+						"You can cast {@spell inflict wounds} at 1st-level, without expending a spell slot a number of times equal to your Wisdom modifier (a minimum of once). You regain all expended uses when you finish a long rest."
 					]
 				},
-				"If you lose your harvest scythe, you can perform a 1-hour ritual to conjure another. This ritual can be performed during a short or long rest, and the previous scythe turns to ash."
+				"If you lose your Scythe, you can perform a 1-hour ritual and conjure another, and the previous scythe turns to ash."
 			]
 		},
 		{
@@ -812,7 +884,8 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Starting at 6th level, you can attack twice, instead of once, when you take the Attack action on your turn. Moreover, you can cast one of your cantrips in place of one of those attacks."
+				"{@i 6th-level Circle of the Harvest feature}",
+				"You can attack twice, instead of once, whenever you take the Attack action on your turn. Moreover, you can cast one of your Druid cantrips in place of one of those attacks."
 			]
 		},
 		{
@@ -825,7 +898,8 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"You can use your druidic magic to absorb incoming blows while in your Avenger form. Starting at 10th level, when you take damage, you can use your reaction to expend a spell slot. The incoming damage is reduced by an amount equal to five times the level of the spell slot you expended."
+				"{@i 10th-level Circle of the Harvest feature}",
+				"You can channel druidic magic to absorb incoming blows. As a reaction when you take damage in your Avenger Form, you can expend a spell slot to reduce the incoming damage by five times the level of the spell slot you expended."
 			]
 		},
 		{
@@ -838,7 +912,9 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"Upon reaching 14th level, your desire to destroy the enemies of nature empowers your attacks. You can add your Wisdom modifier (minimum of +1) to the damage of any attacks you make with your harvest scythe."
+				"{@i 14th-level Circle of the Harvest feature}",
+				"Your desire to destroy the enemies of nature empowers your attacks. You add your Wisdom modifier (minimum of +1) to the damage of any attacks you make with your Harvest Scythe while you are in your Avenger Form.",
+				"Finally, your ancient magic grants you resistance to unnatural powers. You gain resistance to necrotic damage when you are in your Avenger Form."
 			]
 		},
 		{
@@ -850,7 +926,7 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"While most druids protect places of natural power or wield the forces of nature, some form their Druidic Circles in the service of powerful dragons. In an effort to defend their lair, elder dragons will bestow some of their power upon druids who maintain the surrounding environment. The older the dragon, the greater its influence, and the larger its Circle.",
+				"While most Druids protect places of natural power or wield the forces of nature, some form Circles in service of ancient dragons. In an effort to defend their lair, elder dragons will bestow some of their power upon Druids who maintain its territory. The older the dragon, the larger its Druidic Circle.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Circle Spells|Druid||Scales|LL:DC|2"
@@ -875,7 +951,8 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your elder dragon grants you access to certain spells. At 2nd level, and again when you reach certain Druid levels, you gain access to the spells in the table below. They count as druid spells for you and you always have them prepared, but they don't count against the number of spells you can prepare.",
+				"{@i 2nd-level Circle of Scales feature}",
+				"Your elder dragon grants you access to certain spells. When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they don't count against the total number of Druid spells you can prepare each day.",
 				{
 					"type": "table",
 					"caption": "Circle of Scales Spells",
@@ -922,10 +999,10 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"When you join this Circle at 2nd level, you pledge yourself in service to a great dragon. Choose the scale color of dragon you serve from the table below. You gain resistance to the damage type associated with your elder dragon's Element.",
+				"{@i 2nd-level Circle of Scales feature}",
+				"When you join this Circle you pledge yourself in service to a great dragon. Choose the scale color of the dragon you serve. You gain resistance to the damage type associated with your elder dragon's Element on the table below.",
 				{
 					"type": "table",
-					"caption": "Circle of Scales Spells",
 					"colLabels": [
 						"Color",
 						"Element"
@@ -1013,17 +1090,19 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"The draconic power you have been gifted allows you to adopt more powerful beast forms. Starting at 2nd level, you can use your Wild Shape to transform into a {@filter beast with a challenge rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max CR column of the Beast Shapes table, but must abide by the other limitations.",
-				"Also, when you Wild Shape you can expend a druid spell slot of 1st-level or higher to empower your beast form with draconic magic, granting you the following benefits:",
+				"{@i 2nd-level Circle of Scales feature}",
+				"The draconic power you have been gifted allows you to adopt more powerful forms. As a bonus action, you can use Wild Shape to transform into a {@filter beast with a Challenge Rating as high as 1|bestiary|challenge rating=[&0;&1]|type=beast|speed type=!fly;!swim|miscellaneous=!swarm}. You can ignore the Max. CR column of the Beast Shapes table, but you must abide by all other limitations.",
+				"Also, when you use Wild Shape to transform into a beast, you can expend a spell slot of 1st-level or higher to empower your transformation with the draconic magic of your Circle, granting your beast form the following additional benefits:",
 				{
 					"type": "list",
 					"items": [
-						"The beast is covered in a thin sheen of draconic scales that resemble those of the dragon you serve. Your beast form's Armor Class is equal to 13 + its Dexterity modifier.",
+						"The beast is covered in a thin sheen of draconic scales that resemble those of the dragon you serve. The beast's Armor Class is equal to 13 + it's Dexterity modifier unless its natural Armor Class was already higher.",
 						"The beast gains resistance to the damage type associated with the Element of the elder dragon you serve.",
 						"The beast gains temporary hit points equal to five times the level of the spell slot you used to empower this form.",
-						"As a bonus action, you can expend a druid spell slot to grant your beast form temporary hit points equal to five times the level of the spell slot you expend."
+						"As a bonus action, you can expend a spell slot of 1st-level or higher to grant your beast form temporary hit points equal to five times the level of the spell slot you expend."
 					]
-				}
+				},
+				"Once you empower your Wild Shape in this way you must finish a short or long rest before you can do so again."
 			]
 		},
 		{
@@ -1036,8 +1115,9 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Beginning at 6th level, when you empower your beast form with draconic magic, you can choose for its natural weapon attacks to deal the damage type of your dragon's Element.",
-				"In addition, you can now Wild Shape into a beast with a CR as high as your druid level divided by 3, rounded down."
+				"{@i 6th-level Circle of Scales feature}",
+				"When you empower your Wild Shape transformation with draconic magic, your beast's natural weapon attacks deal the damage type of your dragon's Element.",
+				"In addition, you can now Wild Shape into a beast with a CR as high as your Druid level divided by 3, rounded down."
 			]
 		},
 		{
@@ -1050,7 +1130,8 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"Your body has been suffused with draconic magic, allowing you to take on the forms of true dragon. Starting at 10th level, you can expend two uses of Wild Shape at the same time to take the form of a {@filter dragon with a CR of 5 or lower|bestiary|challenge rating=[&0;&5]|type=dragon|miscellaneous=!swarm}.",
+				"{@i 10th-level Circle of Scales feature}",
+				"Your mastery over the draconic magic you wield allows you to take on the form of a true dragon. As a bonus action, you can expend two uses of Wild Shape at the same time to take the form of a {@filter dragon with a CR of 5 or lower|bestiary|challenge rating=[&0;&5]|type=dragon|miscellaneous=!swarm}.",
 				"If you Wild Shape into a dragon with a breath weapon, you can choose for its breath weapon to deal the damage type of your elder dragon's Element in place of the normal damage."
 			]
 		},
@@ -1064,7 +1145,8 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"You have become valued as one of your elder dragon's most loyal servants and are given increased power. Beginning at 14th level, when you empower your beast form with draconic magic, the beast sprouts a leathery pair of draconic wings and gains a 40 foot flying or swimming speed (your choice)."
+				"{@i 14th-level Circle of Scales feature}",
+				"You have become one of the most loyal servants of your elder dragon and are given increased power. When you empower your Wild Shape transformation with draconic magic, the beast sprouts a leathery pair of draconic wings and gains a 40-foot flying or swimming speed (your choice)."
 			]
 		},
 		{
@@ -1076,19 +1158,79 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"The Druid Circle that is most revered by civilized peoples is that of the Sowers. Folktales tell of an ancient druidic sage that guided mortals to the discovery of agriculture. Drawing on their mystical knowledge of the natural world, this druid led ancient peoples to establish the first farms and towns.",
+				"The Druid Circle that is most revered by civilized peoples is that of the Sowers. Folktales tell of an ancient druidic sage that guided mortals to the discovery of agriculture. Drawing on their mystical knowledge of the natural world, this Druid led ancient peoples to establish the first farms and towns.",
 				"Those who join the Circle of the Sower follow the example of that ancient sage. They wander the countryside and offer magical aid to farmers, gardeners, and all who till the soil.",
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Circle Spells|Druid||Sower|LL:DC|2"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Mystic Fruit|Druid||Sower|LL:DC|2"
-				},
-				{
-					"type": "refSubclassFeature",
 					"subclassFeature": "Wandering Sage|Druid||Sower|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Mystic Harvest|Druid||Sower|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Sower|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Wandering Sage",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Sower feature}",
+				"You gain a mystical understanding of the natural cycle of life, growth, and death. You gain proficiency in Nature. Whenever you make an Intelligence (Nature) check you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
+			]
+		},
+		{
+			"name": "Mystic Harvest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Sower",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Sower feature}",
+				"When you join this Circle, you learn to use druidic magic to produce wondrous fruits. As a bonus action, you can expend a use of Wild Shape to produce one Mystical Fruit from the list below in your empty hand. The Fruit can be eaten as an action. Any uneaten Fruit spoils after 1 minute.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "options",
+							"entries": [
+								{
+									"type": "entries",
+									"name": "Invigorating Fruit",
+									"entries": [
+										"The creature that eats this Fruit regains hit points equal to your Wisdom modifier + your Druid level. Any hit points over its hit point maximum become temporary hit points."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Mystic Fruit",
+									"entries": [
+										"The creature that eats this Fruit regains a single expended spell slot of a level equal to your Wisdom modifier or lower.",
+										"Once a creature benefits from this Fruit it must complete a long rest before it can do so again."
+									]
+								},
+								{
+									"type": "entries",
+									"name": "Revitalizing Fruit",
+									"entries": [
+										"The creature that eats this Fruit is instantly cured of one of the following conditions: {@condition blinded}, {@condition deafened}, {@condition paralyzed}, {@condition petrified}, {@condition poisoned}, a reduction to an ability score or its hit point maximum, or its exhaustion level is reduced by 1."
+									]
+								}
+							]
+						}
+					]
 				}
 			]
 		},
@@ -1102,7 +1244,8 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your understanding of the natural world grants you access to certain spells. At 2nd level, and again when you reach certain Druid levels, you gain access to the spells listed in the table below. These spells count as druid spells for you and you always have them prepared, but they don't count against the total number of druid spells you prepare each day.",
+				"{@i 2nd-level Circle of the Sower feature}",
+				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they do not count against the total number of Druid spells you can prepare each day. ",
 				{
 					"type": "table",
 					"caption": "Circle of the Sower Spells",
@@ -1140,63 +1283,6 @@
 			]
 		},
 		{
-			"name": "Mystic Fruit",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Sower",
-			"subclassSource": "LL:DC",
-			"level": 2,
-			"header": 1,
-			"entries": [
-				"When you join this Circle at 2nd level, you learn to use your druidic magic to produce wondrous fruits. As a bonus action, you can expend a use of Wild Shape to produce a mystical fruit from the list below in your empty hand. The fruit can be eaten as an action. Any uneaten fruit spoils after 1 minute.",
-				{
-					"type": "entries",
-					"entries": [
-						{
-							"type": "options",
-							"entries": [
-								{
-									"type": "entries",
-									"name": "Invigorating Fruit",
-									"entries": [
-										"The creature regains hit points equal to your Wisdom modifier + your druid level. Any hit points over their hit point maximum become temporary hit points."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Mystical Fruit",
-									"entries": [
-										"The creature regains one expended spell slot of a level equal to your proficiency bonus or lower."
-									]
-								},
-								{
-									"type": "entries",
-									"name": "Revitalizing Fruit",
-									"entries": [
-										"The creature is immediately cured of one of the following conditions: {@condition blinded}, {@condition deafened}, {@condition paralyzed}, {@condition petrified}, {@condition poisoned}, a reduction to an ability score or their hit point maximum, or their exhaustion level is reduced by 1."
-									]
-								}
-							]
-						}
-					]
-				}
-			]
-		},
-		{
-			"name": "Wandering Sage",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Sower",
-			"subclassSource": "LL:DC",
-			"level": 2,
-			"header": 1,
-			"entries": [
-				"At 2nd level, you gain a mystical understanding of the natural cycles of life and growth. You gain proficiency in the Nature skill, and whenever you make an Intelligence (Nature) check related to agriculture, animal husbandry, the weather, or the growing and harvesting of plants you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
-			]
-		},
-		{
 			"name": "Wild Growth",
 			"source": "LL:DC",
 			"className": "Druid",
@@ -1206,7 +1292,8 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Beginning at 6th level, you cause plants to blossom and grow wherever you set foot. When you take a short or long rest, the effects of the 8 hour casting of {@spell plant growth} immediately take effect in the area around you, unless you withhold them.",
+				"{@i 6th-level Circle of the Sower feature}",
+				"You cause plants to blossom and thrive wherever you travel. When you take a short or long rest, the effects of the 8-hour casting of {@spell plant growth} immediately take effect in the area around you, unless you choose to withhold them.",
 				"Your connection with plant life also grants you immunity to poison damage, the {@condition poisoned} condition, and natural poisons."
 			]
 		},
@@ -1220,7 +1307,8 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"Starting at 10th level, you can use your Wild Shape to grow more potent produce. When you produce a Mystic Fruit you can choose from the following additional options:",
+				"{@i 10th-level Circle of the Sower feature}",
+				"You can use the magic of your Wild Shape to produce more potent produce. When you produce a Mystic Fruit you can choose from the following additional options:",
 				{
 					"type": "entries",
 					"entries": [
@@ -1231,14 +1319,14 @@
 									"type": "entries",
 									"name": "Emboldening Fruit",
 									"entries": [
-										"If the d20 roll for the first attack roll, ability check, or saving throw the creature makes after eating this fruit is lower then your Wisdom score, the creature can choose to substitute their d20 roll with your Wisdom score."
+										"The next time the creature that eats this Fruit rolls a d20, it can choose to substitute its d20 roll with your Druid level."
 									]
 								},
 								{
 									"type": "entries",
 									"name": "Primal Fruit",
 									"entries": [
-										"The creature is resistant to all bludgeoning, piercing, and slashing damage for the next minute."
+										"The creature that eats this Fruit is resistant to bludgeoning, piercing, and slashing damage for the next minute."
 									]
 								}
 							]
@@ -1257,8 +1345,306 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"Starting when you reach 14th level, you can cast {@spell grasping vine} without expending a spell slot a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest.",
+				"{@i 14th-level Circle of the Sower feature}",
+				"You have an unparalleled command over plant life. You can cast {@spell grasping vine} without expending a spell slot a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest.",
 				"When you cast {@spell grasping vine}, you can conjure two vines at once in separate locations within range of the spell. You can direct both vines at once with the same bonus action."
+			]
+		},
+		{
+			"name": "Circle of the Swarm",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Swarm",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"Druids defend every life, no matter how small or unseemly it may be. Some take this call more seriously than others and join a Circle of the Swarm. Often centered around sewers of great settlements or among festering swamps, these Druids have an affinity for vermin with many legs or gnawing teeth.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Swarmcaller|Druid||Swarm|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Swarm|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Swarmcaller",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Swarm",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Swarm feature}",
+				"The swarms of pests you defend are never far. You learn the {@spell infestation|xge} cantrip, but it does not count against your total number of Cantrips Known. When you cast {@spell infestation|xge}, you can target two creatures that are within 5 feet of each other, and when a creature fails its saving throw against this spell, you can choose which direction it moves.",
+				"Moreover, you can use a bonus action on your turn to use Wild Shape to turn into a {@filter swarm of beasts, such as a swarm of rats|bestiary|challenge rating=[&0;&1]|type=beast|miscellaneous=swarm}. When you do so, it gains the following benefits:",
+				{
+					"type": "list",
+					"items": [
+						"It gains a number of bonus hit points equal to 1 + your Druid level.",
+						"It can add your Wisdom modifier to all ability checks, attack rolls, and saving throws."
+					]
+				}
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Swarm",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Swarm feature}",
+				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they do not count against the total number of spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Swarm Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell faerie fire}, {@spell ray of sickness}"
+						],
+						[
+							"3rd",
+							"{@spell blur}, {@spell web}"
+						],
+						[
+							"5th",
+							"{@spell gaseous form}, {@spell slow}"
+						],
+						[
+							"7th",
+							"{@spell arcane eye}, {@spell giant insect}"
+						],
+						[
+							"9th",
+							"{@spell commune with nature}, {@spell insect plague}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Greater Swarm",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Swarm",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"{@i 6th-level Circle of the Swarm feature}",
+				"You call and the swarm answers. While you are Wild Shaped into a swarm, you can cast {@spell infestation|xge} and your Circle Spells as normal, and their effects manifest as part of your swarm.",
+				"Also, your attacks while you are Wild Shaped into a swarm count as magical for the sake of overcoming resistance and immunity to nonmagical attacks and damage."
+			]
+		},
+		{
+			"name": "Eyes of the Swarm",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Swarm",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"{@i 10th-level Circle of the Swarm feature}",
+				"Your vermin are always gathering information for you. When you finish a short or long rest, you gain information about the surrounding area as if you had cast {@spell commune with nature}.",
+				"When cast in this way, the spell works even where nature has been replaced by construction, such as cities and towns."
+			]
+		},
+		{
+			"name": "From Many, One",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Swarm",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"{@i 14th-level Circle of the Swarm feature}",
+				"You and the multitudes you protect have become one being. When you are reduced to 0 hit points, but are not killed outright, you can expend a use of Wild Shape to turn into a {@filter swarm of beasts with a Challenge Rating of 1/2 or lower|bestiary|challenge rating=[&0;&1/2]|type=beast|miscellaneous=swarm}, and immediately move up to the swarm's walking, flying, or climbing speed without provoking opportunity attacks.",
+				"Once you use this feature you must finish a long rest before you can use your Wild Shape in this way again."
+			]
+		},
+		{
+			"name": "Circle of the Tempest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"entries": [
+				"Drawn to the most destructive forces of the natural world, the Tempest Druids wield the power of storms. They often view themselves as great defenders of nature and use their power to strike back when civilization encroaches upon the wilds. Theirs is the power of lightning, thunder, ice, and wind, and woe to any who stand against these acolytes of destruction.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Servants of the Tempest|Druid||Tempest|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Circle Spells|Druid||Tempest|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Nature's Wrath|Druid||Tempest|LL:DC|2"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Tempestuous Rebuke|Druid||Tempest|LL:DC|2"
+				}
+			]
+		},
+		{
+			"name": "Servants of the Tempest",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"type": "inset",
+			"entries": [
+				"While Tempest Domain and Circle of the Tempest are similar mechanically, they almost always serve different masters. Clerics serve gods of storms and destruction, but Tempest Druids are often found in the service of nature itself or ancient elementals."
+			]
+		},
+		{
+			"name": "Circle Spells",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Tempest feature}",
+				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they do not count against the total number of spells you prepare each day.",
+				{
+					"type": "table",
+					"caption": "Circle of the Tempest Spells",
+					"colLabels": [
+						"Druid Level",
+						"Spells"
+					],
+					"colStyles": [
+						"col-2 text-center",
+						"col-10"
+					],
+					"rows": [
+						[
+							"2nd",
+							"{@spell fog cloud}, {@spell thunderwave}"
+						],
+						[
+							"3rd",
+							"{@spell shatter}, {@spell warding wind|xge}"
+						],
+						[
+							"5th",
+							"{@spell lightning bolt}, {@spell thunder step|xge}"
+						],
+						[
+							"7th",
+							"{@spell ice storm}, {@spell storm sphere|xge}"
+						],
+						[
+							"9th",
+							"{@spell control winds|xge}, {@spell maelstrom|xge}"
+						]
+					]
+				}
+			]
+		},
+		{
+			"name": "Nature's Wrath",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Tempest feature}",
+				"You can channel the destructive power of nature. When you cast a Druid spell that deals lightning or thunder damage, you can expend a use of Wild Shape and cause it to deal maximum damage to one target, instead of rolling."
+			]
+		},
+		{
+			"name": "Tempestuous Rebuke",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 2,
+			"header": 1,
+			"entries": [
+				"{@i 2nd-level Circle of the Tempest feature}",
+				"The elemental powers rebuke those who strike at you, their acolyte. When a creature within 5 feet that you can see hits you with an attack, you can use your reaction to force it to make a Dexterity saving throw. It takes 2d8 thunder damage on a failed save, and half as much on a successful save.",
+				"You can use this reaction a number of times equal to your Wisdom modifier (minimum of once), and you regain all of your expended uses when you finish a long rest."
+			]
+		},
+		{
+			"name": "Thunderous Strike",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"{@i 6th-level Circle of the Tempest feature}",
+				"You carry the fury of the storm. Once per turn, when you hit a Large or smaller creature with a melee attack, you can also push it up to 10 feet away from you in a straight line."
+			]
+		},
+		{
+			"name": "Tempestuous Form",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"{@i 10th-level Circle of the Tempest feature}",
+				"You can use druidic magic to transform into a minor version of the tempest you serve. As an action, you can expend two uses of Wild Shape to transform into an air elemental."
+			]
+		},
+		{
+			"name": "One with the Storm",
+			"source": "LL:DC",
+			"className": "Druid",
+			"classSource": "PHB",
+			"subclassShortName": "Tempest",
+			"subclassSource": "LL:DC",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"{@i 14th-level Circle of the Tempest feature}",
+				"You have become one with the destructive power of nature. You gain a flying speed equal to your walking speed.",
+				"In addition, whenever you use Nature's Wrath, the spell deals maximum damage to every target, instead of just one."
 			]
 		},
 		{
@@ -1270,7 +1656,7 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"Few natural forces exert as much influence over mortals as the waters of the world. Rain for crops, raging storms, and winding rivers all influence mortal folk throughout their lives. Tidal druids monitor the relationship between civilization and the waters of oceans, rivers, and lakes. They are often found using the innate magic of the waters to heal the sick, provide rest to the weary, and nurture the crops of common folk.",
+				"Few natural forces exert as much influence over mortals as the waters of the world. Rain for crops, raging storms, and winding rivers all influence the lives of mortals. Tidal Druids monitor the relationship between civilization and the waters of oceans, rivers, and lakes. They are often found using the innate magic found in the waters to heal the sick, provide rest to the weary, and nurture the crops of common folk.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Disciple of the Sea|Druid||Tides|LL:DC|2"
@@ -1295,7 +1681,8 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your dedication and service to the life giving primal waters has changed you. When you join this Circle at 2nd level, you gain the ability to breathe both air and water, and you gain a swimming speed equal to your movement speed."
+				"{@i 2nd-level Circle of the Tides feature}",
+				"Your dedication to primal waters has changed you. When you join this Circle, you gain the ability to breathe both air and water, and you gain a swimming speed equal to your walking speed."
 			]
 		},
 		{
@@ -1308,8 +1695,9 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Your connection with the primal waters grants you access to certain spells. At 2nd level, you learn the shape water cantrip.",
-				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as druid spells for you and you always have them prepared, but they don't count against the total number of spells you prepare each day.",
+				"{@i 2nd-level Circle of the Tides feature}",
+				"Your connection with the primal waters grants you access to certain spells. You learn the {@spell shape water} cantrip, but it does not count against your total number of Cantrips Known.",
+				"When you reach certain Druid levels, you gain access to the spells in the table below. They count as Druid spells for you, and you always have them prepared, but they don't count against the total number of spells you prepare each day.",
 				{
 					"type": "table",
 					"caption": "Circle of the Tides Spells",
@@ -1356,9 +1744,10 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"At 2nd level, you learn to channel the mystical power of the Tides, even when you are away from bodies of water. As a bonus action, you can expend a use of Wild Shape to exude a mystical watery force in a 15-foot radius. Creatures of your choice within your Tidal Aura treat it as {@quickref difficult terrain||3}. If a creature has a swimming speed it can ignore this effect.",
-				"Your Tidal Aura also enhances your healing powers. When you cast a spell of 1st-level or higher that restores hit points to a creature within your Tidal Aura, one target of the spell within your Tidal Aura regains additional hit points equal to your Wisdom modifier (minimum of 1 additional hit point).",
-				"Your Tidal Aura lasts for 1 minute. The effects end early if you end it as a bonus action, or if you are {@condition incapacitated}."
+				"{@i 2nd-level Circle of the Tides feature}",
+				"As a bonus action, you can expend a use of Wild Shape to exude a mystical watery force in a 15-foot radius. Creatures of your choice within this Aura treat it as {@quickref difficult terrain||3}. If a creature has a swimming speed it ignores this effect.",
+				"Your Tidal Aura also enhances your healing powers. When you cast a spell that restores hit points to a creature within this Tidal Aura, one target within the Aura regains additional hit points equal to your Wisdom modifier (minimum of 1).",
+				"Your Tidal Aura lasts for 1 minute. Its effects end early if you end it as a bonus action, or if you are {@condition incapacitated}."
 			]
 		},
 		{
@@ -1371,7 +1760,8 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Your Tidal magic has grown in power. Starting at 6th level, when you cast a spell of 1st-level or higher that forces a creature in your Tidal Aura to make a Strength, Dexterity, or Constitution saving throw, you can choose to empower the spell. Any creature within your Tidal Aura makes their initial saving throw against the empowered spell at disadvantage.",
+				"{@i 6th-level Circle of the Tides feature}",
+				"Your Tidal magic has grown in power. When you cast a spell that forces a creature in your Tidal Aura to make a Strength, Dexterity, or Constitution saving throw, you can empower the spell. Any creature within your Tidal Aura makes their initial saving throw against the empowered spell at disadvantage.",
 				"You can empower a spell in this way a number of times equal to your Wisdom modifier (minimum of once), and you regain all expended uses when you finish a long rest."
 			]
 		},
@@ -1385,8 +1775,9 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"Upon reaching 10th level, you can wield the magic of primal water to rejuvenate your allies as you hinder your foes. When you activate your Tidal Aura you gain a pool of temporary hit points equal to your druid level + your Wisdom modifier. While that Tidal Aura is active, you can use a bonus action to distribute any amount of temporary hit points from that pool to any creature that is within your Tidal Aura, including you.",
-				"When your Tidal Aura ends, any unused temporary hit points from your pool immediately disappear."
+				"{@i 10th-level Circle of the Tides feature}",
+				"You can wield the magic of primal water to rejuvenate your allies as you hinder your foes. When you activate your Tidal Aura, you gain a pool of temporary hit points equal to your Druid level + your Wisdom modifier that you can distribute to creatures of your choice within your Tidal Aura.",
+				"When your Tidal Aura ends, any remaining temporary hit points from this feature are immediately dispelled."
 			]
 		},
 		{
@@ -1399,7 +1790,8 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"Your bond with the mystical waters of the world has reached its apex. Starting at 14th level, you can cast {@spell control water} at will, without expending a spell slot, so long as you can target a body of water of sufficient size for you to manipulate.",
+				"{@i 14th-level Circle of the Tides feature}",
+				"Your bond with the mystical waters has reached its apex. You can cast {@spell control water} at will, without expending a spell slot, so long as you target a body of water of sufficient size.",
 				"Also, the radius of your Tidal Aura increases to 30 feet, and creatures of your choice treat the area of your Tidal Aura as difficult terrain even if they have a swimming speed."
 			]
 		},
@@ -1412,14 +1804,10 @@
 			"subclassSource": "LL:DC",
 			"level": 2,
 			"entries": [
-				"Druids of the Circle of the Land are the most common sort of druid, if druids can be considered common at all. These sages of the natural world are able to attune themselves to almost any environment, giving them an increased ability to draw out the natural magic of the flora and fauna that surround them.",
+				"Druids of the Circle of the Land are the most common Druid, if Druids can be considered common at all. These sages of the natural world are able to attune themselves to almost any environment, giving them an increased ability to draw out the natural magic of the flora and fauna that surround them.",
 				{
 					"type": "refSubclassFeature",
-					"subclassFeature": "Bonus Cantrip|Druid||Land (LL)|LL:DC|2"
-				},
-				{
-					"type": "refSubclassFeature",
-					"subclassFeature": "Environmental Attunement|Druid||Land (LL)|LL:DC|2"
+					"subclassFeature": "Localized Spells|Druid||Land (LL)|LL:DC|2"
 				},
 				{
 					"type": "refSubclassFeature",
@@ -1428,7 +1816,7 @@
 			]
 		},
 		{
-			"name": "Bonus Cantrip",
+			"name": "Localized Spells",
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
@@ -1437,27 +1825,16 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"At 2nd level you learn one additional cantrip of your choice from the {@filter druid spell list|spells|level=0|class=druid}. This cantrip doesn't count against your total number of Cantrips Known."
-			]
-		},
-		{
-			"name": "Environmental Attunement",
-			"source": "LL:DC",
-			"className": "Druid",
-			"classSource": "PHB",
-			"subclassShortName": "Land (LL)",
-			"subclassSource": "LL:DC",
-			"level": 2,
-			"header": 1,
-			"entries": [
-				"Your connection to the natural world grants you increased druidic power. At 2nd level, you are infused with the ability to cast certain spells based on your environment. These spells are listed in the Environment Spells table below. When you finish a long rest, you can attune to the environment around you, choosing from one of the following options: arctic, cave, coast, desert, forest, grassland, mountain, or swamp.",
-				"While you are attuned to that environment you gain access to the spells in the corresponding column of the Environment Spells table below. They count as druid spells for you and you always have them prepared, but they don't count against the total number of druid spells you can prepare each day.",
+				"{@i 2nd-level Circle of the Land feature}",
+				"You have mastered a greater amount of druidic magic. You learn one additional {@filter Druid cantrip|spells|level=0|class=druid} of your choice, but it does not count against your total number of Cantrips Known.",
+				"In addition, you are infused with the ability to cast certain spells based on your environment. When you finish a long rest, you can attune to the local environment, choosing the option that best represents your surroundings: arctic, cave, coast, desert, forest, grassland, mountain, or swamp.",
+				"While attuned to that environment you gain access to the corresponding spells on the Localized Spells table below. These spells count as Druid spells for you and you always have them prepared, but they don't count against the total number of Druid spells you can prepare each day.",
 				{
 					"type": "table",
 					"caption": "Arctic",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1466,11 +1843,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell armor of agathys}, {@spell ice knife|xge}"
+							"{@spell armor of agathys}"
 						],
 						[
 							"3rd",
-							"{@spell hold person}, {@spell spike growth}"
+							"{@spell hold person}"
 						],
 						[
 							"5th",
@@ -1491,7 +1868,7 @@
 					"caption": "Cave",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1500,11 +1877,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell cause fear|xge}, {@spell faerie fire}"
+							"{@spell cause fear|xge}"
 						],
 						[
 							"3rd",
-							"{@spell darkvision}, {@spell web}"
+							"{@spell web}"
 						],
 						[
 							"5th",
@@ -1525,7 +1902,7 @@
 					"caption": "Coast",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1534,11 +1911,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell cure wounds}, {@spell fog cloud}"
+							"{@spell fog cloud}"
 						],
 						[
 							"3rd",
-							"{@spell gust of wind}, {@spell misty step}"
+							"{@spell misty step}"
 						],
 						[
 							"5th",
@@ -1559,7 +1936,7 @@
 					"caption": "Desert",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1568,11 +1945,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell silent image}, {@spell sleep}"
+							"{@spell silent image}"
 						],
 						[
 							"3rd",
-							"{@spell blur}, {@spell dust devil|xge}"
+							"{@spell dust devil|xge}"
 						],
 						[
 							"5th",
@@ -1593,7 +1970,7 @@
 					"caption": "Forest",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1602,11 +1979,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell entangle}, {@spell goodberry}"
+							"{@spell entangle}"
 						],
 						[
 							"3rd",
-							"{@spell barkskin}, {@spell spider climb}"
+							"{@spell spider climb}"
 						],
 						[
 							"5th",
@@ -1627,7 +2004,7 @@
 					"caption": "Grassland",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1636,11 +2013,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell jump}, {@spell longstrider}"
+							"{@spell longstrider}"
 						],
 						[
 							"3rd",
-							"{@spell pass without trace}, {@spell sleep}"
+							"{@spell pass without trace}"
 						],
 						[
 							"5th",
@@ -1661,7 +2038,7 @@
 					"caption": "Mountain",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1670,11 +2047,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell earth tremor|xge}, {@spell feather fall}"
+							"{@spell earth tremor|xge}"
 						],
 						[
 							"3rd",
-							"{@spell maximilian's earthen grasp|xge}, {@spell spike growth}"
+							"{@spell maximilian's earthen grasp|xge}"
 						],
 						[
 							"5th",
@@ -1695,7 +2072,7 @@
 					"caption": "Swamp",
 					"colLabels": [
 						"Druid Level",
-						"Environment Spells"
+						"Localized Spells"
 					],
 					"colStyles": [
 						"col-2 text-center",
@@ -1704,11 +2081,11 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell ray of sickness}, {@spell tasha's caustic brew|tce}"
+							"{@spell tasha's caustic brew|tce}"
 						],
 						[
 							"3rd",
-							"{@spell melf's acid arrow}, {@spell spider climb}"
+							"{@spell melf's acid arrow}"
 						],
 						[
 							"5th",
@@ -1736,11 +2113,13 @@
 			"level": 2,
 			"header": 1,
 			"entries": [
-				"Starting at 2nd level, you can regain some of your druidic magic by communing with nature. During a short rest, you choose expended spell slots to recover. The spell slots can have a combined level that is equal to or less than half your druid level (rounded up), and none can be 6th-level or higher. You can't use this feature again until you finish a long rest."
+				"{@i 2nd-level Circle of the Land feature}",
+				"You can regain some of your druidic magic by communing with nature. At the end of a short rest, you can choose to recover a number of expended spell slots with a combined level less than or equal to half your Druid level rounded up. Spell slots you regain must be 5th-level or lower.",
+				"Once you use this feature to recover spell slots you must finish a long rest before you can use it again."
 			]
 		},
 		{
-			"name": "Land's Stride",
+			"name": "Acolyte of Nature",
 			"source": "LL:DC",
 			"className": "Druid",
 			"classSource": "PHB",
@@ -1749,8 +2128,9 @@
 			"level": 6,
 			"header": 2,
 			"entries": [
-				"Starting at 6th level, you move effortlessly through the native obstacles of your attuned environment. You ignore the effects of natural {@quickref difficult terrain||3} in your attuned environment.",
-				"In addition, you have advantage on saving throws to resist the harmful effects of your attuned environment. Examples include resisting extreme temperatures, magically created or manipulated plants, or other magical environmental effects."
+				"{@i 6th-level Circle of the Land feature}",
+				"You move effortlessly through the wild. You ignore the effects of {@quickref difficult terrain||3} imposed by your attuned environment.",
+				"Moreover, you have advantage on saving throws to resist the harmful effects of your attuned environment. Examples include extreme temperatures and weather, hostile flora, or other magical environmental effects."
 			]
 		},
 		{
@@ -1763,7 +2143,8 @@
 			"level": 10,
 			"header": 2,
 			"entries": [
-				"You are able to adapt to the hostile effects of nearly any wild place. Beginning at 10th level, when you finish a short or long rest, choose one of the following damage types: acid, cold, fire, lightning, poison, or thunder. You gain resistance to that type of damage until the end of your next short or long rest."
+				"{@i 10th-level Circle of the Land feature}",
+				"You are able to adapt to the hostile effects of nearly any wild place. When you finish a short or long rest, choose one of the following damage types: acid, cold, fire, lightning, poison, or thunder. You gain resistance to that type of damage until the end of your next short or long rest."
 			]
 		},
 		{
@@ -1776,7 +2157,8 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"When you reach 14th level, creatures of the natural world sense your connection to nature and become hesitant to attack you. When a beast or plant attacks you, you can force the creature to make a Wisdom saving throw. On a failed save, the attack automatically misses. On a successful save, the creature is immune to this effect for 24 hours.",
+				"{@i 14th-level Circle of the Land feature}",
+				"Creatures of the natural world can sense your devotion to nature and are hesitant to attack you. When a beast or plant attacks you, you can force it to make a Wisdom saving throw. On a failure, the attack automatically misses. On a success, the creature is immune to this effect for 24 hours.",
 				"Beasts and plants with a Wisdom of 4 or higher are aware of this effect before they make their attack against you."
 			]
 		}

--- a/subclass/LaserLlama; Druid Circles.json
+++ b/subclass/LaserLlama; Druid Circles.json
@@ -1382,7 +1382,7 @@
 			"entries": [
 				"{@i 2nd-level Circle of the Swarm feature}",
 				"The swarms of pests you defend are never far. You learn the {@spell infestation|xge} cantrip, but it does not count against your total number of Cantrips Known. When you cast {@spell infestation|xge}, you can target two creatures that are within 5 feet of each other, and when a creature fails its saving throw against this spell, you can choose which direction it moves.",
-				"Moreover, you can use a bonus action on your turn to use Wild Shape to turn into a {@filter swarm of beasts, such as a swarm of rats|bestiary|challenge rating=[&0;&1]|type=beast|miscellaneous=swarm}. When you do so, it gains the following benefits:",
+				"Moreover, you can use a bonus action on your turn to use Wild Shape to turn into a {@filter swarm of beasts, such as a swarm of rats|bestiary|type=beast|miscellaneous=swarm}. When you do so, it gains the following benefits:",
 				{
 					"type": "list",
 					"items": [

--- a/subclass/LaserLlama; Druid Circles.json
+++ b/subclass/LaserLlama; Druid Circles.json
@@ -103,6 +103,10 @@
 				"Extra Attack|Druid||Harvest|LL:DC|6",
 				"Mantle of Defense|Druid||Harvest|LL:DC|10",
 				"Cull the Unnatural|Druid||Harvest|LL:DC|14"
+			],
+			"subclassSpells": [
+				"Chill Touch",
+				"Inflict Wounds"
 			]
 		},
 		{

--- a/subclass/LaserLlama; Druid Circles.json
+++ b/subclass/LaserLlama; Druid Circles.json
@@ -15,8 +15,8 @@
 				"url": "https://www.gmbinder.com/share/-M0iZqG1CjdCXsEKFKnc"
 			}
 		],
-		"dateAdded": 1676753660,
-		"dateLastModified": 1676753660
+		"dateAdded": 1676754510,
+		"dateLastModified": 1676754510
 	},
 	"subclass": [
 		{
@@ -773,7 +773,7 @@
 						"When you make a Constitution saving throw to maintain concentration on a spell, you gain a bonus to your roll equal to your Wisdom modifier (minimum of +1)."
 					]
 				},
-				"Your Avenger form lasts for 1 minute. It ends early if you are incapacitated or you choose to end it as a bonus action."
+				"Your Avenger form lasts for 1 minute. It ends early if you are {@condition incapacitated} or you choose to end it as a bonus action."
 			]
 		},
 		{
@@ -1354,7 +1354,7 @@
 			"entries": [
 				"At 2nd level, you learn to channel the mystical power of the Tides, even when you are away from bodies of water. As a bonus action, you can expend a use of Wild Shape to exude a mystical watery force in a 15-foot radius. Creatures of your choice within your Tidal Aura treat it as {@quickref difficult terrain||3}. If a creature has a swimming speed it can ignore this effect.",
 				"Your Tidal Aura also enhances your healing powers. When you cast a spell of 1st-level or higher that restores hit points to a creature within your Tidal Aura, one target of the spell within your Tidal Aura regains additional hit points equal to your Wisdom modifier (minimum of 1 additional hit point).",
-				"Your Tidal Aura lasts for 1 minute. The effects end early if you end it as a bonus action, or if you are incapacitated."
+				"Your Tidal Aura lasts for 1 minute. The effects end early if you end it as a bonus action, or if you are {@condition incapacitated}."
 			]
 		},
 		{


### PR DESCRIPTION
Adds seven new Druid subclasses and an alternative Circle of the Land.

EDIT: Nine new subclasses with the addition of Swarm and Tempest. Also adjusted some previous subclasses with this new update.