### PR TITLE
eliminate external-internal refs

### DIFF
--- a/background/DaveParkinglot; SelerimBackgroundEdits.json
+++ b/background/DaveParkinglot; SelerimBackgroundEdits.json
@@ -107,8 +107,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Acolyte.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Acolyte.webp"
 					}
 				},
 				{
@@ -427,8 +427,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Artisan.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Artisan.webp"
 					}
 				},
 				{
@@ -746,8 +746,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Charlatan.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Charlatan.webp"
 					}
 				},
 				{
@@ -1118,8 +1118,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Criminal.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Criminal.webp"
 					}
 				},
 				{
@@ -1496,8 +1496,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Entertainer.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Entertainer.webp"
 					}
 				},
 				{
@@ -1884,8 +1884,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Farmer.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Farmer.webp"
 					}
 				},
 				{
@@ -2217,8 +2217,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Guard.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Guard.webp"
 					}
 				},
 				{
@@ -2547,8 +2547,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Guide.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Guide.webp"
 					}
 				},
 				{
@@ -2878,8 +2878,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Hermit.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Hermit.webp"
 					}
 				},
 				{
@@ -3250,8 +3250,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Merchant.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Merchant.webp"
 					}
 				},
 				{
@@ -3668,8 +3668,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Noble.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Noble.webp"
 					}
 				},
 				{
@@ -3995,8 +3995,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Sage.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Sage.webp"
 					}
 				},
 				{
@@ -4369,8 +4369,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Sailor.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Sailor.webp"
 					}
 				},
 				{
@@ -4694,8 +4694,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Scribe.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Scribe.webp"
 					}
 				},
 				{
@@ -5025,8 +5025,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Soldier.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Soldier.webp"
 					}
 				},
 				{
@@ -5407,8 +5407,8 @@
 				{
 					"type": "image",
 					"href": {
-						"type": "external",
-						"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/backgrounds/XPHB/Wayfarer.webp"
+						"type": "internal",
+						"path": "backgrounds/XPHB/Wayfarer.webp"
 					}
 				},
 				{

--- a/book/MCDM Productions; Arcadia Issue 19.json
+++ b/book/MCDM Productions; Arcadia Issue 19.json
@@ -711,10 +711,6 @@
 				"type": "external",
 				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/Arcadia19/Artimitei.webp"
 			},
-			"foundryTokenSubjectHref": {
-				"type": "external",
-				"url": "https://raw.githubusercontent.com/5etools-mirror-1/foundry-token-subjects/refs/heads/master/img/bestiary/token-subjects/MM/Deva.webp"
-			},
 			"hasFluff": true,
 			"hasFluffImages": true
 		},

--- a/class/Dusk Zargoth; Barbarian Rework.json
+++ b/class/Dusk Zargoth; Barbarian Rework.json
@@ -25,7 +25,6 @@
 		{
 			"name": "Barbarian Rework",
 			"source": "DZC:ANA:B",
-			"foundryImg": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/classes/PHB/Barbarian.webp",
 			"page": 1,
 			"hd": {
 				"number": 1,
@@ -1479,6 +1478,15 @@
 							]
 						}
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "classes/PHB/Barbarian.webp"
+					}
 				}
 			]
 		}

--- a/class/Dusk Zargoth; Fighter Rework.json
+++ b/class/Dusk Zargoth; Fighter Rework.json
@@ -34,7 +34,6 @@
 		{
 			"name": "Fighter Rework",
 			"source": "DZC:ANA:F",
-			"foundryImg": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/classes/PHB/Fighter.webp",
 			"page": 1,
 			"hd": {
 				"number": 1,
@@ -2953,6 +2952,15 @@
 							]
 						}
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "classes/PHB/Fighter.webp"
+					}
 				}
 			]
 		}

--- a/class/Dusk Zargoth; Monk Rework.json
+++ b/class/Dusk Zargoth; Monk Rework.json
@@ -46,7 +46,6 @@
 		{
 			"name": "Monk Rework",
 			"source": "DZC:ANA:M",
-			"foundryImg": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/classes/PHB/Monk.webp",
 			"page": 1,
 			"hd": {
 				"number": 1,
@@ -4368,6 +4367,15 @@
 							]
 						}
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "classes/PHB/Monk.webp"
+					}
 				}
 			]
 		}

--- a/class/Dusk Zargoth; Rogue Rework.json
+++ b/class/Dusk Zargoth; Rogue Rework.json
@@ -33,7 +33,6 @@
 		{
 			"name": "Rogue Rework",
 			"source": "DZC:ANA:Ro",
-			"foundryImg": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/classes/PHB/Rogue.webp",
 			"page": 1,
 			"hd": {
 				"number": 1,
@@ -2426,6 +2425,15 @@
 							]
 						}
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "internal",
+						"path": "classes/PHB/Rogue.webp"
+					}
 				}
 			]
 		}

--- a/collection/Niels de Jong; Legacy of the Dragon.json
+++ b/collection/Niels de Jong; Legacy of the Dragon.json
@@ -14011,9 +14011,9 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"tokenHref": {
-				"type": "external",
-				"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/ERLW/Valenar%20Hound.webp"
+			"token": {
+				"name": "Valenar Hound",
+				"source": "ERLW"
 			},
 			"fluff": {
 				"entries": [
@@ -14023,8 +14023,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/ERLW/Valenar%20Hound.webp"
+							"type": "internal",
+							"path": "bestiary/ERLW/Valenar Hound.webp"
 						}
 					}
 				]
@@ -30418,8 +30418,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/races/PHB/Dragonborn.webp"
+							"type": "internal",
+							"path": "races/PHB/Dragonborn.webp"
 						}
 					}
 				]
@@ -30862,8 +30862,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/races/EEPC/Genasi.webp"
+							"type": "internal",
+							"path": "races/EEPC/Genasi.webp"
 						}
 					}
 				]
@@ -34923,8 +34923,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/races/EEPC/Genasi.webp"
+							"type": "internal",
+							"path": "races/EEPC/Genasi.webp"
 						}
 					}
 				]
@@ -35043,8 +35043,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/races/EEPC/Genasi.webp"
+							"type": "internal",
+							"path": "races/EEPC/Genasi.webp"
 						}
 					}
 				]
@@ -35166,8 +35166,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/races/EEPC/Genasi.webp"
+							"type": "internal",
+							"path": "races/EEPC/Genasi.webp"
 						}
 					}
 				]
@@ -35301,8 +35301,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/races/EEPC/Genasi.webp"
+							"type": "internal",
+							"path": "races/EEPC/Genasi.webp"
 						}
 					}
 				]

--- a/collection/Zordnael; Curse Of Strahd.json
+++ b/collection/Zordnael; Curse Of Strahd.json
@@ -392,13 +392,16 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/MM/Incubus.webp"
+							"type": "internal",
+							"path": "bestiary/MM/Incubus.webp"
 						}
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/MM/Incubus.webp",
+			"token": {
+				"name": "Incubus",
+				"source": "MM"
+			},
 			"soundClip": {
 				"type": "internal",
 				"path": "bestiary/succubus-incubus.mp3"

--- a/creature/Tychi101; Tychi101's Creatures.json
+++ b/creature/Tychi101; Tychi101's Creatures.json
@@ -504,13 +504,16 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/Archer.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/VGM/Archer.webp"
 						}
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/Archer.webp",
+			"token": {
+				"name": "Archer",
+				"source": "VGM"
+			},
 			"actionTags": [
 				"Multiattack"
 			],
@@ -638,7 +641,10 @@
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/GGR/Soldier.webp",
+			"token": {
+				"name": "Soldier",
+				"source": "GGR"
+			},
 			"actionTags": [
 				"Multiattack"
 			],
@@ -761,7 +767,10 @@
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Veteran.webp",
+			"token": {
+				"name": "Veteran",
+				"source": "MM"
+			},
 			"actionTags": [
 				"Multiattack"
 			],
@@ -860,13 +869,16 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/Guard Drake.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/VGM/Guard Drake.webp"
 						}
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/White Guard Drake.webp",
+			"token": {
+				"name": "White Guard Drake",
+				"source": "VGM"
+			},
 			"senseTags": [
 				"D"
 			],
@@ -1002,13 +1014,16 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/Swashbuckler.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/VGM/Swashbuckler.webp"
 						}
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/VGM/Swashbuckler.webp",
+			"token": {
+				"name": "Swashbuckler",
+				"source": "VGM"
+			},
 			"traitTags": [
 				"Fey Ancestry"
 			],
@@ -1104,7 +1119,10 @@
 					}
 				]
 			},
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Commoner.webp",
+			"token": {
+				"name": "Commoner",
+				"source": "MM"
+			},
 			"languageTags": [
 				"C"
 			],
@@ -1629,7 +1647,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/Druid.webp",
+			"token": {
+				"name": "Druid",
+				"source": "MM"
+			},
 			"fluff": {
 				"name": "Druid",
 				"source": "MM",
@@ -1650,8 +1671,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Druid.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Druid.webp"
 						}
 					}
 				]
@@ -1782,7 +1803,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/ERLW/Karrnathi Undead Soldier.webp",
+			"token": {
+				"name": "Karrnathi Undead Soldier",
+				"source": "ERLW"
+			},
 			"fluff": {
 				"name": "Karrnathi Undead Soldier",
 				"source": "ERLW",
@@ -1828,8 +1852,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/ERLW/Karrnathi Undead Soldier.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/ERLW/Karrnathi Undead Soldier.webp"
 						}
 					}
 				]
@@ -2012,7 +2036,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/Death Knight.webp",
+			"token": {
+				"name": "Death Knight",
+				"source": "MM"
+			},
 			"fluff": {
 				"name": "Death Knight",
 				"source": "MM",
@@ -2061,8 +2088,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Death Knight.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Death Knight.webp"
 						}
 					}
 				]
@@ -2159,8 +2186,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Mastiff.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Mastiff.webp"
 						}
 					}
 				]
@@ -2259,8 +2286,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Mastiff.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Mastiff.webp"
 						}
 					}
 				]
@@ -2362,8 +2389,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Mastiff.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Mastiff.webp"
 						}
 					}
 				]
@@ -2466,8 +2493,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -2594,8 +2621,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -2718,8 +2745,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -2846,8 +2873,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -2988,8 +3015,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -3130,8 +3157,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -3242,8 +3269,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -3434,8 +3461,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -3578,8 +3605,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -3774,8 +3801,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -3920,8 +3947,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Centaur.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Centaur.webp"
 						}
 					}
 				]
@@ -4307,7 +4334,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MPMM/Necromancer Wizard.webp",
+			"token": {
+				"name": "Necromancer Wizard",
+				"source": "MPMM"
+			},
 			"fluff": {
 				"name": "Necromancer Wizard",
 				"source": "MPMM",
@@ -4315,8 +4345,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MPMM/Necromancer Wizard.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MPMM/Necromancer Wizard.webp"
 						}
 					}
 				],
@@ -4969,7 +4999,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/Nightmare.webp",
+			"token": {
+				"name": "Nightmare",
+				"source": "MM"
+			},
 			"fluff": {
 				"name": "Nightmare",
 				"source": "MM",
@@ -5004,8 +5037,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Nightmare.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Nightmare.webp"
 						}
 					}
 				]
@@ -5130,7 +5163,10 @@
 			"conditionInflict": [
 				"prone"
 			],
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/Rhinoceros.webp",
+			"token": {
+				"name": "Rhinoceros",
+				"source": "MM"
+			},
 			"senses": [
 				"darkvision 60 ft."
 			],
@@ -5302,7 +5338,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/Cult Fanatic.webp",
+			"token": {
+				"name": "Cult Fanatic",
+				"source": "MM"
+			},
 			"fluff": {
 				"name": "Cult Fanatic",
 				"source": "MM",
@@ -5323,8 +5362,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Cult Fanatic.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Cult Fanatic.webp"
 						}
 					}
 				]
@@ -5431,7 +5470,10 @@
 			],
 			"hasFluff": true,
 			"hasFluffImages": true,
-			"tokenUrl": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/Cultist.webp",
+			"token": {
+				"name": "Cultist",
+				"source": "MM"
+			},
 			"fluff": {
 				"name": "Cultist",
 				"source": "MM",
@@ -5452,8 +5494,8 @@
 					{
 						"type": "image",
 						"href": {
-							"type": "external",
-							"url": "https://raw.githubusercontent.com/5etools-mirror-2/5etools-img/main/bestiary/tokens/MM/Cultist.webp"
+							"type": "internal",
+							"path": "bestiary/tokens/MM/Cultist.webp"
 						}
 					}
 				]


### PR DESCRIPTION
Suggest using this in the schema `pattern`
`"^https?://(5e\\.tools|5etools-mirror-\\d+\\.github\\.io|raw\\.githubusercontent\\.com\/5etools-mirror-\\d+)/"`