### PR TITLE
Fix typo: StoneStrix; Monster a Day Compendium.json

### DIFF
--- a/creature/StoneStrix; Monster a Day Compendium.json
+++ b/creature/StoneStrix; Monster a Day Compendium.json
@@ -9967,7 +9967,7 @@
 			"size": [
 				"T"
 			],
-			"type": "constuct",
+			"type": "construct",
 			"alignment": [
 				"L",
 				"E"


### PR DESCRIPTION
Fix typo: Evil Doll type "constuct" -> "construct"