### PR TITLE
Update CftD token images

### DIFF
--- a/adventure/JVC Parry; Call from the Deep.json
+++ b/adventure/JVC Parry; Call from the Deep.json
@@ -24732,7 +24732,7 @@
 				"name": "Merrenoloth",
 				"source": "MTF"
 			},
-			"tokenUrl": "https://noads.5e.tools/img/MTF/Merrenoloth.png",
+			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MTF/Merrenoloth.webp",
 			"soundClip": {
 				"type": "internal",
 				"path": "bestiary/merrenoloth.mp3"
@@ -28902,7 +28902,7 @@
 				"coastal",
 				"underwater"
 			],
-			"tokenUrl": "https://noads.5e.tools/img/VGM/Deep%20Scion.png",
+			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/Deep%20Scion.webp",
 			"fluff": {
 				"images": [
 					{
@@ -30108,7 +30108,7 @@
 					]
 				}
 			],
-			"tokenUrl": "https://5etools-mirror-1.github.io/img/MM/Helmed%20Horror.png",
+			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Helmed%20Horror.webp",
 			"traitTags": [
 				"Magic Resistance",
 				"Spell Immunity"


### PR DESCRIPTION
Three creatures in here use the same tokens as WotC creatures due to their statblocks being variations of them. However, because they're _substantial_ variations, they're not `_copy`. Migrating one of these from `mirror-1` and _two_ of these from `noads`!

If there's a better way to point `tokenUrl` to an internal image please let me know 👍