### PR TITLE
BREW-019; Gemstones

### DIFF
--- a/magicvariant/aeyana; Gemstones.json
+++ b/magicvariant/aeyana; Gemstones.json
@@ -1,0 +1,745 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "GMSTN",
+				"abbreviation": "GMSTN",
+				"full": "Gemstones",
+				"authors": [
+					"aeyana"
+				],
+				"convertedBy": [
+					"Lyra [he/him]"
+				],
+				"version": "2024-01-23",
+				"color": "45508e",
+				"url": "https://www.gmbinder.com/share/-L_6L-eogCFybZFhPrZL",
+				"dateReleased": "2024-01-23"
+			}
+		],
+		"status": "ready",
+		"dateAdded": 1706029751,
+		"dateLastModified": 1706029751
+	},
+	"baseitem": [
+		{
+			"name": "Common Primal Gem",
+			"source": "GMSTN",
+			"page": 1,
+			"type": "GMSTN",
+			"rarity": "common",
+			"property": [
+				"GMSTN"
+			],
+			"dmg1": "d4"
+		},
+		{
+			"name": "Legendary Primal Gem",
+			"source": "GMSTN",
+			"page": 1,
+			"type": "GMSTN",
+			"rarity": "legendary",
+			"property": [
+				"GMSTN"
+			],
+			"dmg1": "d12",
+			"bonusWeaponAttack": "+3",
+			"entries": [
+				"You gain a +3 bonus to the attack roll."
+			]
+		},
+		{
+			"name": "Rare Primal Gem",
+			"source": "GMSTN",
+			"page": 1,
+			"type": "GMSTN",
+			"rarity": "rare",
+			"property": [
+				"GMSTN"
+			],
+			"dmg1": "d8",
+			"bonusWeaponAttack": "+1",
+			"entries": [
+				"You gain a +1 bonus to the attack roll."
+			]
+		},
+		{
+			"name": "Uncommon Primal Gem",
+			"source": "GMSTN",
+			"page": 1,
+			"type": "GMSTN",
+			"rarity": "uncommon",
+			"property": [
+				"GMSTN"
+			],
+			"dmg1": "d6",
+			"entries": [
+				"The attack count as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage."
+			]
+		},
+		{
+			"name": "Very Rare Primal Gem",
+			"source": "GMSTN",
+			"page": 1,
+			"type": "GMSTN",
+			"rarity": "very rare",
+			"property": [
+				"GMSTN"
+			],
+			"dmg1": "d10",
+			"bonusWeaponAttack": "+2",
+			"entries": [
+				"You gain a +2 bonus to the attack roll."
+			]
+		}
+	],
+	"item": [
+		{
+			"name": "Boots of Frigid Waters",
+			"source": "GMSTN",
+			"page": 2,
+			"rarity": "uncommon",
+			"wondrous": true,
+			"recharge": "special",
+			"charges": 4,
+			"entries": [
+				"These grey-leather boots are trimmed with wolf's pelt, and laced across the front with brown leather cord. Woven into the cord on each boot is a small opal. It has 4 charges, and regains all expended charges after being left in cold water for one hour.",
+				"While wearing these boots, you can expend a charge as a bonus action to come under the effects of {@spell water walk} until the end of your next turn. Water under your feet freezes, forming temporary sheets of ice that thaw as you step away from them.",
+				"In addition, you can use your reaction to expend a charge to resist being knocked {@condition prone} or pushed."
+			],
+			"attachedSpells": [
+				"water walk"
+			]
+		},
+		{
+			"name": "Dwarven Forge Gauntlets",
+			"source": "GMSTN",
+			"page": 2,
+			"rarity": "uncommon",
+			"wondrous": true,
+			"entries": [
+				"These steel gauntlets are inset with flakes of ruby in their palms. While wearing these gloves, you can handle scalding hot items (such as white-hot metals from a forge, or objects under the effects of {@spell heat metal}) without harm to your hands.",
+				"As an action, you can cast {@spell burning hands} at its lowest level, (save {@dc 12}). Once these gauntlets have been used this way, it must be left in a roaring fire for one hour, or targeted by the {@spell heat metal} spell, before it can be used again."
+			],
+			"attachedSpells": [
+				"burning hands"
+			]
+		},
+		{
+			"name": "Nettle's Thorn",
+			"source": "GMSTN",
+			"page": 2,
+			"baseItem": "dart|PHB",
+			"type": "R",
+			"rarity": "uncommon",
+			"weight": 0.25,
+			"weaponCategory": "simple",
+			"property": [
+				"F",
+				"T"
+			],
+			"range": "20/60",
+			"dmg1": "1d4",
+			"dmgType": "P",
+			"bonusWeapon": "+1",
+			"entries": [
+				"This golden hairpin bears a flower motif and is topped with a stunning emerald. A seemingly innocuous ornament, the hairpin can be used as a poison dart and has been used through the ages by numerous assassins. Hidden in the center of the long straight shaft runs a concentric tube, which can deliver the venom to its victims.",
+				"The hairpin's emerald shines faintly in the presence of poison. When dipped into food or drink, you can depress a thorn on the side to absorb any poisons that may be present. This simultaneously purifies the food or drink of any poisons and primes the hairpin with poison for later use.",
+				{
+					"type": "entries",
+					"name": "Primed",
+					"entries": [
+						"You can dipped the primed hairpin into food or drink and press the thorn to release the poison into the food or drink. Additionally, you have a +1 bonus to attack and damage rolls made with the primed dart, and can inject the poison into the target when you hit a creature with it."
+					]
+				}
+			]
+		},
+		{
+			"name": "Telepathic Earpiece",
+			"source": "GMSTN",
+			"page": 2,
+			"rarity": "uncommon",
+			"wondrous": true,
+			"entries": [
+				"This brass earpiece is set with a small amethyst, and can be clipped to the wearer's ear. These earpieces can be found in sets of {@dice 1d4 + 1}, and are magically paired with all other earpieces in the same set.",
+				"While you are wearing the earpiece, you can communicate telepathically with all other creatures wearing earpieces from the same set, provided they are on the same plane of existence as you."
+			]
+		}
+	],
+	"itemGroup": [
+		{
+			"name": "Primal Gem",
+			"source": "GMSTN",
+			"page": 2,
+			"type": "GMSTN",
+			"rarity": "varies",
+			"reqAttune": true,
+			"wondrous": true,
+			"entries": [
+				"Charged with primal elemental power, these gleaming gemstones come in a variety of types and rarities. The {@table Types of Gems|GMSTN} table shows what kinds of gems exist, and {@table Rarity of Gems|GMSTN|Quality of Gems} table shows their effects and potency.",
+				{
+					"type": "entries",
+					"name": "Elemental Strike",
+					"entries": [
+						"As a bonus action on your turn while you are holding the gem, you can infuse your weapon with elemental power. The next time you hit a creature with an attack before the start of your next turn, you can roll the gem die and add the total as additional damage of the gem's type.",
+						"The attack gains additional bonuses depending on the rarity of the gem.",
+						{
+							"type": "list",
+							"page": 1,
+							"items": [
+								{
+									"type": "item",
+									"name": "Uncommon:",
+									"entries": [
+										"The attack counts as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Rare:",
+									"entries": [
+										"You gain a +1 bonus to the attack roll."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Very Rare:",
+									"entries": [
+										"You gain a +2 bonus to the attack roll."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Legendary:",
+									"entries": [
+										"You gain a +3 bonus to the attack roll."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Elemental Absorption",
+					"entries": [
+						"As a reaction to taking damage of the gem's type while you are holding the gem, you can roll the gem die and reduce the damage taken by the total rolled."
+					]
+				},
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "GMSTN",
+					"name": "Rarity of Gems",
+					"page": 1
+				},
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "GMSTN",
+					"name": "Types of Gems",
+					"page": 1
+				}
+			],
+			"items": [
+				"Primal Amber|GMSTN",
+				"Primal Amethyst|GMSTN",
+				"Primal Emerald|GMSTN",
+				"Primal Onyx|GMSTN",
+				"Primal Opal|GMSTN",
+				"Primal Quartz|GMSTN",
+				"Primal Ruby|GMSTN",
+				"Primal Topaz|GMSTN"
+			]
+		}
+	],
+	"magicvariant": [
+		{
+			"name": "Primal Amber",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Amber",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "lightning"
+				}
+			}
+		},
+		{
+			"name": "Primal Amethyst",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Amethyst",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "psychic"
+				}
+			}
+		},
+		{
+			"name": "Primal Emerald",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Emerald",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "poison"
+				}
+			}
+		},
+		{
+			"name": "Primal Onyx",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Onyx",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "necrotic"
+				}
+			}
+		},
+		{
+			"name": "Primal Opal",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Opal",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "cold"
+				}
+			}
+		},
+		{
+			"name": "Primal Quartz",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Quartz",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "thunder"
+				}
+			}
+		},
+		{
+			"name": "Primal Ruby",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Ruby",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "fire"
+				}
+			}
+		},
+		{
+			"name": "Primal Topaz",
+			"requires": [
+				{
+					"type": "GMSTN"
+				}
+			],
+			"entries": [
+				"{#itemEntry Primal Gem General|GMSTN}"
+			],
+			"inherits": {
+				"nameSuffix": " Topaz",
+				"nameRemove": " Gem",
+				"source": "GMSTN",
+				"page": 2,
+				"type": "GMSTN",
+				"rarity": "varies",
+				"reqAttune": true,
+				"wondrous": true,
+				"hasRefs": true,
+				"entries": [
+					"{#itemEntry Primal Gem Specific|GMSTN}"
+				],
+				"customProperties": {
+					"type": "radiant"
+				}
+			}
+		}
+	],
+	"itemProperty": [
+		{
+			"name": "Gemstone",
+			"abbreviation": "GMSTN",
+			"source": "GMSTN",
+			"page": 1
+		}
+	],
+	"itemType": [
+		{
+			"name": "Gemstone",
+			"source": "GMSTN",
+			"page": 1,
+			"abbreviation": "GMSTN"
+		}
+	],
+	"itemEntry": [
+		{
+			"name": "Primal Gem Specific",
+			"source": "GMSTN",
+			"entriesTemplate": [
+				"A gleaming gemstone charged with primal elemental power.",
+				{
+					"type": "entries",
+					"name": "Elemental Strike",
+					"entries": [
+						"As a bonus action on your turn while you are holding the gem, you can infuse your weapon with elemental power. The next time you hit a creature with an attack before the start of your next turn, you can roll a {{item.dmg1}} additional {{item.customProperties.type}} damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Elemental Absorption",
+					"entries": [
+						"As a reaction to taking {{item.customProperties.type}} damage while you are holding the gem, you can reduce the damage taken by a {{item.dmg1}}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Rarity Benefit",
+					"entries": [
+						""
+					]
+				}
+			]
+		},
+		{
+			"name": "Primal Gem General",
+			"source": "GMSTN",
+			"entriesTemplate": [
+				"Charged with primal elemental power, these gleaming gemstones come in a variety of types and rarities. The {@table Rarity of Gems|GMSTN|Quality of Gems} table shows their effects and potency.",
+				{
+					"type": "entries",
+					"name": "Elemental Strike",
+					"entries": [
+						"As a bonus action on your turn while you are holding the gem, you can infuse your weapon with elemental power. The next time you hit a creature with an attack before the start of your next turn, you can roll the gem die and add the total as additional {{item.inherits.customProperties.type}} damage.",
+						"The attack gains additional bonuses depending on the rarity of the gem.",
+						{
+							"type": "list",
+							"page": 1,
+							"items": [
+								{
+									"type": "item",
+									"name": "Uncommon:",
+									"entries": [
+										"The attack counts as magical for the purpose of overcoming resistance and immunity to nonmagical attacks and damage."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Rare:",
+									"entries": [
+										"You gain a +1 bonus to the attack roll."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Very Rare:",
+									"entries": [
+										"You gain a +2 bonus to the attack roll."
+									]
+								},
+								{
+									"type": "item",
+									"name": "Legendary:",
+									"entries": [
+										"You gain a +3 bonus to the attack roll."
+									]
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Elemental Absorption",
+					"entries": [
+						"As a reaction to taking {{item.inherits.customProperties.type}} damage while you are holding the gem, you can roll the gem die and reduce the damage taken by the total rolled."
+					]
+				},
+				{
+					"type": "statblock",
+					"tag": "table",
+					"source": "GMSTN",
+					"name": "Rarity of Gems",
+					"page": 1
+				}
+			]
+		}
+	],
+	"variantrule": [
+		{
+			"name": "Gemstones",
+			"source": "GMSTN",
+			"page": 1,
+			"ruleType": "O",
+			"entries": [
+				"The gleam of shimmering coins and ornate trinkets dazzle our brave adventurers as they stumble into the dragon's lair. Contained inside, a vast fortune on the scale of a small kingdom's treasury. One gleam in particular catches the rogue's eye: a brilliant gemstone, deep blue in color and iridescent in the light. Gingerly reaching down, he plucks the stone from amidst the mound of gold.",
+				{
+					"type": "statblock",
+					"tag": "item",
+					"source": "GMSTN",
+					"name": "Primal Gem",
+					"page": 1,
+					"collapsed": true
+				},
+				{
+					"type": "entries",
+					"name": "Specific Gemstone Items",
+					"page": 2,
+					"entries": [
+						"Presented here are items that utilize the primal gems in ways that do not fit the Generic Gem-Set Items category. These items are presented in alphabetical order.",
+						{
+							"type": "statblock",
+							"tag": "item",
+							"source": "GMSTN",
+							"name": "Boots of Frigid Waters",
+							"page": 2,
+							"collapsed": true
+						},
+						{
+							"type": "statblock",
+							"tag": "item",
+							"source": "GMSTN",
+							"name": "Dwarven Forge Gauntlets",
+							"page": 2,
+							"collapsed": true
+						},
+						{
+							"type": "statblock",
+							"tag": "item",
+							"source": "GMSTN",
+							"name": "Nettle's Thorn",
+							"page": 2,
+							"collapsed": true
+						},
+						{
+							"type": "statblock",
+							"tag": "item",
+							"source": "GMSTN",
+							"name": "Telepathic Earpiece",
+							"page": 2,
+							"collapsed": true
+						}
+					]
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://www.gmbinder.com/images/OvXfuJ3.png"
+					},
+					"credit": "{@link SaxonSurokov|https://www.deviantart.com/saxonsurokov/art/Material-Study-5-Translucent-Uncut-Gemstones-478353592}",
+					"width": 1000,
+					"height": 595,
+					"altText": "Four differently coloured gemstones on a black background"
+				}
+			]
+		}
+	],
+	"table": [
+		{
+			"name": "Rarity of Gems",
+			"source": "GMSTN",
+			"page": 1,
+			"colLabels": [
+				"Rarity",
+				"Gem Die"
+			],
+			"colStyles": [
+				"col-6",
+				"col-6 text-center"
+			],
+			"rows": [
+				[
+					"Common",
+					"{@dice d4}"
+				],
+				[
+					"Uncommon",
+					"{@dice d6}"
+				],
+				[
+					"Rare",
+					"{@dice d8}"
+				],
+				[
+					"Very Rare",
+					"{@dice d10}"
+				],
+				[
+					"Legendary",
+					"{@dice d12}"
+				]
+			]
+		},
+		{
+			"name": "Types of Gems",
+			"source": "GMSTN",
+			"page": 1,
+			"colLabels": [
+				"Gem Type",
+				"Damage Type"
+			],
+			"colStyles": [
+				"col-6",
+				"col-6"
+			],
+			"rows": [
+				[
+					"Amber",
+					"Lightning"
+				],
+				[
+					"Amethyst",
+					"Psychic"
+				],
+				[
+					"Emerald",
+					"Poison"
+				],
+				[
+					"Onyx",
+					"Necrotic"
+				],
+				[
+					"Opal",
+					"Cold"
+				],
+				[
+					"Quartz",
+					"Thunder"
+				],
+				[
+					"Ruby",
+					"Fire"
+				],
+				[
+					"Topaz",
+					"Radiant"
+				]
+			]
+		}
+	]
+}


### PR DESCRIPTION
This homebrew is blocked requiring `bonusWeaponAttack` to be made available to `baseitem`s.
`bonusWeapon` is already available as a precedent.