### PR TITLE
Circle of Kudzu (v2) Circle Spells tweak

### DIFF
--- a/subclass/Korvinagor; Circle of Kudzu (v2).json
+++ b/subclass/Korvinagor; Circle of Kudzu (v2).json
@@ -35,7 +35,7 @@
 			"subclassSpells": [
 				"Thorn Whip",
 				"Entangle",
-				"Longstrider",
+				"Expeditious Retreat",
 				"Earthbind|xge",
 				"Spider Climb",
 				"Speak with Plants",
@@ -105,7 +105,7 @@
 					"rows": [
 						[
 							"2nd",
-							"{@spell entangle}, {@spell longstrider}"
+							"{@spell entangle}, {@spell expeditious retreat}"
 						],
 						[
 							"3rd",


### PR DESCRIPTION
Replaced Longstrider with Expeditious Retreat.