### PR TITLE
fix(OneShotWondersHolidayPack): No U's allowed in the USA

### DIFF
--- a/adventure/Roll & Play Press; One Shot Wonders - Holiday Adventure Pack.json
+++ b/adventure/Roll & Play Press; One Shot Wonders - Holiday Adventure Pack.json
@@ -4412,7 +4412,8 @@
 									"type": "statblock",
 									"tag": "item",
 									"source": "OneShotWondersHolidayPack",
-									"name": "Partridge Armour",
+									"name": "Partridge Armor",
+									"displayName": "Partridge Armour",
 									"style": "narrow"
 								},
 								{


### PR DESCRIPTION
Note the entire source uses the `en-GB` version throughout but someone decided the item itself had to be `en-US`.