### PR TITLE
Change AAA edition from 'one' to 'classic'

### DIFF
--- a/collection/FungusAmongUs; Abi-Dalzim's Abhorrent Adventurers.json
+++ b/collection/FungusAmongUs; Abi-Dalzim's Abhorrent Adventurers.json
@@ -21,7 +21,7 @@
 		"optionalFeatureTypes": {
 			"CD": "Channel Divinity"
 		},
-		"edition": "one",
+		"edition": "classic",
 		"_dateLastModifiedHash": "c06ede570a"
 	},
 	"item": [


### PR DESCRIPTION
Update Abi-Dalzim's version from "one" to "classic" to make it appear in both versions of the site. 