### PR TITLE
Updated Warmage Signature Focus trick in Valda's Spire of Secrets

### DIFF
--- a/collection/Mage Hand Press; Valda's Spire of Secrets.json
+++ b/collection/Mage Hand Press; Valda's Spire of Secrets.json
@@ -37580,14 +37580,14 @@
 				}
 			],
 			"entries": [
-				"When you finish a long rest, you can place a unique sigil on a simple weapon, which becomes your signature focus until you use this trick again. This weapon becomes magical, and it can be used as a spellcasting focus for your warmage spells. Your signature focus is bonded to you, and gains a number of special abilities:",
+				"When you finish a long rest, you can place a unique sigil on a simple or martial weapon, which becomes your signature focus until you use this ability again. This weapon becomes magical, and you can use it as a spellcasting focus for your warmage spells. Your signature focus is bonded to you, and gains a number of special abilities:",
 				{
 					"type": "list",
 					"style": "list-hang-notitle",
 					"items": [
 						"As a bonus action, you can call your signature focus to your hand, as long as you are on the same plane of existence as it.",
-						"You can add your Intelligence modifier, instead of your Strength or Dexterity modifier, to attack rolls using your signature focus.",
-						"Your signature focus gains a number of charges equal to your Intelligence modifier (a minimum of 1). When you damage a creature with it or a cantrip cast through it, you can expend 1 charge to deal an extra {@damage 1d8} force damage to that creature. Your focus regains all spent charges after you finish a long rest."
+						"You can add your Intelligence modifier, instead of your Strength or Dexterity modifier, to attack and damage rolls using your signature focus.",
+						"Your signature focus gains a number of charges equal to your Intelligence modifier (a minimum of 1). When you deal damage to a creature with it or a cantrip cast through it, you can expend 1 charge to deal an extra {@damage 1d8} force damage to that creature. Your focus regains all expended charges when you finish a long rest."
 					]
 				}
 			]


### PR DESCRIPTION
Update Signature Focus to Valda's 1.4

Notable change: Can be used on a simple or martial weapon now, not just simple, and Int applies to both attack and damage rolls.

✅ checked it works by uploading from raw url in my fork