### PR TITLE
Update KibblesTasty; Kibbles' Compendium of Legends and Legacies.json

### DIFF
--- a/collection/KibblesTasty; Kibbles' Compendium of Legends and Legacies.json
+++ b/collection/KibblesTasty; Kibbles' Compendium of Legends and Legacies.json
@@ -50,7 +50,7 @@
 		},
 		"status": "ready",
 		"dateAdded": 1559943252,
-		"dateLastModified": 1759591649,
+		"dateLastModified": 1759945486,
 		"_dateLastModifiedHash": "e7d7d95437",
 		"edition": "classic"
 	},
@@ -21966,7 +21966,8 @@
 		{
 			"name": "Aldricor's Elemental Rebuke",
 			"source": "TheArenaGuy",
-			"level": 208,
+			"page": 208,
+			"level": 2,
 			"school": "V",
 			"components": {
 				"s": true
@@ -36985,7 +36986,8 @@
 		{
 			"name": "Time Slip",
 			"source": "KT-CLL",
-			"level": 262,
+			"page": 262,
+			"level": 2,
 			"school": "T",
 			"time": [
 				{


### PR DESCRIPTION
-Fixed Typo: 'Time Slip' and 'Aldricor's Elemental Rebuke' spell's level. The 'level' was incorrectly displaying the 'page' count.