### PR TITLE
Updated LaserLlama's Alt Bard to 1.1.1

### DIFF
--- a/class/LaserLlama; Alternate Bard.json
+++ b/class/LaserLlama; Alternate Bard.json
@@ -865,66 +865,21 @@
 			"classSource": "LaserLlamaAlternateBard",
 			"level": 2,
 			"entries": [
-				"You have traveled far and wide and gleaned various bits of knowledge. At 2nd level, you gain proficiency with two Bard class skills, {@item musical instrument|PHB|musical instruments}, or {@filter tools|items|type=artisan's tools;gaming set}. You can learn to speak, read, and write one {@5etools language|languages.html} of your choice in place of one or both of these proficiencies.",
-				"At certain Bard levels, you learn more Folklore. You gain proficiency with one Bard skill, musical instrument, tool, or learn another language of your choice at 7th, 10th, 14th, and 20th level."
+				"You have traveled far and wide and gleaned various bits of knowledge. At 2nd level, you gain proficiency with two skills, {@item musical instrument|PHB|musical instruments}, or {@filter tools|items|type=artisan's tools;gaming set}. You can learn to speak, read, and write one {@5etools language|languages.html} of your choice in place of one or both of these skill, instrument, or tool proficiencies.",
+				"At certain Bard levels, you learn more Folklore. You gain proficiency with one skill, musical instrument, tool, or learn another language of your choice at 7th, 10th, 14th, and 20th level."
 			],
-			"languageProficiencies": [
-				{},
+			"skillToolLanguageProficiencies": [
 				{
-					"any": 1
-				},
-				{
-					"any": 2
-				}
-			],
-			"skillProficiencies": [
-				{},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 2
-					}
-				}
-			],
-			"toolProficiencies": [
-				{},
-				{
-					"any": 1
-				},
-				{
-					"any": 2
+					"choose": [
+						{
+							"from": [
+								"anyLanguage",
+								"anySkill",
+								"anyTool"
+							],
+							"count": 2
+						}
+					]
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1039,40 +994,20 @@
 			"classSource": "LaserLlamaAlternateBard",
 			"level": 7,
 			"entries": [
-				"At 7th level, you learn more Folklore. You gain proficiency with one Bard skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
+				"At 7th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"languageProficiencies": [
-				{},
+			"skillToolLanguageProficiencies": [
 				{
-					"any": 1
-				}
-			],
-			"skillProficiencies": [
-				{},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				}
-			],
-			"toolProficiencies": [
-				{},
-				{
-					"any": 1
+					"choose": [
+						{
+							"from": [
+								"anyLanguage",
+								"anySkill",
+								"anyTool"
+							],
+							"count": 1
+						}
+					]
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1121,40 +1056,20 @@
 			"classSource": "LaserLlamaAlternateBard",
 			"level": 10,
 			"entries": [
-				"At 10th level, you choose another of Bard class skill, {@item musical instrument|PHB}, or language. If you were not already, you gain the chosen proficiency, or learn to speak, read, and write that language."
+				"At 10th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"languageProficiencies": [
-				{},
+			"skillToolLanguageProficiencies": [
 				{
-					"any": 1
-				}
-			],
-			"skillProficiencies": [
-				{},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				}
-			],
-			"toolProficiencies": [
-				{},
-				{
-					"any": 1
+					"choose": [
+						{
+							"from": [
+								"anyLanguage",
+								"anySkill",
+								"anyTool"
+							],
+							"count": 1
+						}
+					]
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1197,40 +1112,20 @@
 			"classSource": "LaserLlamaAlternateBard",
 			"level": 14,
 			"entries": [
-				"At 14th level, you choose another of Bard class skill, {@item musical instrument|PHB}, or language. If you were not already, you gain the chosen proficiency, or learn to speak, read, and write that language."
+				"At 14th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"languageProficiencies": [
-				{},
+			"skillToolLanguageProficiencies": [
 				{
-					"any": 1
-				}
-			],
-			"skillProficiencies": [
-				{},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				}
-			],
-			"toolProficiencies": [
-				{},
-				{
-					"any": 1
+					"choose": [
+						{
+							"from": [
+								"anyLanguage",
+								"anySkill",
+								"anyTool"
+							],
+							"count": 1
+						}
+					]
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1294,40 +1189,20 @@
 			"classSource": "LaserLlamaAlternateBard",
 			"level": 20,
 			"entries": [
-				"At 20th level, you choose another of Bard class skill, {@item musical instrument|PHB}, or language. If you were not already, you gain the chosen proficiency, or learn to speak, read, and write that language."
+				"At 20th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"languageProficiencies": [
-				{},
+			"skillToolLanguageProficiencies": [
 				{
-					"any": 1
-				}
-			],
-			"skillProficiencies": [
-				{},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				}
-			],
-			"toolProficiencies": [
-				{},
-				{
-					"any": 1
+					"choose": [
+						{
+							"from": [
+								"anyLanguage",
+								"anySkill",
+								"anyTool"
+							],
+							"count": 1
+						}
+					]
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"

--- a/class/LaserLlama; Alternate Bard.json
+++ b/class/LaserLlama; Alternate Bard.json
@@ -868,18 +868,31 @@
 				"You have traveled far and wide and gleaned various bits of knowledge. At 2nd level, you gain proficiency with two skills, {@item musical instrument|PHB|musical instruments}, or {@filter tools|items|type=artisan's tools;gaming set}. You can learn to speak, read, and write one {@5etools language|languages.html} of your choice in place of one or both of these skill, instrument, or tool proficiencies.",
 				"At certain Bard levels, you learn more Folklore. You gain proficiency with one skill, musical instrument, tool, or learn another language of your choice at 7th, 10th, 14th, and 20th level."
 			],
-			"skillToolLanguageProficiencies": [
+			"languageProficiencies": [
+				{},
 				{
-					"choose": [
-						{
-							"from": [
-								"anyLanguage",
-								"anySkill",
-								"anyTool"
-							],
-							"count": 2
-						}
-					]
+					"any": 1
+				},
+				{
+					"any": 2
+				}
+			],
+			"skillProficiencies": [
+				{},
+				{
+					"any:": 1
+				},
+				{
+					"any:": 2
+				}
+			],
+			"toolProficiencies": [
+				{},
+				{
+					"any": 1
+				},
+				{
+					"any": 2
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -996,18 +1009,22 @@
 			"entries": [
 				"At 7th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"skillToolLanguageProficiencies": [
+			"languageProficiencies": [
+				{},
 				{
-					"choose": [
-						{
-							"from": [
-								"anyLanguage",
-								"anySkill",
-								"anyTool"
-							],
-							"count": 1
-						}
-					]
+					"any": 1
+				}
+			],
+			"skillProficiencies": [
+				{},
+				{
+					"any:": 1
+				}
+			],
+			"toolProficiencies": [
+				{},
+				{
+					"any": 1
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1058,18 +1075,22 @@
 			"entries": [
 				"At 10th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"skillToolLanguageProficiencies": [
+			"languageProficiencies": [
+				{},
 				{
-					"choose": [
-						{
-							"from": [
-								"anyLanguage",
-								"anySkill",
-								"anyTool"
-							],
-							"count": 1
-						}
-					]
+					"any": 1
+				}
+			],
+			"skillProficiencies": [
+				{},
+				{
+					"any:": 1
+				}
+			],
+			"toolProficiencies": [
+				{},
+				{
+					"any": 1
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1114,18 +1135,22 @@
 			"entries": [
 				"At 14th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"skillToolLanguageProficiencies": [
+			"languageProficiencies": [
+				{},
 				{
-					"choose": [
-						{
-							"from": [
-								"anyLanguage",
-								"anySkill",
-								"anyTool"
-							],
-							"count": 1
-						}
-					]
+					"any": 1
+				}
+			],
+			"skillProficiencies": [
+				{},
+				{
+					"any:": 1
+				}
+			],
+			"toolProficiencies": [
+				{},
+				{
+					"any": 1
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
@@ -1191,18 +1216,22 @@
 			"entries": [
 				"At 20th level, you learn more Folklore. You gain proficiency with one skill, {@item musical instrument|PHB|musical instruments}, {@filter tool|items|type=artisan's tools;gaming set}, or learn another {@5etools language|languages.html} of your choice."
 			],
-			"skillToolLanguageProficiencies": [
+			"languageProficiencies": [
+				{},
 				{
-					"choose": [
-						{
-							"from": [
-								"anyLanguage",
-								"anySkill",
-								"anyTool"
-							],
-							"count": 1
-						}
-					]
+					"any": 1
+				}
+			],
+			"skillProficiencies": [
+				{},
+				{
+					"any:": 1
+				}
+			],
+			"toolProficiencies": [
+				{},
+				{
+					"any": 1
 				}
 			],
 			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"

--- a/class/LaserLlama; Alternate Bard.json
+++ b/class/LaserLlama; Alternate Bard.json
@@ -13,7 +13,7 @@
 					"hakr14"
 				],
 				"color": "ba0bba",
-				"version": "1.1.0",
+				"version": "1.1.1",
 				"url": "https://www.gmbinder.com/share/-NN-4ej_kwDJyO0_98BM",
 				"targetSchema": "1.10.8"
 			}
@@ -229,6 +229,20 @@
 									{
 										"choose": "level=1;2;3;4;5",
 										"count": 2
+									}
+								]
+							}
+						},
+						"20":  {
+							"daily": {
+								"1e": [
+									{
+										"choose": "level=6",
+										"count": 1
+									}, 
+									{
+										"choose": "level=7",
+										"count": 1
 									}
 								]
 							}
@@ -767,101 +781,6 @@
 			}
 		},
 		{
-			"name": "Folklore",
-			"source": "LaserLlamaAlternateBard",
-			"className": "Bard (Alternate)",
-			"classSource": "LaserLlamaAlternateBard",
-			"level": 2,
-			"entries": [
-				"You have traveled far and wide and gleaned various bits of knowledge. At 2nd level, you gain proficiency with two Bard class skills, musical instruments, or tools. You can learn to speak, read, and write one language of your choice in place of one or both of these proficiencies.",
-				"At certain Bard levels, you learn more Folklore. You gain proficiency with one Bard skill, musical instrument, tool, or learn another language of your choice at 7th, 10th, 14th, and 20th level."
-			],
-			"languageProficiencies": [
-				{},
-				{
-					"any": 1
-				},
-				{
-					"any": 2
-				}
-			],
-			"skillProficiencies": [
-				{},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 1
-					}
-				},
-				{
-					"choose": {
-						"from": [
-							"acrobatics",
-							"arcana",
-							"deception",
-							"history",
-							"insight",
-							"investigation",
-							"perception",
-							"performance",
-							"persuasion",
-							"religion",
-							"sleight of hand",
-							"stealth"
-						],
-						"count": 2
-					}
-				}
-			],
-			"toolProficiencies": [
-				{},
-				{
-					"any": 1
-				},
-				{
-					"any": 2
-				}
-			],
-			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
-		},
-		{
-			"name": "Song of Rest",
-			"source": "LaserLlamaAlternateBard",
-			"className": "Bard (Alternate)",
-			"classSource": "LaserLlamaAlternateBard",
-			"level": 2,
-			"entries": [
-				"Beginning at 2nd level, you can use soothing music or oration to help revitalize your wounded allies during a short rest. If you or any friendly creatures who can hear your performance regains hit points at the end of the short rest by spending one or more Hit Dice, each of those creatures regains additional hit points equal to one roll of your Bardic Inspiration Die.",
-				"In place of regaining these additional hit points, a creature can choose to reduce its current level of exhaustion by 1."
-			],
-			"foundrySystem": {
-				"actionType": "heal",
-				"activation": {
-					"type": "special",
-					"condition": "At the end of a short rest"
-				},
-				"damage.parts": [
-					[
-						"@scale.bard-alternate.bardic-inspiration",
-						"healing"
-					]
-				]
-			}
-		},
-		{
 			"name": "Spellcasting",
 			"source": "LaserLlamaAlternateBard",
 			"className": "Bard (Alternate)",
@@ -948,7 +867,67 @@
 			"entries": [
 				"You have traveled far and wide and gleaned various bits of knowledge. At 2nd level, you gain proficiency with two Bard class skills, {@item musical instrument|PHB|musical instruments}, or {@filter tools|items|type=artisan's tools;gaming set}. You can learn to speak, read, and write one {@5etools language|languages.html} of your choice in place of one or both of these proficiencies.",
 				"At certain Bard levels, you learn more Folklore. You gain proficiency with one Bard skill, musical instrument, tool, or learn another language of your choice at 7th, 10th, 14th, and 20th level."
-			]
+			],
+			"languageProficiencies": [
+				{},
+				{
+					"any": 1
+				},
+				{
+					"any": 2
+				}
+			],
+			"skillProficiencies": [
+				{},
+				{
+					"choose": {
+						"from": [
+							"acrobatics",
+							"arcana",
+							"deception",
+							"history",
+							"insight",
+							"investigation",
+							"perception",
+							"performance",
+							"persuasion",
+							"religion",
+							"sleight of hand",
+							"stealth"
+						],
+						"count": 1
+					}
+				},
+				{
+					"choose": {
+						"from": [
+							"acrobatics",
+							"arcana",
+							"deception",
+							"history",
+							"insight",
+							"investigation",
+							"perception",
+							"performance",
+							"persuasion",
+							"religion",
+							"sleight of hand",
+							"stealth"
+						],
+						"count": 2
+					}
+				}
+			],
+			"toolProficiencies": [
+				{},
+				{
+					"any": 1
+				},
+				{
+					"any": 2
+				}
+			],
+			"foundryImg": "icons/sundries/documents/document-official-brownl.webp"
 		},
 		{
 			"name": "Song of Rest",
@@ -959,7 +938,20 @@
 			"entries": [
 				"Beginning at 2nd level, you can use soothing music or oration to help revitalize your wounded allies during a short rest. If you or any friendly creatures who can hear your performance regains hit points at the end of the short rest by spending one or more Hit Dice, each of those creatures regains additional hit points equal to one roll of your Bardic Inspiration Die.",
 				"In place of regaining these additional hit points, a creature can choose to reduce its current level of {@condition exhaustion} by 1."
-			]
+			],
+			"foundrySystem": {
+				"actionType": "heal",
+				"activation": {
+					"type": "special",
+					"condition": "At the end of a short rest"
+				},
+				"damage.parts": [
+					[
+						"@scale.bard-alternate.bardic-inspiration",
+						"healing"
+					]
+				]
+			}
 		},
 		{
 			"name": "Bardic Tradition",
@@ -983,7 +975,7 @@
 			"entries": [
 				"In your varied travels, you have plundered magical knowledge from an assortment of disciplines. At 3rd level, you learn two {@filter 1st-level spells of your choice from any class spell list|spells|level=1}. These Magical Secrets spells become Bard spells for you, but they do not count against your total number of Spells Known.",
 				"You can cast each of your Magical Secret spells once, at its lowest level, without expending a spell slot, and you regain all expended uses when you finish a long rest. You can also cast Magical Secrets spells with any spell slots you have.",
-				"You learn two additional Magical Secrets spells of your choice when you reach 6th level, and again at 10th level, 14th level, and 18th level in this class. Any Magical Secret spells you learn must be of a level for which you have spell slots as shown on the Bard table.",
+				"You learn two additional Magical Secrets spells of your choice when you reach 6th level, and again at 10th level, 14th level, and 18th level in this class. Any additional Magical Secrets you learn must be of a level for which you have spell slots as per the Bard table.",
 				"Unlike your other Bard spells, any Bard spells that you learn as a Magical Secret through this feature cannot be switched out for another Bard spell when you gain a level in this class."
 			],
 			"foundrySystem": {
@@ -1347,7 +1339,7 @@
 			"classSource": "LaserLlamaAlternateBard",
 			"level": 20,
 			"entries": [
-				"At 20th level, your words and song inspire legendary feats of heroism. You can cast Magical Secrets spells by expending a number of your Bardic Inspiration dice equal to the level of the spell slot you would have expended to cast the spell."
+				"By 20th level, you have unlocked some of the most powerful and secret magics of the multiverse. You learn one 6th-level and one 7th-level spell of your choice from any spell list, and you can cast each spell once per long rest at its lowest level."
 			],
 			"foundryImg": "icons/tools/instruments/harp-yellow-teal.webp"
 		}
@@ -1456,7 +1448,7 @@
 			"shortName": "Conspirator",
 			"subclassFeatures": [
 				"Conspirator|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|3|LaserLlamaAlternateBard",
-				"Extra Attack|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|5|LaserLlamaAlternateBard",
+				"Devious Strike|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|5|LaserLlamaAlternateBard",
 				"Visage of Shadows|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|5|LaserLlamaAlternateBard",
 				"Mental Anguish|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|11|LaserLlamaAlternateBard",
 				"Sinister Manipulation|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|15|LaserLlamaAlternateBard"
@@ -1824,7 +1816,7 @@
 			"header": 2,
 			"entries": [
 				"{@i 15th-level Fool Tradition feature}",
-				"You can snatch defeat from victory to regain some of your bardic magic. Whenever you succeed on an ability check or saving throw, or hit with an attack roll, you can choose to fail or miss with your attack, often in comical fashion, and regain one of your expended Bardic Inspiration dice."
+				"You can snatch defeat from victory to regain some of your bardic magic. When the DM calls for you to make an ability check or forces you to make a saving throw and you succeed, you can instead choose to fail in comical fashion, and regain one of your expended Bardic Inspiration dice."
 			],
 			"consumes": {
 				"name": "Bardic Inspiration",
@@ -1833,7 +1825,7 @@
 			"foundrySystem": {
 				"activation": {
 					"type": "special",
-					"condition": "Whenever you succeed on an ability check or saving throw, or hit with an attack roll"
+					"condition": "When the DM calls for you to make an ability check or forces you to make a saving throw and you succeed"
 				}
 			},
 			"foundryImg": "icons/magic/symbols/clover-luck-white-green.webp"
@@ -1927,13 +1919,13 @@
 			"header": 2,
 			"entries": [
 				"{@i 11th-level Loremaster Tradition feature}",
-				"Your skills are beyond reproach. When you use your Bardic Inspiration reaction to add to an ability check, you can invoke a magical success. When you do, the creature automatically succeeds on its ability check in an overtly magical fashion.",
+				"Your skills are beyond reproach. When you use your Bardic Inspiration reaction to add to an ability check, you can invoke a magical success and turn the creature's {@dice d20} roll into a 20. If the target succeeds, it does so in an overtly magical way.",
 				"Once you use your Bardic Inspiration in this way you must finish a short or long rest before you can do so again.",
 				{
 					"type": "inset",
 					"name": "Inspiration & Magical Success",
 					"entries": [
-						"With their Wondrous Success feature a Loremaster Bard can allow a creature to automatically succeed on any one ability check it makes once per rest.",
+						"With their Wondrous Success feature a Loremaster Bard can allow a creature to almost automatically succeed on one ability check once per rest.",
 						"Remember, characters should only make ability checks when the DM calls for an ability check, and ability checks should not be called for unless there is a chance, however small, of a successful result."
 					]
 				}
@@ -2106,7 +2098,7 @@
 			],
 			"foundrySystem": {
 				"activation": {
-					"type": "speical",
+					"type": "special",
 					"condition": "Whenever you hit a creature with a weapon attack"
 				},
 				"damage.parts": [
@@ -2155,8 +2147,9 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 1,
 			"entries": [
-				"The Bards known as Conspirators use their skills and talents for their own benefit. They abuse the trust most folks have for Bards and work their way into positions where they can find incriminating secrets to use for blackmail. Operating behind the scenes to accumulate wealth and influence, Conspirators rarely reveal their true motivations to others.",
+				"The Bards known as Conspirators use their skills and talents for their own benefit. They abuse the trust most folks have for Bards and work their way into positions where they can find incriminating secrets to use for blackmail. These narcissistic Bards often masquerade as practitioners of other Traditions, operating in secret to accumulate wealth and influence, and rarely, if ever, reveal their true motivations to others.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Cunning Influence|Bard (Alternate)|LaserLlamaAlternateBard|Conspirator|LaserLlamaAlternateBard|3|LaserLlamaAlternateBard"
@@ -2179,7 +2172,9 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Conspirator Tradition feature}",
 				"You are an expert at manipulating creatures that make the mistake of trusting you. You gain proficiency in {@skill Deception} and with two of the following tools of your choice: {@item disguise kit|phb|disguise kits}, {@item forgery kit|phb|forgery kits}, {@item poisoner's kit|phb|poisoner's kits}, or {@item thieves' tools|phb}.",
 				"Whenever you make an ability check that uses any of the skill or tool proficiencies listed above you gain a bonus to your roll equal to one roll of your Bardic Inspiration die."
 			],
@@ -2211,7 +2206,9 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Conspirator Tradition feature}",
 				"Your strikes assault body and mind. When you hit a creature with a weapon attack, you can expend a Bardic Inspiration die to deal additional psychic damage to the creature equal to two rolls of your Bardic Inspiration die."
 			],
 			"consumes": {
@@ -2239,7 +2236,9 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Conspirator Tradition feature}",
 				"You can lace innocent speech with insidious bardic magic to inspire terror and paranoia. If you speak with a humanoid for at least 1 minute, you can expend one Bardic Inspiration die and force it to make a Wisdom saving throw. On a failed save, it is {@condition frightened} of a creature of your choice that it can see for 1 hour. This effect ends early if the frightened creature or its allies are attacked or damaged by you or your allies.",
 				"Regardless of the outcome of the saving throw, the target is unaware that you tried to magically influence its feelings."
 			],
@@ -2255,15 +2254,18 @@
 			"foundryImg": "icons/magic/unholy/barrier-fire-pink.webp"
 		},
 		{
-			"name": "Extra Attack",
+			"name": "Devious Strike",
 			"source": "LaserLlamaAlternateBard",
 			"className": "Bard (Alternate)",
 			"classSource": "LaserLlamaAlternateBard",
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 5,
+			"header": 2,
 			"entries": [
-				"You can attack twice, instead of once, whenever you take the Attack action on your turn. Moreover, you can cast one Bard cantrip you know in place of one of these attacks."
+				"{@i 5th-level Conspirator Tradition feature}",
+				"Once per turn, you can deal an additional {@damage 2d6} damage to one creature you hit with a weapon attack if another enemy of the target, other then you is within 5 feet of it, that enemy isn’t {@condition incapacitated}, and you don’t have disadvantage.",
+				"This additional damage increases at certain levels in this class: at 9th level ({@damage 3d6}), 13th level ({@damage 4d6}), and 17th level ({@damage 5d6})."
 			]
 		},
 		{
@@ -2274,12 +2276,13 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 5,
+			"header": 2,
 			"entries": [
+				"{@i 5th-level Conspirator Tradition feature}",
 				"You can use sinister magic to trap the visage of other people who fall victim to you. When a humanoid dies within 30 feet of you, you can use your reaction to capture its Shadow.",
 				"As an action, you can expend this Shadow and magically transform so that you resemble that humanoid as it looked in life. The effect lasts for 1 hour or until you end it as an action.",
 				"While you are transformed by a Shadow, you have access to any information that humanoid would have shared with a casual acquaintance, such as general details on its personal life and background, but not any secret information.",
-				"Creatures can attempt to see through this transformation by using their action to make an Intelligence ({@skill Investigation}) or Wisdom ({@skill Insight}) check against your Bard Spell save DC.",
-				"You can only have one Shadow captured at a time. Should you capture another Shadow, the previous Shadow is lost."
+				"Creatures can attempt to see through this transformation by using their action to make an Intelligence ({@skill Investigation}) or Wisdom ({@skill Insight}) check against your Bard Spell save DC."
 			],
 			"foundrySystem": {
 				"activation": {
@@ -2297,9 +2300,11 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 11,
+			"header": 2,
 			"entries": [
+				"{@i 11th-level Conspirator Tradition feature}",
 				"You weave manipulative magic into every strike. When you use Psychic Assault, you can force the creature to make a Wisdom saving throw against your Bard Spell save DC, or it becomes {@condition frightened} of you until the end of your next turn.",
-				"Also, when you hit a creature that is frightened of you with a weapon attack, you can end the frightened condition for it and turn your weapon attack into an automatic critical hit."
+				"Also, when you hit a creature that is {@condition frightened} of you with a weapon attack, you can end the {@condition frightened} condition for it and turn your weapon attack into an automatic critical hit."
 			],
 			"foundrySystem": {
 				"activation": {
@@ -2317,11 +2322,13 @@
 			"subclassShortName": "Conspirator",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 15,
+			"header": 2,
 			"entries": [
+				"{@i 15th-level Conspirator Tradition feature}",
 				"Your manipulative magic knows no bounds. As an action, you can whisper into the ear of a creature that can both hear and understand you within 5 feet and force it to make a Wisdom saving throw against your Bard Spell save DC.",
 				"On a failed save, the creature believes that you know of its darkest secret, though you have no knowledge of it. It is then {@condition charmed} by you until you or your allies attack or damage it.",
-				"While charmed this way, a creature will secretly aid you in any way it can, short of fighting or risking its life for you.",
-				"You can only have one creature charmed in this way at a time, and attempting to charm another creature in this way ends this effect for the previous creature. You can also end these effects on the charmed creature as an action."
+				"While {@condition charmed} this way, a creature will secretly aid you in any way it can, short of fighting or risking its life for you.",
+				"You can only have one creature {@condition charmed} in this way at a time, and attempting to charm another creature in this way ends this effect for the previous creature. You can also end these effects on the {@condition charmed} creature as an action."
 			],
 			"foundryImg": "icons/magic/control/debuff-energy-hold-pink.webp"
 		},
@@ -2333,6 +2340,7 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 1,
 			"entries": [
 				"Often hailing from the wondrous courts of the Feywild, these glamorous Bards use their magic to beguile and captivate all who look upon them. Never to be upstaged, Bards known as Mesmers use their powerful personalities to manipulate or motivate an audience to serve their goals.",
 				{
@@ -2353,7 +2361,9 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Mesmer Tradition feature}",
 				"Your words are laced with seductive Fey magic. You learn the {@spell friends|LaserLlamaAlternateBard}, {@spell charm person}, and {@spell command} spells, but they do not count against your total number of Cantrips Known or Spells Known.",
 				"Also, if you perform for, or speak with a creature for at least 1 minute, you can expend one Bardic Inspiration die to cast {@spell charm person} targeting that creature. When you cast the spell in this way, the target is unaware that you attempted to influence it with magic."
 			],
@@ -2376,8 +2386,10 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
-				"You can temporarily enhance your appearance with bardic magic. As a bonus action, you can expend a Bardic Inspiration die to empower yourself with Fey magic and choose any number of creatures, up to your Charisma modifier, that can see you within 60 feet.",
+				"{@i 3rd-level Mesmer Tradition feature}",
+				"You can momentarily enhance your appearance with bardic magic. As a bonus action, you can expend a Bardic Inspiration die to empower yourself with Fey magic and choose any number of creatures, up to your Charisma modifier, that can see you within 60 feet.",
 				"Creatures gain temporary hit points equal to one roll of your Bardic Inspiration die and can instantly move up to their speed.",
 				"This special movement does not provoke opportunity attacks."
 			],
@@ -2402,9 +2414,11 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 5,
+			"header": 2,
 			"entries": [
+				"{@i 5th-level Mesmer Tradition feature}",
 				"The seductive power of your bardic magic has grown. When you use Wondrous Performance it lasts for 1 minute, but it ends early if you are {@condition incapacitated} or you choose to end it.",
-				"While your Wondrous Performance lasts, you can use each subsequent bonus action to either grant a single creature the benefits of Wondrous Performance, or you can cast {@spell charm person} or {@spell command} without expending a spell slot."
+				"While your Wondrous Performance lasts, you can use each subsequent bonus action to either grant a single creature the benefits of Wondrous Performance, or you can cast {@spell charm person} or {@spell command} without expending a spell slot. When cast in this way these spells only last until the end of your Performance."
 			],
 			"foundryImg": "icons/tools/instruments/chimes-wood-brown.webp"
 		},
@@ -2416,7 +2430,9 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 5,
+			"header": 2,
 			"entries": [
+				"{@i 5th-level Mesmer Tradition feature}",
 				"You can attempt to distract your foes with whimsical magic. As a reaction when a creature you can see targets you with a melee attack, you can add one roll of your Bardic Inspiration die to your Armor Class against that attack."
 			],
 			"foundrySystem": {
@@ -2432,7 +2448,9 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 11,
+			"header": 2,
 			"entries": [
+				"{@i 11th-level Mesmer Tradition feature}",
 				"Your performances exude a powerful aura of protective Fey magic. Creatures of your choice within 30 feet that can see or hear you have advantage on saving throws to resist the {@condition charmed}, {@condition frightened}, {@condition paralyzed}, {@condition petrified}, and {@condition stunned} conditions while your Wondrous Performance lasts."
 			],
 			"foundryImg": "icons/magic/defensive/barrier-shield-dome-blue-purple.webp"
@@ -2445,7 +2463,9 @@
 			"subclassShortName": "Mesmer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 15,
+			"header": 2,
 			"entries": [
+				"{@i 15th-level Mesmer Tradition feature}",
 				"The bardic magic you draw from the Feywild has changed you, giving you a lovely yet fierce appearance. When you force a creature that can see you to make a saving throw to resist the {@condition charmed} or {@condition frightened} condition while your Wondrous Performance is active, it has disadvantage on its roll."
 			],
 			"foundryImg": "icons/magic/light/explosion-star-glow-silhouette.webp"
@@ -2458,6 +2478,7 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 1,
 			"entries": [
 				"Known simply as Blades, the Bards that follow this Tradition are famous for their wondrous, yet deadly performances that incorporate bladed weapons. Far from mundane performers, these Bards use their skill with blades to find employment as duelists, vigilantes, and sometimes even turn to adventuring.",
 				{
@@ -2482,9 +2503,11 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Sword Dancer Tradition feature}",
 				"You incorporate deadly blades and combat techniques into your performances. You gain proficiency with {@item scimitar|phb|scimitars}, and if you are proficient with a melee weapon, you can use it as a spellcasting focus for any Bard spell you know.",
-				"You also gain proficiency in {@skill Performance}, and whenever you would make a Charisma (Performance) check, you can make a Dexterity (Performance) check that incorporates a deadly bladed weapon you are proficient with instead."
+				"You also gain proficiency in {@skill Performance}, and whenever you would make a Charisma ({@skill Performance}) check, you can make a Dexterity ({@skill Performance}) check that incorporates a deadly bladed weapon you are proficient with instead."
 			],
 			"skillProficiencies": [
 				{
@@ -2506,7 +2529,9 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Sword Dancer Tradition feature}",
 				"You gain one of the Fighting Styles listed below. You cannot learn the same Fighting Style more than once, even if you are able to learn another Fighting Style.",
 				"Whenever you gain a Bard level, you can replace this Fighting Style with another option from the same list.",
 				{
@@ -2567,13 +2592,15 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 3,
+			"header": 2,
 			"entries": [
+				"{@i 3rd-level Sword Dancer Tradition feature}",
 				"You have studied various exploits to improve your deadly bardic performances. You gain the following features:",
 				{
 					"type": "entries",
 					"name": "Exploits",
 					"entries": [
-						"You learn two Martial Exploits of your choice from those available to the Alternate Fighter. The Exploits Known column of the Blade Dancer Exploits table shows when you learn more Martial Exploits of your choice.",
+						"You learn two {@filter Martial Exploits|optionalfeatures|feature type=ll:me} of your choice from those available to the Alternate Fighter. The Exploits Known column of the Blade Dancer Exploits table shows when you learn more Martial Exploits of your choice.",
 						"To use an Exploit, you expend a Bardic Inspiration die. You can only use one Exploit per ability check, attack, or saving throw. When a Martial Exploit refers to an Exploit Die, you use your Bardic Inspiration die.",
 						"When you gain a Bard level, you can replace one Exploit you know with another Martial Exploit of your choice of that degree."
 					]
@@ -2598,6 +2625,13 @@
 							]
 						}
 					]
+				},
+				{
+					"type": "inset",
+					"name": "Multiclassing & Exploits",
+					"entries": [
+						"Your martial skill depends partly on your combined levels in classes that learn Exploits, and partly on your individual levels in each class. If your group uses the optional rule for multiclassing and you learn Exploits from more than one class, you use the following rules: {@link Alternate Martial Multiclassing|https://www.gmbinder.com/share/-NGUL51kfZCPlESxL1wq}."
+					]
 				}
 			],
 			"consumes": {
@@ -2612,8 +2646,10 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 5,
+			"header": 2,
 			"entries": [
-				"You can attack twice, instead of once, whenever you take the Attack action on your turn. Moreover, you can cast one Bard cantrip you know in place of one of these attacks."
+				"{@i 5th-level Sword Dancer Tradition feature}",
+				"You can attack twice, instead of once, whenever you take the {@action Attack} action on your turn. Moreover, you can cast one Bard cantrip you know in place of one of these attacks."
 			]
 		},
 		{
@@ -2624,7 +2660,9 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 11,
+			"header": 2,
 			"entries": [
+				"{@i 11th-level Sword Dancer Tradition feature}",
 				"You wield your chosen weapons with deadly precision. When you deal damage with a melee weapon that you are proficient with, you can roll your Bardic Inspiration die in place of the weapon's normal damage die, unless its damage die is higher.",
 				"In addition, when you use an Exploit as part of your action, you can take the {@action Dash} or {@action Disengage} action as a bonus action."
 			],
@@ -2638,7 +2676,9 @@
 			"subclassShortName": "Sword Dancer",
 			"subclassSource": "LaserLlamaAlternateBard",
 			"level": 15,
+			"header": 2,
 			"entries": [
+				"{@i 15th-level Sword Dancer Tradition feature}",
 				"You are a master of your deadly yet beautiful craft. Once per turn, you can use an Exploit you know without expending a Bardic Inspiration die, rolling a {@dice d6} in its place.",
 				"Finally, at the end of each long rest, you can spend time practicing your techniques and replace one Martial Exploit you know with another Martial Exploit of your choice."
 			],

--- a/class/LaserLlama; Alternate Bard.json
+++ b/class/LaserLlama; Alternate Bard.json
@@ -880,10 +880,54 @@
 			"skillProficiencies": [
 				{},
 				{
-					"any:": 1
+					"choose": {
+						"from": [
+							"athletics",
+							"acrobatics",
+							"sleight of hand",
+							"stealth",
+							"arcana",
+							"history",
+							"investigation",
+							"nature",
+							"religion",
+							"animal handling",
+							"insight",
+							"medicine",
+							"perception",
+							"survival",
+							"deception",
+							"intimidation",
+							"performance",
+							"persuasion"
+						],
+						"count": 1
+					}
 				},
 				{
-					"any:": 2
+					"choose": {
+						"from": [
+							"athletics",
+							"acrobatics",
+							"sleight of hand",
+							"stealth",
+							"arcana",
+							"history",
+							"investigation",
+							"nature",
+							"religion",
+							"animal handling",
+							"insight",
+							"medicine",
+							"perception",
+							"survival",
+							"deception",
+							"intimidation",
+							"performance",
+							"persuasion"
+						],
+						"count": 2
+					}
 				}
 			],
 			"toolProficiencies": [
@@ -1018,7 +1062,29 @@
 			"skillProficiencies": [
 				{},
 				{
-					"any:": 1
+					"choose": {
+						"from": [
+							"athletics",
+							"acrobatics",
+							"sleight of hand",
+							"stealth",
+							"arcana",
+							"history",
+							"investigation",
+							"nature",
+							"religion",
+							"animal handling",
+							"insight",
+							"medicine",
+							"perception",
+							"survival",
+							"deception",
+							"intimidation",
+							"performance",
+							"persuasion"
+						],
+						"count": 1
+					}
 				}
 			],
 			"toolProficiencies": [
@@ -1084,7 +1150,29 @@
 			"skillProficiencies": [
 				{},
 				{
-					"any:": 1
+					"choose": {
+						"from": [
+							"athletics",
+							"acrobatics",
+							"sleight of hand",
+							"stealth",
+							"arcana",
+							"history",
+							"investigation",
+							"nature",
+							"religion",
+							"animal handling",
+							"insight",
+							"medicine",
+							"perception",
+							"survival",
+							"deception",
+							"intimidation",
+							"performance",
+							"persuasion"
+						],
+						"count": 1
+					}
 				}
 			],
 			"toolProficiencies": [
@@ -1144,7 +1232,29 @@
 			"skillProficiencies": [
 				{},
 				{
-					"any:": 1
+					"choose": {
+						"from": [
+							"athletics",
+							"acrobatics",
+							"sleight of hand",
+							"stealth",
+							"arcana",
+							"history",
+							"investigation",
+							"nature",
+							"religion",
+							"animal handling",
+							"insight",
+							"medicine",
+							"perception",
+							"survival",
+							"deception",
+							"intimidation",
+							"performance",
+							"persuasion"
+						],
+						"count": 1
+					}
 				}
 			],
 			"toolProficiencies": [
@@ -1225,7 +1335,29 @@
 			"skillProficiencies": [
 				{},
 				{
-					"any:": 1
+					"choose": {
+						"from": [
+							"athletics",
+							"acrobatics",
+							"sleight of hand",
+							"stealth",
+							"arcana",
+							"history",
+							"investigation",
+							"nature",
+							"religion",
+							"animal handling",
+							"insight",
+							"medicine",
+							"perception",
+							"survival",
+							"deception",
+							"intimidation",
+							"performance",
+							"persuasion"
+						],
+						"count": 1
+					}
 				}
 			],
 			"toolProficiencies": [


### PR DESCRIPTION
* Capstone changed - added choice of 6th/7th level spell to spells known
* Re-ordered feature so they're in order by level
* Re-added feature headers to Conspirator, Mesmer, and Sword Dancer subclasses
* Conspirator Extra Attack changed to Devious Strike
* Re-added inset to Elegant Exploits
* Tweaked various descriptions that were updated from 1.1.0 to 1.1.1