### PR TITLE
Update SilentSoren; 5th Edition D&D x Final Fantasy XIV - Classes and…

### DIFF
--- a/collection/SilentSoren; 5th Edition D&D x Final Fantasy XIV - Classes and Races Compendium.json
+++ b/collection/SilentSoren; 5th Edition D&D x Final Fantasy XIV - Classes and Races Compendium.json
@@ -4758,8 +4758,8 @@
 			"shortName": "Allagan",
 			"subclassFeatures": [
 				"Allagan|Summoner|FFXIV|Allagan|FFXIV|3",
-				"Allagan Infusion|Summoner|FFXIV|Allagan|FFXIV|6",
-				"Aetherial Transferrence|Summoner|FFXIV|Allagan|FFXIV|10",
+				"Aetherial Transference|Summoner|FFXIV|Allagan|FFXIV|6",
+				"Eikonic Ward|Summoner|FFXIV|Allagan|FFXIV|10",
 				"Atherial Regeneration|Summoner|FFXIV|Allagan|FFXIV|14"
 			]
 		},
@@ -10678,28 +10678,12 @@
 							3
 						],
 						[
-							1,
-							3
-						],
-						[
 							2,
 							3
 						],
 						[
-							2,
-							4
-						],
-						[
 							3,
-							4
-						],
-						[
-							3,
-							4
-						],
-						[
-							4,
-							4
+							3
 						],
 						[
 							4,
@@ -10710,47 +10694,63 @@
 							4
 						],
 						[
-							5,
-							5
-						],
-						[
 							6,
-							5
-						],
-						[
-							6,
-							5
+							4
 						],
 						[
 							7,
-							5
-						],
-						[
-							7,
-							5
+							4
 						],
 						[
 							8,
-							5
-						],
-						[
-							8,
-							5
+							4
 						],
 						[
 							9,
-							5
-						],
-						[
-							9,
-							5
+							4
 						],
 						[
 							10,
 							5
 						],
 						[
-							10,
+							11,
+							5
+						],
+						[
+							12,
+							5
+						],
+						[
+							13,
+							5
+						],
+						[
+							14,
+							5
+						],
+						[
+							15,
+							5
+						],
+						[
+							16,
+							5
+						],
+						[
+							17,
+							5
+						],
+						[
+							18,
+							5
+						],
+						[
+							19,
+							5
+						],
+						[
+							20,
 							5
 						]
 					]
@@ -15923,7 +15923,7 @@
 					"name": "Spells Known of 1st Level and Higher",
 					"type": "entries",
 					"entries": [
-						"You know 2 1st-level spells of your choice from the Summoner spell list. The Spells Known column of the Summoner table shows when you learn more Summoner spells of your choice. Each of these spells must be of a level for which you have spell slots. For instance, when you reach 5th level in this class, you can learn one new spell of 1st, 2nd or 3rd level. Additionally, when you gain a level in this class, you can choose one of the Summoner spells you know and replace it with another spell from the Summoner spell list, which also must be of a level for which you have spell slots."
+						"You know four 1st-level spells of your choice from the summoner spell list. The Spells Known column of the Summoner table shows when you learn more summoner spells of your choice. Each of these spells must be of a level for which you have spell slots, as shown on the table. For instance, when you reach 3rd level in this class, you can learn one new spell of 1st or 2nd level. Additionally, when you gain a level in this class, you can choose one of the summoner spells you know and replace it with another spell from the summoner spell list, which also must be of a level for which you have spell slots."
 					]
 				},
 				{
@@ -15951,7 +15951,7 @@
 					"type": "entries",
 					"name": "Spellcasting Focus",
 					"entries": [
-						"You can use a magically conductive stone inlaid in a decorative mount other similar equipment as an {@item arcane focus|PHB} for your Summoner spells."
+						"You can use a magical grimoire, tome or other similar equipment as an {@item arcane focus|PHB} for your Summoner spells."
 					]
 				},
 				{
@@ -16061,6 +16061,17 @@
 				},
 				"As a bonus action, you can let the unleash the power of your chosen primal, adding your proficiency bonus to your spell attack bonus and spell save DC for 1 minute. Additionally, you add your Charisma modifier to the damage rolls of your primal's cantrip during this time. You can unleash the potential of your Eikonic Trance a number of times equal to your proficiency bonus.",
 				"Uses of this feature are recovered when you complete a long rest."
+			]
+		},
+		{
+			"name": "Eikonic Recovery",
+			"source": "FFXIV",
+			"className": "Summoner",
+			"classSource": "FFXIV",
+			"page": 134,
+			"level": 2,
+			"entries": [
+				"Also beginning at 2nd level, if your eikonic ally is alive, you spend time reclaiming your shared essence from the being. Once per day when you finish a short rest, you can choose expended spell slots to recover. The spell slots can have a combined level that is equal to or less than half your summoner level (rounded up), and none of the slots can be 6th level or higher. For example, if you're a 4th-level summoner, you can recover up to two levels worth of spell slots. You can recover either a 2nd-level spell slot or two 1st-level spell slots."
 			]
 		},
 		{
@@ -17925,7 +17936,7 @@
 			"classSource": "FFXIV",
 			"level": 1,
 			"entries": [
-				"As a student of astrology, you can cast Sage spells. See {@book chapter 10|PHB|10} of the PHB for the general rules of spellcasting and the end of this document for the {@filter Sage spell list|spells|class=Sage (FFXIV5E)}",
+				"As an aspiring mage, you can cast sage spells. See {@book chapter 10|PHB|10} of the PHB for the general rules of spellcasting and the end of this document for the {@filter Sage spell list|spells|class=Sage (FFXIV5E)}",
 				{
 					"type": "entries",
 					"name": "Cantrips",
@@ -17934,68 +17945,32 @@
 					]
 				},
 				{
-					"name": "Spellbook",
-					"type": "entries",
-					"entries": [
-						"At 1st level, you have a spellbook containing six 1st-level Blue Mage spells of your choice.",
-						{
-							"type": "inset",
-							"name": "Your Spellbook",
-							"entries": [
-								"The spells that you add to your spellbook as you gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil Wizards's chest, for example, or in a dusty tome in an ancient library",
-								{
-									"name": "Copying a Spell into the Book",
-									"type": "entries",
-									"entries": [
-										"When You find a Sage spell of 1st level or higher, You can add it to your spellbook if it is of a level for which You have spell slots and if You can spare the time to decipher and copy it. Copying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the mage who wrote it. You must practice the spell until You understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.",
-										"For each level of the spell, the process takes 2 hours and costs 50 gp. The cost represents material components You expend as You experiment with the spell to master it, as well as the fine inks You need to record it. Once You have spent this time and money, You can prepare the spell just like your other spells."
-									]
-								},
-								{
-									"name": "Replacing the Book",
-									"type": "entries",
-									"entries": [
-										"You can copy a spell from your own spellbook into another book-for example, if You want to make a backup copy of your spellbook. This is just like copying a new spell into your spellbook, but faster and easier, since You understand your own notation and already know how to cast the spell. You need spend only 1 hour and 10 gp for each level of the copied spell. If You lose your spellbook, You can use the same procedure to transcribe the spells that You have prepared into a new spellbook. Filling out the remainder of your spellbook requires You to find new spells to do so, as normal. For this reason, many mages keep backup spellbooks in a safe place."
-									]
-								},
-								{
-									"name": "The Book's Appearance",
-									"type": "entries",
-									"entries": [
-										"Your spellbook is a unique compilation of spells, with its own decorative f10urishes and margin notes. It might be a plain, functionalleather volume that You received as a gift from your master, a finely bound gilt-edged tome You found in an ancient library, or even a loose collection of notes scrounged together."
-									]
-								}
-							]
-						}
-					]
-				},
-				{
 					"name": "Preparing and Casting Spells",
 					"type": "entries",
 					"entries": [
 						"The Sage table shows how many spell slots you have to cast your Sage spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",
-						"You prepare the list of Sage spells that are available for you to cast, choosing from the Sage spell list. When you do so, choose a number of Sage spells equal to your Wisdom modifier + your Sage level (minimum of one spell). The spells must be of a level for which you have spell slots.",
-						"For example, if you are a 3rd level Sage, you have four 1st-level and two 2nd-level spell slots. With a Wisdom of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination. If you prepare the 1st-level spell {@spell cure wounds}, you can cast it using a 1st-level or 2nd-level slot. Casting the spell doesn't remove it from your list of prepared spells.",
-						"You can change your list of prepared spells when you finish a long rest. Preparing a new list of Sage spells requires time spent in prayer and meditation: at least 1 minute per spell level for each spell on your list."
+						"You prepare the list of sage spells that are available for you to cast, choosing from the sage spell list. When you do so, choose a number of sage spells equal to your Intelligence modifier + your Sage level (minimum of one spell). The spells must be of a level for which you have spell slots.",
+						"For example, if you are a 3rd-level sage, you have four 1st-level and two 2nd-level spell slots. With an Intelligence of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination. If you prepare the 1st-level spell cure wounds you can cast it using a 1st-level or 2nd-level slot. Casting the spell doesn't remove it from your list of prepared spells.",
+						"You can change your list of prepared spells when you finish a long rest. Preparing a new list of sage spells requires time spent in study and review: at least 1 minute per spell level for each spell on your list."
 					]
 				},
 				{
 					"name": "Spellcasting Ability",
 					"type": "entries",
 					"entries": [
-						"Wisdom is your spellcasting ability for your Sage spells. The power of your spells comes from your understanding of astrological powers. You use your Wisdom whenever an Sage spell refers to your spellcasing ability. In addition, you use your Wisdom modifier when setting the saving throw DC for an Sage spell you cast and when making an attack roll with one.",
+						"Intelligence is your spellcasting ability for your sage spells. The power of your spells comes from your thorough research and preparation into aetherology. You use your Wisdom whenever a sage spell refers to your spellcasting ability. In addition, you use your Intelligence modifier when setting the saving throw DC for a sage spell you cast and when making an attack roll with one.",
 						{
 							"type": "abilityDc",
 							"name": "Spell",
 							"attributes": [
-								"wis"
+								"int"
 							]
 						},
 						{
 							"type": "abilityAttackMod",
 							"name": "Spell",
 							"attributes": [
-								"wis"
+								"int"
 							]
 						}
 					]
@@ -18011,7 +17986,7 @@
 					"name": "Spellcasting Focus",
 					"type": "entries",
 					"entries": [
-						"You can use a star globe, planisphere or other similar tools as an arcane focus (found in {@book chapter 5|PHB} of the player's handbook) for your Sage spells."
+						"You can use a set of nouliths and your anchor stone as a spell casting focus for your sage spells."
 					]
 				}
 			]
@@ -21770,7 +21745,7 @@
 			"classSource": "FFXIV",
 			"level": 1,
 			"entries": [
-				"As a student of astrology, you can cast Scholar spells. See {@book chapter 10|PHB|10} of the PHB for the general rules of spellcasting and the end of this document for the {@filter Scholar spell list|spells|class=Scholar (FFXIV5E)}",
+				"See {@book chapter 10|PHB|10} of the PHB for the general rules of spellcasting and the end of this document for the {@filter Scholar spell list|spells|class=Scholar (FFXIV5E)}",
 				{
 					"type": "entries",
 					"name": "Cantrips",
@@ -21782,17 +21757,17 @@
 					"name": "Spellbook",
 					"type": "entries",
 					"entries": [
-						"At 1st level, you have a spellbook containing six 1st-level Blue Mage spells of your choice.",
+						"At 1st level, you have a spellbook containing six 1st-level scholar spells of your choice. Your spellbook is the repository of the scholar spells you know, except your cantrips, which are fixed in your mind.",
 						{
 							"type": "inset",
 							"name": "Your Spellbook",
 							"entries": [
-								"The spells that you add to your spellbook as you gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil Wizards's chest, for example, or in a dusty tome in an ancient library",
+								"The spells that You add to your spellbook as You gain levels reflect the arcane research you conduct on your own, as well as intellectual breakthroughs you have had about the nature of the multiverse. You might find other spells during your adventures. You could discover a spell recorded on a scroll in an evil wizard's chest, for example, or in a dusty tome in an ancient library.",
 								{
 									"name": "Copying a Spell into the Book",
 									"type": "entries",
 									"entries": [
-										"When You find a scholar spell of 1st level or higher, You can add it to your spellbook if it is of a level for which You have spell slots and if You can spare the time to decipher and copy it. Copying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the mage who wrote it. You must practice the spell until You understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.",
+										"When you find a scholar spell of 1st level or higher, you can add it to your spellbook if it is of a level for which You have spell slots and if you can spare the time to decipher and copy it. Copying a spell into your spellbook involves reproducing the basic form of the spell, then deciphering the unique system of notation used by the mage who wrote it. You must practice the spell until you understand the sounds or gestures required, then transcribe it into your spellbook using your own notation.",
 										"For each level of the spell, the process takes 2 hours and costs 50 gp. The cost represents material components You expend as You experiment with the spell to master it, as well as the fine inks You need to record it. Once You have spent this time and money, You can prepare the spell just like your other spells."
 									]
 								},
@@ -21807,7 +21782,7 @@
 									"name": "The Book's Appearance",
 									"type": "entries",
 									"entries": [
-										"Your spellbook is a unique compilation of spells, with its own decorative f10urishes and margin notes. It might be a plain, functionalleather volume that You received as a gift from your master, a finely bound gilt-edged tome You found in an ancient library, or even a loose collection of notes scrounged together."
+										"Your spellbook is a unique compilation of spells, with its own decorative flourishes and margin notes. It might be a plain, functional leather volume that you received as a gift from your master, a finely bound gold-edged tome you found in an ancient library, or even a loose collection of notes scrounged together."
 									]
 								}
 							]
@@ -21819,28 +21794,28 @@
 					"type": "entries",
 					"entries": [
 						"The Scholar table shows how many spell slots you have to cast your Scholar spells of 1st level and higher. To cast one of these spells, you must expend a slot of the spell's level or higher. You regain all expended spell slots when you finish a long rest.",
-						"You prepare the list of Scholar spells that are available for you to cast, choosing from the Scholar spell list. When you do so, choose a number of Scholar spells equal to your Wisdom modifier + your Scholar level (minimum of one spell). The spells must be of a level for which you have spell slots.",
-						"For example, if you are a 3rd level Scholar, you have four 1st-level and two 2nd-level spell slots. With a Wisdom of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination. If you prepare the 1st-level spell {@spell cure wounds}, you can cast it using a 1st-level or 2nd-level slot. Casting the spell doesn't remove it from your list of prepared spells.",
-						"You can change your list of prepared spells when you finish a long rest. Preparing a new list of Scholar spells requires time spent in prayer and meditation: at least 1 minute per spell level for each spell on your list."
+						"You prepare the list of Scholar spells that are available for you to cast, choosing from the Scholar spell list. To do so, choose a number of scholar spells from your spellbook equal to your Intelligence modifier + your scholar level (minimum of one spell). The spells must be of a level for which you have spell slots.",
+						"For example, if you're a 3rd-level scholar, you have four 1st-level and two 2nd-level spell slots. With an lntelligence of 16, your list of prepared spells can include six spells of 1st or 2nd level, in any combination, chosen from your spellbook. If you prepare the 1st-level spell magic missile, you can cast it using a 1st-level or a 2nd-level slot.",
+						"Casting the spell doesn't remove it from your list of prepared spells. You can change your list of prepared spells when you finish a long rest. Preparing a new list of scholar spells requires time spent studying your spellbook and memorizing the incantations and gestures you must make to cast the spell: at least 1 minute per spell level for each spell on your list."
 					]
 				},
 				{
 					"name": "Spellcasting Ability",
 					"type": "entries",
 					"entries": [
-						"Wisdom is your spellcasting ability for your Scholar spells. The power of your spells comes from your understanding of astrological powers. You use your Wisdom whenever an Scholar spell refers to your spellcasing ability. In addition, you use your Wisdom modifier when setting the saving throw DC for an Scholar spell you cast and when making an attack roll with one.",
+						"Intelligence is your spellcasting ability for your scholar spells. You use your Intelligence whenever a spell refers to your spellcasting ability. In addition, you use your Intelligence modifier when setting the saving throw DC for a scholar spell you cast and when making an attack roll with one.",
 						{
 							"type": "abilityDc",
 							"name": "Spell",
 							"attributes": [
-								"wis"
+								"int"
 							]
 						},
 						{
 							"type": "abilityAttackMod",
 							"name": "Spell",
 							"attributes": [
-								"wis"
+								"int"
 							]
 						}
 					]
@@ -21856,7 +21831,14 @@
 					"name": "Spellcasting Focus",
 					"type": "entries",
 					"entries": [
-						"You can use a star globe, planisphere or other similar tools as an arcane focus (found in {@book chapter 5|PHB} of the player's handbook) for your Scholar spells."
+						"You can use a magical grimoire, tome or other similar equipment as an arcane focus (found in {@book chapter 5|PHB} of the player's handbook) for your Scholar spells."
+					]
+				},
+				{
+					"name": "Learning Spells of 1st Level and Higher",
+					"type": "entries",
+					"entries": [
+						"Each time you gain an scholar level, you can add two scholar Spells of your choice to your Spellbook for free. Each of these spells must be of a level for which you have spell slots, as shown on the scholar table. On your adventures, you might find other spells you can add to your spellbook (see \"Your Spellbook\")."
 					]
 				}
 			]
@@ -21871,21 +21853,6 @@
 			"entries": [
 				"Beginning at the 1st level, you have developed specialized tactics during battle. You can use this feature a number of times equal to your proficiency bonus. You regain any expended uses when you finish a short or long rest.",
 				"You memorize your tactics from the tactics list located after the scholar archetype descriptions. You can change which tactics you have memorized when you complete a long rest. You can have a number of tactics memorized equal to your Intelligence modifier (minimum of one). Some tactics have specific requirements to be met before they can be memorized."
-			]
-		},
-		{
-			"name": "Aetherial Ally",
-			"source": "FFXIV",
-			"className": "Scholar",
-			"classSource": "FFXIV",
-			"page": 125,
-			"level": 2,
-			"entries": [
-				"Beginning at 2nd level you learn to summon an aetherial creature to assist you in battle. Traditionally arcanists and tacticians prefer to summon carbuncles to defend them in battle, while nymian scholars prefer to summon the fey of their namesake. The creature is friendly to you and your companions and obeys your commands. Scholars have learned how to summon both carbuncles and nymian fey as the first step on their journey in this discipline.",
-				"Select the relevant stat block when summoning your aetherial ally. These summons use your proficiency bonus (PB) in several places. Descriptions of your aetherial allies can be found alongside the provided stat blocks at the end of the class description.",
-				"In combat, your aetherial ally acts during your turn. It can move and use its reaction on its own, but the only action it takes is the Dodge action, unless you take a bonus action on your turn to command it to take another action. That action can be one in its stat block or some other action. You can also sacrifice one of your attacks when you take the Attack action to command the ally to take the Attack action. If you are incapacitated, the beast can take any action of its choice, not just Dodge.",
-				"If your aetherial ally is reduced to 0 hit points, its body dissipates into a fog of magical energy which remains intact for one minute. You can use your action to touch it and expend a spell slot of 1st level or higher. Aetherial ally's body returns to life after 1 minute with all its hit points restored.",
-				"You summon your aetherial ally when you complete a long rest. At this time you can summon a different aetherial ally. The new summon appears in an unoccupied space within 5 feet of you, and you choose its stat block. If you already have an aetherial ally from this feature, it vanishes when the new summon appears. The summon also vanishes if you die."
 			]
 		},
 		{
@@ -22060,7 +22027,7 @@
 			"header": 2,
 			"entries": [
 				"{@i 3rd-level Evoker feature}",
-				"Beginning at 3rd level, you may expend an available draw to assist you in revealing dangers of the area. As an action you may do a quick reading to scan for traps in the area, giving you advantage on perception checks for 1 minute.",
+				"Beginning at 3rd level, when you summon your egi you can empower the egi through special evoker summoner techniques. Select one of the following empowerments when you summon your egi.",
 				{
 					"type": "entries",
 					"entries": [
@@ -22352,7 +22319,7 @@
 							"type": "entries",
 							"name": "Inspiring Ascendance",
 							"entries": [
-								"You learn the Firebolt cantrip and gain resistance to fire damage. When you cast a spell using a spell slot you can change the damage type of the spell to fire damage."
+								"You gain a flying speed equal to your movement speed. While you are under the effect of your unleashed eikonic trance, when a friendly creature begins its turn within 30ft. of you, they recover 1d8 + you charisma modifier hit points. When you cast a spell, you may choose to make a ranged spell attack which deals 1d8 + your Charisma Modifier fire damage."
 							]
 						}
 					]
@@ -22369,7 +22336,7 @@
 			"subclassSource": "FFXIV",
 			"level": 3,
 			"entries": [
-				"Timeless practitioners of the art of war, Allagans have been known by many names across the annals of history. A Allagan will use thorough planning and insight to help their allies win the day.",
+				"The Allagans were able to expand their empire and fight against the eikonic threats of their time with the help of summoners. Wielding the strength of eikons in battle against their divine foes Allagans were able to find success. In the end egis were treated as tools of war to help the summoner themselves shine on the battle field and overcome powerful foes.",
 				{
 					"type": "refSubclassFeature",
 					"subclassFeature": "Allagan Infusion|Summoner|FFXIV|Allagan|FFXIV|3"
@@ -22392,7 +22359,7 @@
 			]
 		},
 		{
-			"name": "Allagan Infusion",
+			"name": "Aetherial Transference",
 			"source": "FFXIV",
 			"page": 136,
 			"className": "Summoner",
@@ -22407,7 +22374,7 @@
 			]
 		},
 		{
-			"name": "Aetherial Transferrence",
+			"name": "Eikonic Ward",
 			"source": "FFXIV",
 			"page": 136,
 			"className": "Summoner",
@@ -27816,7 +27783,7 @@
 			"header": 2,
 			"entries": [
 				"{@i 6th-level Arcanist feature}",
-				"Beginning at 6th level, when you cast a spell of the 1st-level or higher that restores the hit points of an ally, you may leave a regenerative effect on all affected allies. After the spell is cast, the affected creatures recover 1d6 hit points at the start of their turn for a number of rounds equal to your Wisdom ability modifier. You must then finish a short or long rest to use Aspected Benefic again."
+				"Starting at 6th level, your bond with your aetherial allies warps your senses. You gain blindsight in a 10ft. radius around your aetherial ally."
 			]
 		},
 		{
@@ -27960,8 +27927,8 @@
 			"level": 14,
 			"header": 2,
 			"entries": [
-				"{@i 14th-level Arcanist feature}",
-				"Starting at the 14th level, you have unlocked the secrets behind the nymian fey are can temporarily ascend the nymian fey into a powerful new form. Your nymian fey is replaced by the Seraph for 1 minute or until its hit points are reduced to 0.",
+				"{@i 14th-level Nymian feature}",
+				"Starting at the 14th level, you have unlocked the secrets behind the nymian fey and can temporarily ascend the nymian fey into a powerful new form. Your nymian fey is replaced by the Seraph for 1 minute or until its hit points are reduced to 0.",
 				"When your aetherial ally returns to its original form, it maintains the amount of hit points it had left as a Seraph, or its maximum hit points, whichever is lower.",
 				"You may use this feature once, use of this feature is recovered when you complete a long rest."
 			]
@@ -28038,6 +28005,9 @@
 						"Strength score",
 						"Dexterity score",
 						"Constitution score",
+						"Intelligence score",
+						"Wisdom score",
+						"Charisma score",
 						"Armor Class",
 						"Current hit points",
 						"Total class levels (if any)"


### PR DESCRIPTION
… Races Compendium.json

- Fixed incorrect Bonus Mana scaling for Black Mage. 
- Fixed various errors in Spellcasting sections of Sage. 
- Fixed various errors in Spellcasting sections of Scholar. 
- Removed duplicate Aetherial Ally entry in Scholar. 
- Fixed incorrect description for Scholar: Arcanist 6th level class feature (Aether Sight). 
- Fixed missing entries for Scholar: Tactician 6th level class feature (Strategic Preparation) 
- Fixed missing class feature at 2nd level of Summoner (Eikonic Recovery). 
- Fixed error in Summoner: Evoker 3rd level class feature (Empowered Egi). 
- Fixed incorrect description for Summoner: Eikonic Channeler 14th level class feature (Inspiring Ascendance). 
- Fixed description for Summoner: Allagan.
- Fixed class feature names for Summoner: Allagan (Aetherial Transference/Eikonic Ward).