### PR TITLE
fix: typo

### DIFF
--- a/book/2CGaming; Total Party Kill Bestiary - Vol. 1.json
+++ b/book/2CGaming; Total Party Kill Bestiary - Vol. 1.json
@@ -15991,7 +15991,7 @@
 				"Rejuvenation"
 			],
 			"group": [
-				"Greater liches"
+				"Greater Liches"
 			],
 			"action": [
 				{


### PR DESCRIPTION
Fix inconsistent capitalization of 'Greater liches' to 'Greater Liches' which caused one monster not to be grouped with others.