### PR TITLE
Circle of Kudzu (v2) feature tweaks.

### DIFF
--- a/subclass/Korvinagor; Circle of Kudzu (v2).json
+++ b/subclass/Korvinagor; Circle of Kudzu (v2).json
@@ -16,8 +16,7 @@
 			}
 		],
 		"dateAdded": 1694655640,
-		"dateLastModified": 1695885840,
-		"_dateLastModifiedHash": "306603aee0"
+		"dateLastModified": 1696845240
 	},
 	"subclass": [
 		{
@@ -190,7 +189,8 @@
 			"entries": [
 				"{@i 10th-level Circle of Kudzu feature}",
 				"While your Lash of a Thousand Thorns is active, you emanate rampant vegetation in a 15-foot aura, and add your Wisdom modifier to any damage you deal using {@spell thorn whip}. The plants you emanate can be manipulated by spells such as {@spell plant growth} and {@spell speak with plants}.",
-				"When you cast a spell of 1st-level or higher, you can use your reaction to force each hostile creature within the aura to make a Strength saving throw. A creature that fails its save has its speed reduced to 0 by entangling plants until the end of your next turn, and loses hit points equal to the spell's level. You then gain temporary hit points equal to the total hit points lost this way."
+				"When you cast a spell of 1st-level or higher, you can use your reaction to force each hostile creature within the aura to make a Strength saving throw.",
+				"A creature that fails its save has its speed reduced to 0 by entangling plants until the end of your next turn, and loses hit points equal to the spell's level. You then gain temporary hit points equal to the total hit points lost this way."
 			]
 		},
 		{
@@ -204,7 +204,7 @@
 			"header": 2,
 			"entries": [
 				"{@i 14th-level Circle of Kudzu feature}",
-				"You traverse the land as freely as any weed. You add {@spell transport via plants} to your list of Circle Spells, and can cast it without expending a spell slot once per long rest.",
+				"You traverse the land as freely as any weed. You add {@spell transport via plants} to your list of Circle Spells.",
 				"When you cast this spell, you can create up to two plants (the target and destination plants) for the spell to use, which vanish when the spell ends. If you create a destination plant, its location is determined in the same way as the {@spell teleport} spell."
 			]
 		}


### PR DESCRIPTION
Removed free casting of Transport via Plants (already able to do so via One with the Weeds).