### PR TITLE
Fixed Popout cards not working on some occasions

### DIFF
--- a/collection/Mage Hand Press; Valda's Spire of Secrets.json
+++ b/collection/Mage Hand Press; Valda's Spire of Secrets.json
@@ -36657,7 +36657,7 @@
 			"prerequisite": [
 				{
 					"spell": [
-						"cryptogram#c"
+						"cryptogram|VSS#c"
 					]
 				}
 			],
@@ -36832,7 +36832,7 @@
 						"level": 10
 					},
 					"spell": [
-						"force buckler#c"
+						"force buckler|VSS#c"
 					]
 				}
 			],
@@ -36961,13 +36961,13 @@
 			"prerequisite": [
 				{
 					"spell": [
-						"quickstep#c",
-						"springheel#c"
+						"quickstep|VSS#c",
+						"springheel|VSS#c"
 					]
 				}
 			],
 			"entries": [
-				"When you cast the {@spell quickstep} cantrip, your speed increases by 20 feet instead of 10 feet. When you cast the {@spell springheel} cantrip, your jumping distance increases by 20 feet instead of 10 feet. If you know both of these cantrips, you can cast both of them as part of the same bonus action."
+				"When you cast the {@spell quickstep|VSS} cantrip, your speed increases by 20 feet instead of 10 feet. When you cast the {@spell springheel|VSS} cantrip, your jumping distance increases by 20 feet instead of 10 feet. If you know both of these cantrips, you can cast both of them as part of the same bonus action."
 			]
 		},
 		{
@@ -36980,8 +36980,8 @@
 			"prerequisite": [
 				{
 					"spell": [
-						"force weapon#c",
-						"magic daggers#c"
+						"force weapon|VSS#c",
+						"magic daggers|VSS#c"
 					]
 				}
 			],
@@ -37010,7 +37010,7 @@
 			"prerequisite": [
 				{
 					"spell": [
-						"phantom grapnel#c"
+						"phantom grapnel|VSS#c"
 					]
 				}
 			],


### PR DESCRIPTION
Added "|VSS" to several cantrips so they no longer link to the non-existant PHB version.