### PR TITLE
Add missing spell to Vulpin species

### DIFF
--- a/collection/Hit Point Press; Humblewood Campaign Setting.json
+++ b/collection/Hit Point Press; Humblewood Campaign Setting.json
@@ -2689,6 +2689,13 @@
 				{
 					"ability": "int",
 					"innate": {
+						"1": {
+							"daily": {
+								"1": [
+									"charm person"
+								]
+							}
+						},
 						"3": {
 							"daily": {
 								"1": [


### PR DESCRIPTION
I noticed the Vulpin is missing "Charm Person" in their innate spellcasting in Foundry. This PR adds it in.

I'd also like to fix the fact that 'Bite' isn't given to the Actor as an action, but I haven't worked out yet how to add it while keeping the `finesse` property.