### PR TITLE
Added `FluffImages:` lines to (some of) Ryoko's Guide to the Yokai Realms entries

### DIFF
--- a/collection/Loot Tavern; Ryoko's Guide to Yokai Realms.json
+++ b/collection/Loot Tavern; Ryoko's Guide to Yokai Realms.json
@@ -14866,7 +14866,7 @@
 					"type": "entries",
 					"name": "Ice Craft",
 					"entries": [
-						"You gain proficiency with one of the following artisan's tools: {@item Carpenter's Tools|PHB}, {@item Glassblower's Tools|PHB}, {@item Jeweler's Tools|PHB}, {@item Mason's Tools|PHB}, {@item Potter's Tools|PHB}, or {@item Smith's Tools|PHB}. You have {@bold advantage} on ability checks you make to use these tools to shape ice.."
+						"You gain proficiency with one of the following artisan's tools: {@item Carpenter's Tools|PHB}, {@item Glassblower's Tools|PHB}, {@item Jeweler's Tools|PHB}, {@item Mason's Tools|PHB}, {@item Potter's Tools|PHB}, or {@item Smith's Tools|PHB}. You have {@bold advantage} on ability checks you make to use these tools to shape ice."
 					]
 				},
 				{
@@ -14884,7 +14884,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Fuyoren",
@@ -15002,7 +15003,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Hanamori",
@@ -15123,7 +15125,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Haniwa",
@@ -15254,7 +15257,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Isetsu",
@@ -15516,7 +15520,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Oniborne",
@@ -15598,7 +15603,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Ryokido",
@@ -15726,7 +15732,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Tatsumi",
@@ -15866,7 +15873,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Tengu",
@@ -15953,7 +15961,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		}
 	],
 	"subrace": [
@@ -16015,7 +16024,8 @@
 					"type": "entries"
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Springtail",
@@ -16093,7 +16103,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Red Oniborne",
@@ -16158,7 +16169,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Blue Oniborne",
@@ -16207,7 +16219,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Green Oniborne",
@@ -16588,7 +16601,8 @@
 					}
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Hanataka",
@@ -16667,7 +16681,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		},
 		{
 			"name": "Karasu",
@@ -16719,7 +16734,8 @@
 					]
 				}
 			],
-			"hasFluff": true
+			"hasFluff": true,
+			"hasFluffImages": true
 		}
 	],
 	"raceFluff": [
@@ -16792,6 +16808,15 @@
 						"Every bit as rugged, resolute, and unflinching as the frigid mountains they call home, hulking enkoh are known for their fierce, calculating minds and explosive physical strength. Rarely do hulking enkoh act swiftly; they prefer to assess, analyse, and contemplate before choosing a path. However, when moved to action, the mountains move with them."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/EnkohHulking.webp"
+					}
+				}
 			]
 		},
 		{
@@ -16832,6 +16857,15 @@
 						"Vibrant, dynamic, and swift, springtail enkoh are the more sociable of their race. Their bonds of fellowship extend to the environment around them; they are masters of taming beasts of land and sky for both work and companionship. Rarely sitting still, springtails walk, speak, and trust quickly."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/EnkohSpringtail.webp"
+					}
+				}
 			]
 		},
 		{
@@ -16859,6 +16893,15 @@
 					"entries": [
 						"Kaiju are feared and worshipped by the fuyoren for their power to obliterate swathes of an environment through their presence alone. Many fuyoren cultural traditions include dances, festivals, and ceremonies which aim to placate such behemoths. Bolder fuyoren may actively seek rampaging kaiju, drawing them away from societies and fragile ecosystems and into the untamed wilderness, usually at the cost of their own lives. Bakuryo and other kaiju that do not interfere with the natural world are revered by the fuyoren, while Raiko and other chaotic beings of wanton destructive force are hated and feared."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Fuyoren.webp"
+					}
 				}
 			]
 		},
@@ -16888,6 +16931,15 @@
 						"Hanamori are naturally passionate and active. They think, speak, and adapt swiftly and are known for their fiery tempers and zealous loyalty. With short lives, hanamori see little value in holding grudges or overanalysing a situation, preferring to think on their feet and revel in the heat of each moment. A hanamori's emotional state can be read on its body: its petals blush darkly when enraged, and the tips of its branches sprout new buds during periods of prolonged grief. It is said that if a hanamori loses a true love, it will forever bloom."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Hanamori.webp"
+					}
+				}
 			]
 		},
 		{
@@ -16908,6 +16960,15 @@
 					"entries": [
 						"Most haniwa, newly reborn, have no memory of their former selves or original task, their hallowed grounds long since plundered or buried beneath the soil of an ever-shifting realm. As such, haniwa often become wanderers, seeking purpose and fortune in an alien world. It isn't uncommon to see haniwa find purpose through devotion to a cause, practice, or order, often working as clerics, paladins, and monks. The few haniwa WHO retain some memory of their past life now find themselves serving a grander purpose than protector of a tomb: they are guardians to the memory of a world no one else remembers. These haniwa are the final stewards of an ancient dynasty, a living record of its culture, wisdom, traditions, and way of life."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Haniwa.webp"
+					}
 				}
 			]
 		},
@@ -16937,6 +16998,15 @@
 					"entries": [
 						"Isetsu hold a deterministic philosophy: just as their destiny was set at the dawn of the world, so are others beating an inevitable path, whether they realise it or not. To the isetsu, luck is a complex, measurable science, and good fortune is a talent that can be trained, a skill they dedicate endless hours to mastering. Many tales of incredible, serendipitous events occurring in favour of the isetsu seem to indicate this training holds worth. Even the most sceptical members of other races begrudgingly accept that the isetsu come up \"lucky\" in battle at a rate far beyond any other creature. A common idiom across the realms, referring to an incredible stroke of good fortune, is \"an isetsu's million-to-one\"."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Isetsu.webp"
+					}
 				}
 			]
 		},
@@ -16972,6 +17042,15 @@
 					"entries": [
 						"Long lives, innate curiosity, and a restless drive to understand others lead ancient kitsune to be revered for their wisdom and knowledge. Many act as wandering counsellors and justicars, drawing on a millennium of experience to right the wrongs of the world according to their own perspective. Others focus on a particular branch of research, gaining and spreading knowledge as they travel, or plying their trade as merchants. Such kitsune are able to observe the ebb and flow of supply and demand across generations, wielding their experience and long lives as tools in the acquisition of incredible wealth."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Kitsune.webp"
+					}
 				}
 			]
 		},
@@ -17042,6 +17121,15 @@
 						"On the cusp of adulthood, red oniborne leave their troop to undertake the Rite of the Hunt. They venture into the wilderness armed with nothing more than their wits in a quest to slay a dangerous foe and craft a weapon from its body. The rite remains an essential foundation of red oniborne culture across their lives. The more deadly the prey, the greater the respect an oniborne gains. It is not uncommon to see troop elders proudly clad in pelts and wielding weapons hewn from the remains of chromatic dragons and other vanquished terrors."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/RedOniborne.webp"
+					}
+				}
 			]
 		},
 		{
@@ -17079,6 +17167,15 @@
 						"The magic of the blue oniborne is subtle and primal, a singing river of energy that ripples through the body. It can be relayed through physical contact, a healing stream imparted by a gentle touch, or a crushing wave that surges through their biting jaws.",
 						"Solitary by nature, most blue oniborne choose to remain with the troop across their lives, a peaceful existence of isolation and independence. The few blue oniborne blessed with an adventurous spirit are unlikely to find kin in the wider world. They must journey without the guidance of their troop, every path an unmapped wilderness."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/BlueOniborne.webp"
+					}
 				}
 			]
 		},
@@ -17147,6 +17244,15 @@
 					"entries": [
 						"Ryokido have a long, living history, borne on a stream of shared memory and experience. They find great value in family and community, raising pups as a village, and viewing those they surround themselves with as extensions of themselves. To the ryokido, every friend is family, every family a village, every village a legion. When moved to action, a single ryokido walks as an army."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Ryokido.webp"
+					}
 				}
 			]
 		},
@@ -17242,6 +17348,15 @@
 						}
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/TatsumiRyujin.webp"
+					}
+				}
 			]
 		},
 		{
@@ -17307,6 +17422,15 @@
 						"Less ferocious and impulsive than the karasu, hanataka are widely regarded as the \"higher\" lineage of tengu. With the patience and tenacity of a flowing river, they live, train, and meditate in the towering trees of their mountain home. Hanataka tengu are swiftly provoked by vanity and are quick to humble the arrogant and foolish. To those who show respect, however, elder hanataka tengu make sage counsellors and guides, imparting the wisdom of age and yokai magic. Legend tells that the great warriors of old honed their swiftness of blade and sharpness of mind under the guidance of hanataka masters."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/TenguHanataka.webp"
+					}
+				}
 			]
 		},
 		{
@@ -17342,6 +17466,15 @@
 					"entries": [
 						"Deceptive and witty, cunning and dangerous, karasu tengu are tricksters at heart. They take great joy in pranks, be they simple or elaborate, and cackle gleefully at the humbling of others. Karasu have many avian qualities, including vestigial, feathered wings and powerful, snapping beaks. As bursting with life as their forest homes, and as volatile and passionate as the tempestuous winds, the friendship of a karasu is one of staunch trust and joy. Those who insult them, however, find karasu grudges run long, deep, and deadly."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/TenguKarasu.webp"
+					}
 				}
 			]
 		}
@@ -17886,6 +18019,7 @@
 			],
 			"subclassTitle": "Discipline",
 			"hasFluff": true,
+			"hasFluffImages": true
 			"optionalfeatureProgression": [
 				{
 					"name": "Eleental Affinity",
@@ -22342,6 +22476,43 @@
 						}
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender2.webp"
+					}
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender3.webp"
+					}
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender4.webp"
+					}
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender5.webp"
+					}
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender6.webp"
+					}
+				}
 			]
 		}
 	],
@@ -22359,6 +22530,15 @@
 						"Be it man, beast, or earth itself, everything trembles before me.\""
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/PathOfTheKaiju.webp"
+					}
+				}
 			]
 		},
 		{
@@ -22373,6 +22553,15 @@
 					"entries": [
 						"Yes, these days the College of Hanabi is all arcanotech gizmos and magiflash whatsits, but hanabi\u2014fireworks\u2014is where it all started! Now then, the first question to consider is how important is your hearing?"
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/CollegeOfHanabi.webp"
+					}
 				}
 			]
 		},
@@ -22389,6 +22578,15 @@
 						"This mask doesn't give you power, little girl. This isn't simple addition! Wearing a mask is an act of transformation. You disappear in its shadow; you become something new\u2014something incredible. That is, of course, if you dare."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/CollegeOfMasks.webp"
+					}
+				}
 			]
 		},
 		{
@@ -22403,6 +22601,15 @@
 					"entries": [
 						"Let's face the fading sun, in safety and comfort, and remember what matters."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/ShrineWardenDomain.webp"
+					}
 				}
 			]
 		},
@@ -22419,6 +22626,15 @@
 						"I have flown as a ryume, sung as a nue, and danced as a whirling kamaitachi, and yet the yokai remain every bit as unknowable and enigmatic as the day our bond was formed. They are beyond understanding. Relinquish your instinct to harness their strength and influence their actions; theirs is not a power you can dominate, it is only a power you can share."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/CircleOfYokai.webp"
+					}
+				}
 			]
 		},
 		{
@@ -22433,6 +22649,15 @@
 					"entries": [
 						"Your mistake was confusing my tranquillity for pacifism. The difference between the two is a painful lesson indeed."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/WayOfEightGates.webp"
+					}
 				}
 			]
 		},
@@ -22449,6 +22674,15 @@
 						"I don't know the end to my story, but I can promise that you'll live to see it."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/OathOfTheYojimbo.webp"
+					}
+				}
 			]
 		},
 		{
@@ -22463,6 +22697,15 @@
 					"entries": [
 						"A flash of steel, like a conductor's baton guiding a symphony of slaughter, heralds a helix of death and magic. A blur whips from tree to rock to shadow; corpses fall in its wake."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/Ronin.webp"
+					}
 				}
 			]
 		},
@@ -22479,6 +22722,15 @@
 						"A talented rogue knows how to be quiet. A master knows how to be very loud, very far away."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/Tamaya.webp"
+					}
+				}
 			]
 		},
 		{
@@ -22493,6 +22745,22 @@
 					"entries": [
 						"Do you ever wonder what you're worth? How strong you really are, deep down? What if others could glimpse your soul? Would they cower at your strength? They cower at mine."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/SpiritCaller.webp"
+					}
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/SpiritCaller2.webp"
+					}
 				}
 			]
 		},
@@ -22509,6 +22777,15 @@
 						"You'll fight until your last breath, and beyond."
 					]
 				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/TheShinagami.webp"
+					}
+				}
 			]
 		},
 		{
@@ -22523,6 +22800,15 @@
 					"entries": [
 						"As children, we learned that magic was loud, exciting, and dangerous. It meant jets of flame and dazzling light\u2014distinct from the mundane blade or arrow. But the Shinobi are different, harnessing a subtle magic in synchronicity with deadly swordplay. I've come to realise that the most terrifying spell isn't one that leaves a smoking crater; it's the magic nobody can ever be sure was cast, accompanied by a vortex of steel."
 					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/Shinobi.webp"
+					}
 				}
 			]
 		}
@@ -37471,7 +37757,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Adept_of_Aqueous_Fusion.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Adept_of_Aqueous_Fusion.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -37614,7 +37900,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Nue_Large_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nue_Large_Monstrosity_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -37830,7 +38116,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Omukade_Huge_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Omukade_Huge_Fey_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -38165,7 +38451,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Aspect-of-Ashura_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Aspect-of-Ashura_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -38386,7 +38672,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Avatar_of_Elements.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Avatar_of_Elements.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -38515,7 +38801,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Bakezori_Tiny_Construct_01_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Bakezori_Tiny_Construct_01_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -38766,7 +39052,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Bakuryo_Kaiju_Dragon_[5x12]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Bakuryo_Kaiju_Dragon_[5x12]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -38892,7 +39178,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Bancho-gama_Small_Monstrosity_Fire_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Bancho-gama_Small_Monstrosity_Fire_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39053,7 +39339,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Betobeto-kun_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Betobeto-kun_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39259,7 +39545,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Betobeto-Sama_Huge_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Betobeto-Sama_Huge_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39387,7 +39673,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Betobeto-San_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Betobeto-San_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39585,7 +39871,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Caller_of_Destruction.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Caller_of_Destruction.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39740,7 +40026,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Disciple_of_Ferocious_Dust.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Disciple_of_Ferocious_Dust.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39862,7 +40148,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Dodomeki_Medium_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Dodomeki_Medium_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39999,7 +40285,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Dorotabo_Medium_Undead_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Dorotabo_Medium_Undead_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40128,7 +40414,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ebi-ishi_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ebi-ishi_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40281,7 +40567,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ebi-ishi-Elder_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ebi-ishi-Elder_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40405,7 +40691,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Hone-Karakasa_Medium_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Hone-Karakasa_Medium_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40537,7 +40823,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Hunting-Narcissus_Large_Plant_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Hunting-Narcissus_Large_Plant_WEBP.webp"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -40784,7 +41070,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Iminada_Kaiju_Undead_[5x11]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Iminada_Kaiju_Undead_[5x11]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -40951,7 +41237,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Initiate_of_Fortifying_Flames.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Initiate_of_Fortifying_Flames.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41118,7 +41404,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Komainu-Jade_Large_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Komainu-Jade_Large_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41282,7 +41568,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Jorogumo_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Jorogumo_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41435,7 +41721,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Jorogumo-Huks_Large_Undead_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Jorogumo-Huks_Large_Undead_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41563,7 +41849,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kabuto-Matriarch_Large_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kabuto-Matriarch_Large_Monstrosity_WEBP.webp"
 			},
 			"senseTags": [
 				"T"
@@ -41659,7 +41945,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kamaitachi_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kamaitachi_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41799,7 +42085,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kanibozu_Medium_Fiend_Smoke_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kanibozu_Medium_Fiend_Smoke_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41927,7 +42213,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kappa_Medium_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kappa_Medium_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42072,7 +42358,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kappa-Tideweaver_Medium_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kappa-Tideweaver_Medium_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42205,7 +42491,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kasha_Medium_Fiend_Fire_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kasha_Medium_Fiend_Fire_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42305,7 +42591,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kawawappa_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kawawappa_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42470,7 +42756,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ko-Inari_Small_Celestial_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ko-Inari_Small_Celestial_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42662,7 +42948,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Korori_Large_Fiend_Fumes_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Korori_Large_Fiend_Fumes_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42881,7 +43167,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Magatsuchi_Kaiju_Plant_Trunk-Goldenheart_[5x5]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Magatsuchi_Kaiju_Plant_Trunk-Goldenheart_[5x5]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -43005,7 +43291,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Manifested_Spirit1.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Manifested_Spirit1.webp"
 			},
 			"senseTags": [
 				"D"
@@ -43138,7 +43424,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Mask_of_Solitude.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Mask_of_Solitude.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43286,7 +43572,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Onryo_Large_Undead_Mounted_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Onryo_Large_Undead_Mounted_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43405,7 +43691,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Narigama_Small_Fey_Flame_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Narigama_Small_Fey_Flame_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43644,7 +43930,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Nomi_Kaiju_Monstrosity_[6x7]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nomi_Kaiju_Monstrosity_[6x7]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -43839,7 +44125,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Novice_of_Gates.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Novice_of_Gates.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43971,7 +44257,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Nue_Large_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nue_Large_Monstrosity_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44074,7 +44360,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Nueko_Tiny_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nueko_Tiny_Monstrosity_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44222,7 +44508,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Omukade_Huge_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Omukade_Huge_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44343,7 +44629,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Omukade-Spawn_Medium_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Omukade-Spawn_Medium_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44497,7 +44783,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Onryo_Medium_Undead_Sword_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Onryo_Medium_Undead_Sword_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44655,7 +44941,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Pyrotechnic_Adept.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Pyrotechnic_Adept.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44884,7 +45170,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Raiko_Kaiju_Elemental_[5x4]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Raiko_Kaiju_Elemental_[5x4]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -45069,7 +45355,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ronin_Scarred.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ronin_Scarred.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45188,7 +45474,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ryume_Large_Celestial_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ryume_Large_Celestial_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45306,7 +45592,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ryuto_Tiny_Elemental_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ryuto_Tiny_Elemental_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45428,7 +45714,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ryuto-Swarm_Large_Elemental_03_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ryuto-Swarm_Large_Elemental_03_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45531,7 +45817,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Senryoka_Small_Undead_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Senryoka_Small_Undead_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45755,7 +46041,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Shinigami_Warlock.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Shinigami_Warlock.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45930,7 +46216,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Shinobi_Wizard.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Shinobi_Wizard.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46083,7 +46369,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Shrine_Warden.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Shrine_Warden.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46219,7 +46505,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Skeletal_Blade.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Skeletal_Blade.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46336,7 +46622,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Manifested_Spirit1.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Manifested_Spirit1.webp"
 			},
 			"hasToken": true
 		},
@@ -46471,7 +46757,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Komainu-Stone_Medium_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Komainu-Stone_Medium_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46620,7 +46906,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Stormsinger.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Stormsinger.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46749,7 +47035,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Swarm-of-Tsukumogami_Medium_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Swarm-of-Tsukumogami_Medium_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46893,7 +47179,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Kabuto-Take_Huge_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kabuto-Take_Huge_Monstrosity_WEBP.webp"
 			},
 			"traitTags": [
 				"Charge"
@@ -47075,7 +47361,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Taki-Reio_Huge_Celestial_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Taki-Reio_Huge_Celestial_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47252,7 +47538,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Tamaya_Rogue.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Tamaya_Rogue.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47384,7 +47670,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Surge-Elemental_Large_Elemental_Tempest_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Surge-Elemental_Large_Elemental_Tempest_WEBP.webp"
 			},
 			"senseTags": [
 				"D"
@@ -47518,7 +47804,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ushi-Oni_Huge_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ushi-Oni_Huge_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47637,7 +47923,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Ushi-Oni_Moultling_Medium_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ushi-Oni_Moultling_Medium_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47778,7 +48064,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Wanyudo_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Wanyudo_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47965,7 +48251,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Yojimbo.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yojimbo.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48108,7 +48394,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Yokai_Druid.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yokai_Druid.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48251,7 +48537,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Yuki-Onna-Wraith_Medium_Elemental_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yuki-Onna-Wraith_Medium_Elemental_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48388,7 +48674,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Yuki-no-Ko_Medium_Elemental_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yuki-no-Ko_Medium_Elemental_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48545,7 +48831,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/tokens/Zuwai_Large_Fiend_Water_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Zuwai_Large_Fiend_Water_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {

--- a/collection/Loot Tavern; Ryoko's Guide to Yokai Realms.json
+++ b/collection/Loot Tavern; Ryoko's Guide to Yokai Realms.json
@@ -18019,7 +18019,7 @@
 			],
 			"subclassTitle": "Discipline",
 			"hasFluff": true,
-			"hasFluffImages": true
+			"hasFluffImages": true,
 			"optionalfeatureProgression": [
 				{
 					"name": "Eleental Affinity",

--- a/collection/Loot Tavern; Ryoko's Guide to Yokai Realms.json
+++ b/collection/Loot Tavern; Ryoko's Guide to Yokai Realms.json
@@ -16814,7 +16814,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/EnkohHulking.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/EnkohHulking.webp"
 					}
 				}
 			]
@@ -16863,7 +16863,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/EnkohSpringtail.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/EnkohSpringtail.webp"
 					}
 				}
 			]
@@ -16900,7 +16900,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Fuyoren.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/Fuyoren.webp"
 					}
 				}
 			]
@@ -16937,7 +16937,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Hanamori.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/Hanamori.webp"
 					}
 				}
 			]
@@ -16967,7 +16967,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Haniwa.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/Haniwa.webp"
 					}
 				}
 			]
@@ -17005,7 +17005,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Isetsu.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/Isetsu.webp"
 					}
 				}
 			]
@@ -17049,7 +17049,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Kitsune.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/Kitsune.webp"
 					}
 				}
 			]
@@ -17127,7 +17127,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/RedOniborne.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/RedOniborne.webp"
 					}
 				}
 			]
@@ -17174,7 +17174,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/BlueOniborne.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/BlueOniborne.webp"
 					}
 				}
 			]
@@ -17251,7 +17251,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/Ryokido.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/Ryokido.webp"
 					}
 				}
 			]
@@ -17354,7 +17354,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/TatsumiRyujin.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/TatsumiRyujin.webp"
 					}
 				}
 			]
@@ -17428,7 +17428,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/TenguHanataka.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/TenguHanataka.webp"
 					}
 				}
 			]
@@ -17473,7 +17473,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Species/TenguKarasu.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Species/TenguKarasu.webp"
 					}
 				}
 			]
@@ -22482,35 +22482,35 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender2.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Classes/Bender2.webp"
 					}
 				},
 				{
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender3.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Classes/Bender3.webp"
 					}
 				},
 				{
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender4.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Classes/Bender4.webp"
 					}
 				},
 				{
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender5.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Classes/Bender5.webp"
 					}
 				},
 				{
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Classes/Bender6.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Classes/Bender6.webp"
 					}
 				}
 			]
@@ -22536,7 +22536,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/PathOfTheKaiju.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/PathOfTheKaiju.webp"
 					}
 				}
 			]
@@ -22560,7 +22560,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/CollegeOfHanabi.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/CollegeOfHanabi.webp"
 					}
 				}
 			]
@@ -22584,7 +22584,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/CollegeOfMasks.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/CollegeOfMasks.webp"
 					}
 				}
 			]
@@ -22608,7 +22608,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/ShrineWardenDomain.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/ShrineWardenDomain.webp"
 					}
 				}
 			]
@@ -22632,7 +22632,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/CircleOfYokai.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/CircleOfYokai.webp"
 					}
 				}
 			]
@@ -22656,7 +22656,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/WayOfEightGates.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/WayOfEightGates.webp"
 					}
 				}
 			]
@@ -22680,7 +22680,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/OathOfTheYojimbo.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/OathOfTheYojimbo.webp"
 					}
 				}
 			]
@@ -22704,7 +22704,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/Ronin.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/Ronin.webp"
 					}
 				}
 			]
@@ -22728,7 +22728,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/Tamaya.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/Tamaya.webp"
 					}
 				}
 			]
@@ -22752,14 +22752,14 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/SpiritCaller.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/SpiritCaller.webp"
 					}
 				},
 				{
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/SpiritCaller2.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/SpiritCaller2.webp"
 					}
 				}
 			]
@@ -22783,7 +22783,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/TheShinagami.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/TheShinagami.webp"
 					}
 				}
 			]
@@ -22807,7 +22807,7 @@
 					"type": "image",
 					"href": {
 						"type": "external",
-						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RGTYR/Subclasses/Shinobi.webp"
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/RyokoGuideToYokaiRealms/Subclasses/Shinobi.webp"
 					}
 				}
 			]
@@ -37757,7 +37757,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Adept_of_Aqueous_Fusion.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Adept_of_Aqueous_Fusion.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -37900,7 +37900,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nue_Large_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Nue_Large_Monstrosity_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -38116,7 +38116,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Omukade_Huge_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Omukade_Huge_Fey_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -38451,7 +38451,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Aspect-of-Ashura_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Aspect-of-Ashura_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -38672,7 +38672,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Avatar_of_Elements.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Avatar_of_Elements.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -38801,7 +38801,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Bakezori_Tiny_Construct_01_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Bakezori_Tiny_Construct_01_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39052,7 +39052,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Bakuryo_Kaiju_Dragon_[5x12]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Bakuryo_Kaiju_Dragon_[5x12]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -39178,7 +39178,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Bancho-gama_Small_Monstrosity_Fire_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Bancho-gama_Small_Monstrosity_Fire_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39339,7 +39339,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Betobeto-kun_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Betobeto-kun_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39545,7 +39545,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Betobeto-Sama_Huge_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Betobeto-Sama_Huge_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39673,7 +39673,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Betobeto-San_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Betobeto-San_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -39871,7 +39871,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Caller_of_Destruction.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Caller_of_Destruction.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40026,7 +40026,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Disciple_of_Ferocious_Dust.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Disciple_of_Ferocious_Dust.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40148,7 +40148,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Dodomeki_Medium_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Dodomeki_Medium_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40285,7 +40285,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Dorotabo_Medium_Undead_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Dorotabo_Medium_Undead_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40414,7 +40414,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ebi-ishi_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ebi-ishi_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40567,7 +40567,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ebi-ishi-Elder_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ebi-ishi-Elder_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40691,7 +40691,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Hone-Karakasa_Medium_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Hone-Karakasa_Medium_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -40823,7 +40823,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Hunting-Narcissus_Large_Plant_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Hunting-Narcissus_Large_Plant_WEBP.webp"
 			},
 			"traitTags": [
 				"False Appearance",
@@ -41070,7 +41070,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Iminada_Kaiju_Undead_[5x11]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Iminada_Kaiju_Undead_[5x11]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -41237,7 +41237,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Initiate_of_Fortifying_Flames.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Initiate_of_Fortifying_Flames.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41404,7 +41404,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Komainu-Jade_Large_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Komainu-Jade_Large_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41568,7 +41568,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Jorogumo_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Jorogumo_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41721,7 +41721,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Jorogumo-Huks_Large_Undead_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Jorogumo-Huks_Large_Undead_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -41849,7 +41849,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kabuto-Matriarch_Large_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kabuto-Matriarch_Large_Monstrosity_WEBP.webp"
 			},
 			"senseTags": [
 				"T"
@@ -41945,7 +41945,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kamaitachi_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kamaitachi_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42085,7 +42085,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kanibozu_Medium_Fiend_Smoke_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kanibozu_Medium_Fiend_Smoke_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42213,7 +42213,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kappa_Medium_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kappa_Medium_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42358,7 +42358,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kappa-Tideweaver_Medium_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kappa-Tideweaver_Medium_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42491,7 +42491,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kasha_Medium_Fiend_Fire_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kasha_Medium_Fiend_Fire_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42591,7 +42591,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kawawappa_Small_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kawawappa_Small_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42756,7 +42756,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ko-Inari_Small_Celestial_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ko-Inari_Small_Celestial_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -42948,7 +42948,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Korori_Large_Fiend_Fumes_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Korori_Large_Fiend_Fumes_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43167,7 +43167,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Magatsuchi_Kaiju_Plant_Trunk-Goldenheart_[5x5]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Magatsuchi_Kaiju_Plant_Trunk-Goldenheart_[5x5]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -43291,7 +43291,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Manifested_Spirit1.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Manifested_Spirit1.webp"
 			},
 			"senseTags": [
 				"D"
@@ -43424,7 +43424,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Mask_of_Solitude.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Mask_of_Solitude.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43572,7 +43572,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Onryo_Large_Undead_Mounted_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Onryo_Large_Undead_Mounted_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43691,7 +43691,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Narigama_Small_Fey_Flame_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Narigama_Small_Fey_Flame_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -43930,7 +43930,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nomi_Kaiju_Monstrosity_[6x7]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Nomi_Kaiju_Monstrosity_[6x7]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -44125,7 +44125,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Novice_of_Gates.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Novice_of_Gates.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44257,7 +44257,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nue_Large_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Nue_Large_Monstrosity_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44360,7 +44360,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Nueko_Tiny_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Nueko_Tiny_Monstrosity_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44508,7 +44508,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Omukade_Huge_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Omukade_Huge_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44629,7 +44629,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Omukade-Spawn_Medium_Fey_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Omukade-Spawn_Medium_Fey_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44783,7 +44783,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Onryo_Medium_Undead_Sword_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Onryo_Medium_Undead_Sword_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -44941,7 +44941,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Pyrotechnic_Adept.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Pyrotechnic_Adept.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45170,7 +45170,7 @@
 			},
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Raiko_Kaiju_Elemental_[5x4]_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Raiko_Kaiju_Elemental_[5x4]_WEBP.webp"
 			},
 			"traitTags": [
 				"Legendary Resistances"
@@ -45355,7 +45355,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ronin_Scarred.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ronin_Scarred.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45474,7 +45474,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ryume_Large_Celestial_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ryume_Large_Celestial_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45592,7 +45592,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ryuto_Tiny_Elemental_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ryuto_Tiny_Elemental_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45714,7 +45714,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ryuto-Swarm_Large_Elemental_03_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ryuto-Swarm_Large_Elemental_03_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -45817,7 +45817,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Senryoka_Small_Undead_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Senryoka_Small_Undead_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46041,7 +46041,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Shinigami_Warlock.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Shinigami_Warlock.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46216,7 +46216,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Shinobi_Wizard.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Shinobi_Wizard.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46369,7 +46369,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Shrine_Warden.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Shrine_Warden.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46505,7 +46505,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Skeletal_Blade.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Skeletal_Blade.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46622,7 +46622,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Manifested_Spirit1.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Manifested_Spirit1.webp"
 			},
 			"hasToken": true
 		},
@@ -46757,7 +46757,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Komainu-Stone_Medium_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Komainu-Stone_Medium_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -46906,7 +46906,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Stormsinger.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Stormsinger.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47035,7 +47035,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Swarm-of-Tsukumogami_Medium_Construct_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Swarm-of-Tsukumogami_Medium_Construct_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47179,7 +47179,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Kabuto-Take_Huge_Monstrosity_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Kabuto-Take_Huge_Monstrosity_WEBP.webp"
 			},
 			"traitTags": [
 				"Charge"
@@ -47361,7 +47361,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Taki-Reio_Huge_Celestial_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Taki-Reio_Huge_Celestial_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47538,7 +47538,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Tamaya_Rogue.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Tamaya_Rogue.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47670,7 +47670,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Surge-Elemental_Large_Elemental_Tempest_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Surge-Elemental_Large_Elemental_Tempest_WEBP.webp"
 			},
 			"senseTags": [
 				"D"
@@ -47804,7 +47804,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ushi-Oni_Huge_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ushi-Oni_Huge_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -47923,7 +47923,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Ushi-Oni_Moultling_Medium_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Ushi-Oni_Moultling_Medium_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48064,7 +48064,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Wanyudo_Large_Fiend_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Wanyudo_Large_Fiend_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48251,7 +48251,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yojimbo.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Yojimbo.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48394,7 +48394,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yokai_Druid.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Yokai_Druid.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48537,7 +48537,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yuki-Onna-Wraith_Medium_Elemental_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Yuki-Onna-Wraith_Medium_Elemental_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48674,7 +48674,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Yuki-no-Ko_Medium_Elemental_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Yuki-no-Ko_Medium_Elemental_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {
@@ -48831,7 +48831,7 @@
 			],
 			"tokenHref": {
 				"type": "external",
-				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RGTYR/Tokens/Zuwai_Large_Fiend_Water_WEBP.webp"
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/RyokoGuideToYokaiRealms/Tokens/Zuwai_Large_Fiend_Water_WEBP.webp"
 			},
 			"hasToken": true,
 			"fluff": {


### PR DESCRIPTION
I created a matching pull request in the `homebrew-img` repo. I downloaded some rough images of certain RGTYR entries like species, classes and creatures. I went through the file from this repo and added the correct lines to most entries (excluding creatures/backgrounds) and changed the tokens url to reflect changes I made to the structure of the folder (also reflected in corresponding `homebrew-img` pull request).