### PR TITLE
fix Beastheart starting equipment

### DIFF
--- a/class/MCDM Productions; Beastheart.json
+++ b/class/MCDM Productions; Beastheart.json
@@ -80,7 +80,7 @@
 				"defaultData": [
 					{
 						"a": [
-							"chain mail|phb"
+							"hide armor|phb"
 						],
 						"b": [
 							"leather armor|phb",


### PR DESCRIPTION
The text of `startingEquipment` correctly lists hide armor as the first equipment option on line 1, but the VTT data has chain mail instead. This PR fixes the VTT data.