### PR TITLE
added missing subschools to GH:PG spells

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Player's Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Player's Guide.json
@@ -11119,6 +11119,9 @@
 			"page": 124,
 			"level": 8,
 			"school": "C",
+			"subschools": [
+				"sangromancy"
+			],
 			"time": [
 				{
 					"number": 10,
@@ -11578,6 +11581,9 @@
 			"page": 126,
 			"level": 9,
 			"school": "T",
+			"subschools": [
+				"sangromancy"
+			],
 			"time": [
 				{
 					"number": 1,
@@ -11785,6 +11791,9 @@
 			"page": 127,
 			"level": 2,
 			"school": "T",
+			"subschools": [
+				"sangromancy"
+			],
 			"time": [
 				{
 					"number": 1,


### PR DESCRIPTION
The following spells were missing the "sangromancy" subclass:
- Red Rain
- Steal Immortality
- Theft of Vitae