### PR TITLE
Create School of Arcane Strategy Subclass

### DIFF
--- a/subclass/School of Arcane Strategy Subclass
+++ b/subclass/School of Arcane Strategy Subclass
@@ -1,0 +1,141 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "School of Arcane Strategy Subclass",
+				"abbreviation": "SAS",
+				"full": "School of Arcane Strategy",
+				"authors": [
+					"Seraph"
+				],
+				"convertedBy": [
+					"Seraph"
+				],
+				"version": "2025/05/24",
+				"dateReleased": "2025/05/24",
+				"url": "https://github.com/School of Arcane Strategy"
+			}
+		],
+		"dateAdded": 1694700000,
+		"dateLastModified": 1729630006,
+		"_dateLastModifiedHash": "e2a1aa6f68",
+		"edition": "classic"
+	},
+	"subclass": [
+		{
+			"name": "School of Arcane Strategy",
+			"shortName": "Arcane Strategy",
+			"source": "School of Arcane Strategy Subclass",
+			"className": "Wizard",
+			"classSource": "PHB",
+			"page": 1,
+			],
+			"subclassFeatures": [
+				"Voice of Strategy|Wizard|Arcane Strategy|School of Arcane Strategy Subclass|3",
+				"Guided Strike|Wizard|Arcane Strategy|School of Arcane Strategy Subclass|3",
+				"Full Battlefield Control|Wizard|Arcane Strategy|School of Arcane Strategy Subclass|6",
+				"Command Troops|Wizard|Arcane Strategy|School of Arcane Strategy Subclass|10",
+				"Tactical Wit|Wizard|Arcane Strategy|School of Arcane Strategy Subclass|10",
+				"Calculated Foresight|Wizard|Arcane Strategy|School of Arcane Strategy Subclass|14",
+			]
+		}
+	],
+	"subclassFeature": [
+		{
+			"name": "School of Arcane Strategy",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 3,
+			"entries": [
+				"Wizards who master Arcane Strategy prefer to stay in the backlines, forsaking the flashy spells of other schools to focus on battlefield manipulation and control. They turn every encounter into a calculated victory through meticulous enemy analysis and ally empowerment.",
+			]
+		},
+		{
+			"name": "Voice of Strategy",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"When you cast a 1st-level or higher spell on an ally, that ally can immediately use their reaction to make a weapon attack."
+			]
+		},
+		{
+			"name": "Guided Strike",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"When you or an ally misses an attack, you can use your reaction and expend a spell slot to grant a +10 bonus to that attack roll."
+			]
+		},
+		{
+      "name": "Full Battlefield Control",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 6,
+			"header": 1,
+			"entries": [
+				"While concentrating on a spell, you can expend 2 spell slots to cast a second concentration spell without losing concentration on the first. However, you roll concentration checks with disadvantage. If you fail, you lose concentration on both spells."
+			]
+		},
+		{
+      "name": "Command Troops",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 10,
+			"header": 1,
+			"entries": [
+				"Your commanding presence empowers your allies. While concentrating on a spell, you radiate an aura of confidence within 60 feet. Each ally in the aura can, as a bonus action, either Dash, Disengage, or add 1d4 to all their damage rolls for that turn."
+			]
+		},
+		{
+      "name": "Tactical Wit",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 10,
+			"header": 1,
+			"entries": [
+				"You add your Intelligence modifier to Initiative rolls."
+			]
+		},
+		{
+      "name": "Calculated Foresight",
+			"source": "School of Arcane Strategy Subclass",
+			"page": 1,
+			"className": "Wizard",
+			"classSource": "PHB",
+			"subclassShortName": "Arcane Strategy",
+			"subclassSource": "School of Arcane Strategy Subclass",
+			"level": 14,
+			"header": 1,
+			"entries": [
+				"You have learned to anticipate your enemies’ moves before they happen. Once per short rest, when a creature within 60 feet makes an attack roll, ability check, or saving throw, you can use your reaction to impose disadvantage or force them to reroll the die and take the lower result."
+			]
+		},
+		{


### PR DESCRIPTION
Wizards who master Arcane Strategy prefer to stay in the backlines, forsaking the flashy spells of other schools to focus on battlefield manipulation and control. They turn every encounter into a calculated victory through meticulous enemy analysis and ally empowerment.