### PR TITLE
Resolve Occasional Link Error in TGS Book 2

### DIFF
--- a/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 2.json
+++ b/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 2.json
@@ -17788,7 +17788,7 @@
 						"type": "image",
 						"href": {
 							"type": "external",
-							"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/GriffonsSaddlebag2/Items/Seraphim's-Stiletto.webp"
+							"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/GriffonsSaddlebag2/Items/Seraphim%E2%80%99s-Stiletto.webp"
 						}
 					}
 				]
@@ -20017,7 +20017,7 @@
 						"type": "image",
 						"href": {
 							"type": "external",
-							"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/GriffonsSaddlebag2/Items/Thomas'-Dimensional-Trousers.webp"
+							"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/GriffonsSaddlebag2/Items/Thomas%E2%80%99-Dimensional-Trousers.webp"
 						}
 					}
 				]

--- a/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 3.json
+++ b/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 3.json
@@ -32494,6 +32494,8 @@
 				"tier": "major",
 				"reqAttune": true,
 				"bonusWeapon": "+1",
+				"bonusSavingThrow": "+1",
+				"bonusSa
 				"entries": [
 					"An Ioun blade is named after Ioun, a god of knowledge and prophecy revered on some worlds. You gain a {=bonusWeapon} bonus to attack and damage rolls made with this magic weapon. The blade and crossguard are each inset with a gemstone. While you're attuned to the weapon, you also gain a {=bonusSavingThrow} bonus to Intelligence, Wisdom, and Charisma checks and saving throws.",
 					"If you're also attuned to an {@item Ioun stone}, you don't need to attune to this weapon to use its properties. Furthermore, you can choose to have that stone magically replace one of the gemstones in the sword, instead of having it orbit your head. For each replaced stone, the sword's bonuses increase by 1."

--- a/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 3.json
+++ b/collection/Griffin Macaulay; The Griffon's Saddlebag, Book 3.json
@@ -32495,7 +32495,6 @@
 				"reqAttune": true,
 				"bonusWeapon": "+1",
 				"bonusSavingThrow": "+1",
-				"bonusSa
 				"entries": [
 					"An Ioun blade is named after Ioun, a god of knowledge and prophecy revered on some worlds. You gain a {=bonusWeapon} bonus to attack and damage rolls made with this magic weapon. The blade and crossguard are each inset with a gemstone. While you're attuned to the weapon, you also gain a {=bonusSavingThrow} bonus to Intelligence, Wisdom, and Charisma checks and saving throws.",
 					"If you're also attuned to an {@item Ioun stone}, you don't need to attune to this weapon to use its properties. Furthermore, you can choose to have that stone magically replace one of the gemstones in the sword, instead of having it orbit your head. For each replaced stone, the sword's bonuses increase by 1."


### PR DESCRIPTION
When utilizing the ttrpg-cli software, I ran into issues pulling two images from TGS Book 2 which appear to be related to characters in the image link. I modified the image links to properly match the ones that were set up in the 'gallery' section. 

I also added a change to TGS Book 3 to resolve a missing bonusSavingThrow.