### PR TITLE
Create Bovenbrew; Bovenbrew Weapon Arts

### DIFF
--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -1,0 +1,1269 @@
+{
+    "_meta": {
+        "sources": [
+            {
+                "json": "Bovenbrew Weapon Arts",
+                "abbreviation": "BBWA",
+                "full": "Bovenbrew Weapon Arts",
+                "authors": [
+                    "Bovenbrew"
+                ],
+                "version": "1.0",
+                "url": "http://bovenbrew.wikidot.com/",
+                "targetSchema": "1.0"
+            }
+        ],
+        "dateAdded": 1725412983,
+        "dateLastModified": 1725412983,
+	    "optionalFeatureTypes": {
+			"Weapon Art": "Weapon Art"
+		}
+    },
+    "variantrule": [
+        {
+            "name": "Bovenbrew Weapon Arts",
+            "source": "Bovenbrew Weapon Arts",
+            "entries": ["Weapon Arts are techniques that characters can use when they are proficient with a weapon. Unless otherwise noted, most Weapon Arts replace an attack or have a passive effect as described. All mundane weapons have between 1-3 Weapon Arts, but magical weapons can have more at the DM's discretion. Other than passive Weapon Arts, by default a character can use Weapon Arts an amount of times equal to their proficiency bonus. Characters who have Martial Weapon Proficiency are able to use their Weapon Arts an amount of times equal to double their proficiency bonus. See the relevant features for more detail. A character cannot use the same Weapon Art twice in one turn. Characters regain all uses of Weapon Arts on a short or long rest. Some Weapon Arts may have further restrictions. Lastly, not all Weapon Arts are effective against all creatures. A Weapon Art that cripples the legs will not work on a creature that has no legs, is incorporeal, or does not rely on their legs."]
+            }
+    ],
+    "feat": [
+        {
+            "name": "Weapon Arts",
+            "foundryImg": "icons/weapons/clubs/club-banded-brown.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Proficiency with any weapons"
+				}
+			],
+            "entries": ["Your proficiency with one or more weapons allows you utilize their unique features when you use them to attack. When you use the attack action, you may replace any attack with any Weapon Art assigned to that weapon. You may use multiple Weapon Arts per turn, but may not use the same one twice in one turn. You may use Weapon Arts a number of times equal to your proficiency bonus, regaining all uses when you finish a short or long rest. ",
+            {
+                "type": "options",
+                "count": "666",
+                "entries": [
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Backbreaker|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Blinding Strike (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Blinding Strike (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Brace (Melee)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Brace (Ranged)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Cheap Shot (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Cheap Shot (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Cleave|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Concussive Smash|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Crippling Strike|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Disarming Strike (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Disarming Strike (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Dwarven Takedown|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Elven Swift Strike|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Flourish (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Flourish (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Gnomish Cunning Gambit|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Hamstring Shot|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Heartstopper|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Lacerate (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Lacerate (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Mobile Shot|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Orcish Bloodfrenzy|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Piercing Shot|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Piercing Strike (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Piercing Strike (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Pommel Strike (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Pommel Strike (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Prepare (Melee)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Prepare (Ranged)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Rush Attack|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Tenacity|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Topple (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Topple (STR)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Weakening Strike (DEX)|Bovenbrew Weapon Arts"
+                    },
+                    {
+                        "type": "refOptionalfeature",
+                        "optionalfeature": "Weakening Strike (STR)|Bovenbrew Weapon Arts"
+                    }
+                ]
+            }
+        ],
+        "foundrySystem": {
+				"uses": {
+					"max": "@prof",
+					"per": "sr",
+					"value": 1
+				}
+            }
+        },
+        {
+            "name": "Advanced Weapon Arts",
+            "foundryImg": "icons/weapons/swords/greatsword-blue.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Proficiency with simple and martial weapons"
+				}
+			],
+            "entries": ["Your proficiency with both simple and martial weapons allows you utilize their unique features to a greater extent than others when you use them to attack. When you use the attack action, you may replace any attack with any Weapon Art assigned to that weapon. You may use multiple Weapon Arts per turn, but may not use the same one twice in one turn. You may use Weapon Arts a number of times equal to twice your proficiency bonus, regaining all uses when you finish a short or long rest. This feature doubles the uses of the Weapon Arts feature."]
+        },
+        {
+            "name": "Specialized Weapon Arts",
+            "foundryImg": "icons/skills/melee/weapons-crossed-swords-yellow-teal.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+                {
+                    "other": "A feat or fighting style which specializes in a weapon"
+                }
+            ],
+            "entries": ["Your mastery over a weapon class or fighting style grants you further benefits to your Weapon Arts. You may use any Weapon Art twice per turn when wielding a weapon you specialize in."]
+        }    
+    ],
+	"condition": [
+		{
+			"name": "Chest Trauma",
+            "foundryImg": "icons/svg/heal.svg",
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"A creature with chest trauma has disadvantage on Constitution saving throws.",
+						"A creature with chest trauma is unable to use bonus actions for three turns unless they succeed on Constitution saving throw at the beginning of their turn.",
+						"The chest trauma condition can be removed by healing."
+					]
+				}
+			],
+			"source": "Bovenbrew Weapon Arts"
+		},
+        {
+			"name": "Crippled",
+            "foundryImg": "icons/svg/bones.svg",
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"A crippled creature is unable to move for the first turn of the condition.",
+						"A crippled creature has disadvantage on Dexterity saving throws.",
+						"The crippled condition can be removed by healing."
+					]
+				}
+			],
+			"source": "Bovenbrew Weapon Arts"
+		},
+        {
+			"name": "Dazed",
+            "foundryImg": "icons/svg/daze.svg",
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"A dazed creature has disadvantage on their next Wisdom saving throw.",
+						"A dazed creature cannot use reactions.",
+						"At the end of the creature’s turn, they may attempt the Constitution saving throw again to end the dazed effect."
+					]
+				}
+			],
+			"source": "Bovenbrew Weapon Arts"
+		},
+        {
+			"name": "Gaping Wounds",
+            "foundryImg": "icons/svg/blood.svg",
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"Attacks against a creature with gaping wounds deal an additional 2 piercing damage.",
+						"The gaping wounds condition can be removed by healing."
+					]
+				}
+			],
+			"source": "Bovenbrew Weapon Arts"
+		},
+        {
+			"name": "Off Balance",
+            "foundryImg": "icons/svg/falling.svg",
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"A creature who is off balance has disadvantage on Strength and Dexterity checks and attack rolls against it have advantage.",
+						"Attack rolls have advantage against a creature who is off balance.",
+						"A creature regains their balance if they take damage or are helped."
+					]
+				}
+			],
+			"source": "Bovenbrew Weapon Arts"
+		},
+        {
+			"name": "Weak Grip",
+            "foundryImg": "icons/svg/sword.svg",
+			"entries": [
+				{
+					"type": "list",
+					"items": [
+						"A creature with weak grip has disadvantage on attack rolls.",
+						"A creature with weak grip has disadvantage on Strength saving throws.",
+						"The weak grip condition ends if the creature is helped. Also, the creature can repeat the saving throw at the end of their turn to end the condition."
+					]
+				}
+			],
+			"source": "Bovenbrew Weapon Arts"
+		}
+    ],
+    "optionalfeature": [
+        {
+            "name": "Backbreaker",
+            "foundryImg": "icons/skills/wounds/injury-pain-body-orange.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Maul, Warhammer"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Put extra force behind your strike to possibly knock your target away from you and onto the ground. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier + your proficiency bonus or be knocked {@condition prone} and knocked 5 feet away from you."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Backbreaker Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "str",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "prone"
+			    ]
+            }
+        },
+        {
+            "name": "Blinding Strike (DEX)",
+            "foundryImg": "icons/skills/wounds/injury-eyes-blood-red-pink.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Scimitar, Whip"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Target a creature's eyes to deal damage and possibly strike their eyes. The targeted enemy must make a Dexterity saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or become {@condition blinded}. Blindness inflicted by this attack lasts until removed with an action or until helped."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Blinding Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "blinded"
+			    ]
+            }
+        },
+        {
+            "name": "Blinding Strike (STR)",
+            "foundryImg": "icons/skills/wounds/injury-eyes-blood-red-pink.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Scimitar, Whip"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Target a creature's eyes to deal damage and possibly strike their eyes. The targeted enemy must make a Dexterity saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or become {@condition blinded}. Blindness inflicted by this attack lasts until removed with an action or until helped."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Blinding Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "blinded"
+			    ]
+            }
+        },
+        {
+            "name": "Brace (Melee)",
+            "foundryImg": "icons/weapons/polearms/spear-barbed-silver.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Dwarven Urgosh, Glaive, Pike"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Spend 25 feet of your movement speed. For the rest of your turn, roll melee weapon damage dice twice and use the higher result."]
+        },
+        {
+            "name": "Brace (Ranged)",
+            "foundryImg": "icons/skills/ranged/person-archery-bow-attack-orange.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Blowgun, Dart, Heavy Crossbow, Longbow, Repeating Heavy Crossbow"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Spend 20 feet of your movement speed. For the rest of your turn, roll ranged weapon damage dice twice and use the higher result."]
+        },
+        {
+            "name": "Cheap Shot (DEX)",
+            "foundryImg": "icons/skills/wounds/injury-face-impact-orange.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Unarmed"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Strike a creature in a vulnerable place to deal damage and possibly disrupt their balance. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be pushed off balance. A creature who is off balance has disadvantage on Strength and Dexterity checks and attack rolls against it have advantage. The creature regains their balance if they take damage or are helped."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Blinding Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "str",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "off balance"
+			    ]
+            }
+        },
+        {
+            "name": "Cheap Shot (STR)",
+            "foundryImg": "icons/skills/wounds/injury-face-impact-orange.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Unarmed"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Strike a creature in a vulnerable place to deal damage and possibly disrupt their balance. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be pushed off balance. A creature who is off balance has disadvantage on Strength and Dexterity checks and attack rolls against it have advantage. The creature regains their balance if they take damage or are helped."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Blinding Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "str",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "off balance"
+			    ]
+            }
+        },
+        {
+            "name": "Cleave",
+            "foundryImg": "icons/skills/melee/strike-axe-blood-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Bastard Sword, Battleaxe, Dwarven Urgosh, Dwarven Waraxe, Greataxe, Greatsword, Halberd, Orc Double Axe"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Swing your weapon in a large arc to attack up to three adjacent spaces at once, hitting every target in the arc with one attack and dealing half damage to each."]
+        },
+        {
+            "name": "Concussive Smash",
+            "foundryImg": "icons/skills/melee/strike-club-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Club, Dire Flail, Flail, Gnomish Hooked Hammer, Greatclub, Light Hammer, Mace, Maul, Morningstar, Reinforceed Tankard, Warhammer"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Hit a creature with all your might to deal damage and possibly concuss them. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier + your proficiency bonus or become dazed. A dazed enemy has disadvantage on their next Wisdom saving throw and cannot use reactions. At the end of the creature’s turn, they may attempt the Constitution saving throw again to end the dazed effect."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Concussive Smash Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "dazed"
+			    ]
+            }
+        },
+        {
+            "name": "Crippling Strike",
+            "foundryImg": "icons/skills/wounds/bone-broken-knee-beam.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Batlleaxe, Dwarven Waraxe, War Pick"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Swing at a creature's limbs to deal damage and possibly impair their ability to move. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier + your proficiency bonus or become crippled. A crippled creature is unable to move for the first turn of the condition and has disadvantage on Dexterity saving throws thereafter. The crippled condition can be removed by healing."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Crippling Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "dazed"
+			    ]
+            }
+        },
+        {
+            "name": "Disarming Strike (DEX)",
+            "foundryImg": "icons/skills/melee/sword-damaged-broken-glow-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Whip"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Focus your attack on your foe's hands to deal damage and possibly force them to drop a weapon they are holding. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be forced to drop a weapon in their hands onto the ground beneath them. If the creature is dual-wielding, you may target only one weapon. Shields cannot be targeted. Creatures wielding two-handed weapons have advantage on the saving throw. "],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Disarming Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "str",
+			    "save.scaling": "dex"
+            }
+        },
+        {
+            "name": "Disarming Strike (STR)",
+            "foundryImg": "icons/skills/melee/sword-damaged-broken-glow-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Trident, Whip"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Focus your attack on your foe's hands to deal damage and possibly force them to drop a weapon they are holding. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be forced to drop a weapon in their hands onto the ground beneath them. If the creature is dual-wielding, you may target only one weapon. Shields cannot be targeted. Creatures wielding two-handed weapons have advantage on the saving throw. "],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Disarming Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "str",
+			    "save.scaling": "str"
+            }
+        },
+        {
+            "name": "Dwarven Takedown",
+            "foundryImg": "icons/skills/trades/mining-pickaxe-iron-blue.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Dwarven Urgosh, Dwarven Waraxe"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Dig your weapon into your opponent's leg as part of your attack and attempt to hold them in place. You and your target compete in a grappling contest, but you get a bonus to the roll equal to your proficiency modifier. For as long as your target is grappled, you have two options.",
+            {
+                "type": "list",
+                "items": [
+                    "You may sweep your weapon out from under them as a bonus action and cause them to fall prone while ending the grapple.",
+                    "On an ally's turn you may use your reaction to do a deadly tag team combo as you boost your ally off your back toward the enemy. As they strike from the air, they roll twice the number of damage dice for all attacks against that enemy this turn, ending the grapple. For this to work they must attack the enemy from a tile adjacent to you and the target."
+                ]
+            }
+        ]
+        },
+        {
+            "name": "Elven Swift Strike",
+            "foundryImg": "icons/skills/targeting/target-strike-gray.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Elven Longsword"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "foundrySystem": {
+			    "uses": {
+                "value": 1,
+                "max": "@prof/2",
+                "per": "sr"
+            }
+            },
+            "entries": ["With the speed and precision afforded to elves, you attempt to strike an enemy's weakest point to inflict critical damage. Your proficiency bonus is doubled for this attack roll and if successful, becomes an automatic critical hit. You may only use this weapon art a number of times equal to half your proficiency modifier."]
+        },
+        {
+            "name": "Flourish (DEX)",
+            "foundryImg": "icons/skills/melee/sword-twirl-orange.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Elven Longsword, Rapier, Scimitar, Shortsword"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["As a bonus action, feint an attack after a successful attack to possibly throw your target off kilter. The targeted creature must make a Dexterity saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be pushed off balance. A creature who is off balance has disadvantage on Strength and Dexterity checks and attack rolls against it have advantage. The creature regains their balance if they take damage or are helped."],
+            "foundrySystem": {
+			    "activation.type": "bonus",
+                "activation.cost": 1,
+			    "activation.condition": "Successfully hit with a weapon that has the Florish Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "off balance"
+			    ]
+            }
+        },
+        {
+            "name": "Flourish (STR)",
+            "foundryImg": "icons/skills/melee/sword-twirl-orange.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Elven Longsword, Rapier, Scimitar, Shortsword"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["As a bonus action, feint an attack after a successful attack to possibly throw your target off kilter. The targeted creature must make a Dexterity saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be pushed off balance. A creature who is off balance has disadvantage on Strength and Dexterity checks and attack rolls against it have advantage. The creature regains their balance if they take damage or are helped."],
+            "foundrySystem": {
+			    "activation.type": "bonus",
+                "activation.cost": 1,
+			    "activation.condition": "Successfully hit with a weapon that has the Florish Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "off balance"
+			    ]
+            }
+        },
+        {
+            "name": "Gnomish Cunning Gambit",
+            "foundryImg": "icons/skills/movement/figure-running-gray.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Gnomish Hooked Hammer"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["When a creature melee attacks you and fails to hit you, you may make one of the following reactions.",
+            {
+                "type": "list",
+                "items": [
+                    "You may use their failed attack as an opportunity to make a guileful counterattack. You may make an attack roll and add the difference between the creature's earlier failed attack roll and your AC to your attack roll. Additionally, the critical range for this attack is extended to 19-20.",
+                    "You may use their failed attack as an opportunity to escape from their reach. You may disengage and move up to half your movement in any direction."
+                ]
+            }
+            ],
+            "foundrySystem": {
+			    "activation.type": "reaction",
+                "activation.cost": 1,
+			    "activation.condition": "A creature fails to hit you with a melee attack while you are wielding a weapon with the Gnomish Cunning Gambit Weapon Art"
+            }
+        },
+        {
+            "name": "Hamstring Shot",
+            "foundryImg": "icons/skills/ranged/arrow-flying-white-blue.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Longbow, Shortbow"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Focus your attack on your foe's hands to deal damage and possibly force them to drop a weapon they are holding. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be forced to drop a weapon in their hands onto the ground beneath them. If the creature is dual-wielding, you may target only one weapon. Shields cannot be targeted. Creatures wielding two-handed weapons have advantage on the saving throw."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Hamstring Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "dex"
+            }
+        },
+        {
+            "name": "Heartstopper",
+            "foundryImg": "icons/skills/wounds/anatomy-organ-heart-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Morningstar"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Smash a creature's chest to deal damage and possibly inflict internal trauma. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier + your proficiency bonus or receive chest trauma. A creature with chest trauma has disadvantage on Constitution saving throws until the condition is removed and is unable to use bonus actions for three turns unless they succeed on Constitution saving throw at the beginning of their turn. The chest trauma condition ends when the creature is healed."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Heartstopper Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "chest trauma"
+			    ]
+            }
+        },
+        {
+            "name": "Lacerate (DEX)",
+            "foundryImg": "icons/skills/wounds/blood-drip-droplet-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Elven Longsword, Scimitar, Whip"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Slash at a creature's arterial blood vessels to deal damage and possibly cause them to bleed profusely. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or begin bleeding. Attacks against a creature that is bleeding deal an additional 2 slashing damage and the creature has disadvantage on saving throws against disease or poisons. The bleeding condition can be removed by healing."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Lacerate Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "bleeding"
+			    ]
+            }
+        },
+        {
+            "name": "Lacerate (STR)",
+            "foundryImg": "icons/skills/wounds/blood-drip-droplet-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Bastard Sword, Battleaxe, Elven Longsword, Glaive, Greataxe, Greatsword, Halberd, Handaxe, Longsword, Orc Double Axe, Scimitar, Sickle, Whip"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Slash at a creature's arterial blood vessels to deal damage and possibly cause them to bleed profusely. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or begin. Attacks against a creature that is bleeding deal an additional 2 slashing damage and the creature has disadvantage on saving throws against disease or poisons. The bleeding condition can be removed by healing."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Lacerate Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "bleeding"
+			    ]
+            }
+        },
+        {
+            "name": "Mobile Shot",
+            "foundryImg": "icons/weapons/crossbows/handcrossbow-black.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Blowgun, Hand Crossbow"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["As a bonus action after dashing or disengaging, make a ranged attack while moving."],
+            "foundrySystem": {
+			    "activation.type": "bonus",
+                "activation.cost": 1,
+			    "activation.condition": "Dash or disengage while wielding a weapon that has the Mobile Shot Weapon Art"
+            }
+        },
+        {
+            "name": "Orcish Bloodfrenzy",
+            "foundryImg": "icons/skills/wounds/injury-triple-slash-bleed.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+                {
+                    "other": "Orc Double Axe"
+                }
+            ],
+            "consumes": {
+                "name": "Weapon Arts",
+                "amount": 1
+            },
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["When you are below half health, you may enter an Orcish Bloodfrenzy and strike your enemies with wild abandon. You must begin the Bloodfrenzy as a free action prior to any other activity on that turn. For this turn you may roll two additional damage for each successful attack with valid weapons. However, in your frenzy you worsen your wounds and thus you receive half the damage in return. This damage cannot be reduced in any way. If your Hit Point total is reduced to zero during the Bloodfrenzy you remain standing until your turn is over, but automatically fail a death saving throw upon falling unconscious. "],
+            "foundrySystem": {
+                "activation.type": "special",
+                "activation.cost": 1,
+                "activation.condition": "Be below half health and have done no other acitivites during this turn"
+            }
+        },
+        {
+            "name": "Piercing Shot",
+            "foundryImg": "icons/skills/ranged/projectile-strike-impale-gray.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Hand Crossbow, Heavy Crossbow, Light Crossbow, Repeating Heavy Crossbow, Repeating Light Crossbow"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Shoot a creature in a vital spot to deal damage and possibly inflict deep wounds. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Dexterity modifier + your proficiency bonus or receive gaping wounds. Attacks against a creature with gaping wounds deal an additional 2 piercing damage. The gaping wounds condition can be removed by healing."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Piercing Shot Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "gaping wounds"
+			    ]
+            }
+        },
+        {
+            "name": "Piercing Strike (DEX)",
+            "foundryImg": "icons/skills/melee/strike-sword-stabbed-brown.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Blade Boot, Dagger, Rapier, Shortsword"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Deftly stab a creature to deal damage and possibly inflict deep wounds. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or receive gaping wounds. Attacks against a creature with gaping wounds deal an additional 2 piercing damage. The gaping wounds condition can be removed by healing."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Piercing Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "gaping wounds"
+			    ]
+            }
+        },
+        {
+            "name": "Piercing Strike (STR)",
+            "foundryImg": "icons/skills/melee/strike-sword-stabbed-brown.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Blade Boot, Dagger, Javelin, Hoopak, Lance, Pike, Rapier, Shortsword, Trident, War Pick"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Deftly stab a creature to deal damage and possibly inflict deep wounds. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or receive gaping wounds. Attacks against a creature with gaping wounds deal an additional 2 piercing damage. The gaping wounds condition can be removed by healing."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Piercing Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "con",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "gaping wounds"
+			    ]
+            }
+        },
+        {
+            "name": "Pommel Strike (DEX)",
+            "foundryImg": "icons/skills/melee/hand-grip-sword-white-brown.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Shortsword"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["As a bonus action, make a non-lethal attack with your pommel after a successful attack to deal 1d4 damage + your Strength modifier or your Dexterity modifier and possibly concuss them. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or become dazed. A dazed enemy has disadvantage on their next Wisdom saving throw and cannot use their reaction. At the end of the creature’s turn, they may attempt the Constitution saving throw again to end the effect."],
+            "foundrySystem": {
+			    "activation.type": "bonus",
+                "activation.cost": 1,
+			    "activation.condition": "Hit with a weapon that has the Pommel Strike Weapon Art",
+			    "actionType": "save",
+                "damage.parts": [
+					[
+						"1d4 + @abilities.dex.mod",
+						"bludgeoning"
+					]
+				],
+			    "save.ability": "con",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "dazed"
+			    ]
+            }
+        },
+        {
+            "name": "Pommel Strike (STR)",
+            "foundryImg": "icons/skills/melee/hand-grip-sword-white-brown.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Greatsword, Longsword, Shortsword"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["As a bonus action, make a non-lethal attack with your pommel after a successful attack to deal 1d4 damage + your Strength modifier or your Dexterity modifier and possibly concuss them. The targeted creature must make a Constitution saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or become dazed. A dazed enemy has disadvantage on their next Wisdom saving throw and cannot use their reaction. At the end of the creature’s turn, they may attempt the Constitution saving throw again to end the effect."],
+            "foundrySystem": {
+			    "activation.type": "bonus",
+                "activation.cost": 1,
+			    "activation.condition": "Hit with a weapon that has the Pommel Strike Weapon Art",
+			    "actionType": "save",
+                "damage.parts": [
+					[
+						"1d4 + @abilities.str.mod",
+						"bludgeoning"
+					]
+				],
+			    "save.ability": "con",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "dazed"
+			    ]
+            }
+        },
+        {
+            "name": "Prepare (Melee)",
+            "foundryImg": "icons/skills/melee/maneuver-greatsword-yellow.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Greataxe"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Spend 25 feet of your movement. For the rest of your turn, roll an additional damage die for each successful hit."]
+        },
+        {
+            "name": " Prepare (Ranged)",
+            "foundryImg": "icons/skills/ranged/archery-bow-attack-yellow.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Hoopak, Sling"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Spend 20 feet of your movement. For the rest of your turn, roll an additional damage die for each successful hit."]
+        },
+        {
+            "name": "Rush Attack",
+            "foundryImg": "icons/skills/movement/feet-winged-boots-glowing-yellow.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Bastard Sword, Glaive, Halberd, Lance, Longsword, Pike, Spear, Trident"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Charge forward and after moving at least 10 feet in a straight line attack the first creature in your way, dealing damage and possibly pushing them off kilter. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier + your proficiency bonus or be pushed off balance. A creature who is off balance has disadvantage on Strength and Dexterity checks and attack rolls against it have advantage. The creature regains their balance if they take damage or are helped."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Rush Attack Weapon Art and move 10 feet",
+			    "actionType": "save",
+			    "save.ability": "str",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "off balance"
+			    ]
+            }
+        },
+        {
+            "name": "Tenacity",
+            "foundryImg": "icons/skills/melee/strike-flail-destructive-yellow.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Dire Flail, Greatclub, Flail, Maul, Morningstar"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["When you miss an attack with this weapon, always deal bludgeoning damage equal to your Strength modifier anyway."],
+            "foundrySystem": {
+			    "activation.type": "special",
+                "activation.cost": 1,
+			    "activation.condition": "Attack with a weapon that has the Tenacity Weapon Art and miss",
+                "damage.parts": [
+					[
+						"@abilities.str.mod",
+						"bludgeoning"
+					]
+				]
+            }
+        },
+        {
+            "name": "Topple (DEX)",
+            "foundryImg": "icons/magic/control/silhouette-fall-slip-prone.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Quarterstaff"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Swipe at a creature's legs to knock it to the ground. The targeted creature must make a Dexterity saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be knocked prone."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Topple Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "prone"
+			    ]
+            }
+        },
+        {
+            "name": "Topple (STR)",
+            "foundryImg": "icons/magic/control/silhouette-fall-slip-prone.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Dire Flail, Gnomish Hooked Hammer, Quarterstaff"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Swipe at a creature's legs to knock it to the ground. The targeted creature must make a Dexterity saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be knocked prone."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Topple Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "prone"
+			    ]
+            }
+        },
+        {
+            "name": "Weakening Strike (DEX)",
+            "foundryImg": "icons/skills/wounds/injury-hand-blood-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Nunchaku, Rapier"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Target a creature's weapon arm with a non-lethal attack to deal damage and possibly impair their weapon usage. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be inflicted with weak grip. A creature with weak grip has disadvantage on attack rolls and Strength saving throws. The weak grip condition ends if the creature is helped. Also, the creature can repeat the saving throw at the end of their turn to end the condition."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Weaking Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "dex", 
+                "conditionInflict": [
+			        "weak grip"
+			    ]
+            }
+        },
+        {
+            "name": "Weakening Strike (STR)",
+            "foundryImg": "icons/skills/wounds/injury-hand-blood-red.webp",
+            "source": "Bovenbrew Weapon Arts",
+            "prerequisite": [
+				{
+					"other": "Flail, Nunchaku, Rapier, War Pick, Warhammer"
+				}
+			],
+            "consumes": {
+				"name": "Weapon Arts",
+				"amount": 1
+			},
+            "featureType": [
+                "Weapon Art"
+            ],
+            "entries": ["Target a creature's weapon arm with a non-lethal attack to deal damage and possibly impair their weapon usage. The targeted creature must make a Strength saving throw with DC equal to 8 + your Strength modifier or your Dexterity modifier + your proficiency bonus or be inflicted with weak grip. A creature with weak grip has disadvantage on attack rolls and Strength saving throws. The weak grip condition ends if the creature is helped. Also, the creature can repeat the saving throw at the end of their turn to end the condition."],
+            "foundrySystem": {
+			    "activation.type": "special",
+			    "activation.condition": "Attack with a weapon that has the Weaking Strike Weapon Art",
+			    "actionType": "save",
+			    "save.ability": "dex",
+			    "save.scaling": "str", 
+                "conditionInflict": [
+			        "weak grip"
+			    ]
+            }
+        }
+    ]  
+}

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -311,7 +311,8 @@
 					]
 				}
 			],
-			"source": "Bovenbrew Weapon Arts"
+			"source": "Bovenbrew Weapon Arts",
+			"page": ""
 		}
     ],
     "optionalfeature": [

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -232,7 +232,8 @@
 					]
 				}
 			],
-			"source": "Bovenbrew Weapon Arts"
+			"source": "Bovenbrew Weapon Arts",
+			"page": ""
 		},
         {
 			"name": "Crippled",

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -38,7 +38,7 @@
             "entries": ["Your proficiency with one or more weapons allows you utilize their unique features when you use them to attack. When you use the attack action, you may replace any attack with any Weapon Art assigned to that weapon. You may use multiple Weapon Arts per turn, but may not use the same one twice in one turn. You may use Weapon Arts a number of times equal to your proficiency bonus, regaining all uses when you finish a short or long rest. ",
             {
                 "type": "options",
-                "count": "666",
+                "count": 666,
                 "entries": [
                     {
                         "type": "refOptionalfeature",

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -9,8 +9,7 @@
                     "Bovenbrew"
                 ],
                 "version": "1.0",
-                "url": "http://bovenbrew.wikidot.com/",
-                "targetSchema": "1.0"
+                "url": "http://bovenbrew.wikidot.com/"
             }
         ],
         "dateAdded": 1725412983,

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -264,7 +264,8 @@
 					]
 				}
 			],
-			"source": "Bovenbrew Weapon Arts"
+			"source": "Bovenbrew Weapon Arts",
+			"page": ""
 		},
         {
 			"name": "Gaping Wounds",

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -279,7 +279,8 @@
 					]
 				}
 			],
-			"source": "Bovenbrew Weapon Arts"
+			"source": "Bovenbrew Weapon Arts",
+			"page": ""
 		},
         {
 			"name": "Off Balance",

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -247,7 +247,8 @@
 					]
 				}
 			],
-			"source": "Bovenbrew Weapon Arts"
+			"source": "Bovenbrew Weapon Arts",
+			"page": ""
 		},
         {
 			"name": "Dazed",

--- a/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
+++ b/variantrule/Bovenbrew; Bovenbrew Weapon Arts.json
@@ -295,7 +295,8 @@
 					]
 				}
 			],
-			"source": "Bovenbrew Weapon Arts"
+			"source": "Bovenbrew Weapon Arts",
+			"page": ""
 		},
         {
 			"name": "Weak Grip",


### PR DESCRIPTION
An alternative take on the BG3 weapon actions system meant to give weapon users more tactical options compared to their option-rich spellcaster party members. 

Also includes some weapon arts meant to work with exotic weapons that I will upload homebrew for later.