### PR TITLE
Remove UA from Blood Hunter classes

### DIFF
--- a/class/Matthew Mercer; Blood Hunter (2020).json
+++ b/class/Matthew Mercer; Blood Hunter (2020).json
@@ -415,7 +415,6 @@
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2020|4",
-				"Proficiency Versatility|Fighter||4|UAClassFeatureVariants",
 				"Extra Attack|Blood Hunter|BH2020|5",
 				"Brand of Castigation|Blood Hunter|BH2020|6",
 				"Blood Maledict Improvement|Blood Hunter|BH2020|6",
@@ -425,7 +424,6 @@
 				},
 				"Primal Rite|Blood Hunter|BH2020|7",
 				"Ability Score Improvement|Blood Hunter|BH2020|8",
-				"Proficiency Versatility|Fighter||8|UAClassFeatureVariants",
 				"Grim Psychometry|Blood Hunter|BH2020|9",
 				"Dark Augmentation|Blood Hunter|BH2020|10",
 				{
@@ -433,7 +431,6 @@
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2020|12",
-				"Proficiency Versatility|Fighter||12|UAClassFeatureVariants",
 				"Brand of Tethering|Blood Hunter|BH2020|13",
 				"Blood Maledict Improvement|Blood Hunter|BH2020|13",
 				"Hardened Soul|Blood Hunter|BH2020|14",
@@ -443,14 +440,12 @@
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2020|16",
-				"Proficiency Versatility|Fighter||16|UAClassFeatureVariants",
 				"Blood Maledict Improvement|Blood Hunter|BH2020|17",
 				{
 					"classFeature": "Order feature|Blood Hunter|BH2020|18",
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2020|19",
-				"Proficiency Versatility|Fighter||19|UAClassFeatureVariants",
 				"Sanguine Mastery|Blood Hunter|BH2020|20"
 			],
 			"subclassTitle": "Blood Hunter Order",

--- a/class/Matthew Mercer; Blood Hunter (2022).json
+++ b/class/Matthew Mercer; Blood Hunter (2022).json
@@ -414,7 +414,6 @@
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2022|4",
-				"Proficiency Versatility|Fighter||4|UAClassFeatureVariants",
 				"Extra Attack|Blood Hunter|BH2022|5",
 				"Brand of Castigation|Blood Hunter|BH2022|6",
 				"Blood Maledict Improvement|Blood Hunter|BH2022|6",
@@ -424,7 +423,6 @@
 				},
 				"Crimson Rite Improvement|Blood Hunter|BH2022|7",
 				"Ability Score Improvement|Blood Hunter|BH2022|8",
-				"Proficiency Versatility|Fighter||8|UAClassFeatureVariants",
 				"Grim Psychometry|Blood Hunter|BH2022|9",
 				"Dark Augmentation|Blood Hunter|BH2022|10",
 				{
@@ -432,7 +430,6 @@
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2022|12",
-				"Proficiency Versatility|Fighter||12|UAClassFeatureVariants",
 				"Brand of Tethering|Blood Hunter|BH2022|13",
 				"Blood Maledict Improvement|Blood Hunter|BH2022|13",
 				"Hardened Soul|Blood Hunter|BH2022|14",
@@ -442,14 +439,12 @@
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2022|16",
-				"Proficiency Versatility|Fighter||16|UAClassFeatureVariants",
 				"Blood Maledict Improvement|Blood Hunter|BH2022|17",
 				{
 					"classFeature": "Order feature|Blood Hunter|BH2022|18",
 					"gainSubclassFeature": true
 				},
 				"Ability Score Improvement|Blood Hunter|BH2022|19",
-				"Proficiency Versatility|Fighter||19|UAClassFeatureVariants",
 				"Sanguine Mastery|Blood Hunter|BH2022|20"
 			],
 			"subclassTitle": "Blood Hunter Order",


### PR DESCRIPTION
Removes the "Proficiency Versatility" features from UAClassFeatureVariants in the Blood Hunter 2020 and 2022 classes, to stop the UA from being forcefully enabled when going to the classes page.