### PR TITLE
5ET-1173 Oversized Longbow baseitem

### DIFF
--- a/item/enders; Oversized Longbow.json
+++ b/item/enders; Oversized Longbow.json
@@ -1,0 +1,68 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "Generic Oversized Longbow",
+				"abbreviation": "WDH-GOL",
+				"full": "Generic Oversized Longbow",
+				"authors": [
+					"enders"
+				],
+				"convertedBy": [
+					"Lyra [he/him]"
+				],
+				"version": "1",
+				"url": "https://github.com/TheGiddyLimit/homebrew",
+				"dateReleased": "2023-12-12",
+				"color": "d4af37"
+			}
+		],
+		"status": "ready",
+		"dateAdded": 1702410358,
+		"dateLastModified": 1702410358
+	},
+	"baseitem": [
+		{
+			"name": "Oversized Longbow",
+			"source": "Generic Oversized Longbow",
+			"page": 201,
+			"type": "R",
+			"rarity": "unknown",
+			"weight": 2,
+			"weaponCategory": "martial",
+			"property": [
+				"A",
+				"H",
+				"2H"
+			],
+			"range": "150/600",
+			"dmg1": "2d6",
+			"dmgType": "P",
+			"bow": true,
+			"weapon": true,
+			"entries": [
+				"This unique weapon can be used only by a Medium or larger creature that has a Strength of 18 or higher. The bow shoots oversized arrows that deal piercing damage equal to {@dice 2d6} + the wielder's Strength modifier."
+			],
+			"ammoType": "arrow|phb",
+			"hasFluffImages": true,
+			"fluff": {
+				"images": [
+					{
+						"type": "image",
+						"href": {
+							"type": "external",
+							"url": "https://5etools-mirror-1.github.io/img/bestiary/WDH/Ziraj%20the%20Hunter.webp"
+						},
+						"title": "Ziraj the Hunter"
+					}
+				]
+			},
+			"foundrySystem": {
+				"damage.parts": [
+					"2d6 + @abilities.str.mod",
+					"piercing"
+				]
+			}
+		}
+	]
+}


### PR DESCRIPTION
Adds a homebrew for the Oversized Longbow as a `baseitem` supporting declined 5ET-1173