### PR TITLE
Mysteriously Missing and Merrily Met - Sample

### DIFF
--- a/collection/Giuseppe Rotondo; Mysteriously_Missing.json
+++ b/collection/Giuseppe Rotondo; Mysteriously_Missing.json
@@ -1,0 +1,966 @@
+{
+    "$schema": "https://raw.githubusercontent.com/TheGiddyLimit/5etools-utils/master/schema/brew-fast/homebrew.json",
+    "_meta": {
+        "sources": [
+            {
+                "json": "MysteriouslyMissing",
+                "abbreviation": "MysteriouslyMissing",
+                "full": "Mysteriously Missing and Merrily Met - Sample",
+                "authors": [
+                    "Mysteriously_Missing"
+                ],
+                "color": "452A00",
+                "convertedBy": [
+                    "VAD"
+                ],
+                "version": "2023.09.29",
+                "url": "https://www.drivethrurpg.com/product/378185/Mysteriously-Missing--Merrily-Met"
+            }
+        ],
+        "dateAdded": 1696033867,
+        "dateLastModified": 1696736716
+    },
+    "book": [
+        {
+            "name": "Mysteriously Missing and Merrily Met - Sample",
+            "id": "MysteriouslyMissing",
+            "source": "MysteriouslyMissing",
+            "published": "2021-11-23",
+            "group": "homebrew",
+            "coverUrl": "https://i.imgur.com/2YuGUIb.png",
+            "contents": [
+                {
+                    "name": "Cover Page & Credits"
+                },
+                {
+                    "name": "Introduction"
+                },
+                {
+                    "name": "Last Seen in Town"
+                },
+                {
+                    "name": "Last Seen in a Dungeon"
+                },
+                {
+                    "name": "Last Seen in the Wilderness"
+                }
+            ]
+        }
+    ],
+    "bookData": [
+        {
+            "id": "MysteriouslyMissing",
+            "source": "MysteriouslyMissing",
+            "data": [
+                {
+                    "type": "section",
+                    "name": "Mysteriously Missing and Merrily Met - Sample",
+                    "page": 1,
+                    "entries": [
+                        {
+                            "type": "image",
+                            "href": {
+                                "type": "external",
+                                "url": "https://i.imgur.com/2YuGUIb.png"
+                            },
+                            "credit": "",
+                            "altText": "The cover of {@b Mysteriously Missing and Merrily Met}"
+                        },
+                        {
+                            "type": "section",
+                            "name": "Credits",
+                            "page": 2,
+                            "entries": [
+                                "Optional Story Tables for Old-School Essentials by {@b Giuseppe Rotondo}",
+                                {
+                                    "type": "entries",
+                                    "name": "Cover Art:",
+                                    "entries": [
+                                        "Carlos Castilho"
+                                    ]
+                                },
+                                {
+                                    "type": "entries",
+                                    "name": "Images:",
+                                    "entries": [
+                                        "Carlos Castilho"
+                                    ]
+                                },
+                                {
+                                    "type": "entries",
+                                    "name": "Layout:",
+                                    "entries": [
+                                        "A.Sword.In.Da.Eye. Studio"
+                                    ]
+                                },
+                                {
+                                    "type": "entries",
+                                    "name": "Slabbo font by:",
+                                    "entries": [
+                                        "Mauro GATTI"
+                                    ]
+                                },
+                                {
+                                    "type": "entries",
+                                    "name": "{@b Thanks} to:",
+                                    "entries": [
+                                        "George Patterson"
+                                    ]
+                                },
+                                "Old-School Essentials is a trademark of Necrotic Gnome.",
+                                "The trademark and Old-School Essentials logo are use with permission of Necrotic Gnome, under license."
+                            ]
+                        }
+                    ]
+                },
+                {
+                    "type": "section",
+                    "name": "Introduction",
+                    "page": 4,
+                    "entries": [
+                        "The follwing tables and rules require {@b Old-School Essentials}, and are generally compatible with any other Original, BX, or BECMI clone of the classic fantasy role-playing game.",
+                        "These tables provide an instant, retroactive story to explain why a character disappeared and was not around during the last session, when a player could not participate in the game.",
+                        "These tables aim at providing intereseting events to inject more story into the campaign. Sometimes the results are simple and bear little or no consequence; sometimes a result may produce a significant change in the character's story.",
+                        "The referee is expected to adree with the players on using these tables in their games.",
+                        "This is important because these tables often \"steal\" the power of decision from the players, determining specific courses of action for their characters, and these may have positive or negative outcomes.",
+                        "Use these tables when a player misses one or more sessions. The assumption is that the rest of the party continue playing, even though one of their comrades has somehow disappeared. There is no trace of them, no clue. As soon as the player joins the game again, it's time to answer the obvious question: {@i Where have you been?} The player rolls on the appropriate table, determined by the referee, who checks the table and informs them of the reason why their character disappeared and what they have been up to. If a player misses more than one session, the referee may require a roll for each missed session, using the appropriate tables required to catch up with the party.",
+                        "{@b Truth of Lies}: The tables tell what really happened. The player may always decide to tell a slightly or completely different story to the party, so the referee and the player should work it out aside from the other players.",
+                        "{@b Take Your Time but Make it Quick}: The referee and the player should take five minutes to work out the result, fleshing out the details where necessary, but not longer than that.",
+                        "{@b No Dying}: No result may cause the character's death. If a result drops the character's hit piints to 0 or lower, they are returned to 1."
+                    ]
+                },
+                {
+                    "type": "table",
+                    "caption": "Last Seen in Town",
+                    "page": 7,
+                    "colLabels": [
+                        "{@dice d20}",
+                        "result"
+                    ],
+                    "colStyles": [
+                        "col-1 text-center",
+                        "col-8"
+                    ],
+                    "rows": [
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 1,
+                                    "pad": true
+                                }
+                            },
+                            "Old creditors pursued the character, who owes them 1d100 gp per character level. The player may decide to finally pay their debt, or face the consequences (which may involve the local criminal underworld, at the referee's discretion)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 2,
+                                    "pad": true
+                                }
+                            },
+                            "The character was sick and needed to rest. The player must make a Constitution check. If the check fails, the character suffers 1d3 damage but gains 1 point of Constitution."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 3,
+                                    "pad": true
+                                }
+                            },
+                            "The character fruitlessly courted a romantic interest, and they've spent 1d100 gp per character level in gifts, dinners, entertaining and fancy clothes. At least now they have some elegant clothes! The player must make a Charisma check. If the cehck fails, the character spend 1d100 gp more, but gains 1 point of Charisma."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 4,
+                                    "pad": true
+                                }
+                            },
+                            "A rabdin uten frin tge cgaracter's inventory was stolen, ad they tried to get it back. The character retrieved it if they now succeed in three ability checks. The player can choose the ability, but each roll must be a different ability."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 5,
+                                    "pad": true
+                                }
+                            },
+                            "The achracter was in jail as a consequence of a \"misunderstanding\" with the local authorities. Everything is settled now, but the guards will keep an eye on the character from now on, unless the character bribes them with 1d100 gp per character level."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 6,
+                                    "pad": true
+                                }
+                            },
+                            "The character was offered a dangerous task. If they accepted, the player must make an ability check with an ability of their choice. If the Character succeeds, the character has earned 1d100 platinum pieces per level. If the check fails, the character sufferes 1d3 damage per character level."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 7,
+                                    "pad": true
+                                }
+                            },
+                            "The character drank a \"miraculous\" concoction bought from a peddler. They've now recovered from the dizziness, and the player must reroll a random ability score with 4d6 (maximum result 18). At the referee's discretion, this effect can be canceled with some kind of treatment (e.g. a dissolve magic or remove curse spell)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 8,
+                                    "pad": true
+                                }
+                            },
+                            "A mighty wizard from another plane summoned the character to take part in a glorious quest! They don't remember much, except the flying ships and the treasures they could not carry over to this plane. Also, any alcoholic beverage the character had is now gone, along with 4d10 gold pieces (if they had them)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 9,
+                                    "pad": true
+                                }
+                            },
+                            "The character has met the love of their life... and the two are about to marry! The character has spent 1/3 of their riches to buy a house in town, and is ready to spend as much for the celebration. Congratulations! If the character is already married, this result is the beginning of a secret affair instead."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 10,
+                                    "pad": true
+                                }
+                            },
+                            "The character had a great hand, so they bet they would have cleaned the whole tavern if they had lost. Which they did. The tavern is now pristine! Several people in town now call the character \"The cleanser\"."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 11,
+                                    "pad": true
+                                }
+                            },
+                            "The character accidentally bumped their head somewhere. For a few days they lost their memory and lived like a beggar, until a bunch of street rascals \"healed\" them with a volley of stones. They've also earned 3d6 copper pieces."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 12,
+                                    "pad": true
+                                }
+                            },
+                            "The character joined a secret religious ritual. They are healed of all damage and cleansed of all disease, poison and curse (including cursed items)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 13,
+                                    "pad": true
+                                }
+                            },
+                            "The character took care of sick stray dog or cat, who is now well and happy to follow them."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 14,
+                                    "pad": true
+                                }
+                            },
+                            "The character met an old sage who taught them about his life experiences. Increase the character's Intelligence by 1 (maximum 18)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 15,
+                                    "pad": true
+                                }
+                            },
+                            "The character spent their time reseaching old books or talking to the right people. The referee must reveal to the player a clue, rumor or other useful information."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 16,
+                                    "pad": true
+                                }
+                            },
+                            "The character has undergone a mystical crisis and has spent all this time praying. The player may change the character's alignment, or increase their Wisdom by 1 point."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 17,
+                                    "pad": true
+                                }
+                            },
+                            "The character met a traveler from another land, has learned the basics of their language."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 18,
+                                    "pad": true
+                                }
+                            },
+                            "The character came across an old debtor. The player may make a Charisma or Strength check. If the check succeeds, the character gets 2d100 gp back. If the check fails, the chosen ability increases by 1 point."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 19,
+                                    "pad": true
+                                }
+                            },
+                            "The character took care of an easy job, and has earned 1d100 gp per character level."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 20,
+                                    "pad": true
+                                }
+                            },
+                            "The character made friends with an important, powerful NPC who had them as their guest at their abode. Roll 1d6 for more details about the NPC:",
+                            {
+                                "type": "table",
+                                "colLabels": [
+                                    "{@dice d6}",
+                                    "Item"
+                                ],
+                                "colStyles": [
+                                    "col-1 text-center",
+                                    "col-11"
+                                ],
+                                "rows": [
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 1,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Ruling class"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 2,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Merchant"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 3,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Criminal underworld"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 4,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Clergy"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 5,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Adventurer"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 6,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Magical"
+                                    ]
+                                ]
+                            }
+                        ]
+                    ]
+                },
+                {
+                    "type": "table",
+                    "caption": "Last Seen in a Dungeon",
+                    "page": 11,
+                    "colLabels": [
+                        "{@dice d20}",
+                        "result"
+                    ],
+                    "colStyles": [
+                        "col-1 text-center",
+                        "col-8"
+                    ],
+                    "rows": [
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 1,
+                                    "pad": true
+                                }
+                            },
+                            "The character fell into a deep pit or pit trap, and they had to climb back up to freedom. The player must make a Dexterity check. If the check fails, their Dexterity increases by 1 but they suffer 3d6+3 damage. If the check succeeds, they climb back up unscathed."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 2,
+                                    "pad": true
+                                }
+                            },
+                            "The character was ambushed and taken prisoner by a group of monsters of the same type as the party last encountered! They took all the gold and treasure the character had with them and then set them free."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 3,
+                                    "pad": true
+                                }
+                            },
+                            "The character fell into a deep pit or pit trap. Before they rejoin the party, they might bave to face a Wondering Monster (standard chances for the dungeon they were in)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 4,
+                                    "pad": true
+                                }
+                            },
+                            "The character touched a tiny, brilliant rune on the wall, and was teleported to the last bed they had slept upon!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 5,
+                                    "pad": true
+                                }
+                            },
+                            "The character fell into a pit or pit trap, and they had to use all their strength to break free. The player must make a Strength check. If they fail, their Strength increases by 1 but they suffer 1d3+1 damage. If they succeed, they suffer 1 damage."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 6,
+                                    "pad": true
+                                }
+                            },
+                            "A mighty wizard from another plane summoned the character to take part in a glorious quest! They don't remember much, except the burning lava wastes and the treasures they could not carry over to this plane. Also, any alcoholic beverage they had with them is now gone."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 7,
+                                    "pad": true
+                                }
+                            },
+                            "The character tasted something that looked like cheese, and they've only regained consciousness now. Luckily, nothing ate them while they were unconscious. They player must make a Wisdom check. If they fail, their Wisdom increases by 1."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 8,
+                                    "pad": true
+                                }
+                            },
+                            "The character found a potion and carelessly drank it. They passed out and have only recovered now. The player must reroll a random ability score with 4d6 (maximum result 18). At the referee's discretion, this effect can be canceled with some kind of treatment (e.g. a dissolve magic or remove curse spell)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 9,
+                                    "pad": true
+                                }
+                            },
+                            "An extremely short-sighted carcass crawler mistook the character for one of its offspring. It paralyzed them and took them to its lair, where it lovingly fed them with garbage. The cahracter must save versus paralysis or lose 1 point of Dexterity. From now on they are immune to paralysis caused by carcass crawlers, and they add +2 to all saves versus paralysis from any other source."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 10,
+                                    "pad": true
+                                }
+                            },
+                            "The character saw an eerie apparition behind a corner, and was magically lured to follow it. It was the ghost of an adventurer who died here! The spirit has warned them through a vision about a great threat in the dungeon."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 11,
+                                    "pad": true
+                                }
+                            },
+                            "The character found a coin stuck between two stones, and remained behind to recover it. The player must make a Strength check. If they fail, the character's Strength increases by 1. If they succeed, the characters gains 1 gp!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 12,
+                                    "pad": true
+                                }
+                            },
+                            "The character remained behind to decipher a graffiti, which revealed a clue about the dungeon (at the referee's discretion)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 13,
+                                    "pad": true
+                                }
+                            },
+                            "The character was kidnapped by a group of sprites, who taught them the manguage of mice!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 14,
+                                    "pad": true
+                                }
+                            },
+                            "The player must make up another story, because what has happened must remain a secret. The character touched a small rune, and is now imprisoned inside it, while their evil twin came out. The player now plays the evil twin (which has the same game statistics), until the twin is slain or discovered. The actual characte still receives the experience the player would gain, plus a 10% bonus for each sentient creature it manages to kill (please note it doesn't have to be the other players' characters, as they are probably more useful as allies... until they find out). When the evil twin dies or is detected, the original character is released from the magic rune prison, but must roll 2 times on this table and 1 time on the {@b Last Seen In the Wilderness} table."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 15,
+                                    "pad": true
+                                }
+                            },
+                            "The character followed a Will-o-the-Wisp which led them out of the dungeon (through a different way than they came in, if available)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 16,
+                                    "pad": true
+                                }
+                            },
+                            "The character pushed a brick or rock, the wall rotated and they found a secret passage to a hidden treasure: 1d100 platinum pieces and 50% chance of a random magic item! Then they spent hours and hours trying to open the secret passage again."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 17,
+                                    "pad": true
+                                }
+                            },
+                            "The character found a coin stuck between two stones and remained behind to recover it. The player makes a Strength check. If the check fails, their Strength increases by 1. If the check succeeds, they discover it was not a coin at all, but a random magic ring!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 18,
+                                    "pad": true
+                                }
+                            },
+                            "The character heard a soft moaning and followed it to a lost adventureer (a level 1 Fighter), the sole survivor of a party that entered the dungeon shortly after or before they players. The rest of their group is either dead or has fled the dungeon, so the lone warrior wants to follow the player's character."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 19,
+                                    "pad": true
+                                }
+                            },
+                            "As above [19], except the lost adventure actually is a Doppelganger."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 20,
+                                    "pad": true
+                                }
+                            },
+                            "The character heard a soft moaning and followed it to a young creature that wandered the dungeon and got lost. The character fed it out of compassion and now the creature follows them loyally. Roll a d10 to determine the creature type. it only has 1 HD and consequent THAC0 and saves. The creature grows to adult size and maximum HD by 1 HD per month.",
+                            {
+                                "type": "table",
+                                "colLabels": [
+                                    "{@dice d10}",
+                                    "creature"
+                                ],
+                                "colStyles": [
+                                    "col-1 text-center",
+                                    "col-11"
+                                ],
+                                "rows": [
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 1,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Draco (1d3 damage)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 2,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Owl Bear (1d3 damage)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 3,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Warp Beast (1d3 damage)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 4,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Blink Dog (1d3 damage)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 5,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Goblin (already adult)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 6,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Giant Weasel (1d3 damage)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 7,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Stirge (already adult)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 8,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Giant Bat (already adult)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 9,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Cave Bear (1d3 damage)"
+                                    ],
+                                    [
+                                        {
+                                            "type": "cell",
+                                            "roll": {
+                                                "exact": 10,
+                                                "pad": true
+                                            }
+                                        },
+                                        "Gnome (already adult)"
+                                    ]
+                                ]
+                            }
+                        ]
+                    ]
+                },
+                {
+                    "type": "table",
+                    "caption": "Last Seen in the Wilderness",
+                    "page": 11,
+                    "colLabels": [
+                        "{@dice d20}",
+                        "result"
+                    ],
+                    "colStyles": [
+                        "col-1 text-center",
+                        "col-11"
+                    ],
+                    "rows": [
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 1,
+                                    "pad": true
+                                }
+                            },
+                            "The character remained behind to contemplate the landscape. The player must make a Wisdom check. If the check fails, the character's Wisdom increases by 1."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 2,
+                                    "pad": true
+                                }
+                            },
+                            "The character got lost but managed to spy another group of adventureers, who seem to have the same objective as the group!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 3,
+                                    "pad": true
+                                }
+                            },
+                            "The character stepped on a mysterious brown substance. After cleaning their boots, they found themselves alone. Roll again."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 4,
+                                    "pad": true
+                                }
+                            },
+                            "The character found a coin stuck between two stones and remained behind to recover it. The player must make a Strength check. If the check fails, the character's Strength increases by 1. If the check succeeds, the character gainst 1gp!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 5,
+                                    "pad": true
+                                }
+                            },
+                            "A wizard from another plane summoned the character to take part on a glorious quest! They don't remember much, except the emerald suns and the treasures they could not carry over to this plane. Also, any alcoholic beverage they had with them is now gone."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 6,
+                                    "pad": true
+                                }
+                            },
+                            "The character fell asleep. A farmer or wayfarer woke them up, treated them to a nice breakfast and also gifted them a cheese wheel."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 7,
+                                    "pad": true
+                                }
+                            },
+                            "The character was kidnapped by a group of sprites! They imprisoned them in the dark, and set them free only after they agreed to yield one of their items (randomly determined)!"
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 8,
+                                    "pad": true
+                                }
+                            },
+                            "The character was kidnapped by a group of sprites! They invited them to a feast and treated them to a magical concoction. The player must reroll a random ability score with 4d6 (maximize 18). At the referee's discretion, this effect can be canceled with some kind of treatment (e.g. a dissolve magic or remove curse spell)."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 9,
+                                    "pad": true
+                                }
+                            },
+                            "The character fell into a ditch or down a precipice, and bumped their head, suffering 1d3 damage."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 10,
+                                    "pad": true
+                                }
+                            },
+                            "The character pursued a hare for hours and hours, driven by a primordial instinct. The player must make a Dexterity check. If the check fails, the character's Dexterity increases by 1. If the check succeeds, the character caught it and here they are, with dinner for two."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 11,
+                                    "pad": true
+                                }
+                            },
+                            "The character bumped their head against a branch. The player must make a save versus death or lose 1 point of Intelligence. A squirrel has grown fond of the character and follows them."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 12,
+                                    "pad": true
+                                }
+                            },
+                            "That silly nursery rhyme scrambled on a piece of scroll actually was a powerful spell! The character was with the party all the time, inside someone's backpack, because they've been shrunk to the size of an apple. Same effects of a Potion of Diminution, but the duraction is permanent, unless a Dispel Magic or Remove Curse spell is cast of them."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 13,
+                                    "pad": true
+                                }
+                            },
+                            "The character wandered alone following their curiosity and inspiration. The players gains one useful clue, rumor or information about the area."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 14,
+                                    "pad": true
+                                }
+                            },
+                            "The character got lost and met a hermit, who treated them to a herbal twa of visions. The referee must reveal to the player a clue of something that {@i might} be in their future."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 15,
+                                    "pad": true
+                                }
+                            },
+                            "The character saw something shining in a glade, a sword stuck into a rock! The player must make a Strength check: if the check fails, their Strength increases by 1; if the check succeeds, they got the sword: roll a d100. 1-50: It's just an old, rusted sword; 51-99: it is a random magic sword; 100: it is a random sentient sword."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 16,
+                                    "pad": true
+                                }
+                            },
+                            "The character got lost and stumbled upon an isolated group of sentient creatures that live in this area (farmers, or more exotic creatures including those found in the random encounter tables for this region or terrain type). The character has made friends with them and can't wait to introduce them to the rest of the group."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 17,
+                                    "pad": true
+                                }
+                            },
+                            "The cahracter got lost and met a caravan of merchants. They can buy any items they want from the Adventuring Gear section."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 18,
+                                    "pad": true
+                                }
+                            },
+                            "The cahracter got lost and met a caravan of travellers from another land or culture. They've learned the basics of their language and also received standard rations for 7 days as a gift."
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 19,
+                                    "pad": true
+                                }
+                            },
+                            "The character got lost, so they followed a set of tracks that they believed were their friends'. "
+                        ],
+                        [
+                            {
+                                "type": "cell",
+                                "roll": {
+                                    "exact": 20,
+                                    "pad": true
+                                }
+                            },
+                            "The character got lost and stumbled upon a mysterious wanderer. Make a standard Reaction roll (apply the NPC reaction modifier due to Charisma). The wanderer actually is a Golden Dragon in human form. Whatever the Reaction result, this encounter does not become a combat, but the dragon might keep an eye on the character's adventures."
+                        ]
+                    ]
+                }
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
These tables provide an instant, retroactive story to explain why a character disappeared and was not around during the last session, when a player could not participate in the game.
- Last Seen in Town
- Last Seen in a Dungeon
- Last Seen in the Wilderness