### PR TITLE
Fix footnotes in Flee Mortals

### DIFF
--- a/creature/MCDM Productions; Flee, Mortals!.json
+++ b/creature/MCDM Productions; Flee, Mortals!.json
@@ -11668,16 +11668,19 @@
 						"In addition to any other spells in this stat block, the channeler can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell light}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell message}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell light}{@sup A}",
+						"{@spell message}{@sup A}"
 					],
 					"daily": {
 						"1e": [
-							"{@spell detect magic}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell disguise self}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell identify}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell detect magic}{@sup A}",
+							"{@spell disguise self}{@sup A}",
+							"{@spell identify}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -17158,12 +17161,15 @@
 					],
 					"daily": {
 						"3e": [
-							"{@spell commune}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell commune with nature}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell legend lore}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell scrying}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell commune}{@sup +}",
+							"{@spell commune with nature}{@sup +}",
+							"{@spell legend lore}{@sup +}",
+							"{@spell scrying}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "wis"
 				}
 			],
@@ -22796,20 +22802,23 @@
 						"In addition to any other spells in this stat block, the hag can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 14}):"
 					],
 					"will": [
-						"{@spell alter self} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell dancing lights} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell minor illusion} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell alter self}{@sup A}",
+						"{@spell dancing lights}{@sup A}",
+						"{@spell minor illusion}{@sup A}"
 					],
 					"daily": {
 						"1": [
-							"{@spell scrying} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell scrying}{@sup +}"
 						],
 						"3e": [
-							"{@spell animal messenger} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell legend lore} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell speak with animals} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell animal messenger}{@sup A}",
+							"{@spell legend lore}{@sup +}",
+							"{@spell speak with animals}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -22976,20 +22985,23 @@
 						"In addition to any other spells in this stat block, the hag can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell alter self}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell detect magic}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell pass without trace}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell alter self}{@sup A}",
+						"{@spell detect magic}{@sup A}",
+						"{@spell pass without trace}{@sup A}"
 					],
 					"daily": {
 						"1": [
-							"{@spell scrying}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell scrying}{@sup +}"
 						],
 						"3e": [
-							"{@spell dream}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell legend lore}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell mirage arcane}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell dream}{@sup +}",
+							"{@spell legend lore}{@sup +}",
+							"{@spell mirage arcane}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -23154,19 +23166,22 @@
 						"In addition to any other spells in this stat block, the hag can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 13}):"
 					],
 					"will": [
-						"{@spell create or destroy water}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell disguise self}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell create or destroy water}{@sup A}",
+						"{@spell disguise self}{@sup A}"
 					],
 					"daily": {
 						"3e": [
-							"{@spell control water}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell identify}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell control water}{@sup A}",
+							"{@spell identify}{@sup +}"
 						],
 						"1e": [
-							"{@spell clairvoyance}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell legend lore}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell clairvoyance}{@sup +}",
+							"{@spell legend lore}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -23340,19 +23355,22 @@
 						"In addition to any other spells in this stat block, Shtriga Nonna can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell alter self}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell detect thoughts}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell thaumaturgy}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell alter self}{@sup A}",
+						"{@spell detect thoughts}{@sup A}",
+						"{@spell thaumaturgy}{@sup A}"
 					],
 					"daily": {
 						"1": [
-							"{@spell scrying}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell scrying}{@sup +}"
 						],
 						"3e": [
-							"{@spell fabricate}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell legend lore}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell fabricate}{@sup +}",
+							"{@spell legend lore}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -26606,17 +26624,20 @@
 						"In addition to any other spells in this stat block, the wizard can cast the following spells, using Intelligence as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell mage hand}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell prestidigitation}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell mage hand}{@sup A}",
+						"{@spell prestidigitation}{@sup A}"
 					],
 					"daily": {
 						"1e": [
-							"{@spell clairvoyance}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell mage armor}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell see invisibility}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell sending}{@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell clairvoyance}{@sup +}",
+							"{@spell mage armor}{@sup A}",
+							"{@spell see invisibility}{@sup A}",
+							"{@spell sending}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "int"
 				}
 			],
@@ -35838,8 +35859,11 @@
 						"In addition to any other spells in this stat block, the treant can cast the following spells, using Wisdom as the spellcasting ability (spell save {@dc 16}):"
 					],
 					"will": [
-						"{@spell speak with animals}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell speak with plants}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell speak with animals}{@sup A}",
+						"{@spell speak with plants}{@sup A}"
+					],
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
 					],
 					"ability": "wis"
 				}
@@ -38560,31 +38584,34 @@
 						"In addition to any other spells in this stat block, the lich can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 20}):"
 					],
 					"will": [
-						"{@spell arcane lock}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell charm person}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell detect magic}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell detect thoughts}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell disguise self}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell identify}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-						"{@spell locate object}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell mage hand}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell arcane lock}{@sup A}",
+						"{@spell charm person}{@sup A}",
+						"{@spell detect magic}{@sup A}",
+						"{@spell detect thoughts}{@sup A}",
+						"{@spell disguise self}{@sup A}",
+						"{@spell identify}{@sup +}",
+						"{@spell locate object}{@sup A}",
+						"{@spell mage hand}{@sup A}"
 					],
 					"daily": {
 						"3e": [
-							"{@spell arcane eye}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell arcanist's magic aura}{@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell contact other plane}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell legend lore}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell scrying}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell arcane eye}{@sup A}",
+							"{@spell arcanist's magic aura}{@sup A}",
+							"{@spell contact other plane}{@sup +}",
+							"{@spell legend lore}{@sup +}",
+							"{@spell scrying}{@sup +}"
 						],
 						"1e": [
-							"{@spell forbiddance}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell geas}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell hallow}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell mirage arcane}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell symbol}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell forbiddance}{@sup +}",
+							"{@spell geas}{@sup +}",
+							"{@spell hallow}{@sup +}",
+							"{@spell mirage arcane}{@sup +}",
+							"{@spell symbol}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -39815,17 +39842,20 @@
 						"In addition to any other spells in this stat block, the vampire can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 18}):"
 					],
 					"will": [
-						"{@spell charm person}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell detect thoughts}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell disguise self}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell sending}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell charm person}{@sup A}",
+						"{@spell detect thoughts}{@sup A}",
+						"{@spell disguise self}{@sup A}",
+						"{@spell sending}{@sup A}"
 					],
 					"daily": {
 						"1e": [
-							"{@spell clairvoyance}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell geas}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell clairvoyance}{@sup +}",
+							"{@spell geas}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -40146,18 +40176,21 @@
 						"In addition to any other spells in this stat block, Rhodar can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 20}):"
 					],
 					"will": [
-						"{@spell charm person}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell detect thoughts}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell disguise self}{@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell sending}{@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell charm person}{@sup A}",
+						"{@spell detect thoughts}{@sup A}",
+						"{@spell disguise self}{@sup A}",
+						"{@spell sending}{@sup A}"
 					],
 					"daily": {
 						"3e": [
-							"{@spell clairvoyance}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell geas} (at 9th level) {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell legend lore}{@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell clairvoyance}{@sup +}",
+							"{@spell geas} (at 9th level){@sup +}",
+							"{@spell legend lore}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "cha"
 				}
 			],
@@ -42972,13 +43005,16 @@
 						"In addition to any other spells in this stat block, the bonestalker can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 16}):"
 					],
 					"will": [
-						"{@spell minor illusion} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell minor illusion}{@sup A}"
 					],
 					"daily": {
 						"3": [
-							"{@spell silent image} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell silent image}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
+					],
 					"ability": "cha"
 				}
 			],
@@ -47049,9 +47085,9 @@
 						"In addition to any other spells in this stat block, Lestheris can cast the following spells, using Intelligence as the spellcasting ability (spell save {@dc 14}):"
 					],
 					"will": [
-						"{@spell mage hand} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell message} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell minor illusion} {@footnote {@sup A}|Casting time: 1 action}",
+						"{@spell mage hand}{@sup A}",
+						"{@spell message}{@sup A}",
+						"{@spell minor illusion}{@sup A}",
 						{
 							"entry": "{@spell Grave Grasp}",
 							"hidden": true
@@ -47059,14 +47095,17 @@
 					],
 					"daily": {
 						"3e": [
-							"{@spell detect magic} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell mage armor} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell detect magic}{@sup A}",
+							"{@spell mage armor}{@sup A}"
 						],
 						"1e": [
-							"{@spell knock} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell speak with dead} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell knock}{@sup A}",
+							"{@spell speak with dead}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
+					],
 					"ability": "int"
 				}
 			],
@@ -47213,14 +47252,17 @@
 						"In addition to any other spells in this stat block, Jedar can cast the following spells, using Wisdom as the spellcasting ability (spell save {@dc 12}):"
 					],
 					"will": [
-						"{@spell light} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell thaumaturgy} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell light}{@sup A}",
+						"{@spell thaumaturgy}{@sup A}"
 					],
 					"daily": {
 						"1": [
-							"{@spell augury} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell augury}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "wis"
 				}
 			],
@@ -47356,17 +47398,20 @@
 						"In addition to any other spells in this stat block, Mycete can cast the following spells, using Wisdom as the spellcasting ability (spell save {@dc 13}):"
 					],
 					"will": [
-						"{@spell druidcraft} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell druidcraft}{@sup A}"
 					],
 					"daily": {
 						"3": [
-							"{@spell locate animals or plants} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell locate animals or plants}{@sup A}"
 						],
 						"1e": [
-							"{@spell fog cloud} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell pass without trace} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell fog cloud}{@sup A}",
+							"{@spell pass without trace}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
+					],
 					"ability": "wis"
 				}
 			],
@@ -48353,15 +48398,18 @@
 						"In addition to any other spells in this stat block, Athenodorus can cast the following spells, using Wisdom as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell light} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell mending} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell light}{@sup A}",
+						"{@spell mending}{@sup A}"
 					],
 					"daily": {
 						"1e": [
-							"{@spell divination} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell glyph of warding} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell divination}{@sup A}",
+							"{@spell glyph of warding}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "wis"
 				}
 			],
@@ -48623,9 +48671,9 @@
 						"In addition to any other spells in this stat block, Avalla can cast the following spells, using Intelligence as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell light} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell mage hand} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell message} {@footnote {@sup A}|Casting time: 1 action}",
+						"{@spell light}{@sup A}",
+						"{@spell mage hand}{@sup A}",
+						"{@spell message}{@sup A}",
 						{
 							"entry": "{@spell Lightning Lash}",
 							"hidden": true
@@ -48633,15 +48681,18 @@
 					],
 					"daily": {
 						"3e": [
-							"{@spell detect magic} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell mage armor} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell detect magic}{@sup A}",
+							"{@spell mage armor}{@sup A}"
 						],
 						"1e": [
-							"{@spell detect thoughts} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell disguise self} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell sending} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell detect thoughts}{@sup A}",
+							"{@spell disguise self}{@sup A}",
+							"{@spell sending}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
+					],
 					"ability": "int"
 				}
 			],
@@ -49357,21 +49408,24 @@
 						"In addition to any other spells in this stat block, Tuval-Uthriar can cast the following spells, using Charisma as the spellcasting ability (spell save {@dc 15}):"
 					],
 					"will": [
-						"{@spell light} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell mage hand} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell message} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell light}{@sup A}",
+						"{@spell mage hand}{@sup A}",
+						"{@spell message}{@sup A}"
 					],
 					"daily": {
 						"3e": [
-							"{@spell detect magic} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell speak with animals} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell detect magic}{@sup A}",
+							"{@spell speak with animals}{@sup A}"
 						],
 						"1e": [
-							"{@spell detect thoughts} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell find traps} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell pass without trace} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell detect thoughts}{@sup A}",
+							"{@spell find traps}{@sup A}",
+							"{@spell pass without trace}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
+					],
 					"ability": "cha"
 				}
 			],
@@ -50417,10 +50471,10 @@
 						"In addition to any other spells in this stat block, Argan can cast the following spells, using Intelligence as his spellcasting ability (spell save {@dc 18}):"
 					],
 					"will": [
-						"{@spell dancing lights} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell mage hand} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell message} {@footnote {@sup A}|Casting time: 1 action}",
-						"{@spell prestidigitation} {@footnote {@sup A}|Casting time: 1 action}",
+						"{@spell dancing lights}{@sup A}",
+						"{@spell mage hand}{@sup A}",
+						"{@spell message}{@sup A}",
+						"{@spell prestidigitation}{@sup A}",
 						{
 							"entry": "{@spell Arcane Lance}",
 							"hidden": true
@@ -50428,11 +50482,14 @@
 					],
 					"daily": {
 						"2e": [
-							"{@spell detect magic} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell mage armor} {@footnote {@sup A}|Casting time: 1 action}",
-							"{@spell sending} {@footnote {@sup A}|Casting time: 1 action}"
+							"{@spell detect magic}{@sup A}",
+							"{@spell mage armor}{@sup A}",
+							"{@spell sending}{@sup A}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action"
+					],
 					"ability": "int"
 				}
 			],
@@ -51213,15 +51270,18 @@
 						"In addition to any other spells in this stat block, Aronar can cast the following spells, using Wisdom as the spellcasting ability (spell save {@dc 19}):"
 					],
 					"will": [
-						"{@spell augury} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-						"{@spell thaumaturgy} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell augury}{@sup +}",
+						"{@spell thaumaturgy}{@sup A}"
 					],
 					"daily": {
 						"1e": [
-							"{@spell hallow} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell raise dead} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell hallow}{@sup +}",
+							"{@spell raise dead}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "wis"
 				}
 			],
@@ -51690,15 +51750,18 @@
 						"In addition to any other spells in this stat block, Draven can cast the following spells, using Intelligence as the spellcasting ability (spell save {@dc 19}):"
 					],
 					"will": [
-						"{@spell alarm} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-						"{@spell mage hand} {@footnote {@sup A}|Casting time: 1 action}"
+						"{@spell alarm}{@sup +}",
+						"{@spell mage hand}{@sup A}"
 					],
 					"daily": {
 						"1e": [
-							"{@spell glyph of warding} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}",
-							"{@spell scrying} {@footnote {@sup +}|Casting time: Longer than 1 action (see spell description)}"
+							"{@spell glyph of warding}{@sup +}",
+							"{@spell scrying}{@sup +}"
 						]
 					},
+					"footerEntries": [
+						"Casting time: {@sup A} = 1 action; {@sup +} = Longer than 1 action (see spell description)"
+					],
 					"ability": "int"
 				}
 			],


### PR DESCRIPTION
Use the footnoteEntries attribute in spellcasting to explain symbols for casting time