### PR TITLE
UAH Hotfix

### DIFF
--- a/collection/Sterling Vermin Adventuring Co.; The Ultimate Adventurer's Handbook.json
+++ b/collection/Sterling Vermin Adventuring Co.; The Ultimate Adventurer's Handbook.json
@@ -3551,7 +3551,7 @@
 				"haste"
 			],
 			"subclassFeatures": [
-				"freerunners|Ranger|PHB|Freerunner|UltimateAdventurer|3",
+				"Freerunner|Ranger|PHB|Freerunner|UltimateAdventurer|3",
 				"Safety Roll|Ranger|PHB|Freerunner|UltimateAdventurer|7",
 				"Kinetic Precision|Ranger|PHB|Freerunner|UltimateAdventurer|11",
 				"Fluid Movement|Ranger|PHB|Freerunner|UltimateAdventurer|15"


### PR DESCRIPTION
Fixes subclass feature entries for the Freerunner Ranger that I broke in #2741. Whoops.