### PR TITLE
Add `additionalSpells` counterparts to existing `subclassSpells`

### DIFF
--- a/adventure/Arcanum Worlds; Odyssey of the Dragonlords.json
+++ b/adventure/Arcanum Worlds; Odyssey of the Dragonlords.json
@@ -247,6 +247,11 @@
 							"dream",
 							"scrying"
 						]
+					},
+					"known": {
+						"1": [
+							"message#c"
+						]
 					}
 				}
 			],
@@ -282,7 +287,7 @@
 				{
 					"expanded": {
 						"s1": [
-							"Detect evil and good",
+							"detect evil and good",
 							"identify"
 						],
 						"s2": [

--- a/adventure/DMsGuild; Rats of Waterdeep.json
+++ b/adventure/DMsGuild; Rats of Waterdeep.json
@@ -1847,6 +1847,24 @@
 				"Master of Pestilence|Druid||Plagues|RatsofWaterdeep|10",
 				"Pestilent Rebirth|Druid||Plagues|RatsofWaterdeep|14"
 			],
+			"additionalSpells": [
+				{
+					"known": {
+						"2": [
+							"infestation|xge#c"
+						]
+					},
+					"prepared": {
+						"6": [
+							"detect poison and disease",
+							"lesser restoration"
+						],
+						"9": [
+							"contagion"
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				"Infestation|xge",
 				"Detect Poison and Disease",
@@ -1861,10 +1879,6 @@
 			"className": "Ranger",
 			"classSource": "PHB",
 			"subclassSpells": [
-				{
-					"className": "Ranger",
-					"classSource": "PHB"
-				},
 				"comprehend languages",
 				"darkness",
 				"fear",
@@ -1876,9 +1890,30 @@
 			"additionalSpells": [
 				{
 					"prepared": {
+						"ritual": {
+							"3": [
+								"animal messenger"
+							]
+						}
+					},
+					"known": {
 						"3": [
-							"animal messenger"
+							"comprehend languages"
 						],
+						"5": [
+							"darkness"
+						],
+						"9": [
+							"fear"
+						],
+						"13": [
+							"greater invisibility"
+						],
+						"17": [
+							"mislead"
+						]
+					},
+					"innate": {
 						"7": [
 							"clairvoyance"
 						]
@@ -1964,6 +1999,12 @@
 			"header": 2,
 			"entries": [
 				"Starting at 10th level, you are immune to disease and gain resistance to poison damage."
+			],
+			"resist": [
+				"poison"
+			],
+			"conditionImmune": [
+				"disease"
 			]
 		},
 		{
@@ -2022,7 +2063,7 @@
 			"name": "Rat Swarm",
 			"entries": [
 				"At 3rd level, you can summon a {@creature swarm of rats} to accompany you and defend you in combat.",
-				"To summon the swarm, you must perform a tenminute ritual within an urban environment. You can perform this ritual a number of times equal to your Wisdom modifier (a minimum of once), but you can only have one swarm active at a time. You regain all expended uses when you finish a long rest. You can use your action to dismiss the swarm, causing it to disassemble and vanish.",
+				"To summon the swarm, you must perform a ten-minute ritual within an urban environment. You can perform this ritual a number of times equal to your Wisdom modifier (a minimum of once), but you can only have one swarm active at a time. You regain all expended uses when you finish a long rest. You can use your action to dismiss the swarm, causing it to disassemble and vanish.",
 				"The swarm acts on its own initiative in combat. On its turn, you can use your Reaction to command the swarm to attack a creature you can see or move its speed to a location you can see. If you don't give the swarm a command, it focuses on protecting you.",
 				"While you have a swarm present, you always have the {@spell animal messenger} spell prepared and can cast it as a ritual. This spell doesn't count against the number of spells you can cast each day."
 			],

--- a/book/Goob the Goblin; A Guide for Warlocks, Mysteries of Magic.json
+++ b/book/Goob the Goblin; A Guide for Warlocks, Mysteries of Magic.json
@@ -72,8 +72,32 @@
 				"Life Drain|Warlock||The Life Giver|GfW:MoM|10|GfW:MoM",
 				"Magical Refresh|Warlock||The Life Giver|GfW:MoM|14|GfW:MoM"
 			],
-			"casterProgression": "pact",
-			"spellcastingAbility": "cha",
+			"additionalSpells": [
+				{
+					"expanded": {
+						"1": [
+							"ray of sickness",
+							"inflict wounds"
+						],
+						"2": [
+							"blindness/deafness",
+							"silence"
+						],
+						"3": [
+							"feign death",
+							"lightning bolt"
+						],
+						"4": [
+							"greater invisibility",
+							"vitriolic sphere"
+						],
+						"5": [
+							"contagion",
+							"bigby's hand"
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				"ray of sickness",
 				"inflict wounds",

--- a/class/AgenderArcee; The Martial Ranger.json
+++ b/class/AgenderArcee; The Martial Ranger.json
@@ -917,6 +917,12 @@
 					}
 				}
 			],
+			"subclassSpells": [
+				"misty step",
+				"dimension door",
+				"teleport",
+				"plane shift"
+			],
 			"subclassFeatures": [
 				"Horizon Walker|Martial Ranger|TMR|Horizon Walker|TMR|3|TMR",
 				"Planar Wanderer|Martial Ranger|TMR|Horizon Walker|TMR|7|TMR",
@@ -1061,19 +1067,36 @@
 				{
 					"known": {
 						"3": [
-							"shillelagh#c"
+							"shillelagh#c",
+							{
+								"choose": "level=0|class=Druid",
+								"count": 2
+							}
+						],
+						"10": [
+							{
+								"choose": "level=0|class=Druid"
+							}
 						]
 					},
 					"innate": {
-						"7": [
-							"speak with animals",
-							"beast sense"
-						],
-						"15": [
-							"speak with plants",
-							"locate creature",
-							"commune with nature"
-						]
+						"7": {
+							"daily": {
+								"1e": [
+									"speak with animals",
+									"beast sense"
+								]
+							}
+						},
+						"15": {
+							"daily": {
+								"1e": [
+									"speak with plants",
+									"locate creature",
+									"commune with nature"
+								]
+							}
+						}
 					}
 				}
 			],
@@ -1085,7 +1108,13 @@
 				{
 					"className": "Ranger",
 					"classSource": "PHB"
-				}
+				},
+				"shillelagh",
+				"speak with animals",
+				"beast sense",
+				"speak with plants",
+				"locate creature",
+				"commune with nature"
 			],
 			"subclassTableGroups": [
 				{

--- a/class/Aussifer; Unchained Warlock.json
+++ b/class/Aussifer; Unchained Warlock.json
@@ -1813,6 +1813,47 @@
 				"Beguiling Defenses|Warlock|UW|Archfey|UW|10",
 				"Dark Delirium|Warlock|UW|Archfey|UW|14"
 			],
+			"additionalSpells": [
+				{
+					"known": {
+						"1": [
+							{
+								"choose": "level=0|class=druid"
+							}
+						]
+					},
+					"expanded": {
+						"1": [
+							"Faerie Fire",
+							"Sleep"
+						],
+						"3": [
+							"Calm Emotions",
+							"Phantasmal Force"
+						],
+						"5": [
+							"Blink",
+							"Plant Growth"
+						],
+						"7": [
+							"Dominate Beast",
+							"Greater Invisibility",
+							"Mirage Arcane"
+						],
+						"9": [
+							"Dominate Person",
+							"Seeming",
+							"shapechange"
+						],
+						"6": [
+							"Transport via Plants"
+						],
+						"8": [
+							"Control Weather"
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				"Faerie Fire",
 				"Sleep",
@@ -1842,6 +1883,52 @@
 				"Radiant Soul|Warlock|UW|Celestial|UW|6",
 				"Celestial Resilience|Warlock|UW|Celestial|UW|10",
 				"Searing Vengeance|Warlock|UW|Celestial|UW|14"
+			],
+			"additionalSpells": [
+				{
+					"expanded": {
+						"1": [
+							"Cure Wounds",
+							"Guiding Bolt"
+						],
+						"3": [
+							"Flaming Sphere",
+							"Lesser Restoration"
+						],
+						"5": [
+							"Daylight",
+							"Revivify"
+						],
+						"7": [
+							"Guardian of Faith",
+							"Wall of Fire",
+							"Conjure Celestial"
+						],
+						"9": [
+							"Greater Restoration",
+							"Holy Weapon|XGE",
+							"True Resurrection"
+						],
+						"6": [
+							"Heal"
+						],
+						"8": [
+							"Sunburst"
+						]
+					},
+					"known": {
+						"1": [
+							{
+								"choose": {
+									"from": [
+										"light#c",
+										"sacred flame#c"
+									]
+								}
+							}
+						]
+					}
+				}
 			],
 			"subclassSpells": [
 				"Cure Wounds",
@@ -1875,6 +1962,40 @@
 				"Fiendish Resilience|Warlock|UW|Fiend|UW|10",
 				"Hurl Through Hell|Warlock|UW|Fiend|UW|14"
 			],
+			"additionalSpells": [
+				{
+					"expanded": {
+						"1": [
+							"Burning Hands",
+							"Command"
+						],
+						"3": [
+							"Blindness/Deafness",
+							"Scorching Ray"
+						],
+						"5": [
+							"Fireball",
+							"Stinking Cloud"
+						],
+						"7": [
+							"Compulsion",
+							"Wall of Fire",
+							"Fire Storm"
+						],
+						"9": [
+							"Hallow",
+							"Immolation|XGE",
+							"Meteor Swarm"
+						],
+						"6": [
+							"Harm"
+						],
+						"8": [
+							"Incendiary Cloud"
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				"Burning Hands",
 				"Command",
@@ -1904,6 +2025,52 @@
 				"Gatekeeper's Bond|Warlock|UW|Gatekeeper|UW|6",
 				"Deathwalker's Shield|Warlock|UW|Gatekeeper|UW|10",
 				"Cycle of Demise|Warlock|UW|Gatekeeper|UW|14"
+			],
+			"additionalSpells": [
+				{
+					"prepared": {
+						"1": [
+							"bane",
+							"sanctuary"
+						],
+						"3": [
+							"silence",
+							"spiritual weapon"
+						],
+						"5": [
+							"blink",
+							"speak with dead"
+						],
+						"7": [
+							"banishment",
+							"locate creature",
+							"sequester"
+						],
+						"9": [
+							"cone of cold",
+							"teleportation circle",
+							"gate"
+						],
+						"6": [
+							"disintegrate"
+						],
+						"8": [
+							"antimagic field"
+						]
+					},
+					"known": {
+						"1": [
+							{
+								"choose": {
+									"from": [
+										"guidance#c",
+										"toll the dead|XGE#c"
+									]
+								}
+							}
+						]
+					}
+				}
 			],
 			"subclassSpells": [
 				"Bane",
@@ -1936,6 +2103,144 @@
 				"Elemental Blessing|Warlock|UW|Genie|UW|6",
 				"Sanctuary Vessel|Warlock|UW|Genie|UW|10",
 				"Limited Wish|Warlock|UW|Genie|UW|14"
+			],
+			"additionalSpells": [
+				{
+					"name": "Dao",
+					"expanded": {
+						"1": [
+							"Sanctuary",
+							"Thunderwave",
+							"Mold Earth|XGE#c"
+						],
+						"3": [
+							"Phantasmal Force",
+							"Spike Growth"
+						],
+						"5": [
+							"Create Food and Water",
+							"Erupting Earth|XGE"
+						],
+						"7": [
+							"Phantasmal Killer",
+							"Stone Shape",
+							"Project Image"
+						],
+						"9": [
+							"Creation",
+							"Wall of Stone",
+							"Wish"
+						],
+						"6": [
+							"Planar Ally"
+						],
+						"8": [
+							"Control Weather"
+						]
+					}
+				},
+				{
+					"name": "Djinni",
+					"expanded": {
+						"1": [
+							"Sanctuary",
+							"Thunderwave",
+							"Gust|XGE#c"
+						],
+						"3": [
+							"Phantasmal Force",
+							"Gust of Wind"
+						],
+						"5": [
+							"Create Food and Water",
+							"Wind Wall"
+						],
+						"7": [
+							"Phantasmal Killer",
+							"Greater Invisibility",
+							"Project Image"
+						],
+						"9": [
+							"Creation",
+							"Seeming",
+							"Wish"
+						],
+						"6": [
+							"Planar Ally"
+						],
+						"8": [
+							"Control Weather"
+						]
+					}
+				},
+				{
+					"name": "Efreeti",
+					"expanded": {
+						"1": [
+							"Sanctuary",
+							"Searing Smite",
+							"Control Flames|XGE#c"
+						],
+						"3": [
+							"Phantasmal Force",
+							"Scorching Ray"
+						],
+						"5": [
+							"Create Food and Water",
+							"Fireball"
+						],
+						"7": [
+							"Phantasmal Killer",
+							"Fire Shield",
+							"Project Image"
+						],
+						"9": [
+							"Creation",
+							"Flame Strike",
+							"Wish"
+						],
+						"6": [
+							"Planar Ally"
+						],
+						"8": [
+							"Control Weather"
+						]
+					}
+				},
+				{
+					"name": "Marid",
+					"expanded": {
+						"1": [
+							"Sanctuary",
+							"Fog Cloud",
+							"Shape Water|XGE#c"
+						],
+						"3": [
+							"Phantasmal Force",
+							"Blur"
+						],
+						"5": [
+							"Create Food and Water",
+							"Control Water"
+						],
+						"7": [
+							"Phantasmal Killer",
+							"Fire Shield",
+							"Project Image"
+						],
+						"9": [
+							"Creation",
+							"Cone of Cold",
+							"Wish"
+						],
+						"6": [
+							"Planar Ally"
+						],
+						"8": [
+							"Control Weather"
+						]
+					}
+				}
 			],
 			"subclassSpells": [
 				"Detect Evil and Good",
@@ -1976,7 +2281,6 @@
 				"Marid": [
 					"Fog Cloud",
 					"Blur",
-					"Tidal Wave|XGE",
 					"Control Water",
 					"Cone of Cold",
 					"Shape Water|XGE"
@@ -1995,6 +2299,41 @@
 				"Entropic Backlash|Warlock|UW|Great Old One|UW|6",
 				"Thought Shield|Warlock|UW|Great Old One|UW|10",
 				"Create Thrall|Warlock|UW|Great Old One|UW|14"
+			],
+			"additionalSpells": [
+				{
+					"prepared": {
+						"1": [
+							"dissonant whispers",
+							"Tasha's hideous laughter",
+							"mind sliver|TCE#c"
+						],
+						"3": [
+							"detect thoughts",
+							"Tasha's mind whip|TCE"
+						],
+						"5": [
+							"clairvoyance",
+							"sending"
+						],
+						"7": [
+							"confusion",
+							"evard's black tentacles",
+							"symbol"
+						],
+						"9": [
+							"dominate person",
+							"telekinesis",
+							"time stop"
+						],
+						"6": [
+							"programmed illusion"
+						],
+						"8": [
+							"mind blank"
+						]
+					}
+				}
 			],
 			"subclassSpells": [
 				"Dissonant Whispers",
@@ -2027,6 +2366,40 @@
 				"Armor of Hexes|Warlock|UW|Hexblade|UW|10",
 				"Master of Hexes|Warlock|UW|Hexblade|UW|14"
 			],
+			"additionalSpells": [
+				{
+					"prepared": {
+						"1": [
+							"wrathful smite",
+							"shield"
+						],
+						"3": [
+							"blur",
+							"magic weapon"
+						],
+						"5": [
+							"blink",
+							"elemental weapon"
+						],
+						"7": [
+							"phantasmal killer",
+							"staggering smite",
+							"mordenkainen's sword"
+						],
+						"9": [
+							"banishing smite",
+							"cone of cold",
+							"time stop"
+						],
+						"6": [
+							"blade barrier"
+						],
+						"8": [
+							"illusory dragon|XGE"
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				"Shield",
 				"Wrathful Smite",
@@ -2057,6 +2430,40 @@
 				"Devouring Depths|Warlock|UW|Leviathan|UW|10",
 				"Call of the Leviathan|Warlock|UW|Leviathan|UW|14"
 			],
+			"additionalSpells": [
+				{
+					"prepared": {
+						"1": [
+							"create or destroy water",
+							"thunderwave"
+						],
+						"3": [
+							"gust of wind",
+							"silence"
+						],
+						"5": [
+							"lightning bolt",
+							"sleet storm"
+						],
+						"7": [
+							"control water",
+							"summon elemental|TCE",
+							"teleport"
+						],
+						"9": [
+							"bigby's hand",
+							"cone of cold",
+							"storm of vengeance"
+						],
+						"6": [
+							"chain lightning"
+						],
+						"8": [
+							"tsunami"
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				"Create or Destroy Water",
 				"Thunderwave",
@@ -2086,6 +2493,52 @@
 				"Indelible Censure|Warlock|UW|Logos|UW|6",
 				"Infusion of Eloquence|Warlock|UW|Logos|UW|10",
 				"The True Word|Warlock|UW|Logos|UW|14"
+			],
+			"additionalSpells": [
+				{
+					"prepared": {
+						"1": [
+							"command",
+							"healing word"
+						],
+						"3": [
+							"blindness/deafness",
+							"suggestion"
+						],
+						"5": [
+							"sending",
+							"tongues"
+						],
+						"7": [
+							"banishment",
+							"compulsion",
+							"divine word"
+						],
+						"9": [
+							"dominate person",
+							"rary's telepathic bond",
+							"power word heal"
+						],
+						"6": [
+							"word of recall"
+						],
+						"8": [
+							"telepathy"
+						]
+					},
+					"known": {
+						"1": [
+							{
+								"choose": {
+									"from": [
+										"vicious mockery#c",
+										"word of radiance|XGE#c"
+									]
+								}
+							}
+						]
+					}
+				}
 			],
 			"subclassSpells": [
 				"Command",
@@ -2118,6 +2571,41 @@
 				"Touch of the Grave|Warlock|UW|Undying|UW|6",
 				"Mortal Husk|Warlock|UW|Undying|UW|10",
 				"Spirit Projection|Warlock|UW|Undying|UW|14"
+			],
+			"additionalSpells": [
+				{
+					"prepared": {
+						"1": [
+							"bane",
+							"false life",
+							"spare the dying#c"
+						],
+						"3": [
+							"blindness/deafness",
+							"phantasmal force"
+						],
+						"5": [
+							"feign death",
+							"speak with dead"
+						],
+						"6": [
+							"magic jar"
+						],
+						"7": [
+							"death ward",
+							"greater invisibility",
+							"regenerate"
+						],
+						"8": [
+							"clone"
+						],
+						"9": [
+							"antilife shell",
+							"contagion",
+							"invulnerability|XGE"
+						]
+					}
+				}
 			],
 			"subclassSpells": [
 				"Bane",

--- a/class/Avaricium; Arbiter.json
+++ b/class/Avaricium; Arbiter.json
@@ -694,6 +694,34 @@
 			],
 			"casterProgression": "1/3",
 			"spellcastingAbility": "wis",
+			"additionalSpells": [
+				{
+					"known": {
+						"1": [
+							{
+								"choose": "level=0|class=cleric"
+							}
+						],
+						"3": [
+							{
+								"choose": "level=0|class=cleric"
+							}
+						],
+						"10": [
+							{
+								"choose": "level=0|class=cleric"
+							}
+						]
+					},
+					"expanded": {
+						"3": [
+							{
+								"all": "class=cleric"
+							}
+						]
+					}
+				}
+			],
 			"subclassSpells": [
 				{
 					"className": "Cleric",
@@ -1717,12 +1745,10 @@
 				{
 					"type": "entries",
 					"name": "Spellcasting Ability",
-					"page": 0,
 					"entries": [
 						"Wisdom is your spellcasting ability for your cleric spells. The power of your spells comes from the primordial threads that you possess, awakened by your adherence to the person you aid. You use your Wisdom whenever a cleric spell refers to your spellcasting ability. In addition, you use your Wisdom modifier when setting the saving throw DC for a cleric spell you cast and when making an attack roll with one.",
 						{
 							"type": "inset",
-							"name": "",
 							"entries": [
 								{
 									"type": "abilityDc",

--- a/class/aiir_; Unearthed Aiircana Red Mage.json
+++ b/class/aiir_; Unearthed Aiircana Red Mage.json
@@ -610,6 +610,73 @@
 				"Minor Dualcast|Red Mage|aiirRedMage|Red Wizard|aiirRedMage|11",
 				"Vermilion Spells|Red Mage|aiirRedMage|Red Wizard|aiirRedMage|14"
 			],
+			"additionalSpells": [
+				{
+					"known": {
+						"3": [
+							{
+								"choose": {
+									"from": [
+										"cure wounds",
+										"Ice Knife|XGE"
+									]
+								}
+							}
+						],
+						"4": [
+							{
+								"choose": {
+									"from": [
+										"Enhance Ability",
+										"Shatter"
+									]
+								}
+							}
+						],
+						"7": [
+							{
+								"choose": {
+									"from": [
+										"Fireball",
+										"Haste"
+									]
+								}
+							}
+						],
+						"10": [
+							{
+								"choose": {
+									"from": [
+										"Stoneskin",
+										"Wall of Fire"
+									]
+								}
+							}
+						],
+						"13": [
+							{
+								"choose": {
+									"from": [
+										"Cone of Cold",
+										"Mass Cure Wounds"
+									]
+								}
+							}
+						]
+					},
+					"resourceName": "Balance Die",
+					"innate": {
+						"14": {
+							"resource": {
+								"1": [
+									"Verflare|aiirRedMage",
+									"Verholy|aiirRedMage"
+								]
+							}
+						}
+					}
+				}
+			],
 			"subclassSpells": [
 				"Cure Wounds",
 				"Ice Knife|XGE",


### PR DESCRIPTION
- Does not add `additionalSpells` to everything, only tries to ensure no data loss on deprecation of `subclassSpells`
- Some bonus typo/tag fixes