### PR TITLE
Clarified Seasons Druid wording

### DIFF
--- a/subclass/Korvinagor; Circle of the Seasons.json
+++ b/subclass/Korvinagor; Circle of the Seasons.json
@@ -98,7 +98,7 @@
 			"entries": [
 				"{@i 2nd-level Circle of the Seasons feature}",
 				"As an action, you can expend a Wild Shape usage to Call the essence of one of the seasons through yourself, temporarily harnessing its power.",
-				"Calling a season grants you access to its respective spells on the Seasonal Spells table below, along with an additional druid cantrip of your choice. Wisdom is your spellcasting ability for these spells.",
+				"While Calling a season, you gain access to its respective spells on the Seasonal Spells table below, along with an additional druid cantrip of your choice. Wisdom is your spellcasting ability for these spells.",
 				"This transformation lasts for 8 hours. It ends early if you dismiss it (no action required), are {@condition incapacitated}, die, or use this feature again.",
 				{
 					"type": "table",


### PR DESCRIPTION
Tweaked text to make it clear that spell/cantrip access was tied to the Seasons Druid's transformation.