### PR TITLE
Update Ghostfire Gaming; Grim Hollow Campaign Guide.json

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
@@ -12417,7 +12417,7 @@
 			]
 		},
 		{
-			"name": "Tears of the Hungerger",
+			"name": "Tears of the Hungerer",
 			"source": "GH",
 			"page": 220,
 			"entries": [
@@ -22942,7 +22942,7 @@
 									"items": [
 										"{@disease Seven Shades of Sitri|GH}",
 										"{@disease Faith Cough|GH}",
-										"{@disease Tears of the Hungerger|GH}",
+										"{@disease Tears of the Hungerer|GH}",
 										"{@disease The Weeping Pox|GH}"
 									]
 								}


### PR DESCRIPTION
Fix Typo
Also the web editor for a two-character change seems to have destroyed the tab stop size, apologies