### PR TITLE
Tweak Circle of Kudzu wording.

### DIFF
--- a/subclass/Korvinagor; Circle of Kudzu.json
+++ b/subclass/Korvinagor; Circle of Kudzu.json
@@ -73,7 +73,8 @@
 					"items": [
 						"You learn the {@spell thorn whip} cantrip, and can cast it without using verbal or material components.",
 						"You can target and interact with objects using {@spell thorn whip} in the same ways as the {@spell mage hand} cantrip.",
-						"You have the {@spell entangle} spell prepared, and can expend a Wild Shape usage as part of casting it to maintain it without {@condition concentration}. The spell ends early if you recast or dismiss it (no action required)."
+						"You have the {@spell entangle} spell prepared, and can expend a Wild Shape usage as part of casting it to maintain it without {@condition concentration}. The spell ends early if you recast or dismiss it (no action required).",
+						"Moving through {@quickref difficult terrain||3} caused by nonmagical plants or your own spell effects does not cost you extra movement."
 					]
 				}
 			]
@@ -125,7 +126,7 @@
 					"type": "entries",
 					"name": "Uproot",
 					"entries": [
-						"If the target is a creature, you make an ability check with your spellcasting ability contested by that creature's Strength check. If you succeed, you can pull the creature towards you up to your distance from it. Objects worn or carried by a creature can also be targeted in the same way: on a success, you pull the object to the creature's feet instead of towards you."
+						"If the target is a creature, you make an ability check with your spellcasting ability contested by that creature's Strength check. If you succeed, you can pull the creature towards you up to your distance from it."
 					]
 				}
 			]

--- a/subclass/Korvinagor; Circle of Kudzu.json
+++ b/subclass/Korvinagor; Circle of Kudzu.json
@@ -74,7 +74,7 @@
 						"You learn the {@spell thorn whip} cantrip, and can cast it without using verbal or material components.",
 						"You can target and interact with objects using {@spell thorn whip} in the same ways as the {@spell mage hand} cantrip.",
 						"You have the {@spell entangle} spell prepared, and can expend a Wild Shape usage as part of casting it to maintain it without {@condition concentration}. The spell ends early if you recast or dismiss it (no action required).",
-						"Moving through {@quickref difficult terrain||3} caused by nonmagical plants or your own spell effects does not cost you extra movement."
+						"You can pass through any movement impediments caused by nonmagical plants or your own spell effects without being slowed by them."
 					]
 				}
 			]

--- a/subclass/Korvinagor; Circle of Kudzu.json
+++ b/subclass/Korvinagor; Circle of Kudzu.json
@@ -96,7 +96,7 @@
 						"You can change its casting time to a bonus action.",
 						"Attack rolls on willing targets automatically hit.",
 						"You can choose not to apply damage to a target.",
-						"Instead of pulling a creature, you can choose to move them up to 10 feet in any horizontal direction."
+						"Instead of pulling a creature, you can choose to move it up to 10 feet in any horizontal direction."
 					]
 				},
 				"Additionally, once per turn, when you hit a target with {@spell thorn whip}, you can cause one of the below effects:",


### PR DESCRIPTION
Change "them" to "it" when referring to a creature, as is standard.