### PR TITLE
Vermin Lord Update Ghostfire Gaming; Grim Hollow Player's Guide.json

### DIFF
--- a/book/Ghostfire Gaming; Grim Hollow Player's Guide.json
+++ b/book/Ghostfire Gaming; Grim Hollow Player's Guide.json
@@ -17509,8 +17509,8 @@
 			"header": 1,
 			"entries": [
 				"At 3rd level, you can comprehend and verbally communicate with vermin (mice, rats, and other rodents determined by your DM).",
-				"Additionally, you can use an action and expend a spell slot to summon rodent hordes. When you do, you summon a number of {@creature swarms of vermin|GHPG} equal to twice the level of spell slot expended. Each swarm is summoned to a space you can see within 30 feet.",
-				"Swarms summoned in this way go on your initiative, starting on your next turn. These swarms obey your verbal commands (no action required by you), defending themselves by taking the {@action Dodge} action if you do not give them a command. Your vermin swarms flee the area and disperse after 10 minutes or when you use this feature to summon other swarms of vermin."
+				"Additionally, you can use an action and expend a spell slot to summon rodent hordes. When you do, you summon a number of {@creature swarms of vermin|GHPG} equal to the level of spell slot expended. Each swarm is summoned to a space you can see within 30 feet. This feature recharges after a short or long rest.",
+				"Swarms summoned in this way go on your initiative, starting on your next turn. These swarms obey your verbal commands (no action required by you), defending themselves by taking the {@action Dodge} action if you do not give them a command. Your vermin swarms flee the area and disperse after 1 minute."
 			]
 		},
 		{
@@ -20822,7 +20822,7 @@
 				{
 					"name": "Unarmed Strike",
 					"entries": [
-						"{@atk mw} {@hitYourSpellAttack} to hit, reach 5 ft., one target in the swarm's space. {@h}8 ({@damage 2d6 + 1}) damage."
+						"{@atk mw} {@hitYourSpellAttack} to hit, reach 0 ft., one target in the swarm's space. {@h}8 ({@damage 2d6 + 1}) damage."
 					]
 				}
 			],


### PR DESCRIPTION
closes #2025 
fixed errors in conversion of Vermin Lord's Verminkin ability:
> number of swarms summoned is equal to spell slot level, not twice spell slot level
> feature recharges after a short or long rest
> swarms disperse after 1 minute, not 10
> reusing the feature does not end the present use (due to recharge on rest)

Attack reach of Swarm of Vermin also changed to 0 ft. to match book