### PR TITLE
Update Poison Potion Press; Shore of Dreams.json

### DIFF
--- a/adventure/Poison Potion Press; Shore of Dreams.json
+++ b/adventure/Poison Potion Press; Shore of Dreams.json
@@ -1533,7 +1533,43 @@
 			],
 			"fluff": {
 				"entries": [
-					"These dinosaur-like creatures resemble large crocodiles but with shorter snouts and longer necks. They have a ridge of blue plates running down their backs and a gaping maw containing rows of sharp teeth. Their proximity to the temple of the Cult of the Crushing Wave has imbued in them some elemental power, which the original inhabitants of the temple bred into the species. "
+					{
+						"type": "section",
+						"name": "Mephits",
+						"entries": [
+							"Mephits are capricious, imp-like creatures native to the elemental planes. They come in six varieties, each one representing the mixture of two elements.",
+							"Ageless tricksters, mephits gather in large numbers on the Elemental Planes and in the Elemental Chaos. They also find their way to the Material Plane, where they prefer to dwell in places where their base elements are abundant. For example, a magma mephit is composed of earth and fire, and it favors volcanic lairs, while an ice mephit, which is composed of air and water, favors frigid locales.",
+							{
+								"type": "entries",
+								"entries": [
+									{
+										"type": "entries",
+										"entries": [
+											{
+												"type": "entries",
+												"name": "Elemental Nature",
+												"entries": [
+													"A mephit doesn't require food, drink, or sleep."
+												]
+											}
+										]
+									}
+								]
+							}
+						]
+					},
+					{
+						"name": "Storm Mephit",
+						"type": "entries",
+						"entries": [
+							{
+								"type": "entries",
+								"entries": [
+									"Composed of water, air, and fire storm mephits..."
+								]
+							}
+						]
+					}
 				]
 			}
 		},


### PR DESCRIPTION
Description for tempest beast was used for the description of the storm mephit.  I updated it with the basic mephit description since there is no description information about storm mephits in the source adventure.