### PR TITLE
Update Ghostfire Gaming; Grim Hollow Campaign Guide

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Campaign Guide.json
@@ -12532,7 +12532,7 @@
 			"source": "GH",
 			"id": "GH3",
 			"published": "2020-08-22",
-			"storyline": "Etharis",
+			"storyline": "Grim Hollow",
 			"group": "homebrew",
 			"level": {
 				"custom": "-"

--- a/collection/SilentSoren; 5th Edition D&D x Final Fantasy XIV - Classes and Races Compendium.json
+++ b/collection/SilentSoren; 5th Edition D&D x Final Fantasy XIV - Classes and Races Compendium.json
@@ -1085,7 +1085,7 @@
 						],
 						[
 							"Wir",
-							"Any member of the yoral family not in line for the throne"
+							"Any member of the royal family not in line for the throne"
 						],
 						[
 							"Van",


### PR DESCRIPTION
fixes a typo in the adventure storylines

Also tacked on is a simple typo fix in FFXIV5E