### PR TITLE
Updated Storm Mephit

### DIFF
--- a/adventure/Poison Potion Press; Shore of Dreams.json
+++ b/adventure/Poison Potion Press; Shore of Dreams.json
@@ -1545,7 +1545,8 @@
 			],
 			"savingThrowForced": [
 				"dexterity"
-			]
+			],
+			"hasFluff": true
 		},
 		{
 			"name": "Tempest Beast",

--- a/adventure/Poison Potion Press; Shore of Dreams.json
+++ b/adventure/Poison Potion Press; Shore of Dreams.json
@@ -23,7 +23,7 @@
 		"dateLastModified": 1729630006,
 		"_dateLastModifiedHash": "a351ce05fa",
 		"edition": "classic",
-		"internalCopies": {
+		"dependencies": {
 			"monsterFluff": [
 				"MM"
 			]

--- a/adventure/Poison Potion Press; Shore of Dreams.json
+++ b/adventure/Poison Potion Press; Shore of Dreams.json
@@ -23,7 +23,7 @@
 		"dateLastModified": 1729630006,
 		"_dateLastModifiedHash": "a351ce05fa",
 		"edition": "classic",
-		"dependencies": {
+		"internalCopies": {
 			"monsterFluff": [
 				"MM"
 			]

--- a/adventure/Poison Potion Press; Shore of Dreams.json
+++ b/adventure/Poison Potion Press; Shore of Dreams.json
@@ -20,7 +20,7 @@
 			}
 		],
 		"dateAdded": 0,
-		"dateLastModified": 1729630006,
+		"dateLastModified": 1735017286,
 		"_dateLastModifiedHash": "a351ce05fa",
 		"edition": "classic",
 		"dependencies": {

--- a/adventure/Poison Potion Press; Shore of Dreams.json
+++ b/adventure/Poison Potion Press; Shore of Dreams.json
@@ -22,8 +22,23 @@
 		"dateAdded": 0,
 		"dateLastModified": 1729630006,
 		"_dateLastModifiedHash": "a351ce05fa",
-		"edition": "classic"
+		"edition": "classic",
+		"dependencies": {
+			"monsterFluff": [
+				"MM"
+			]
+		}
 	},
+	"monsterFluff": [
+		{
+			"name": "Storm Mephit",
+			"source": "SOD",
+			"_copy": {
+				"name": "Mephits",
+				"source": "MM"
+			}
+		}
+	],
 	"adventure": [
 		{
 			"name": "Shore of Dreams",
@@ -1530,12 +1545,7 @@
 			],
 			"savingThrowForced": [
 				"dexterity"
-			],
-			"fluff": {
-				"entries": [
-					"These dinosaur-like creatures resemble large crocodiles but with shorter snouts and longer necks. They have a ridge of blue plates running down their backs and a gaping maw containing rows of sharp teeth. Their proximity to the temple of the Cult of the Crushing Wave has imbued in them some elemental power, which the original inhabitants of the temple bred into the species. "
-				]
-			}
+			]
 		},
 		{
 			"name": "Tempest Beast",


### PR DESCRIPTION
Updated Storm Mephit to use the Mephits monsterFluff from MM, instead of erroneous description of tempest beast.