### PR TITLE
Added Orb of Memories to The Prestige: Spells of Illusion

### DIFF
--- a/spell/Johnny Tek; The Prestige Spells of Illusion.json
+++ b/spell/Johnny Tek; The Prestige Spells of Illusion.json
@@ -301,7 +301,7 @@
 		{
 			"name": "Cage of Unreality",
 			"source": "JohnnyTekThePrestigeSpellsOfIllusion",
-			"page": 44,
+			"page": 43,
 			"level": 7,
 			"school": "I",
 			"time": [
@@ -2609,7 +2609,7 @@
 		{
 			"name": "Illusory Gathering",
 			"source": "JohnnyTekThePrestigeSpellsOfIllusion",
-			"page": 44,
+			"page": 43,
 			"level": 7,
 			"school": "I",
 			"time": [
@@ -3727,9 +3727,66 @@
 			]
 		},
 		{
+			"name": "Orb of Memories",
+			"source": "JohnnyTekThePrestigeSpellsOfIllusion",
+			"page": 28,
+			"level": 2,
+			"school": "I",
+			"time": [
+				{
+					"number": 1,
+					"unit": "minute"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "touch"
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "hour",
+						"amount": 1,
+						"upTo": true
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"You touch a crystal ball, imbuing it with the ability to display mental images. A willing creature in physical contact with the ball can take an action to display a personal memory as a visible image within the ball; another action can be taken to change the memory being displayed. The image being displayed vanishes if the creature sharing the memory ends physical contact with the ball or takes a reaction to stop the memory from being displayed. If you end physical contact with the ball, the spell ends."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "At Higher Levels",
+					"entries": [
+						"When you cast this spell with a slot of 4th level or higher, the ball can emit audible sound as well, to the maximum volume possible without causing harm to others. The sound that is produced is dependent on the memory being displayed. When you cast this spell with a slot of 7th level or higher, every willing creature touching the ball experiences the memory being shared as if the creature is the owner of the memory, with the exception of smell, touch, and taste, which are not shared."
+					]
+				}
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Wizard",
+						"source": "PHB"
+					}
+				]
+			},
+			"miscTags": [
+				"OBJ"
+			]
+		},
+		{
 			"name": "Orbs of Message",
 			"source": "JohnnyTekThePrestigeSpellsOfIllusion",
-			"page": 44,
+			"page": 43,
 			"level": 7,
 			"school": "I",
 			"time": [
@@ -5384,8 +5441,7 @@
 			"range": {
 				"type": "point",
 				"distance": {
-					"type": "feet",
-					"amount": 10
+					"type": "touch"
 				}
 			},
 			"components": {


### PR DESCRIPTION
Added Orb of Memories, which was previously missing. Also updated a few page numbers to be correct and updated "Silent Speak" to be a Touch spell, as it was implied by the text, but not the range listed in the book.