### PR TITLE
Fix issue with SaF The Queen of Bones.

### DIFF
--- a/collection/MCDM Productions; Strongholds and Followers.json
+++ b/collection/MCDM Productions; Strongholds and Followers.json
@@ -5129,7 +5129,10 @@
 							"spells": [
 								"{@spell animate dead}",
 								"{@spell bestow curse}",
-								"{@spell }"
+								"{@spell dispel magic}",
+								"{@spell protection from energy}",
+								"{@spell revivify}",
+								"{@spell water walk}"
 							]
 						},
 						"4": {


### PR DESCRIPTION
Added missing spells. Fixed empty `{@spell }` object.

I discovered this issue when attempting to search the bestiary with regex. This entry caused the search to fail as parsing broke on the empty spell object.

I also took the liberty of listing out the other spells in the book.