### PR TITLE
Closes Custom feat #2027

### DIFF
--- a/feat/ordek09; Pact of the Titan.json
+++ b/feat/ordek09; Pact of the Titan.json
@@ -1,0 +1,137 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "PotTord",
+				"abbreviation": "PotT",
+				"full": "Pact of the Titan",
+				"authors": [
+					"ordek09"
+				],
+				"convertedBy": [
+					"ordek09"
+				],
+				"version": "1.0"
+			}
+		],
+		"dateAdded": 1709375925,
+		"dateLastModified": 1709375925
+	},
+	"feat": [
+		{
+			"source": "PotTord",
+			"name": "Pact of the Titan",
+			"entries": [
+				"A shard of powerful entity now lives within you, empowering you with ancient magic...at a cost. Every time you use powers that was granted upon you, Titan tries to overwhelm your mind and come back to life.",
+				"You start with 3 Shards of Control. Each time you use Blighted Blast or Form of Blight, you roll {@dice 1d6}. If value rolled is 6, one of your Shards of Control is destroyed. If you lost all of your Shards, Titan banishes your soul to the realm of Malbolge, 6th layer of Hell. Your body is left intact in the Material Plane until soul is either destroyed or returned.",
+				"You regain your Shards of Control each time you kill a creature that was under effect of frightened caused by your Form of Blight during the encounter.",
+				{
+					"type": "table",
+					"caption": "You gain following powers from your Pact",
+					"colLabels": [
+						"Power",
+						"Lvl"
+					],
+					"colStyles": [
+						"col-6 text-center",
+						"col-4-5 text-center"
+					],
+					"rows": [
+						[
+							"Metals insight, Ancient knowledge",
+							"6"
+						],
+						[
+							"Blighted Blast",
+							"8"
+						],
+						[
+							"Form of Blight",
+							"10"
+						],
+						[
+							"Empowered Elemental",
+							"14"
+						],
+						[
+							"One with Titan",
+							"18"
+						]
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Metals insight",
+					"entries": [
+						"Your titan grants you the ability to look through the nature of metals. Each time you see any metal surface, item or structure, you immediately know, what kind of metal it is. If a metalic item is created in a way to disguise it's true nature (for example fake gold), you immediately know the difference."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Ancient knowledge",
+					"entries": [
+						"Your titan lived in ancient era and you can see the glimpse of his knowledge. If you haven't already, you gain proficiency in {@skill History}. Each time you roll 1 on History check, you can roll again and use new value."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Blighted Blast",
+					"entries": [
+						"Each time you cast {@spell Eldritch Blast||Eldritch Blast}, you can use your Titan's magic to empower it. You add {@dice 1d6} to each beam you shoot towards the opponents.",
+						"The damage caused by Blighted Blast is necrotic.",
+						"You must decide to use Blighted Blast and roll for Shards of Control before any of the spell attack rolls you would normally take."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Form of Blight",
+					"entries": [
+						"You manifest an aspect of your patron's blighted power. As a bonus action, you transform for 1 minute. You gain the following benefits while transformed:",
+						{
+							"type": "list",
+							"items": [
+								"You gain resistance to necrotic damage",
+								"As a bonus action you can regain health equal to half of necrotic damage done by you this turn",
+								"You lose {@dice 1d10} health at the end of your turn",
+								"You gain advantage in {@skill Intimidation} rolls",
+								"Range of your {@spell Eldritch Blast} is doubled",
+								"Once during each of your turns, when you hit a creature with an attack roll, you can force it to make a Wisdom saving throw, and if the saving throw fails, the target is frightened of you until the end of your next turn."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Empowered Elemental",
+					"entries": [
+						"Whenever you are controlling an earth elemental, your Titan empowers it with special powers:",
+						{
+							"type": "list",
+							"items": [
+								"Friendly creatures within melee range of an elemental gain +2 AC. You gain +2 AC despite being out of melee range.",
+								"You can use your reaction to redirect damage from a friendly creature that is within 15 feet of elemental.",
+								"Your elemental now gains additional Slam attack"
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "One with Titan",
+					"entries": [
+						"The boundary between you and your Titan blurs. You are not longer yourself in a same way, that your Titan is not longer himself. You become a true Avatar of Sagdrelath",
+						"You gain the following effects:",
+						{
+							"type": "list",
+							"items": [
+								"The avatar disgorges a swarm of biting flies at a point it can see within 300 feet of itself. Each creature within a 20-foot-radius sphere centered on that point must make a Constitution saving throw. A creature takes {@dice 10d10} piercing damage on a failed save, or half as much damage on a successful one. The biting flies persist for 1 minute or until the avatar is slain. A creature must also make this saving throw when it enters the insects' area for the first time on a turn or ends its turn there.",
+								"Hurl Through Malbolge. The avatar targets a creature he damaged previous turn. The creature must succeed on a Charisma saving throw or take {@dice 8d10} psychic damage and be banished to Malbolge (the sixth layer of the Nine Hells). At the start of the avatars's next turn, the creature reappears in an unoccupied space within 10 feet of the avatar.",
+								"You gain +2 to one ability of your choice and +1 to two abilities of your choice."
+							]
+						}
+					]
+				}
+			]
+		}
+	]
+}


### PR DESCRIPTION
Closes #2027 

A bit strange... this isn't really a feat, it's a multi-level pact, nonetheless it's added.

Fixes:
- Removed `"type": "section"` from root of `feat` object
- Spelling typos