### PR TITLE
Fixed inconsistencies in the "time" and "duration" fields of multiple spells

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
@@ -399,7 +399,7 @@
 				{
 					"type": "timed",
 					"duration": {
-						"type": "minutes",
+						"type": "minute",
 						"amount": 10
 					}
 				}

--- a/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
@@ -587,7 +587,7 @@
 				{
 					"number": 1,
 					"unit": "reaction",
-					"condition": "(which you take when you see a creature within 60 feet of you casting a spell)"
+					"condition": "which you take when you see a creature within 60 feet of you casting a spell"
 				}
 			],
 			"range": {

--- a/book/MCDM Productions; Arcadia Issue 3.json
+++ b/book/MCDM Productions; Arcadia Issue 3.json
@@ -1719,7 +1719,7 @@
 												"type": "timed",
 												"duration": {
 													"amount": 10,
-													"type": "minutes"
+													"type": "minute"
 												},
 												"concentration": true
 											}

--- a/class/Aron; Demi-Dragon.json
+++ b/class/Aron; Demi-Dragon.json
@@ -6559,7 +6559,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -6695,7 +6695,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/class/ChronicleOfHeroes; Weaveknight.json
+++ b/class/ChronicleOfHeroes; Weaveknight.json
@@ -5905,7 +5905,7 @@
 				{
 					"type": "timed",
 					"duration": {
-						"type": "minutes",
+						"type": "minute",
 						"amount": 10
 					}
 				}

--- a/class/KibblesTasty; Inventor.json
+++ b/class/KibblesTasty; Inventor.json
@@ -9672,7 +9672,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -9759,7 +9759,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -9810,7 +9810,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -9852,7 +9852,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -9888,7 +9888,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/class/KibblesTasty; Psion.json
+++ b/class/KibblesTasty; Psion.json
@@ -535,7 +535,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -799,7 +799,8 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "reaction, when you would take damage"
+					"unit": "reaction",
+					"condition": "which you take when you would take damage"
 				}
 			],
 			"range": {

--- a/class/Walrock Homebrew; Witch.json
+++ b/class/Walrock Homebrew; Witch.json
@@ -1271,7 +1271,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -1696,7 +1696,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/class/xMartu; Surgebinder.json
+++ b/class/xMartu; Surgebinder.json
@@ -2768,7 +2768,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -2953,7 +2953,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -3277,7 +3277,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/collection/Anthony Turco; Korranberg Chronicle Psions Primer.json
+++ b/collection/Anthony Turco; Korranberg Chronicle Psions Primer.json
@@ -8718,7 +8718,7 @@
 			"time": [
 				{
 					"number": 16,
-					"unit": "hours"
+					"unit": "hour"
 				}
 			],
 			"range": {

--- a/collection/DMsGuild; Rashemen.json
+++ b/collection/DMsGuild; Rashemen.json
@@ -6248,7 +6248,7 @@
 			"time": [
 				{
 					"number": 8,
-					"unit": "hours"
+					"unit": "hour"
 				}
 			],
 			"range": {
@@ -6302,7 +6302,7 @@
 			"time": [
 				{
 					"number": 8,
-					"unit": "hours"
+					"unit": "hour"
 				}
 			],
 			"range": {

--- a/collection/Genuine Fantasy Press; The Compendium of Forgotten Secrets - Awakening.json
+++ b/collection/Genuine Fantasy Press; The Compendium of Forgotten Secrets - Awakening.json
@@ -13187,7 +13187,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -13372,7 +13372,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -13927,7 +13927,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -14551,7 +14551,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/collection/Gustavo Ramirez; Zorindis Campaign Setting.json
+++ b/collection/Gustavo Ramirez; Zorindis Campaign Setting.json
@@ -2163,7 +2163,7 @@
 				{
 					"type": "timed",
 					"duration": {
-						"type": "minutes",
+						"type": "minute",
 						"amount": 1
 					},
 					"concentration": true

--- a/collection/Haven; All Beneath the Yonder Seas and Streams.json
+++ b/collection/Haven; All Beneath the Yonder Seas and Streams.json
@@ -5486,7 +5486,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus "
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/collection/Jeremy Forbing; Elminsters Guide to Magic.json
+++ b/collection/Jeremy Forbing; Elminsters Guide to Magic.json
@@ -10293,7 +10293,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -11155,7 +11155,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -11425,7 +11425,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -12092,7 +12092,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -12146,7 +12146,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -12803,7 +12803,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -14334,7 +14334,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -14386,7 +14386,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -14845,7 +14845,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -15290,7 +15290,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -15691,7 +15691,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -15760,7 +15760,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -16481,7 +16481,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -17191,7 +17191,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -19316,7 +19316,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -19780,7 +19780,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -20442,7 +20442,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -20751,7 +20751,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -21249,7 +21249,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -21906,7 +21906,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -22148,7 +22148,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/collection/Kobold Press; Deep Magic 13 Dragon Magic.json
+++ b/collection/Kobold Press; Deep Magic 13 Dragon Magic.json
@@ -1113,7 +1113,7 @@
 			"time": [
 				{
 					"number": 10,
-					"unit": "minutes"
+					"unit": "minute"
 				}
 			],
 			"range": {

--- a/collection/Kobold Press; Tome of Heroes.json
+++ b/collection/Kobold Press; Tome of Heroes.json
@@ -42697,7 +42697,7 @@
 				{
 					"type": "timed",
 					"duration": {
-						"type": "minutes",
+						"type": "minute",
 						"amount": 10
 					}
 				}

--- a/collection/Plus Three Press; Crystalpunk Campaign Guide.json
+++ b/collection/Plus Three Press; Crystalpunk Campaign Guide.json
@@ -8678,7 +8678,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -8765,7 +8765,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/collection/Rynosaur94; Planeshift Equestria.json
+++ b/collection/Rynosaur94; Planeshift Equestria.json
@@ -2107,7 +2107,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {

--- a/spell/Jessica Wolfman; The (Not Really) Complete Tome of Spells.json
+++ b/spell/Jessica Wolfman; The (Not Really) Complete Tome of Spells.json
@@ -3111,7 +3111,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -10786,7 +10786,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {
@@ -15908,7 +15908,7 @@
 			"time": [
 				{
 					"number": 1,
-					"unit": "bonus action"
+					"unit": "bonus"
 				}
 			],
 			"range": {


### PR DESCRIPTION
I originally only wanted to fix the incorrect usage of plural in `spell.duration.type` (e.g.: `minutes` instead of `minute`) which lead to the site displaying a double 's' at the end. I then noticed a few other easy fixes and thought it would be better to do them all at once instead of spamming PRs.

The changes are:
- changing instances of `minutes` / `hours` in `spell.duration.type` to `minute` / `hour`
- changing `bonus action` / `bonus ` (trailing space) in `spell.time.unit` to `bonus`
- fixing an instance where the reaction condition was included in `spell.time.unit`, by moving it to `spell.time.condition`
- removing parentheses from one `spell.reaction.condition`