### PR TITLE
Add Valda's Gunslinger class JSON on Items list to use on BetterR20

### DIFF
--- a/item/CaioTome; Valda's Gunslinger.json
+++ b/item/CaioTome; Valda's Gunslinger.json
@@ -1,0 +1,5356 @@
+{
+	"_meta": {
+		"sources": [
+			{
+				"json": "ValdaGunslinger",
+				"abbreviation": "GC:VSS'24",
+				"full": "The Gunslinger Class: Valda's Spire of Secrets",
+				"url": "https://marketplace.dndbeyond.com/category/DBGYLCFKE",
+				"version": "1.0",
+				"dateReleased": "2025-06-10",
+				"authors": [
+					"Mage Hand Press"
+				],
+				"convertedBy": [
+					"Unknown"
+				],
+				"partnered": true,
+				"color": "ca8464"
+			}
+		],
+		"optionalFeatureTypes": {
+			"MV:G": "Maneuver, Gunslinger"
+		},
+		"dateAdded": 1749673328,
+		"dateLastModified": 1776257629
+	},
+	"$schema": "https://raw.githubusercontent.com/TheGiddyLimit/5etools-utils/master/schema/brew-fast/homebrew.json",
+	"class": [
+		{
+			"name": "Gunslinger",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"primaryAbility": [
+				{
+					"dex": true
+				}
+			],
+			"hd": {
+				"number": 1,
+				"faces": 8
+			},
+			"proficiency": [
+				"dex",
+				"cha"
+			],
+			"featProgression": [
+				{
+					"name": "Fighting Style",
+					"category": [
+						"FS"
+					],
+					"progression": {
+						"1": 1
+					}
+				},
+				{
+					"name": "Epic Boon",
+					"category": [
+						"EB"
+					],
+					"progression": {
+						"19": 1
+					}
+				}
+			],
+			"startingProficiencies": {
+				"armor": [
+					"light"
+				],
+				"weapons": [
+					"simple",
+					"{@filter Martial Ranged weapons|items|type=ranged weapon}"
+				],
+				"weaponProficiencies": [
+					{
+						"simple": true,
+						"all": {
+							"fromFilter": "type=ranged weapon"
+						}
+					}
+				],
+				"skills": [
+					{
+						"choose": {
+							"from": [
+								"acrobatics",
+								"animal handling",
+								"athletics",
+								"deception",
+								"insight",
+								"intimidation",
+								"perception",
+								"persuasion",
+								"sleight of hand",
+								"stealth"
+							],
+							"count": 2
+						}
+					}
+				]
+			},
+			"startingEquipment": {
+				"additionalFromBackground": true,
+				"defaultData": [
+					{
+						"A": [
+							{
+								"item": "leather armor|xphb"
+							},
+							{
+								"item": "dagger|xphb",
+								"quantity": 2
+							},
+							{
+								"item": "revolver|valdagunslinger"
+							},
+							{
+								"item": "bullet|valdagunslinger",
+								"quantity": 50
+							},
+							{
+								"item": "explorer's pack|xphb"
+							},
+							{
+								"value": 1100
+							}
+						],
+						"B": [
+							{
+								"value": 17500
+							}
+						]
+					}
+				],
+				"entries": [
+					"{@i Choose A or B:} (A) {@item Leather Armor|XPHB}, 2 {@item Dagger|XPHB|Daggers}, {@item Revolver|ValdaGunslinger}, 50 {@item Bullet|ValdaGunslinger}, {@item Explorer's Pack|XPHB}, and 11 GP; or (B) 175 GP"
+				]
+			},
+			"multiclassing": {
+				"proficienciesGained": {
+					"weapons": [
+						"{@filter Martial Ranged weapons|items|type=ranged weapon}"
+					],
+					"weaponProficiencies": [
+						{
+							"all": {
+								"fromFilter": "type=ranged weapon"
+							}
+						}
+					]
+				}
+			},
+			"classTableGroups": [
+				{
+					"colLabels": [
+						"Risk Dice",
+						"Weapon Mastery"
+					],
+					"rows": [
+						[
+							"-",
+							"2"
+						],
+						[
+							"{@dice 4d8}",
+							"2"
+						],
+						[
+							"{@dice 4d8}",
+							"2"
+						],
+						[
+							"{@dice 4d8}",
+							"3"
+						],
+						[
+							"{@dice 4d8}",
+							"3"
+						],
+						[
+							"{@dice 5d8}",
+							"3"
+						],
+						[
+							"{@dice 5d8}",
+							"3"
+						],
+						[
+							"{@dice 5d8}",
+							"3"
+						],
+						[
+							"{@dice 5d8}",
+							"3"
+						],
+						[
+							"{@dice 5d10}",
+							"4"
+						],
+						[
+							"{@dice 5d10}",
+							"4"
+						],
+						[
+							"{@dice 5d10}",
+							"4"
+						],
+						[
+							"{@dice 5d10}",
+							"4"
+						],
+						[
+							"{@dice 6d10}",
+							"4"
+						],
+						[
+							"{@dice 6d10}",
+							"4"
+						],
+						[
+							"{@dice 6d10}",
+							"4"
+						],
+						[
+							"{@dice 6d10}",
+							"4"
+						],
+						[
+							"{@dice 6d12}",
+							"4"
+						],
+						[
+							"{@dice 6d12}",
+							"4"
+						],
+						[
+							"{@dice 6d12}",
+							"4"
+						]
+					]
+				}
+			],
+			"classFeatures": [
+				"Fighting Style|Gunslinger|ValdaGunslinger|1",
+				"Quick Draw|Gunslinger|ValdaGunslinger|1",
+				"Weapon Mastery|Gunslinger|ValdaGunslinger|1",
+				"Critical Shot|Gunslinger|ValdaGunslinger|2",
+				"Risk|Gunslinger|ValdaGunslinger|2",
+				{
+					"classFeature": "Gunslinger Subclass|Gunslinger|ValdaGunslinger|3",
+					"gainSubclassFeature": true
+				},
+				"Ability Score Improvement|Gunslinger|ValdaGunslinger|4",
+				"Extra Attack|Gunslinger|ValdaGunslinger|5",
+				"Gut Shot|Gunslinger|ValdaGunslinger|5",
+				{
+					"classFeature": "Subclass Feature|Gunslinger|ValdaGunslinger|6",
+					"gainSubclassFeature": true
+				},
+				"Evasion|Gunslinger|ValdaGunslinger|7",
+				"Ability Score Improvement|Gunslinger|ValdaGunslinger|8",
+				"Critical Shot|Gunslinger|ValdaGunslinger|9",
+				{
+					"classFeature": "Subclass Feature|Gunslinger|ValdaGunslinger|10",
+					"gainSubclassFeature": true
+				},
+				"Overkill|Gunslinger|ValdaGunslinger|11",
+				"Ability Score Improvement|Gunslinger|ValdaGunslinger|12",
+				"Cheat Death|Gunslinger|ValdaGunslinger|13",
+				{
+					"classFeature": "Subclass Feature|Gunslinger|ValdaGunslinger|14",
+					"gainSubclassFeature": true
+				},
+				"Dire Gambit|Gunslinger|ValdaGunslinger|15",
+				"Ability Score Improvement|Gunslinger|ValdaGunslinger|16",
+				"Critical Shot|Gunslinger|ValdaGunslinger|17",
+				"Deft Maneuver|Gunslinger|ValdaGunslinger|18",
+				"Epic Boon|Gunslinger|ValdaGunslinger|19",
+				"Headshot|Gunslinger|ValdaGunslinger|20"
+			],
+			"subclassTitle": "Subclass Feature",
+			"hasFluff": true,
+			"hasFluffImages": true,
+			"foundryAdvancement": [
+				{
+					"type": "ScaleValue",
+					"configuration": {
+						"identifier": "critical-shot",
+						"type": "number",
+						"scale": {
+							"3": {
+								"value": 19
+							},
+							"9": {
+								"value": 18
+							},
+							"17": {
+								"value": 17
+							}
+						}
+					},
+					"title": "Critical Shot"
+				},
+				{
+					"type": "ScaleValue",
+					"configuration": {
+						"identifier": "risk-dice",
+						"type": "dice",
+						"scale": {
+							"2": {
+								"number": 4,
+								"faces": 8
+							},
+							"6": {
+								"number": 5,
+								"faces": 8
+							},
+							"10": {
+								"number": 5,
+								"faces": 10
+							},
+							"14": {
+								"number": 6,
+								"faces": 10
+							},
+							"18": {
+								"number": 6,
+								"faces": 12
+							}
+						}
+					},
+					"title": "Risk Dice"
+				}
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/refs/heads/main/img/ValdaGunslinger/Gunslinger-icon.webp"
+		}
+	],
+	"classFluff": [
+		{
+			"name": "Gunslinger",
+			"source": "ValdaGunslinger",
+			"entries": [
+				{
+					"type": "section",
+					"name": "Gunslinger",
+					"source": "ValdaGunslinger",
+					"entries": [
+						"Risk is in a Gunslinger's blood. They are bold renegades, bucking tradition and forging a new path with dangerous and inelegant firearms. Gunslingers are infamous for surviving by their wits and relying on split-second timing and a considerable amount of luck to survive.",
+						{
+							"type": "entries",
+							"name": "Guts and Gunpowder",
+							"entries": [
+								"Black powder isn't for the faint of heart. Its thunderous applause is volatile and imprecise—a barely controlled explosion directed at an enemy. Only the truly fearless seek to master it. But Gunslingers have nerves of steel, hurling death from their guns in a roaring cacophony. Adapted for shootouts, gunslingers are mobile and daring, knowing that life or death hangs on snap decision-making and one's own mettle."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Dangerous Outsiders",
+							"entries": [
+								"A Gunslinger's explosive lifestyle lends well to wandering and adventuring. Gunslingers often shoot first and ask questions later, an attitude which earns them few friends and bountiful enemies. In their travels, most gunslingers are secretive and take great lengths to go unnoticed, lest they be spotted by old foes with scores to settle."
+							]
+						}
+					]
+				}
+			],
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+					},
+					"width": 850,
+					"height": 1336
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-004.gunshot-holes.webp"
+					},
+					"width": 850,
+					"height": 610
+				},
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-003.revolver.webp"
+					},
+					"width": 850,
+					"height": 385
+				}
+			]
+		}
+	],
+	"subclass": [
+		{
+			"name": "Deadeye",
+			"shortName": "Deadeye",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassFeatures": [
+				"Deadeye|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|3",
+				"Concealed Position|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|6",
+				"Reposition|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|10",
+				"Focused Shot|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|14"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "High Roller",
+			"shortName": "High Roller",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassFeatures": [
+				"High Roller|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|3",
+				"Risky Business|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|6",
+				"Risk Taker|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|10",
+				"Double or Nothing|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|14"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Secret Agent",
+			"shortName": "Secret Agent",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"additionalSpells": [
+				{
+					"ability": {
+						"choose": [
+							"int",
+							"wis",
+							"cha"
+						]
+					},
+					"known": {
+						"3": [
+							"concealed shot|valdagunslinger#c"
+						]
+					}
+				}
+			],
+			"subclassSpells": [
+				"concealed shot|valdagunslinger"
+			],
+			"subclassFeatures": [
+				"Secret Agent|Gunslinger|ValdaGunslinger|Secret Agent|ValdaGunslinger|3",
+				"Fieldcraft|Gunslinger|ValdaGunslinger|Secret Agent|ValdaGunslinger|6",
+				"Exit Strategy|Gunslinger|ValdaGunslinger|Secret Agent|ValdaGunslinger|10",
+				"License to Kill|Gunslinger|ValdaGunslinger|Secret Agent|ValdaGunslinger|14"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Spellslinger",
+			"shortName": "Spellslinger",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"spellcastingAbility": "int",
+			"casterProgression": "1/3",
+			"preparedSpellsProgression": [
+				0,
+				0,
+				3,
+				4,
+				4,
+				4,
+				5,
+				6,
+				6,
+				7,
+				8,
+				8,
+				9,
+				10,
+				10,
+				11,
+				11,
+				11,
+				12,
+				13
+			],
+			"preparedSpellsChange": "level",
+			"cantripProgression": [
+				0,
+				0,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				2,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3,
+				3
+			],
+			"additionalSpells": [
+				{
+					"known": {
+						"3": [
+							"finger guns|valdagunslinger#c"
+						]
+					},
+					"expanded": {
+						"3": [
+							{
+								"all": "level=0|class=Wizard"
+							},
+							{
+								"all": "level=1|class=Wizard"
+							}
+						],
+						"7": [
+							{
+								"all": "level=2|class=Wizard"
+							}
+						],
+						"13": [
+							{
+								"all": "level=3|class=Wizard"
+							}
+						],
+						"19": [
+							{
+								"all": "level=4|class=Wizard"
+							}
+						]
+					}
+				}
+			],
+			"subclassSpells": [
+				"finger guns|valdagunslinger",
+				{
+					"className": "Wizard",
+					"classSource": "XPHB"
+				}
+			],
+			"subclassTableGroups": [
+				{
+					"subclasses": [
+						{
+							"name": "Spellslinger",
+							"source": "ValdaGunslinger"
+						}
+					],
+					"colLabels": [
+						"{@filter Spells Prepared|spells|subclass=Gunslinger: Spellslinger (GC:VSS'24)}"
+					],
+					"rows": [
+						[
+							0
+						],
+						[
+							0
+						],
+						[
+							3
+						],
+						[
+							4
+						],
+						[
+							4
+						],
+						[
+							4
+						],
+						[
+							5
+						],
+						[
+							6
+						],
+						[
+							6
+						],
+						[
+							7
+						],
+						[
+							8
+						],
+						[
+							8
+						],
+						[
+							9
+						],
+						[
+							10
+						],
+						[
+							10
+						],
+						[
+							11
+						],
+						[
+							11
+						],
+						[
+							11
+						],
+						[
+							12
+						],
+						[
+							13
+						]
+					]
+				},
+				{
+					"title": "Spell Slots per Spell Level",
+					"subclasses": [
+						{
+							"name": "Spellslinger",
+							"source": "ValdaGunslinger"
+						}
+					],
+					"colLabels": [
+						"{@filter 1st|spells|level=1|subclass=Gunslinger: Spellslinger (GC:VSS'24)}",
+						"{@filter 2nd|spells|level=2|subclass=Gunslinger: Spellslinger (GC:VSS'24)}",
+						"{@filter 3rd|spells|level=3|subclass=Gunslinger: Spellslinger (GC:VSS'24)}",
+						"{@filter 4th|spells|level=4|subclass=Gunslinger: Spellslinger (GC:VSS'24)}"
+					],
+					"rowsSpellProgression": [
+						[
+							0,
+							0,
+							0,
+							0
+						],
+						[
+							0,
+							0,
+							0,
+							0
+						],
+						[
+							2,
+							0,
+							0,
+							0
+						],
+						[
+							3,
+							0,
+							0,
+							0
+						],
+						[
+							3,
+							0,
+							0,
+							0
+						],
+						[
+							3,
+							0,
+							0,
+							0
+						],
+						[
+							4,
+							2,
+							0,
+							0
+						],
+						[
+							4,
+							2,
+							0,
+							0
+						],
+						[
+							4,
+							2,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							0,
+							0
+						],
+						[
+							4,
+							3,
+							2,
+							0
+						],
+						[
+							4,
+							3,
+							2,
+							0
+						],
+						[
+							4,
+							3,
+							2,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							0
+						],
+						[
+							4,
+							3,
+							3,
+							1
+						],
+						[
+							4,
+							3,
+							3,
+							1
+						]
+					]
+				}
+			],
+			"subclassFeatures": [
+				"Spellslinger|Gunslinger|ValdaGunslinger|Spellslinger|ValdaGunslinger|3",
+				"Spellshot|Gunslinger|ValdaGunslinger|Spellslinger|ValdaGunslinger|6",
+				"Counter-Mage|Gunslinger|ValdaGunslinger|Spellslinger|ValdaGunslinger|10",
+				"Magic Bullet [Maneuver]|Gunslinger|ValdaGunslinger|Spellslinger|ValdaGunslinger|14"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "Trick Shot",
+			"shortName": "Trick Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassFeatures": [
+				"Trick Shot|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|3",
+				"Fancy Gunplay|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|6",
+				"Deft Deflection [Maneuver]|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|10",
+				"Pinball Shot|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|14"
+			],
+			"hasFluffImages": true
+		},
+		{
+			"name": "White Hat",
+			"shortName": "White Hat",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassFeatures": [
+				"White Hat|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3",
+				"Reach for the Skies|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|6",
+				"Long Arm of the Law|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|10",
+				"Gold Star Hero|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|14"
+			],
+			"hasFluffImages": true
+		}
+	],
+	"subclassFluff": [
+		{
+			"name": "Deadeye",
+			"shortName": "Deadeye",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-005.deadeye.webp"
+					},
+					"width": 850,
+					"height": 559
+				}
+			]
+		},
+		{
+			"name": "High Roller",
+			"shortName": "High Roller",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-006.high-roller.webp"
+					},
+					"width": 850,
+					"height": 1008
+				}
+			]
+		},
+		{
+			"name": "Secret Agent",
+			"shortName": "Secret Agent",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-008.secret-agent.webp"
+					},
+					"width": 850,
+					"height": 1409
+				}
+			]
+		},
+		{
+			"name": "Spellslinger",
+			"shortName": "Spellslinger",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-009.spellslinger.webp"
+					},
+					"width": 850,
+					"height": 1072
+				}
+			]
+		},
+		{
+			"name": "Trick Shot",
+			"shortName": "Trick Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-010.trick-shot.webp"
+					},
+					"width": 850,
+					"height": 1014
+				}
+			]
+		},
+		{
+			"name": "White Hat",
+			"shortName": "White Hat",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-011.white-hat.webp"
+					},
+					"width": 1700,
+					"height": 1162
+				}
+			]
+		}
+	],
+	"classFeature": [
+		{
+			"name": "Fighting Style",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 1,
+			"entries": [
+				"You gain a {@filter Fighting Style feat|feats|category=FS} of your choice. If you choose a feat, such as {@feat Great Weapon Fighting|XPHB}, that requires you to hold a Melee weapon in one or two hands, you can use that feat with Ranged weapons.",
+				"Whenever you gain a Gunslinger level, you can replace the feat you chose with a different {@filter Fighting Style feat|feats|category=FS}."
+			]
+		},
+		{
+			"name": "Quick Draw",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 1,
+			"entries": [
+				"You're adept at drawing and firing before others have time to react, granting you the following benefits.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Initiative",
+							"entries": [
+								"You have {@variantrule Advantage|XPHB} on {@variantrule Initiative|XPHB} rolls."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Double Draw",
+							"entries": [
+								"You can draw or stow two weapons that lack {@itemProperty 2H|XPHB|Two-Handed} when you would normally be able to draw or stow only one."
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Weapon Mastery",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 1,
+			"entries": [
+				"Your training with weapons allows you to use the mastery properties of two kinds of {@filter Simple|items|type=simple weapon} or {@filter Martial Ranged weapons|items|type=ranged weapon} of your choice. Whenever you finish a {@variantrule Long Rest|XPHB}, you can practice weapon drills and change one of those weapon choices.",
+				"When you reach certain Gunslinger levels, you gain the ability to use the mastery properties of more kinds of weapons, as shown in the Weapon Mastery column of the Gunslinger Features table."
+			]
+		},
+		{
+			"name": "Critical Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 2,
+			"entries": [
+				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 19 or 20 on the {@dice d20}.",
+				"At Gunslinger level 9, your attack rolls with Ranged weapons score a {@variantrule Critical Hit|XPHB} on a roll of 18-20. At Gunslinger level 17, they score a {@variantrule Critical Hit|XPHB} on a roll of 17-20."
+			]
+		},
+		{
+			"name": "Risk",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 2,
+			"entries": [
+				"You can perform incredible feats of daring fueled by special dice called Risk Dice.",
+				{
+					"type": "entries",
+					"entries": [
+						{
+							"type": "entries",
+							"name": "Risk Dice",
+							"entries": [
+								"You have four Risk Dice, which are d8s. A Risk Die is expended when you use it. You regain all expended Risk Dice when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. Your Risk Die changes and more Risk Dice become available as shown on the Risk Dice column of the Gunslinger Features table."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Maneuvers",
+							"entries": [
+								"You can expend Risk Dice to perform maneuvers. Your maneuver options are detailed later in the class description."
+							]
+						},
+						{
+							"type": "entries",
+							"name": "Saving Throws",
+							"entries": [
+								"If a maneuver requires a saving throw, the DC equals 8 plus your Dexterity modifier and {@variantrule Proficiency|XPHB|Proficiency Bonus}."
+							]
+						}
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Maneuver Options",
+					"entries": [
+						{
+							"type": "options",
+							"entries": [
+								{
+									"type": "refOptionalfeature",
+									"optionalfeature": "Bite the Bullet|ValdaGunslinger"
+								},
+								{
+									"type": "refOptionalfeature",
+									"optionalfeature": "Blindfire|ValdaGunslinger"
+								},
+								{
+									"type": "refOptionalfeature",
+									"optionalfeature": "Dodge Roll|ValdaGunslinger"
+								},
+								{
+									"type": "refOptionalfeature",
+									"optionalfeature": "Grazing Shot|ValdaGunslinger"
+								},
+								{
+									"type": "refOptionalfeature",
+									"optionalfeature": "Maverick Spirit|ValdaGunslinger"
+								},
+								{
+									"type": "refOptionalfeature",
+									"optionalfeature": "Skin of Your Teeth|ValdaGunslinger"
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Gunslinger Subclass",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"You gain a Gunslinger subclass of your choice. A subclass is a specialization that grants you features at certain Gunslinger levels. For the rest of your career, you gain each of your subclass's features that are of your Gunslinger level or lower."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 4,
+			"entries": [
+				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
+			]
+		},
+		{
+			"name": "Extra Attack",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 5,
+			"entries": [
+				"You can attack twice instead of once whenever you take the {@action Attack|XPHB} action on your turn."
+			]
+		},
+		{
+			"name": "Gut Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 5,
+			"entries": [
+				"Whenever you score a {@variantrule Critical Hit|XPHB} against a Large or smaller creature with a ranged attack using a weapon, the projectile lodges itself in the target. For 1 minute or until the target replaces one of its attacks with dislodging the projectile, its {@variantrule Speed|XPHB} is halved and it has {@variantrule Disadvantage|XPHB} on attack rolls."
+			]
+		},
+		{
+			"name": "Subclass Feature",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 6,
+			"entries": [
+				"You gain a feature from your Gunslinger Subclass."
+			]
+		},
+		{
+			"name": "Evasion",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 7,
+			"entries": [
+				"When you're subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw and only half damage if you fail.",
+				"You don't benefit from this feature if you have the {@condition Incapacitated|XPHB} condition."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 8,
+			"entries": [
+				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
+			]
+		},
+		{
+			"name": "Critical Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 9,
+			"entries": [
+				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 18, 19, or 20 on the {@dice d20}."
+			]
+		},
+		{
+			"name": "Subclass Feature",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 10,
+			"entries": [
+				"You gain a feature from your Gunslinger Subclass."
+			]
+		},
+		{
+			"name": "Overkill",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 11,
+			"entries": [
+				"When you deal damage with a Ranged weapon that doesn't add your ability modifier to the roll, you add your ability modifier nonetheless. If you already add your modifier to the damage roll, the target takes an extra {@damage 1d8} damage of the weapon's type.",
+				"Note that weapons that have the {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm} property don't add your ability modifier to damage rolls."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 12,
+			"entries": [
+				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
+			]
+		},
+		{
+			"name": "Cheat Death",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 13,
+			"entries": [
+				"When you are reduced to 0 {@variantrule Hit Points|XPHB} and not killed outright, you can drop to 1 {@variantrule Hit Points|XPHB|Hit Point} instead, and you regain a number of {@variantrule Hit Points|XPHB} equal to your Gunslinger level.",
+				"Once you use this feature, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+			]
+		},
+		{
+			"name": "Subclass Feature",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 14,
+			"entries": [
+				"You gain a feature from your Gunslinger Subclass."
+			]
+		},
+		{
+			"name": "Dire Gambit",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 15,
+			"entries": [
+				"Whenever you roll {@variantrule Initiative|XPHB} or score a {@variantrule Critical Hit|XPHB}, you regain one expended {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}."
+			]
+		},
+		{
+			"name": "Ability Score Improvement",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 16,
+			"entries": [
+				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
+			]
+		},
+		{
+			"name": "Critical Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 17,
+			"entries": [
+				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 17-20 on the {@dice d20}."
+			]
+		},
+		{
+			"name": "Deft Maneuver",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 18,
+			"entries": [
+				"You gain a special additional {@variantrule Bonus Action|XPHB} that you can take once on each of your turns. You can take this special {@variantrule Bonus Action|XPHB} only to use a maneuver."
+			]
+		},
+		{
+			"name": "Epic Boon",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 19,
+			"entries": [
+				"You gain an {@filter Epic Boon feat|feats|category=EB} or another feat of your choice for which you qualify. {@feat Boon of Irresistible Offense|XPHB} is recommended."
+			]
+		},
+		{
+			"name": "Headshot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 20,
+			"entries": [
+				"When you score a {@variantrule Critical Hit|XPHB} against a creature using a Ranged weapon, you can choose for it to be a Headshot. If the creature has less than 100 {@variantrule Hit Points|XPHB}, it dies. Otherwise, it takes an extra {@damage 10d10} damage of the weapon's type.",
+				"Once you use this feature, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. You can also restore your use of it by expending three {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Dice} (no action required)."
+			]
+		}
+	],
+	"foundryClassFeature": [
+		{
+			"name": "Quick Draw",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 1,
+			"effects": [
+				{
+					"name": "Quick Draw: Initiative",
+					"transfer": true,
+					"changes": [
+						{
+							"key": "flags.dnd5e.initiativeAdv",
+							"mode": 5,
+							"value": "true",
+							"priority": 20
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Critical Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 2,
+			"effects": [
+				{
+					"name": "Critical Shot",
+					"transfer": true,
+					"changes": [
+						{
+							"key": "flags.dnd5e.weaponCriticalThreshold",
+							"mode": 3,
+							"value": "@scale.gunslinger.critical-shot",
+							"priority": 20
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Risk",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 2,
+			"system": {
+				"uses": {
+					"max": "@scale.gunslinger.risk-dice.number"
+				}
+			}
+		},
+		{
+			"name": "Gut Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 5,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "special",
+						"condition": "whenever you score a Critical Hit against a Large or smaller creature with a ranged attack using a weapon"
+					},
+					"effects": [
+						{
+							"foundryId": "XJZaOTPuJtRH5qAG"
+						}
+					]
+				}
+			],
+			"effects": [
+				{
+					"foundryId": "XJZaOTPuJtRH5qAG",
+					"name": "Gut Shot",
+					"duration": {
+						"seconds": 60
+					},
+					"changes": []
+				}
+			]
+		},
+		{
+			"name": "Critical Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 9,
+			"isIgnored": true
+		},
+		{
+			"name": "Overkill",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 11,
+			"activities": [
+				{
+					"name": "Enchant (Firearm)",
+					"type": "enchant",
+					"activation": {
+						"type": "special"
+					},
+					"duration": {
+						"units": "perm",
+						"concentration": false,
+						"override": false
+					},
+					"restrictions": {
+						"categories": [
+							"simpleR",
+							"martialR"
+						],
+						"type": "weapon"
+					},
+					"effects": [
+						{
+							"foundryId": "QD9d1gE6zl6wsy96"
+						}
+					]
+				},
+				{
+					"name": "Enchant (Non-Firearm)",
+					"type": "enchant",
+					"activation": {
+						"type": "special"
+					},
+					"duration": {
+						"units": "perm",
+						"concentration": false,
+						"override": false
+					},
+					"restrictions": {
+						"categories": [
+							"simpleR",
+							"martialR"
+						],
+						"type": "weapon"
+					},
+					"effects": [
+						{
+							"foundryId": "jtcPhE5HSLpbxj9V"
+						}
+					]
+				}
+			],
+			"effects": [
+				{
+					"foundryId": "QD9d1gE6zl6wsy96",
+					"name": "Overkill",
+					"type": "enchantment",
+					"changes": [
+						{
+							"key": "system.damage.base.bonus",
+							"mode": 2,
+							"value": "@abilities.dex.mod"
+						}
+					]
+				},
+				{
+					"foundryId": "jtcPhE5HSLpbxj9V",
+					"name": "Overkill",
+					"type": "enchantment",
+					"changes": [
+						{
+							"key": "system.damage.base.bonus",
+							"mode": 2,
+							"value": "1d8"
+						}
+					]
+				}
+			]
+		},
+		{
+			"name": "Cheat Death",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 13,
+			"activities": [
+				{
+					"type": "heal",
+					"activation": {
+						"type": "special"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Cheat Death"
+									}
+								}
+							}
+						]
+					},
+					"target": {
+						"affects": {
+							"choice": false,
+							"type": "self",
+							"special": ""
+						}
+					},
+					"range": {
+						"units": "self",
+						"override": false,
+						"special": ""
+					},
+					"healing": {
+						"denomination": 0,
+						"types": [
+							"healing"
+						],
+						"custom": {
+							"enabled": true,
+							"formula": "@classes.gunslinger.levels + 1"
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Dire Gambit",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 15,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "special",
+						"condition": "whenever you roll Initiative or score a Critical Hit"
+					},
+					"consumption": {
+						"scaling": {
+							"allowed": false
+						},
+						"spellSlot": true,
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "-1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Critical Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 17,
+			"isIgnored": true
+		},
+		{
+			"name": "Headshot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"level": 20,
+			"activities": [
+				{
+					"type": "damage",
+					"activation": {
+						"type": "special",
+						"condition": "when you score a Critical Hit against a creature using a Ranged weapon, you can choose for it to be a Headshot"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Headshot"
+									}
+								}
+							}
+						]
+					},
+					"damage": {
+						"parts": [
+							{
+								"number": 10,
+								"denomination": 10
+							}
+						]
+					}
+				},
+				{
+					"name": "Restore Use",
+					"type": "utility",
+					"activation": {
+						"type": "special"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "-1",
+								"target": {
+									"consumes": {
+										"name": "Headshot"
+									}
+								}
+							},
+							{
+								"type": "itemUses",
+								"value": "3",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"subclassFeature": [
+		{
+			"name": "Deadeye",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"{@i Shoot with Bullseye Precision}",
+				"A well-placed bullet is more powerful than a sword, arrow, or spell. Indeed, you believe that every violent conflict should sound like a single loud crack followed by a long silence. Such shots demand perfection, even at range, for when they are done right, they are as deadly for the target as they are stupendous for the audience.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Eagle Eye [Maneuver]|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Sharpshooter's Stance|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|3"
+				}
+			]
+		},
+		{
+			"name": "Eagle Eye [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"Once per turn when you miss with a ranged attack roll, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} and add it to the attack roll, potentially causing the attack to hit."
+			]
+		},
+		{
+			"name": "Sharpshooter's Stance",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"You have trained to fire from a stable {@condition Prone|XPHB} position, granting the following conditions.",
+				{
+					"type": "entries",
+					"name": "Fire While Prone",
+					"entries": [
+						"You don't have {@variantrule Disadvantage|XPHB} on ranged attack rolls as a result of the {@condition Prone|XPHB} condition."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Quick Stand",
+					"entries": [
+						"When you have the {@condition Prone|XPHB} condition, you can right yourself and thereby end the condition with only 5 feet of movement."
+					]
+				}
+			]
+		},
+		{
+			"name": "Concealed Position",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"You excel at firing from concealment, granting you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Camouflage",
+					"entries": [
+						"You can take the {@action Hide|XPHB} action even if you aren't {@variantrule Heavily Obscured|XPHB} or behind {@variantrule Cover|XPHB|Three-Quarters Cover} or {@variantrule Cover|XPHB|Total Cover}, as long as you have the {@condition Prone|XPHB} condition. The {@condition Invisible|XPHB} condition of this {@action Hide|XPHB} action ends if you don't have the {@condition Prone|XPHB} condition."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Sniper's Nest",
+					"entries": [
+						"If you make an attack roll while hidden and the roll misses, making the attack roll doesn't reveal your location."
+					]
+				}
+			]
+		},
+		{
+			"name": "Reposition",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Whenever a creature misses you with an attack roll, you can take a {@variantrule Reaction|XPHB} to end the {@condition Prone|XPHB} condition on yourself and move up to half your {@variantrule Speed|XPHB}."
+			]
+		},
+		{
+			"name": "Focused Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"When you take the {@action Attack|XPHB} action, you can choose to make only one ranged attack roll using a weapon to make a Focused Shot. You have {@variantrule Advantage|XPHB} on this attack roll and, on a hit, score a {@variantrule Critical Hit|XPHB}."
+			]
+		},
+		{
+			"name": "High Roller",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"{@i Gamble with Life and Death}",
+				"Fortune is a fickle thing—unless you're a High Roller. These Gunslingers are master card sharps and dice throwers that mix their love of risk with their talent for gunplay. High Rollers push their luck until it runs out, then push harder. Why settle for a win when you could bet it all and win big?",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Poker Face|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Liar's Dice [Maneuver]|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|3"
+				}
+			]
+		},
+		{
+			"name": "Liar's Dice [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"When you make a damage roll with a Ranged weapon, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} as a {@variantrule Bonus Action|XPHB} and declare it to be a hidden roll. Roll the damage in secret and declare any total you wish. The GM has the option to call your bluff, in which case you reveal the damage dice you rolled. This has different consequences based on whether or not you lied.",
+				{
+					"type": "entries",
+					"name": "The GM Calls Your Bluff; You Lied",
+					"entries": [
+						"The damage you deal is halved."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "The GM Calls Your Bluff; You Told the Truth",
+					"entries": [
+						"The damage you deal is doubled."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "The GM Doesn't Call Your Bluff",
+					"entries": [
+						"Use the total damage you declared, even if you rolled a different total."
+					]
+				}
+			]
+		},
+		{
+			"name": "Poker Face",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"deception",
+							"insight",
+							"perception"
+						],
+						"count": 1
+					}
+				}
+			],
+			"toolProficiencies": [
+				{
+					"gaming set": true,
+					"dice set": true,
+					"dragonchess set": true,
+					"playing card set": true,
+					"three-dragon ante set": true
+				}
+			],
+			"header": 1,
+			"entries": [
+				"You gain proficiency with all {@item Gaming Set|XPHB|Gaming Sets} and in one of the following skills of your choice: {@skill Deception|XPHB}, {@skill Insight|XPHB}, or {@skill Perception|XPHB}."
+			]
+		},
+		{
+			"name": "Risky Business",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Once per turn when you make an attack roll against an enemy and the roll doesn't have {@variantrule Disadvantage|XPHB}, you can choose to make the roll with {@variantrule Disadvantage|XPHB}. When you do, you regain one expended {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}."
+			]
+		},
+		{
+			"name": "Risk Taker",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You can use your {@optfeature Maverick Spirit|ValdaGunslinger} and {@optfeature Skin of Your Teeth|ValdaGunslinger} maneuvers without expending a {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}. When you do so, roll a {@dice d6} instead of a {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}."
+			]
+		},
+		{
+			"name": "Double or Nothing",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"When you score a {@variantrule Critical Hit|XPHB} using a Ranged weapon, you can gamble for a higher result. Roll a {@dice d20}. If the roll is a 10 or higher, roll all of the attack's damage dice four times and add them together, instead of only two times as normal for a {@variantrule Critical Hit|XPHB}. If you roll a 9 or lower on the {@dice d20}, the {@variantrule Critical Hit|XPHB} becomes a normal hit."
+			]
+		},
+		{
+			"name": "Secret Agent",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"{@i Engage in Espionage and Assassination}",
+				"Knowledge is power. The best way to defeat your enemies is by stealing what they know and replacing it with misinformation. To that end, you have been trained in the ways of covert warfare, giving you a broad range of abilities to complement your fearsome gunnery skills.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Operative Training|Gunslinger|ValdaGunslinger|Secret Agent|ValdaGunslinger|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Parting Shot [Maneuver]|Gunslinger|ValdaGunslinger|Secret Agent|ValdaGunslinger|3"
+				}
+			]
+		},
+		{
+			"name": "Operative Training",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"skillProficiencies": [
+				{
+					"choose": {
+						"from": [
+							"deception",
+							"investigation",
+							"persuasion",
+							"sleight of hand",
+							"stealth"
+						],
+						"count": 2
+					}
+				}
+			],
+			"toolProficiencies": [
+				{
+					"disguise kit": true,
+					"thieves' tools": true
+				}
+			],
+			"header": 1,
+			"entries": [
+				"Your covert training grants you the following benefits:",
+				{
+					"type": "entries",
+					"name": "Concealed Shot",
+					"entries": [
+						"You learn the {@spell Concealed Shot|ValdaGunslinger} cantrip. Intelligence, Wisdom, or Charisma is your spellcasting ability for this cantrip (choose when you select this subclass)."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Operative Tools",
+					"entries": [
+						"You gain a {@item Disguise Kit|XPHB} and {@item Thieves' Tools|XPHB}, and you have proficiency with them."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Skill Proficiencies",
+					"entries": [
+						"You gain proficiency in two of these skills of your choice: {@skill Deception|XPHB}, {@skill Investigation|XPHB}, {@skill Persuasion|XPHB}, {@skill Sleight of Hand|XPHB}, or {@skill Stealth|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Parting Shot [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"When you take the {@action Dash|XPHB}, {@action Disengage|XPHB}, or {@action Dodge|XPHB} action on your turn, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to make a ranged attack using a weapon as a {@variantrule Bonus Action|XPHB}. Add the {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to the damage roll on a hit."
+			]
+		},
+		{
+			"name": "Fieldcraft",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your experience in the field grants you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Quick Change",
+					"entries": [
+						"Using a {@item Disguise Kit|XPHB}, you can create a Costume and don it as a {@variantrule Bonus Action|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Slick Talker",
+					"entries": [
+						"Whenever you make a Charisma ({@skill Deception|XPHB}) or Charisma ({@skill Persuasion|XPHB}) check, you can treat a {@dice d20} roll of 9 or lower as a 10."
+					]
+				}
+			]
+		},
+		{
+			"name": "Exit Strategy",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"When you take damage, you can take a {@variantrule Reaction|XPHB} to evade further harm. You have the {@condition Invisible|XPHB} condition until the start of your next turn, and you can immediately move up to 10 feet.",
+				"Once you use this feature, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. You can also restore your use of it by expending one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} (no action required)."
+			]
+		},
+		{
+			"name": "License to Kill",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Whenever you deal damage with a Ranged weapon, you can expend either one or two {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Dice} and add them to the damage roll. If you roll the highest number on a {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}, you can roll the die again and add it to the damage without expending it, rolling again if it is the highest number again, and so on. The maximum number of {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Dice} you can add to the damage equals your {@variantrule Proficiency|XPHB|Proficiency Bonus}."
+			]
+		},
+		{
+			"name": "Spellslinger",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"{@i Complement Your Gunslinging with Arcana}",
+				"Magic and guns aren't so different—arcane power is like gunpowder, a spell is like a bullet, and you are like a gun, directing your spells with precision at unfortunate targets. Spellslingers mix the disciplines of gunplay and spellcasting, sometimes loading arcane charges with your shots and firing bullets enhanced with lighting, frost, or flame.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Spellcasting|Gunslinger|ValdaGunslinger|Spellslinger|ValdaGunslinger|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Bang, You're Dead!|Gunslinger|ValdaGunslinger|Spellslinger|ValdaGunslinger|3"
+				}
+			]
+		},
+		{
+			"name": "Bang, You're Dead!",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"You can use magic in place of guns.",
+				{
+					"type": "entries",
+					"name": "Finger Guns",
+					"entries": [
+						"You learn the {@spell Finger Guns|ValdaGunslinger} cantrip."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Arcane Shot",
+					"entries": [
+						"When you hit a target with a {@spell Finger Guns|ValdaGunslinger} attack, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} as a {@variantrule Bonus Action|XPHB} and add it to the damage roll."
+					]
+				}
+			]
+		},
+		{
+			"name": "Spellcasting",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"You complement your bullets with the ability to cast spells.",
+				{
+					"type": "entries",
+					"name": "Cantrips",
+					"entries": [
+						"You know two cantrips of your choice from the Wizard spell list (see that class's section for its list). {@spell Fire Bolt|XPHB} and {@spell Message|XPHB} are recommended. Whenever you gain a Gunslinger level, you can replace one of these cantrips with another cantrip of your choice from the Wizard spell list.",
+						"When you reach Gunslinger level 10, you learn another Wizard cantrip of your choice."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spell Slots",
+					"entries": [
+						"The Spellslinger Spellcasting table shows how many spell slots you have to cast your level 1+ spells. You regain all expended slots when you finish a {@variantrule Long Rest|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Prepared Spells of Level 1+",
+					"entries": [
+						"You prepare the list of level 1+ spells that are available for you to cast with this feature. To start, choose three level 1 spells from the Wizard spell list. {@spell Chromatic Orb|XPHB}, {@spell Jump|XPHB}, and {@spell Shield|XPHB} are recommended.",
+						"The number of spells on your list increases as you gain Gunslinger levels, as shown in the Prepared Spells column of the Spellslinger Spellcasting table. Whenever that number increases, choose additional spells from the Wizard spell list until the number of spells on your list matches the number on the table. The chosen spells must be of a level for which you have spell slots. For example, if you're a level 7 Gunslinger, your list of prepared spells can include five Wizard spells of levels 1 and 2 in any combination."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Changing your Prepared Spells",
+					"entries": [
+						"Whenever you gain a Gunslinger level, you can replace one spell on your list with another Wizard spell for which you have spell slots."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Ability",
+					"entries": [
+						"Intelligence is your spellcasting ability for your Wizard spells."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spellcasting Focus",
+					"entries": [
+						"You can use an {@item Arcane Focus|XPHB} or a Ranged weapon as a {@variantrule Spellcasting Focus|XPHB} for your Wizard spells."
+					]
+				}
+			]
+		},
+		{
+			"name": "Spellshot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"When you take the {@action Attack|XPHB} action on your turn, you can replace one of the attacks with a casting of one of your Wizard cantrips that has a casting time of an action."
+			]
+		},
+		{
+			"name": "Counter-Mage",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Your experience in combating spellcasters grants you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Abjuration-Breaker",
+					"entries": [
+						"Whenever you make a ranged attack roll, you temporarily disrupt protective magic affecting the target. For the duration of the attack, the effects of spells targeting the creature, such as {@spell Mage Armor|XPHB}, as well as the properties and powers of magic items worn or carried by the creature, are suppressed and don't function. The target of the attack can't take a {@variantrule Reaction|XPHB} to cast spells such as {@spell Shield|XPHB} in response to the attack or damage."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Antimagic Shot",
+					"entries": [
+						"When you score a {@variantrule Critical Hit|XPHB} and the target is affected by your {@classFeature Gut Shot|Gunslinger|ValdaGunslinger|5} feature, it also impedes the target's ability to cast spells. While the projectile is lodged in the target, it can't cast spells or take the {@action Magic|XPHB} action. Additionally, the target has {@variantrule Disadvantage|XPHB} on Constitution saving throws it makes to maintain {@status Concentration|XPHB}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Inured to Magic",
+					"entries": [
+						"When you fail a saving throw against a spell or magical effect, you can take a {@variantrule Reaction|XPHB} to roll {@dice 1d6} and add it to the roll, potentially turning the failure into a success."
+					]
+				}
+			]
+		},
+		{
+			"name": "Magic Bullet [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"When you make a spell attack roll, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} as a {@variantrule Bonus Action|XPHB} to substitute the spell attack with a ranged attack using a weapon. Add the {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to the attack roll. On a hit, the attack deals the weapon's normal damage, in addition to the effects of the spell attack roll."
+			]
+		},
+		{
+			"name": "Trick Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"{@i Ricochet Bullets from Every Angle}",
+				"Accuracy means different things to different people. For you, true accuracy isn't necessarily in hitting a target on the first shot, but might include hitting the mark after the bullet bounces around a dozen times. Your attacks are just as dangerous if they miss, or even after hitting their mark, as others' are while they're still in the air.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Creative Trajectory|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Ricochet [Maneuver]|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|3"
+				}
+			]
+		},
+		{
+			"name": "Creative Trajectory",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"You can make your projectiles travel in unexpected ways. Your ranged attacks with weapons ignore {@variantrule Cover|XPHB|Half Cover} and {@variantrule Cover|XPHB|Three-Quarters Cover}."
+			]
+		},
+		{
+			"name": "Ricochet [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"When you miss with a ranged attack using a weapon, you can take a {@variantrule Bonus Action|XPHB} and expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to reroll the attack and add the {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to the roll. You must use the new roll."
+			]
+		},
+		{
+			"name": "Fancy Gunplay",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"Your flashy weapon tricks grant you the following benefits.",
+				{
+					"type": "entries",
+					"name": "Gun Spinning",
+					"entries": [
+						"Once per turn when you make a Charisma ({@skill Performance|XPHB}) check or a Dexterity ({@skill Sleight of Hand|XPHB}) check using one of your Ranged weapons, you can roll a {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} and add it to the ability check without expending it."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Speed Loader",
+					"entries": [
+						"On your turn, you can reload a weapon with {@itemProperty RLD|XDMG|Reload} without taking an action or {@variantrule Bonus Action|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Deft Deflection [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"You can shoot projectiles out of the air. When an ally within 30 feet of you is hit by an attack, you can take a {@variantrule Reaction|XPHB} and expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to grant that ally the benefit of the {@optfeature Skin of Your Teeth|ValdaGunslinger} maneuver against that attack. You must be holding a Ranged weapon to use this maneuver."
+			]
+		},
+		{
+			"name": "Pinball Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Once on each of your turns when you hit a creature with a ranged attack using a weapon, you can deflect the projectile at additional targets. Choose a different target within 30 feet of the first and make an attack roll against it. On a hit, you can repeat this attack against a new target within 30 feet until you miss or make a total of five attacks. You can't target the same creature with more than one attack each time you use this feature.",
+				"Once you use this feature, you can't use it again until you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}. You can also restore your use of it by expending two {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Dice} (no action required)."
+			]
+		},
+		{
+			"name": "White Hat",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"entries": [
+				"{@i Protect Your Allies and Uphold the Law}",
+				"Some Gunslingers live by a code and expect others to do the same. These Gunslingers, known as White Hats, sometimes serve as officers of the law but never hesitate to do what's right when the law says otherwise. Despite their affinity for deadly weapons, White Hats prefer to keep their friends safe and subdue their enemies nonviolently—a preference their enemies don't often oblige.",
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Lay Down the Law [Maneuver]|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3"
+				},
+				{
+					"type": "refSubclassFeature",
+					"subclassFeature": "Steely-Eyed Aura|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3"
+				}
+			]
+		},
+		{
+			"name": "Lay Down the Law [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"You can take a {@variantrule Bonus Action|XPHB} and expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to keep an eye out for dangers that threaten your companions. Choose an ally that you can see within 60 feet of you. That ally gains {@variantrule Temporary Hit Points|XPHB} equal to the number rolled on the {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}. Until the start of your next turn, if the ally is hit by an attack, you can take a {@variantrule Reaction|XPHB} to make a ranged attack using a weapon against the attacker."
+			]
+		},
+		{
+			"name": "Steely-Eyed Aura",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"header": 1,
+			"entries": [
+				"An aura of stoic confidence radiates from you in a 10-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. You and allies within the {@variantrule Emanation [Area of Effect]|XPHB|Emanation} have {@variantrule Advantage|XPHB} on saving throws made to avoid or end the {@condition Frightened|XPHB} condition. The aura is inactive while you have the {@condition Incapacitated|XPHB} condition."
+			]
+		},
+		{
+			"name": "Reach for the Skies",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"header": 2,
+			"entries": [
+				"When you score a {@variantrule Critical Hit|XPHB} against a creature, you call for the target to surrender instead of lodging a projectile in it. The target must succeed on a Wisdom saving throw against your Maneuver save DC or have the {@condition Frightened|XPHB} and {@condition Incapacitated|XPHB} conditions for 1 minute. These conditions end early if the creature takes any damage, if you have the {@condition Incapacitated|XPHB} condition, or if you die. The creature can repeat the Wisdom saving throw at the end of each of its turns, ending the conditions on itself on a success."
+			]
+		},
+		{
+			"name": "Long Arm of the Law",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"header": 2,
+			"entries": [
+				"Once per turn when you hit a Large or smaller creature with a ranged attack using a weapon, you can hobble the target. The creature can't move on its next turn unless it first takes the {@action Disengage|XPHB} action."
+			]
+		},
+		{
+			"name": "Gold Star Hero",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"header": 2,
+			"entries": [
+				"Though gunslinging heroism, you gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Improved Aura",
+					"entries": [
+						"The range of your {@subclassFeature Steely-Eyed Aura|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3} feature increases to 30 feet."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Iron-Clad Law",
+					"entries": [
+						"When you use your {@subclassFeature Lay Down the Law [Maneuver]|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3|ValdaGunslinger|Lay Down the Law} maneuver, the ally has {@variantrule Resistance|XPHB} to Bludgeoning, Piercing, and Slashing damage until the start of your next turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Stunned Surrender",
+					"entries": [
+						"When a creature fails its saving throw against your {@subclassFeature Reach for the Skies|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|6} feature, it has the {@condition Stunned|XPHB} condition instead of the {@condition Incapacitated|XPHB} condition."
+					]
+				}
+			]
+		}
+	],
+	"foundrySubclassFeature": [
+		{
+			"name": "Eagle Eye [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Deadeye",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "special",
+						"condition": "when you miss with a ranged attack roll"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"roll": {
+						"formula": "1@scale.gunslinger.risk-dice.die",
+						"name": "Add to Attack Roll"
+					}
+				}
+			]
+		},
+		{
+			"name": "Liar's Dice [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "bonus",
+						"value": 1,
+						"condition": "when you make a damage roll with a Ranged weapon"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Risky Business",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"activities": [
+				{
+					"name": "Regain Risk Die",
+					"type": "utility",
+					"activation": {
+						"type": "special"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "-1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Double or Nothing",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "High Roller",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "special",
+						"condition": "when you score a Critical Hit using a Ranged weapon"
+					},
+					"roll": {
+						"formula": "1d20"
+					}
+				}
+			]
+		},
+		{
+			"name": "Parting Shot [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"activities": [
+				{
+					"type": "damage",
+					"activation": {
+						"type": "bonus",
+						"condition": "when you take the {@action Dash|XPHB}, {@action Disengage|XPHB}, or {@action Dodge|XPHB} action on your turn"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"damage": {
+						"parts": [
+							{
+								"custom": {
+									"enabled": true,
+									"formula": "1@scale.gunslinger.risk-dice.die"
+								},
+								"denomination": 0,
+								"types": [
+									"piercing"
+								]
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Exit Strategy",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "reaction",
+						"value": 1,
+						"condition": "when you take damage"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Exit Strategy"
+									}
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "Restore Use",
+					"type": "utility",
+					"activation": {
+						"type": "special"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "-1",
+								"target": {
+									"consumes": {
+										"name": "Exit Strategy"
+									}
+								}
+							},
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "License to Kill",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Secret Agent",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"activities": [
+				{
+					"type": "damage",
+					"activation": {
+						"type": "special",
+						"condition": "whenever you deal damage with a Ranged weapon"
+					},
+					"consumption": {
+						"scaling": {
+							"allowed": true,
+							"max": "2"
+						},
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "@scaling",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"damage": {
+						"parts": [
+							{
+								"custom": {
+									"enabled": true,
+									"formula": "@scaling@scale.gunslinger.risk-dice.die"
+								},
+								"denomination": 0,
+								"types": [
+									"piercing"
+								],
+								"scaling": {
+									"number": 1
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Bang, You're Dead!",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"activities": [
+				{
+					"name": "Arcane Shot",
+					"type": "damage",
+					"activation": {
+						"type": "bonus",
+						"condition": "when you hit a target with a Finger Guns attack"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"damage": {
+						"parts": [
+							{
+								"custom": {
+									"enabled": true,
+									"formula": "1@scale.gunslinger.risk-dice.die"
+								},
+								"denomination": 0,
+								"types": [
+									"piercing"
+								],
+								"scaling": {
+									"number": 1
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Counter-Mage",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "reaction",
+						"value": 1,
+						"condition": "When you fail a saving throw against a spell or magical effect"
+					},
+					"roll": {
+						"formula": "1d6"
+					}
+				}
+			]
+		},
+		{
+			"name": "Magic Bullet [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Spellslinger",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "bonus",
+						"value": 1
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"roll": {
+						"formula": "1@scale.gunslinger.risk-dice.die"
+					}
+				}
+			]
+		},
+		{
+			"name": "Ricochet [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "bonus",
+						"value": 1
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"roll": {
+						"formula": "1@scale.gunslinger.risk-dice.die"
+					}
+				}
+			]
+		},
+		{
+			"name": "Fancy Gunplay",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 6,
+			"activities": [
+				{
+					"name": "Gun Spinning",
+					"type": "utility",
+					"activation": {
+						"type": "special",
+						"value": 1
+					},
+					"roll": {
+						"formula": "1@scale.gunslinger.risk-dice.die"
+					}
+				}
+			]
+		},
+		{
+			"name": "Deft Deflection [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 10,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "reaction",
+						"value": 1,
+						"condition": "when an ally within 30 feet of you is hit by an attack"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"target": {
+						"affects": {
+							"count": "1",
+							"type": "ally"
+						},
+						"prompt": true
+					},
+					"range": {
+						"units": "ft",
+						"value": "30"
+					},
+					"roll": {
+						"formula": "1@scale.gunslinger.risk-dice.die"
+					}
+				}
+			]
+		},
+		{
+			"name": "Pinball Shot",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "Trick Shot",
+			"subclassSource": "ValdaGunslinger",
+			"level": 14,
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "special"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Pinball Shot"
+									}
+								}
+							}
+						]
+					}
+				},
+				{
+					"name": "Restore Use",
+					"type": "utility",
+					"activation": {
+						"type": "",
+						"value": null
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							},
+							{
+								"type": "itemUses",
+								"value": "-1",
+								"target": {
+									"consumes": {
+										"name": "Pinball Shot"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Lay Down the Law [Maneuver]",
+			"source": "ValdaGunslinger",
+			"className": "Gunslinger",
+			"classSource": "ValdaGunslinger",
+			"subclassShortName": "White Hat",
+			"subclassSource": "ValdaGunslinger",
+			"level": 3,
+			"activities": [
+				{
+					"name": "Use",
+					"type": "heal",
+					"activation": {
+						"type": "bonus"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"target": {
+						"affects": {
+							"count": "1",
+							"type": "ally"
+						}
+					},
+					"range": {
+						"units": "ft",
+						"value": "60"
+					},
+					"healing": {
+						"denomination": 0,
+						"types": [
+							"temphp"
+						],
+						"custom": {
+							"enabled": true,
+							"formula": "1@scale.gunslinger.risk-dice.die"
+						}
+					}
+				}
+			]
+		}
+	],
+	"optionalfeature": [
+		{
+			"name": "Bite the Bullet",
+			"source": "ValdaGunslinger",
+			"featureType": [
+				"MV:G"
+			],
+			"entries": [
+				"As a {@variantrule Bonus Action|XPHB}, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to gain {@variantrule Temporary Hit Points|XPHB} equal to the number rolled on the die plus your Gunslinger level."
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+		},
+		{
+			"name": "Blindfire",
+			"source": "ValdaGunslinger",
+			"featureType": [
+				"MV:G"
+			],
+			"entries": [
+				"You can take a {@variantrule Bonus Action|XPHB} and expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to gain {@sense Blindsight|XPHB} with a range of 30 feet until the end of the current turn."
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+		},
+		{
+			"name": "Dodge Roll",
+			"source": "ValdaGunslinger",
+			"featureType": [
+				"MV:G"
+			],
+			"entries": [
+				"You can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} as a {@variantrule Bonus Action|XPHB} to move up to 15 feet and reload any Ranged weapon you are holding. This movement doesn't provoke {@action Opportunity Attack|XPHB|Opportunity Attacks} and is unaffected by {@variantrule Difficult Terrain|XPHB}."
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+		},
+		{
+			"name": "Grazing Shot",
+			"source": "ValdaGunslinger",
+			"featureType": [
+				"MV:G"
+			],
+			"entries": [
+				"When you miss with a ranged attack roll using a weapon, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} (no action required) to deal damage to that creature equal to a roll of the die plus your Dexterity modifier (minimum of 1). This damage is the same type dealt by the weapon, and the damage can be increased only by increasing the ability modifier. You can only use this maneuver once per turn."
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+		},
+		{
+			"name": "Maverick Spirit",
+			"source": "ValdaGunslinger",
+			"featureType": [
+				"MV:G"
+			],
+			"entries": [
+				"When you fail an Intelligence, Wisdom, or Charisma ability check or saving throw, you can expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to add it to the roll, potentially turning it into a success. You can only use this maneuver once per turn."
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+		},
+		{
+			"name": "Skin of Your Teeth",
+			"source": "ValdaGunslinger",
+			"featureType": [
+				"MV:G"
+			],
+			"entries": [
+				"When a creature you can see hits you with an attack roll, you can take a {@variantrule Reaction|XPHB} and expend one {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die} to dodge out of harm's way. Roll the die and add the number rolled to your AC against this attack, potentially causing it to miss."
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+		}
+	],
+	"foundryOptionalfeature": [
+		{
+			"name": "Bite the Bullet",
+			"source": "ValdaGunslinger",
+			"activities": [
+				{
+					"type": "heal",
+					"activation": {
+						"type": "bonus"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"target": {
+						"affects": {
+							"choice": false,
+							"type": "self",
+							"special": ""
+						}
+					},
+					"range": {
+						"units": "self"
+					},
+					"healing": {
+						"denomination": 0,
+						"types": [
+							"temphp"
+						],
+						"custom": {
+							"enabled": true,
+							"formula": "@scale.gunslinger.risk-dice.die + @classes.gunslinger.levels"
+						}
+					}
+				}
+			]
+		},
+		{
+			"name": "Blindfire",
+			"source": "ValdaGunslinger",
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "bonus",
+						"value": 1
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Dodge Roll",
+			"source": "ValdaGunslinger",
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "bonus",
+						"value": 1
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Grazing Shot",
+			"source": "ValdaGunslinger",
+			"activities": [
+				{
+					"type": "damage",
+					"activation": {
+						"type": "special",
+						"condition": "when you miss with a ranged attack roll using a weapon"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"damage": {
+						"parts": [
+							{
+								"custom": {
+									"enabled": true,
+									"formula": "@scale.gunslinger.risk-dice.die + @abilities.dex.mod"
+								},
+								"denomination": 0
+							}
+						]
+					}
+				}
+			]
+		},
+		{
+			"name": "Maverick Spirit",
+			"source": "ValdaGunslinger",
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "special",
+						"condition": "when you fail an Intelligence, Wisdom, or Charisma ability check or saving throw"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					},
+					"roll": {
+						"formula": "@scale.gunslinger.risk-dice.die"
+					}
+				}
+			]
+		},
+		{
+			"name": "Skin of Your Teeth",
+			"source": "ValdaGunslinger",
+			"activities": [
+				{
+					"type": "utility",
+					"activation": {
+						"type": "reaction",
+						"value": 1,
+						"condition": "when a creature you can see hits you with an attack roll"
+					},
+					"consumption": {
+						"targets": [
+							{
+								"type": "itemUses",
+								"value": "1",
+								"target": {
+									"consumes": {
+										"name": "Risk"
+									}
+								}
+							}
+						]
+					}
+				}
+			]
+		}
+	],
+	"feat": [
+		{
+			"name": "Gun-Mage Adept",
+			"source": "ValdaGunslinger",
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"spellcasting2020": true
+				}
+			],
+			"ability": [
+				{
+					"dex": 1
+				}
+			],
+			"weaponProficiencies": [
+				{
+					"all": {
+						"fromFilter": "type=ranged weapon;martial weapon"
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Ranged Weapon Proficiency",
+					"entries": [
+						"You gain proficiency with Ranged Martial weapons."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Cantrip",
+					"entries": [
+						"You learn the {@spell Finger Guns|ValdaGunslinger} cantrip."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Expanded Spell List",
+					"entries": [
+						"The following spells are added to your spell list: {@spell Antiballistics Field|ValdaGunslinger}, {@spell Ballistic Smite|ValdaGunslinger}, {@spell Conjure Cannonball|ValdaGunslinger}, {@spell Conjure Cover|ValdaGunslinger}, {@spell Jam Weapon|ValdaGunslinger}, {@spell Jethro's Instant Reload|ValdaGunslinger}, and {@spell Perforating Shot|ValdaGunslinger}."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Spells Prepared",
+					"entries": [
+						"Choose a number of spells equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus} from among those in the Expanded Spell List benefit. You always have these spells prepared. Whenever you gain a new level, you can replace one of these spells with a different spell from the Expanded Spell List."
+					]
+				}
+			]
+		},
+		{
+			"name": "Iron Hero",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaPlayerPack"
+				}
+			],
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4
+				}
+			],
+			"ability": [
+				{
+					"choose": {
+						"from": [
+							"str",
+							"dex"
+						]
+					}
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Underdog's Resolve",
+					"entries": [
+						"When you are attacked by a creature that has a CR higher than your character level, you gain a +2 bonus to your {@variantrule Armor Class|XPHB} for that attack."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Vengeful Strike",
+					"entries": [
+						"You have {@variantrule Advantage|XPHB} on attack rolls against any creature that has reduced one of your allies to 0 {@variantrule Hit Points|XPHB} since the end of your last turn."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Heroic Intervention",
+					"entries": [
+						"When an enemy you can see takes a Legendary Action, you can take a {@variantrule Reaction|XPHB} to intercede, preventing the Legendary Action from happening. You can take this {@variantrule Reaction|XPHB} a number of times equal to your {@variantrule Proficiency|XPHB|Proficiency Bonus} and regain all expended uses when you finish a {@variantrule Short Rest|XPHB|Short} or {@variantrule Long Rest|XPHB}."
+					]
+				}
+			]
+		},
+		{
+			"name": "Marksman's Luck",
+			"source": "ValdaGunslinger",
+			"category": "G",
+			"prerequisite": [
+				{
+					"level": 4,
+					"ability": [
+						{
+							"dex": 13
+						}
+					]
+				}
+			],
+			"ability": [
+				{
+					"dex": 1
+				}
+			],
+			"entries": [
+				"You gain the following benefits.",
+				{
+					"type": "entries",
+					"name": "Flip Die",
+					"entries": [
+						"Once per turn, when you roll for damage with a Ranged weapon, you can flip one of the damage dice over and use the number on the bottom. You can't use this ability on d4s. Note that for a balanced die, the top and bottom numbers add up to one more than the die's largest number."
+					]
+				},
+				{
+					"type": "entries",
+					"name": "Enhanced Critical",
+					"entries": [
+						"When you score a {@variantrule Critical Hit|XPHB} with a Ranged weapon, the target's {@variantrule Speed|XPHB} is 0 until the end of its next turn."
+					]
+				}
+			]
+		}
+	],
+	"spell": [
+		{
+			"name": "Antiballistics Field",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 6,
+			"school": "A",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "emanation",
+				"distance": {
+					"type": "feet",
+					"amount": 40
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true,
+				"m": "a pinch of wet gunpowder"
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "minute",
+						"amount": 10
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"A 40-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation} extends from you, disrupting projectiles and causing Ranged weapons to malfunction. Within the {@variantrule Emanation [Area of Effect]|XPHB|Emanation}, whenever a Ranged weapon is used for an attack, the weapon immediately malfunctions and the attack is lost. A malfunctioning weapon can't be used to make an attack until a creature takes the {@action Utilize|XPHB} action to fix the weapon malfunction. Ranged attacks using weapons whose projectiles pass through the {@variantrule Emanation [Area of Effect]|XPHB|Emanation} have {@variantrule Disadvantage|XPHB} and deal only half damage on a hit."
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Cleric",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Ballistic Smite",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 1,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "bonus",
+					"condition": "which you take immediately after hitting a creature with a Ranged weapon"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "self"
+				}
+			},
+			"components": {
+				"v": true
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"Choose Acid, Cold, Fire, Lightning, Poison, or Thunder damage. The target hit by the attack takes an extra {@damage 2d6} damage of the chosen type. The triggering attack can deal the chosen damage type or its normal damage type (your choice)."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "Using a Higher-Level Spell Slot",
+					"entries": [
+						"The damage increases by {@dice 1d6} for each spell slot level above 1."
+					]
+				}
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Paladin",
+						"source": "XPHB"
+					}
+				]
+			},
+			"fluff": {
+				"images": [
+					{
+						"type": "image",
+						"href": {
+							"type": "external",
+							"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-015.explosion.webp"
+						},
+						"width": 850,
+						"height": 591
+					}
+				]
+			}
+		},
+		{
+			"name": "Concealed Shot",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 0,
+			"school": "I",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "touch"
+				}
+			},
+			"components": {
+				"s": true,
+				"m": "a Ranged weapon"
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "minute",
+						"amount": 1
+					}
+				}
+			],
+			"entries": [
+				"A Ranged weapon you touch is made supernaturally subtle. For the duration, when you make a ranged attack using the weapon, the weapon or ammunition you're using becomes {@condition invisible} while in flight and the weapon becomes silent. If the weapon produces smoke or light, the spell suppresses these effects. The weapon or projectile you're using becomes visible again after the attack hits or misses. If you are hidden and the target is 80 feet or further from you, the attack doesn't reveal your location."
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Bard",
+						"source": "XPHB"
+					},
+					{
+						"name": "Druid",
+						"source": "XPHB"
+					},
+					{
+						"name": "Sorcerer",
+						"source": "XPHB"
+					},
+					{
+						"name": "Warlock",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Conjure Cannonball",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 3,
+			"school": "C",
+			"subschools": [
+				"Firearm"
+			],
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "feet",
+					"amount": 600
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true,
+				"m": "a small replica cannon"
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"You summon a cannonball, mid-flight and at full velocity, which explodes on impact. Make a ranged spell attack roll against a target you can see within range. On a hit, the target takes {@damage 5d10} Bludgeoning damage and an explosion extends from it in a 5-foot {@variantrule Emanation [Area of Effect]|XPHB|Emanation}. Each creature other than the target within the {@variantrule Emanation [Area of Effect]|XPHB|Emanation} makes a Dexterity saving throw, taking half as much damage as the target on a failed save."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "Using a Higher-Level Spell Slot",
+					"entries": [
+						"The damage increases by {@dice 1d10} for each slot level above 3."
+					]
+				}
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Sorcerer",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			},
+			"damageInflict": [
+				"bludgeoning"
+			],
+			"spellAttack": [
+				"R"
+			],
+			"savingThrow": [
+				"dexterity"
+			],
+			"miscTags": [
+				"SGT",
+				"SMN"
+			]
+		},
+		{
+			"name": "Conjure Cover",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 1,
+			"school": "C",
+			"time": [
+				{
+					"number": 1,
+					"unit": "bonus"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "feet",
+					"amount": 10
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true,
+				"m": "a duck figurine"
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "hour",
+						"amount": 1
+					},
+					"concentration": true
+				}
+			],
+			"entries": [
+				"You conjure a low cobblestone wall along the ground at a point you can see within range. The wall is 18 inches thick and is composed of three 5-foot-long, 3-foot-high segments. Each segment must be contiguous with at least one other segment.",
+				"A Medium creature that hunkers behind the wall has {@variantrule Cover|XPHB|Half Cover}, and a Small creature that hunkers behind it has {@variantrule Cover|XPHB|Three-Quarters Cover}. The wall can be leapt over without spending any additional movement.",
+				"Each segment has AC 10 and 30 {@variantrule Hit Points|XPHB}. Reducing a segment of the wall to 0 {@variantrule Hit Points|XPHB} causes it to crumble, destroying it. The wall disappears when all the segments are destroyed or the spell ends."
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Druid",
+						"source": "XPHB"
+					},
+					{
+						"name": "Paladin",
+						"source": "XPHB"
+					},
+					{
+						"name": "Sorcerer",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			},
+			"miscTags": [
+				"SGT"
+			]
+		},
+		{
+			"name": "Finger Guns",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaPlayerPack"
+				},
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 0,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "bonus"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "self"
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "minute",
+						"amount": 1
+					}
+				}
+			],
+			"entries": [
+				"You extend your forefinger and thumb, a dangerous gesture mimicking a gun. For the duration, your hand counts as a Simple Ranged weapon with a range of 60/240 feet and the {@itemMastery Slow|XPHB} mastery property. You can use your spellcasting ability instead of Dexterity for the attack rolls of this weapon. On a hit, the weapon deals {@damage 2d6} Force damage and doesn't add your ability modifier to damage."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "Cantrip Upgrade",
+					"entries": [
+						"The weapon's normal range increases by 30 feet and its long range increases by 120 feet when you reach levels 5 (90/360 feet), 11 (120/480 feet), and 17 (150/600 feet)."
+					]
+				}
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Bard",
+						"source": "XPHB"
+					},
+					{
+						"name": "Sorcerer",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			},
+			"damageInflict": [
+				"force"
+			],
+			"miscTags": [
+				"SCL"
+			]
+		},
+		{
+			"name": "Jam Weapon",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 2,
+			"school": "T",
+			"time": [
+				{
+					"number": 1,
+					"unit": "reaction",
+					"condition": "which you take when a creature you can see within range makes an attack using a Ranged weapon"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "feet",
+					"amount": 60
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true,
+				"m": "a pinch of wet gunpowder"
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"The weapon you target suffers a malfunction and the attack fails. A malfunctioning weapon can't be used to make an attack until a creature takes the {@action Utilize|XPHB} action to fix the weapon malfunction."
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Bard",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			},
+			"miscTags": [
+				"SGT"
+			]
+		},
+		{
+			"name": "Jethro's Instant Reload",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 2,
+			"school": "C",
+			"time": [
+				{
+					"number": 1,
+					"unit": "action"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "touch"
+				}
+			},
+			"components": {
+				"v": true,
+				"s": true,
+				"m": "a spent bullet casing"
+			},
+			"duration": [
+				{
+					"type": "timed",
+					"duration": {
+						"type": "hour",
+						"amount": 8
+					}
+				}
+			],
+			"entries": [
+				"One Ranged weapon you touch becomes enchanted to reload itself automatically. If the weapon has the {@itemProperty LD|XPHB|Loading} or {@itemProperty RLD|XDMG|Reload} property, you ignore the property for the duration. When the weapon's ammunition is depleted, ammunition you are carrying teleports into the weapon."
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Bard",
+						"source": "XPHB"
+					},
+					{
+						"name": "Ranger",
+						"source": "XPHB"
+					},
+					{
+						"name": "Wizard",
+						"source": "XPHB"
+					}
+				]
+			}
+		},
+		{
+			"name": "Perforating Shot",
+			"source": "ValdaGunslinger",
+			"otherSources": [
+				{
+					"source": "ValdaSpire24"
+				}
+			],
+			"level": 1,
+			"school": "V",
+			"time": [
+				{
+					"number": 1,
+					"unit": "bonus",
+					"condition": "which you take immediately after hitting or missing with a ranged attack using a weapon"
+				}
+			],
+			"range": {
+				"type": "point",
+				"distance": {
+					"type": "self"
+				}
+			},
+			"components": {
+				"v": true
+			},
+			"duration": [
+				{
+					"type": "instant"
+				}
+			],
+			"entries": [
+				"As your attack hits or misses the target, the weapon or ammunition transforms into a 5-foot-wide {@variantrule Line [Area of Effect]|XPHB|Line} of magical energy that extends out to the weapon's normal range. The {@variantrule Line [Area of Effect]|XPHB|Line} includes the attack's original target. Each creature within the {@variantrule Line [Area of Effect]|XPHB|Line} makes a Dexterity saving throw, taking Force damage equal to the weapon's normal damage on a failed save or half as much damage on a successful one."
+			],
+			"entriesHigherLevel": [
+				{
+					"type": "entries",
+					"name": "Using a Higher-Level Spell Slot",
+					"entries": [
+						"The weapon's damage increases by {@dice 1d8} for each slot level above 1."
+					]
+				}
+			],
+			"classes": {
+				"fromClassList": [
+					{
+						"name": "Paladin",
+						"source": "XPHB"
+					},
+					{
+						"name": "Ranger",
+						"source": "XPHB"
+					}
+				]
+			},
+			"savingThrow": [
+				"dexterity"
+			]
+		}
+	],
+	"item": [
+		{
+			"name": "Assault Rifle",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 7,
+			"value": 30000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"2H|XPHB",
+				"RLD|XDMG",
+				"GC:VSS-M|ValdaGunslinger"
+			],
+			"mastery": [
+				"Automatic|ValdaGunslinger"
+			],
+			"range": "80/320",
+			"reload": 20,
+			"dmg1": "2d6",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Combining a high rate of fire with rifle-grade ballistics, the Assault Rifle is a staple weapon for all modern militaries. Dozens of variants exist on this general design, but all share the traits of a flexible and formidable weapon."
+			],
+			"ammoType": "bullet|ValdaGunslinger",
+			"hasFluffImages": true
+		},
+		{
+			"name": "Blunderbuss",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 15,
+			"value": 75000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"H|XPHB",
+				"LD|XPHB",
+				"2H|XPHB",
+				"GC:VSS-Ren|ValdaGunslinger"
+			],
+			"mastery": [
+				"Scatter|ValdaGunslinger"
+			],
+			"range": "20/60",
+			"dmg1": "1d12",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"This distinctive short-range firearm features a dramatically flared muzzle designed to launch shot in a wide spray. Most effective at close range, the Blunderbuss can be considered a precursor to the modern shotgun."
+			],
+			"ammoType": "shot|ValdaGunslinger"
+		},
+		{
+			"name": "Bullet",
+			"source": "ValdaGunslinger",
+			"type": "A|XPHB",
+			"rarity": "none",
+			"weight": 0.15,
+			"value": 30,
+			"bulletFirearm": true,
+			"entries": [
+				"Ammunition is required by a weapon that has {@itemProperty AF|XDMG|Ammunition}. A weapon's description specifies the type of ammunition used by the weapon.",
+				"Firearm ammunition is destroyed upon use."
+			],
+			"miscTags": [
+				"CNS"
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-014.firearm-ammunition.webp"
+		},
+		{
+			"name": "Cannon",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 225,
+			"value": 150000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"H|XPHB",
+				"LD|XPHB",
+				"2H|XPHB",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Explode|ValdaGunslinger"
+			],
+			"range": "100/400",
+			"dmg1": "2d8",
+			"dmgType": "F",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Smoothbore, muzzleloading Cannons are common fixtures on pirate ships and defensive fortifications, capable of splintering wood and reducing stone to gravel with a thunderous boom. Larger siege weapons of this type exist, and require entire teams of operators to position, load, and fire."
+			],
+			"ammoType": "cannonball|ValdaGunslinger"
+		},
+		{
+			"name": "Cannonball",
+			"source": "ValdaGunslinger",
+			"type": "A|XPHB",
+			"rarity": "none",
+			"weight": 2,
+			"value": 500,
+			"bulletFirearm": true,
+			"entries": [
+				"Ammunition is required by a weapon that has {@itemProperty AF|XDMG|Ammunition}. A weapon's description specifies the type of ammunition used by the weapon.",
+				"Firearm ammunition is destroyed upon use."
+			],
+			"miscTags": [
+				"CNS"
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-014.firearm-ammunition.webp"
+		},
+		{
+			"name": "Double-Barrel Shotgun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 8,
+			"value": 17500,
+			"weaponCategory": "simple",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"GC:VSS-R",
+				"RLD|XDMG",
+				"2H|XPHB",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Scatter|ValdaGunslinger"
+			],
+			"range": "20/60",
+			"reload": 2,
+			"dmg1": "2d6",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"A classic design with two loaded barrels, the Double-Barrel Shotgun trades ammo capacity and range for reliability and firepower."
+			],
+			"ammoType": "shell|ValdaGunslinger"
+		},
+		{
+			"name": "Flare",
+			"source": "ValdaGunslinger",
+			"type": "A|XPHB",
+			"rarity": "none",
+			"weight": 1,
+			"value": 100,
+			"bulletFirearm": true,
+			"entries": [
+				"Ammunition is required by a weapon that has {@itemProperty AF|XDMG|Ammunition}. A weapon's description specifies the type of ammunition used by the weapon.",
+				"Firearm ammunition is destroyed upon use."
+			],
+			"miscTags": [
+				"CNS"
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-014.firearm-ammunition.webp"
+		},
+		{
+			"name": "Flare Gun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 1,
+			"value": 10000,
+			"weaponCategory": "simple",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"LD|XPHB",
+				"GC:VSS-M|ValdaGunslinger"
+			],
+			"mastery": [
+				"Slow|XPHB"
+			],
+			"range": "30/120",
+			"dmg1": "2d6",
+			"dmgType": "F",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Less a firearm and more a survival tool, a Flare Gun fires a single white-hot flare, useful for distress signals and last-ditch-effort self defense."
+			],
+			"ammoType": "flare|ValdaGunslinger"
+		},
+		{
+			"name": "Gatling Gun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 125,
+			"value": 75000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"H|XPHB",
+				"RLD|XDMG",
+				"2H|XPHB",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Automatic|ValdaGunslinger"
+			],
+			"range": "60/240",
+			"reload": 40,
+			"dmg1": "2d6",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Infamous for its rate of fire, the Gatling Gun rotates and fires six or more barrels in succession. This weapon is cumbersome, easily recognizable, and utterly terrifying."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Handgun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 3,
+			"value": 12500,
+			"weaponCategory": "simple",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"L|XPHB",
+				"RLD|XDMG",
+				"GC:VSS-M|ValdaGunslinger"
+			],
+			"mastery": [
+				"Vex|XPHB"
+			],
+			"range": "30/120",
+			"reload": 10,
+			"dmg1": "2d4",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Portable, reliable, and with a generous magazine size, the Handgun is the go-to firearm for self-defense and law enforcement."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Hunting Rifle",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 8,
+			"value": 15000,
+			"weaponCategory": "simple",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"RLD|XDMG",
+				"2H|XPHB",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Sighted|ValdaGunslinger"
+			],
+			"range": "80/320",
+			"reload": 4,
+			"dmg1": "2d6",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Designed for big game, Hunting Rifles are slow but accurate, requiring bolt action operation between every shot."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Magnum",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 6,
+			"value": 60000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"GC:VSS-R",
+				"H|XPHB",
+				"RLD|XDMG",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Slow|XPHB"
+			],
+			"range": "30/120",
+			"reload": 6,
+			"dmg1": "2d8",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Chambered for large-caliber bullets, Magnum revolvers pack the most kick possible into a single shot."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Musket",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 10,
+			"value": 50000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"LD|XPHB",
+				"2H|XPHB",
+				"GC:VSS-Ren|ValdaGunslinger"
+			],
+			"mastery": [
+				"Slow|XPHB"
+			],
+			"range": "40/120",
+			"dmg1": "1d12",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Parlor Gun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 1,
+			"value": 7500,
+			"weaponCategory": "simple",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"L|XPHB",
+				"RLD|XDMG",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Vex|XPHB"
+			],
+			"range": "30/120",
+			"reload": 2,
+			"dmg1": "2d4",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"The smallest usable firearm, a Parlor Gun can be tucked into a stocking or hidden down a sleeve for two barrels of point-blank fire."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Pistol",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 3,
+			"value": 25000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"LD|XPHB",
+				"GC:VSS-Ren|ValdaGunslinger"
+			],
+			"mastery": [
+				"Vex|XPHB"
+			],
+			"range": "30/90",
+			"dmg1": "1d10",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"The earliest type of one-handed firearm, a Pistol operates as a miniature Musket, loading and firing a single heavy projectile with deadly results."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Pump Shotgun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 7,
+			"value": 55000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"GC:VSS-R",
+				"2H|XPHB",
+				"RLD|XDMG",
+				"H|XPHB",
+				"GC:VSS-M|ValdaGunslinger"
+			],
+			"mastery": [
+				"Scatter|ValdaGunslinger"
+			],
+			"range": "20/60",
+			"reload": 8,
+			"dmg1": "2d8",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"The Pump Shotgun's namesake is a distinctive sliding grip on the barrel which can be \"pumped\" to chamber a new round."
+			],
+			"ammoType": "shell|ValdaGunslinger"
+		},
+		{
+			"name": "Revolver",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 3,
+			"value": 12500,
+			"weaponCategory": "simple",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"GC:VSS-R",
+				"RLD|XDMG",
+				"GC:VSS-I|ValdaGunslinger"
+			],
+			"mastery": [
+				"Slow|XPHB"
+			],
+			"range": "30/120",
+			"reload": 6,
+			"dmg1": "2d6",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"An iconic handgun, the Revolver stores six bullets in a rotating cylinder. This weapon is favored by Gunslingers for its reliability and stopping-power."
+			],
+			"ammoType": "bullet|ValdaGunslinger",
+			"hasFluffImages": true
+		},
+		{
+			"name": "Shell",
+			"source": "ValdaGunslinger",
+			"type": "A|XPHB",
+			"rarity": "none",
+			"weight": 0.15,
+			"value": 50,
+			"bulletFirearm": true,
+			"entries": [
+				"Ammunition is required by a weapon that has {@itemProperty AF|XDMG|Ammunition}. A weapon's description specifies the type of ammunition used by the weapon.",
+				"Firearm ammunition is destroyed upon use."
+			],
+			"miscTags": [
+				"CNS"
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-014.firearm-ammunition.webp"
+		},
+		{
+			"name": "Shot",
+			"source": "ValdaGunslinger",
+			"type": "A|XPHB",
+			"rarity": "none",
+			"weight": 0.2,
+			"value": 10,
+			"bulletFirearm": true,
+			"entries": [
+				"Ammunition is required by a weapon that has {@itemProperty AF|XDMG|Ammunition}. A weapon's description specifies the type of ammunition used by the weapon.",
+				"Firearm ammunition is destroyed upon use."
+			],
+			"miscTags": [
+				"CNS"
+			],
+			"foundryImg": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-014.firearm-ammunition.webp"
+		},
+		{
+			"name": "Sniper Rifle",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 8,
+			"value": 45000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"2H|XPHB",
+				"LD|XPHB",
+				"H|XPHB",
+				"GC:VSS-M|ValdaGunslinger"
+			],
+			"mastery": [
+				"Sighted|ValdaGunslinger"
+			],
+			"range": "100/400",
+			"dmg1": "2d8",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"An instrument of ranged precision, the Sniper Rifle can take shots from distant, nearly invisible ranges."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		},
+		{
+			"name": "Submachine Gun",
+			"source": "ValdaGunslinger",
+			"edition": "one",
+			"type": "R|XPHB",
+			"rarity": "none",
+			"weight": 6,
+			"value": 25000,
+			"weaponCategory": "martial",
+			"property": [
+				"A|XPHB",
+				"GC:VSS-F",
+				"L|XPHB",
+				"RLD|XDMG",
+				"GC:VSS-M|ValdaGunslinger"
+			],
+			"mastery": [
+				"Automatic|ValdaGunslinger"
+			],
+			"range": "20/60",
+			"reload": 16,
+			"dmg1": "2d4",
+			"dmgType": "P",
+			"bonusWeaponDamage": "-@abilities.dex.mod",
+			"firearm": true,
+			"weapon": true,
+			"entries": [
+				"Firing lighter, easier to control rounds, the Submachine Gun is an effective alternative to larger automatic weapons."
+			],
+			"ammoType": "bullet|ValdaGunslinger"
+		}
+	],
+	"itemFluff": [
+		{
+			"name": "Assault Rifle",
+			"source": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-012.assault-rifle.webp"
+					},
+					"width": 850,
+					"height": 307
+				}
+			]
+		},
+		{
+			"name": "Revolver",
+			"source": "ValdaGunslinger",
+			"images": [
+				{
+					"type": "image",
+					"href": {
+						"type": "external",
+						"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-003.revolver.webp"
+					},
+					"width": 850,
+					"height": 385
+				}
+			]
+		}
+	],
+	"itemProperty": [
+		{
+			"name": "Firearm",
+			"abbreviation": "GC:VSS-F",
+			"source": "ValdaGunslinger",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Firearm",
+					"entries": [
+						"You don't add your ability modifier to the weapon's damage, unless otherwise stated. Firearm ammunition is destroyed upon use."
+					]
+				}
+			]
+		},
+		{
+			"name": "Industrial Era",
+			"abbreviation": "GC:VSS-I",
+			"source": "ValdaGunslinger"
+		},
+		{
+			"name": "Modern Era",
+			"abbreviation": "GC:VSS-M",
+			"source": "ValdaGunslinger"
+		},
+		{
+			"name": "Recoil",
+			"abbreviation": "GC:VSS-R",
+			"source": "ValdaGunslinger",
+			"entries": [
+				{
+					"type": "entries",
+					"name": "Recoil",
+					"entries": [
+						"After you make an attack with this weapon, you can't make ranged attacks beyond the weapon's normal range until the end of the current turn."
+					]
+				}
+			]
+		},
+		{
+			"name": "Renaissance Era",
+			"abbreviation": "GC:VSS-Ren",
+			"source": "ValdaGunslinger"
+		}
+	],
+	"itemMastery": [
+		{
+			"name": "Automatic",
+			"source": "ValdaGunslinger",
+			"entries": [
+				"When you make an attack with this weapon, you can choose to make two attacks instead. These attacks are always made with {@variantrule Disadvantage|XPHB}, regardless of circumstance. You can't replace these attacks. If this weapon has {@itemProperty AF|XDMG|Ammunition}, these attacks use twice the normal amount of ammunition."
+			]
+		},
+		{
+			"name": "Explode",
+			"source": "ValdaGunslinger",
+			"entries": [
+				"When you take the {@action Attack|XPHB} action, you can replace one of your attacks with an explosion from this weapon's projectile. This explosion is a 5-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point you choose within the weapon's normal range. Each creature within the {@variantrule Sphere [Area of Effect]|XPHB|Sphere} makes a Dexterity saving throw (DC 8 plus your Strength or Dexterity modifier and your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, a creature takes the weapon's damage, but don't add your ability modifier to that damage unless that modifier is negative. On a successful save, a creature takes half as much damage. You can create an explosion only once per turn."
+			]
+		},
+		{
+			"name": "Scatter",
+			"source": "ValdaGunslinger",
+			"entries": [
+				"Being within 5 feet of an enemy doesn't impose {@variantrule Disadvantage|XPHB} on your ranged attack rolls with this weapon."
+			]
+		},
+		{
+			"name": "Sighted",
+			"source": "ValdaGunslinger",
+			"entries": [
+				"Attacking at long range with this weapon doesn't impose {@variantrule Disadvantage|XPHB} on your attack rolls. When you hit a creature with an attack using this weapon at long range, you can reroll any of the damage dice and must use the new roll."
+			]
+		}
+	],
+	"book": [
+		{
+			"name": "The Gunslinger Class: Valda's Spire of Secrets",
+			"id": "ValdaGunslinger",
+			"source": "ValdaGunslinger",
+			"group": "supplement-alt",
+			"cover": {
+				"type": "external",
+				"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/cover.webp"
+			},
+			"published": "2025-06-10",
+			"author": "Mage Hand Press",
+			"contents": [
+				{
+					"name": "Cover"
+				},
+				{
+					"name": "Gunslinger"
+				},
+				{
+					"name": "Gunslinger Subclasses"
+				},
+				{
+					"name": "Firearms",
+					"headers": [
+						"Firearm Eras",
+						"Weapon Properties",
+						"Mastery Properties",
+						"Weapon Descriptions",
+						"Firearm Ammunition"
+					]
+				},
+				{
+					"name": "New Feats"
+				},
+				{
+					"name": "New Spells"
+				},
+				{
+					"name": "Credits"
+				}
+			]
+		}
+	],
+	"bookData": [
+		{
+			"id": "ValdaGunslinger",
+			"source": "ValdaGunslinger",
+			"data": [
+				{
+					"type": "section",
+					"name": "Cover",
+					"id": "000",
+					"entries": [
+						{
+							"type": "gallery",
+							"images": [
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-001.gunslinger-cover.webp"
+									},
+									"credit": "Martin Kirby-Jackson",
+									"width": 1700,
+									"height": 2211
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Gunslinger",
+					"id": "001",
+					"entries": [
+						{
+							"type": "gallery",
+							"images": [
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-002.the-gunslinger.webp"
+									},
+									"title": "{@class Gunslinger|ValdaGunslinger}",
+									"width": 850,
+									"height": 1336
+								}
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Gunslinger Subclasses",
+					"id": "002",
+					"entries": [
+						"A Gunslinger subclass is a specialization that grants you features at certain levels, as specified in the subclass.",
+						{
+							"type": "gallery",
+							"images": [
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-005.deadeye.webp"
+									},
+									"title": "{@subclass Deadeye|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"width": 850,
+									"height": 559
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-006.high-roller.webp"
+									},
+									"title": "{@subclass High Roller|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"width": 850,
+									"height": 1008
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-008.secret-agent.webp"
+									},
+									"title": "{@subclass Secret Agent|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"width": 850,
+									"height": 1409
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-009.spellslinger.webp"
+									},
+									"title": "{@subclass Spellslinger|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"width": 850,
+									"height": 1072
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-010.trick-shot.webp"
+									},
+									"title": "{@subclass Trick Shot|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"width": 850,
+									"height": 1014
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-011.white-hat.webp"
+									},
+									"title": "{@subclass White Hat|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"width": 1700,
+									"height": 1162
+								}
+							]
+						},
+						{
+							"type": "image",
+							"href": {
+								"type": "external",
+								"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-007.hand-of-cards.webp"
+							},
+							"maxHeight": 200,
+							"width": 850,
+							"height": 544
+						},
+						{
+							"type": "table",
+							"caption": "Gunslinger Subclasses",
+							"colLabels": [
+								"Name",
+								"Description"
+							],
+							"colStyles": [
+								"col-2",
+								"col-10"
+							],
+							"rows": [
+								[
+									"{@subclass Deadeye|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"A precise, eagle-eyed marksman"
+								],
+								[
+									"{@subclass High Roller|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"Gambles with their life and fortune; no risk is too high"
+								],
+								[
+									"{@subclass Secret Agent|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"A covert agent with a license to kill"
+								],
+								[
+									"{@subclass Spellslinger|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"Fires spells as well as bullets in deadly bombardments"
+								],
+								[
+									"{@subclass Trick Shot|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"Ricochets bullets to hit targets from any angle"
+								],
+								[
+									"{@subclass White Hat|Gunslinger|ValdaGunslinger|ValdaGunslinger}",
+									"A law-abiding protector of the weak that never blinks in the face of danger"
+								]
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Firearms",
+					"id": "003",
+					"entries": [
+						"Black powder represents a paradigm shift in the art of warfare, fueling everything from powerful siege weapons to concealable, handheld guns. In many campaign settings, firearms supplant the traditional scheme of weapons, forcing arrows, swords, and battleaxes into obsolescence. They might even be commonplace, a staple tool for hunting and defense.",
+						{
+							"type": "entries",
+							"name": "Firearm Eras",
+							"entries": [
+								"Firearms have evolved dramatically throughout history, and will continue to evolve into the far future. Therefore, in addition to being organized into Simple and Martial weapons, the following firearms are organized into eras, the periods of time in which they might be encountered. Some firearms might appear in multiple eras, especially if the story demands an unusual weapon, but many are best suited to campaign settings that echo their level of technology.",
+								"The GM determines which era or eras of weapons are in the campaign.",
+								{
+									"type": "entries",
+									"name": "Renaissance Firearms",
+									"entries": [
+										"Renaissance-era firearms, such as {@item Pistol|ValdaGunslinger|Pistols} and {@item Musket|ValdaGunslinger|Muskets}, are weapons that have taken the first steps away from cannons and into portable rifles, making them the progenitors of all modern firearms. Weapons from this era use musket balls and loose black powder, and are therefore slow to reload. Importantly, these weapons exist comfortably in many fantasy settings alongside bows, swords, and axes, especially where pirates are at play.",
+										{
+											"type": "table",
+											"colLabels": [
+												"Name",
+												"Damage",
+												"Properties",
+												"Mastery",
+												"Weight",
+												"Cost"
+											],
+											"colStyles": [
+												"col-4",
+												"col-1",
+												"col-6",
+												"col-1 text-center",
+												"col-1 text-center",
+												"col-4 text-center"
+											],
+											"rows": [
+												[
+													"{@i Martial Ranged Weapons}",
+													"",
+													"",
+													"",
+													"",
+													""
+												],
+												[
+													"{@item Blunderbuss|ValdaGunslinger}",
+													"{@damage 1d12} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 20/60; {@item Shot|ValdaGunslinger}), {@itemProperty H|XPHB|Heavy}, {@itemProperty LD|XPHB|Loading}, {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Scatter|ValdaGunslinger}",
+													"15 lb.",
+													"750 GP"
+												],
+												[
+													"{@item Musket|ValdaGunslinger}",
+													"{@damage 1d12} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 40/120; {@item Bullet|ValdaGunslinger}), {@itemProperty LD|XPHB|Loading}, {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Slow|XPHB}",
+													"10 lb.",
+													"500 GP"
+												],
+												[
+													"{@item Pistol|ValdaGunslinger}",
+													"{@damage 1d10} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 30/90; {@item Bullet|ValdaGunslinger}), {@itemProperty LD|XPHB|Loading}",
+													"{@itemMastery Vex|XPHB}",
+													"3 lb.",
+													"250 GP"
+												]
+											]
+										}
+									],
+									"id": "008"
+								},
+								{
+									"type": "entries",
+									"name": "Industrial Firearms",
+									"entries": [
+										"Industrial Age firearms, such as {@item Revolver|ValdaGunslinger|Revolvers} and {@item Double-Barrel Shotgun|ValdaGunslinger|Double-Barrel Shotguns}, stem from advancements in machinery and assembly lines, granting them more interchangeable parts and cartridge-based bullets. These guns lack the assembly-line consistency of modern firearms, but laid down the bedrock for designs that haven't changed much since: a classic six-shot {@item Revolver|ValdaGunslinger} is as timeless as it is effective. While the heyday of Industrial Age firearms was in the Wild West, their simple and reliable construction means they are still commonplace in the modern day.",
+										{
+											"type": "table",
+											"colLabels": [
+												"Name",
+												"Damage",
+												"Properties",
+												"Mastery",
+												"Weight",
+												"Cost"
+											],
+											"colStyles": [
+												"col-4",
+												"col-1",
+												"col-6",
+												"col-1 text-center",
+												"col-1 text-center",
+												"col-4 text-center"
+											],
+											"rows": [
+												[
+													"{@i Simple Ranged Weapons}",
+													"",
+													"",
+													"",
+													"",
+													""
+												],
+												[
+													"{@item Double-Barrel Shotgun|ValdaGunslinger}",
+													"{@damage 2d6} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 20/60; {@item Shell|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty GC:VSS-R|ValdaGunslinger|Recoil}, {@itemProperty RLD|XDMG|Reload} (2), {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Scatter|ValdaGunslinger}",
+													"8 lb.",
+													"175 GP"
+												],
+												[
+													"{@item Hunting Rifle|ValdaGunslinger}",
+													"{@damage 2d6} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 80/320; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty RLD|XDMG|Reload} (4), {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Sighted|ValdaGunslinger}",
+													"8 lb.",
+													"150 GP"
+												],
+												[
+													"{@item Parlor Gun|ValdaGunslinger}",
+													"{@damage 2d4} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 30/120; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty L|XPHB|Light}, {@itemProperty RLD|XDMG|Reload} (2)",
+													"{@itemMastery Vex|XPHB}",
+													"1 lb.",
+													"75 GP"
+												],
+												[
+													"{@item Revolver|ValdaGunslinger}",
+													"{@damage 2d6} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 30/120; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty GC:VSS-R|ValdaGunslinger|Recoil}, {@itemProperty RLD|XDMG|Reload} (6)",
+													"{@itemMastery Slow|XPHB}",
+													"3 lb.",
+													"125 GP"
+												],
+												[
+													"{@i Martial Ranged Weapons}",
+													"",
+													"",
+													"",
+													"",
+													""
+												],
+												[
+													"{@item Cannon|ValdaGunslinger}",
+													"{@damage 2d8} Fire",
+													"{@itemProperty A|XPHB|Ammunition} (Range 100/400; {@item Cannonball|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty H|XPHB|Heavy}, {@itemProperty LD|XPHB|Loading}, {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Explode|ValdaGunslinger}",
+													"225 lb.",
+													"1,500 GP"
+												],
+												[
+													"{@item Gatling Gun|ValdaGunslinger}",
+													"{@damage 2d6} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 60/240; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty H|XPHB|Heavy}, {@itemProperty RLD|XDMG|Reload} (40), {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Automatic|ValdaGunslinger}",
+													"125 lb.",
+													"750 GP"
+												],
+												[
+													"{@item Magnum|ValdaGunslinger}",
+													"{@damage 2d8} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 30/120, {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty H|XPHB|Heavy}, {@itemProperty GC:VSS-R|ValdaGunslinger|Recoil}, {@itemProperty RLD|XDMG|Reload} (6)",
+													"{@itemMastery Slow|XPHB}",
+													"6 lb.",
+													"600 GP"
+												]
+											]
+										}
+									],
+									"id": "009"
+								},
+								{
+									"type": "entries",
+									"name": "Modern Firearms",
+									"entries": [
+										"Modern firearms have embraced automatic fire, ammunition magazines, and lighter caliber bullets (which can travel at much higher speeds). For these guns, form begets function: weapons are designed for a specific role, such as {@item Sniper Rifle|ValdaGunslinger|Sniper Rifles} for long range and {@item Pump Shotgun|ValdaGunslinger|Pump Shotguns} for close quarters. Moreover, weapons that enjoyed success in the Wild West, such as the {@item Double-Barrel Shotgun|ValdaGunslinger}, can still be found in use today.",
+										{
+											"type": "table",
+											"colLabels": [
+												"Name",
+												"Damage",
+												"Properties",
+												"Mastery",
+												"Weight",
+												"Cost"
+											],
+											"colStyles": [
+												"col-4",
+												"col-1",
+												"col-6",
+												"col-1 text-center",
+												"col-1 text-center",
+												"col-4 text-center"
+											],
+											"rows": [
+												[
+													"{@i Simple Ranged Weapons}",
+													"",
+													"",
+													"",
+													"",
+													""
+												],
+												[
+													"{@item Flare Gun|ValdaGunslinger}",
+													"{@damage 2d6} Fire",
+													"{@itemProperty A|XPHB|Ammunition} (Range 30/120; {@item Flare|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty LD|XPHB|Loading}",
+													"{@itemMastery Slow|XPHB}",
+													"1 lb.",
+													"100 GP"
+												],
+												[
+													"{@item Handgun|ValdaGunslinger}",
+													"{@damage 2d4} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 30/120; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty L|XPHB|Light}, {@itemProperty RLD|XDMG|Reload} (10)",
+													"{@itemMastery Vex|XPHB}",
+													"3 lb.",
+													"125 GP"
+												],
+												[
+													"{@i Martial Ranged Weapons}",
+													"",
+													"",
+													"",
+													"",
+													""
+												],
+												[
+													"{@item Assault Rifle|ValdaGunslinger}",
+													"{@damage 2d6} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 80/320; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty RLD|XDMG|Reload} (20), {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Automatic|ValdaGunslinger}",
+													"7 lb.",
+													"300 GP"
+												],
+												[
+													"{@item Pump Shotgun|ValdaGunslinger}",
+													"{@damage 2d8} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 20/60, {@item Shell|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty H|XPHB|Heavy}, {@itemProperty GC:VSS-R|ValdaGunslinger|Recoil}, {@itemProperty RLD|XDMG|Reload} (8), {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Scatter|ValdaGunslinger}",
+													"7 lb.",
+													"550 GP"
+												],
+												[
+													"{@item Sniper Rifle|ValdaGunslinger}",
+													"{@damage 2d8} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (Range 100/400, {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty H|XPHB|Heavy}, {@itemProperty LD|XPHB|Loading}, {@itemProperty 2H|XPHB|Two-Handed}",
+													"{@itemMastery Sighted|ValdaGunslinger}",
+													"8 lb.",
+													"450 GP"
+												],
+												[
+													"{@item Submachine Gun|ValdaGunslinger}",
+													"{@damage 2d4} Piercing",
+													"{@itemProperty A|XPHB|Ammunition} (20/60; {@item Bullet|ValdaGunslinger}), {@itemProperty GC:VSS-F|ValdaGunslinger|Firearm}, {@itemProperty L|XPHB|Light}, {@itemProperty RLD|XDMG|Reload} (16)",
+													"{@itemMastery Automatic|ValdaGunslinger}",
+													"6 lb.",
+													"250 GP"
+												]
+											]
+										}
+									],
+									"id": "00a"
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-016.shooting-large-gun.webp"
+									},
+									"width": 850,
+									"height": 861
+								}
+							],
+							"id": "007"
+						},
+						{
+							"type": "entries",
+							"name": "Weapon Properties",
+							"entries": [
+								"Here are definitions of the properties in the Properties column of the Firearm tables. New properties are marked with an asterisk (*).",
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@itemProperty A|XPHB|Ammunition}",
+										"{@itemProperty F|XPHB|Finesse}",
+										"{@itemProperty GC:VSS-F|ValdaGunslinger|Firearm*}",
+										"{@itemProperty H|XPHB|Heavy}",
+										"{@itemProperty L|XPHB|Light}",
+										"{@itemProperty F|XPHB|Finesse}",
+										"{@itemProperty GC:VSS-R|ValdaGunslinger|Recoil*}",
+										"{@itemProperty RLD|XDMG|Reload}",
+										"{@itemProperty 2H|XPHB|Two-Handed}"
+									]
+								}
+							],
+							"id": "00b"
+						},
+						{
+							"type": "entries",
+							"name": "Mastery Properties",
+							"entries": [
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@itemMastery Automatic|ValdaGunslinger|Automatic*}",
+										"{@itemMastery Explode|ValdaGunslinger|Explode*}",
+										"{@itemMastery Push|XPHB}",
+										"{@itemMastery Sap|XPHB}",
+										"{@itemMastery Scatter|ValdaGunslinger|Scatter*}",
+										"{@itemMastery Sighted|ValdaGunslinger|Sighted*}",
+										"{@itemMastery Slow|XPHB}",
+										"{@itemMastery Vex|XPHB}"
+									]
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-012.assault-rifle.webp"
+									},
+									"maxHeight": 250,
+									"width": 850,
+									"height": 307
+								}
+							],
+							"id": "00c"
+						},
+						{
+							"type": "entries",
+							"name": "Weapon Descriptions",
+							"entries": [
+								{
+									"type": "list",
+									"columns": 3,
+									"items": [
+										"{@item Assault Rifle|ValdaGunslinger}",
+										"{@item Blunderbuss|ValdaGunslinger}",
+										"{@item Cannon|ValdaGunslinger}",
+										"{@item Double-Barrel Shotgun|ValdaGunslinger}",
+										"{@item Flare Gun|ValdaGunslinger}",
+										"{@item Gatling Gun|ValdaGunslinger}",
+										"{@item Handgun|ValdaGunslinger}",
+										"{@item Hunting Rifle|ValdaGunslinger}",
+										"{@item Magnum|ValdaGunslinger}",
+										"{@item Musket|ValdaGunslinger}",
+										"{@item Parlor Gun|ValdaGunslinger}",
+										"{@item Pistol|ValdaGunslinger}",
+										"{@item Pump Shotgun|ValdaGunslinger}",
+										"{@item Revolver|ValdaGunslinger}",
+										"{@item Sniper Rifle|ValdaGunslinger}",
+										"{@item Submachine Gun|ValdaGunslinger}"
+									]
+								},
+								{
+									"type": "image",
+									"href": {
+										"type": "external",
+										"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-014.firearm-ammunition.webp"
+									},
+									"maxHeight": 250,
+									"width": 850,
+									"height": 767
+								}
+							],
+							"id": "00d"
+						},
+						{
+							"type": "entries",
+							"name": "Firearm Ammunition",
+							"entries": [
+								"Ammunition is required by a weapon that has the {@itemProperty A|XPHB|Ammunition} property. A weapon's description specifies the type of ammunition used by the weapon. The following Ammunition table lists new types of ammunition used by firearms and the amount you get when you buy them.",
+								"Firearm ammunition is destroyed upon use.",
+								{
+									"type": "table",
+									"colLabels": [
+										"Type",
+										"Amount",
+										"Weight",
+										"Cost"
+									],
+									"colStyles": [
+										"col-2",
+										"col-2",
+										"col-2",
+										"col-2"
+									],
+									"rows": [
+										[
+											"{@item Bullet|ValdaGunslinger|Bullets}",
+											"10",
+											"1 ½ lb.",
+											"3 GP"
+										],
+										[
+											"{@item Cannonball|ValdaGunslinger|Cannonballs}",
+											"5",
+											"10 lb.",
+											"25 GP"
+										],
+										[
+											"{@item Flare|ValdaGunslinger|Flares}",
+											"5",
+											"5 lb.",
+											"5 GP"
+										],
+										[
+											"{@item Shell|ValdaGunslinger|Shells}",
+											"10",
+											"1 ½ lb.",
+											"5 GP"
+										],
+										[
+											"{@item Shot|ValdaGunslinger}",
+											"10",
+											"2 lb.",
+											"1 GP"
+										]
+									]
+								}
+							],
+							"id": "00e"
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "New Feats",
+					"id": "004",
+					"entries": [
+						{
+							"type": "image",
+							"href": {
+								"type": "external",
+								"url": "https://raw.githubusercontent.com/TheGiddyLimit/homebrew-img/main/img/ValdaGunslinger/00-013.gear-table.webp"
+							},
+							"width": 1700,
+							"height": 555
+						},
+						"This section offers a collection of new feats, which are special features not tied to a character class. A feat represents a talent or an area of expertise that gives a character special capabilities. It embodies training, experience, and abilities beyond what a class provides.",
+						"By whatever means you acquire a feat, you can take it only once unless its description says otherwise.",
+						{
+							"type": "list",
+							"columns": 3,
+							"items": [
+								"{@feat Iron Hero|ValdaGunslinger}",
+								"{@feat Marksman's Luck|ValdaGunslinger}",
+								"{@feat Gun-Mage Adept|ValdaGunslinger}"
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "New Spells",
+					"id": "005",
+					"entries": [
+						"This section contains the descriptions of spells that are new and available to all classes.",
+						{
+							"type": "list",
+							"columns": 3,
+							"items": [
+								"{@spell Antiballistics Field|ValdaGunslinger}",
+								"{@spell Ballistic Smite|ValdaGunslinger}",
+								"{@spell Concealed Shot|ValdaGunslinger}",
+								"{@spell Conjure Cannonball|ValdaGunslinger}",
+								"{@spell Conjure Cover|ValdaGunslinger}",
+								"{@spell Finger Guns|ValdaGunslinger}",
+								"{@spell Jam Weapon|ValdaGunslinger}",
+								"{@spell Jethro's Instant Reload|ValdaGunslinger}",
+								"{@spell Perforating Shot|ValdaGunslinger}"
+							]
+						}
+					]
+				},
+				{
+					"type": "section",
+					"name": "Credits",
+					"id": "006",
+					"entries": [
+						{
+							"type": "list",
+							"style": "list-hang-notitle",
+							"items": [
+								{
+									"type": "item",
+									"name": "Designers:",
+									"entries": [
+										"Michael Holik, Beniamin Ghita"
+									]
+								},
+								{
+									"type": "item",
+									"name": "Cover Illustrator:",
+									"entries": [
+										"Martin Kirby-Jackson"
+									]
+								},
+								{
+									"type": "item",
+									"name": "Graphic Design:",
+									"entries": [
+										"Michael Holik"
+									]
+								},
+								{
+									"type": "item",
+									"name": "Interior Illustrations:",
+									"entries": [
+										"Martin Kirby-Jackson, Moniek Schilder, Lucas Ferreira CM"
+									]
+								},
+								{
+									"type": "item",
+									"name": "Producers:",
+									"entries": [
+										"Donelloth, Mkscorpio89, Star, Laura Chrismon, Tyler Kohlman, Chase Harris, Blayne Wilson, Kabe-kun, Austin Kavanagh, Shaun Sullivan, Zeke DeLeon, Rude Velez, Suzuki, Anvil, Hayley Nichols, Trey Steele, MorphManDude, GayCowboy, Jesse Smith, Sean Daugherty, Kevin Reynolds, Liam Jones, BillOneEye, Jesse Rosen, NecroJester, Jacob Otwell, Treix Nyte, lungfishwarrior, Zee Xorn, Trivik, Joan Mulberry, Darion Nutter, D Miranda, Joel Grote, Patrick Rooney, PucThePlayful, Mike Litkewitsch, George Tolley, Michael Davis, Kura Tenshi, Alexander Garcia, Joseph Blanc, Ryan MacDonald, Pandric, Kat Woehlert, Matthew Atkins, Eike Schultz, Marc-Antoine Côté"
+									]
+								}
+							]
+						},
+						{
+							"type": "inset",
+							"name": "ON THE COVER",
+							"entries": [
+								"Martin Kirby-Jackson illustrates a gunslinger enjoying their favorite vices: a strong whiskey, freshly-rolled cigarette, and the aftermath of a shootout."
+							],
+							"id": "00f"
+						},
+						{
+							"type": "hr"
+						},
+						{
+							"type": "inset",
+							"entries": [
+								"Mage Hand Press, and their associated logos are trademarks of Mage Hand Press LLC ® 2020 Mage Hand Press LLC. All Rights Reserved.",
+								"Product Identity: The following items are hereby identified as Product Identity, as defined in the Open Game License version 1.0a, Section 1(e), and are not Open Content: All trademarks, registered trademarks, proper names (characters, deities, etc.), dialogue, plots, storylines, locations, characters, artwork, and trade dress. (Elements that have previously been designated as Open Game Content or are in the public domain are not included in this declaration.)",
+								"Open Content: Except for material designated as Product Identity (see above), the game mechanics of this Mage Hand Press game product are Open Game Content, as defined in the Open Gaming License version 1.0a Section 1(d). No portion of this work other than the material designated as Open Game Content may be reproduced in any form without written permission.",
+								"Complete Gunslinger is published by Mage Hand Press LLC under the Open Game License version 1.0a. Copyright 2020 Mage Hand Press LLC. All Rights Reserved"
+							],
+							"id": "010"
+						},
+						{
+							"type": "hr"
+						},
+						"{@i Disclaimer: Rolling Critical Hits has been linked to the following conditions: swollen ego, gambling addiction, head-explode-itus, and DM fever.}"
+					]
+				}
+			]
+		}
+	]
+}

--- a/item/CaioTome; Valda's Gunslinger.json
+++ b/item/CaioTome; Valda's Gunslinger.json
@@ -28,7 +28,7 @@
 	"class": [
 		{
 			"name": "Gunslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"primaryAbility": [
 				{
@@ -338,12 +338,12 @@
 	"classFluff": [
 		{
 			"name": "Gunslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				{
 					"type": "section",
 					"name": "Gunslinger",
-					"source": "ValdaGunslinger",
+					"source": "ItemsValdaGunslinger",
 					"entries": [
 						"Risk is in a Gunslinger's blood. They are bold renegades, bucking tradition and forging a new path with dangerous and inelegant firearms. Gunslingers are infamous for surviving by their wits and relying on split-second timing and a considerable amount of luck to survive.",
 						{
@@ -398,9 +398,9 @@
 		{
 			"name": "Deadeye",
 			"shortName": "Deadeye",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"Deadeye|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|3",
 				"Concealed Position|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|6",
@@ -412,9 +412,9 @@
 		{
 			"name": "High Roller",
 			"shortName": "High Roller",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"High Roller|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|3",
 				"Risky Business|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|6",
@@ -426,9 +426,9 @@
 		{
 			"name": "Secret Agent",
 			"shortName": "Secret Agent",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"additionalSpells": [
 				{
 					"ability": {
@@ -459,9 +459,9 @@
 		{
 			"name": "Spellslinger",
 			"shortName": "Spellslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"spellcastingAbility": "int",
 			"casterProgression": "1/3",
 			"preparedSpellsProgression": [
@@ -555,7 +555,7 @@
 					"subclasses": [
 						{
 							"name": "Spellslinger",
-							"source": "ValdaGunslinger"
+							"source": "ItemsValdaGunslinger"
 						}
 					],
 					"colLabels": [
@@ -629,7 +629,7 @@
 					"subclasses": [
 						{
 							"name": "Spellslinger",
-							"source": "ValdaGunslinger"
+							"source": "ItemsValdaGunslinger"
 						}
 					],
 					"colLabels": [
@@ -773,9 +773,9 @@
 		{
 			"name": "Trick Shot",
 			"shortName": "Trick Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"Trick Shot|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|3",
 				"Fancy Gunplay|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|6",
@@ -787,9 +787,9 @@
 		{
 			"name": "White Hat",
 			"shortName": "White Hat",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"White Hat|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3",
 				"Reach for the Skies|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|6",
@@ -803,9 +803,9 @@
 		{
 			"name": "Deadeye",
 			"shortName": "Deadeye",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -821,9 +821,9 @@
 		{
 			"name": "High Roller",
 			"shortName": "High Roller",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -839,9 +839,9 @@
 		{
 			"name": "Secret Agent",
 			"shortName": "Secret Agent",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -857,9 +857,9 @@
 		{
 			"name": "Spellslinger",
 			"shortName": "Spellslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -875,9 +875,9 @@
 		{
 			"name": "Trick Shot",
 			"shortName": "Trick Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -893,9 +893,9 @@
 		{
 			"name": "White Hat",
 			"shortName": "White Hat",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -912,9 +912,9 @@
 	"classFeature": [
 		{
 			"name": "Fighting Style",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 1,
 			"entries": [
 				"You gain a {@filter Fighting Style feat|feats|category=FS} of your choice. If you choose a feat, such as {@feat Great Weapon Fighting|XPHB}, that requires you to hold a Melee weapon in one or two hands, you can use that feat with Ranged weapons.",
@@ -923,9 +923,9 @@
 		},
 		{
 			"name": "Quick Draw",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 1,
 			"entries": [
 				"You're adept at drawing and firing before others have time to react, granting you the following benefits.",
@@ -952,9 +952,9 @@
 		},
 		{
 			"name": "Weapon Mastery",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 1,
 			"entries": [
 				"Your training with weapons allows you to use the mastery properties of two kinds of {@filter Simple|items|type=simple weapon} or {@filter Martial Ranged weapons|items|type=ranged weapon} of your choice. Whenever you finish a {@variantrule Long Rest|XPHB}, you can practice weapon drills and change one of those weapon choices.",
@@ -963,9 +963,9 @@
 		},
 		{
 			"name": "Critical Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 2,
 			"entries": [
 				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 19 or 20 on the {@dice d20}.",
@@ -974,9 +974,9 @@
 		},
 		{
 			"name": "Risk",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 2,
 			"entries": [
 				"You can perform incredible feats of daring fueled by special dice called Risk Dice.",
@@ -1045,9 +1045,9 @@
 		},
 		{
 			"name": "Gunslinger Subclass",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"You gain a Gunslinger subclass of your choice. A subclass is a specialization that grants you features at certain Gunslinger levels. For the rest of your career, you gain each of your subclass's features that are of your Gunslinger level or lower."
@@ -1055,9 +1055,9 @@
 		},
 		{
 			"name": "Ability Score Improvement",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 4,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1065,9 +1065,9 @@
 		},
 		{
 			"name": "Extra Attack",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 5,
 			"entries": [
 				"You can attack twice instead of once whenever you take the {@action Attack|XPHB} action on your turn."
@@ -1075,9 +1075,9 @@
 		},
 		{
 			"name": "Gut Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 5,
 			"entries": [
 				"Whenever you score a {@variantrule Critical Hit|XPHB} against a Large or smaller creature with a ranged attack using a weapon, the projectile lodges itself in the target. For 1 minute or until the target replaces one of its attacks with dislodging the projectile, its {@variantrule Speed|XPHB} is halved and it has {@variantrule Disadvantage|XPHB} on attack rolls."
@@ -1085,9 +1085,9 @@
 		},
 		{
 			"name": "Subclass Feature",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 6,
 			"entries": [
 				"You gain a feature from your Gunslinger Subclass."
@@ -1095,9 +1095,9 @@
 		},
 		{
 			"name": "Evasion",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 7,
 			"entries": [
 				"When you're subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw and only half damage if you fail.",
@@ -1106,9 +1106,9 @@
 		},
 		{
 			"name": "Ability Score Improvement",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 8,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1116,9 +1116,9 @@
 		},
 		{
 			"name": "Critical Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 9,
 			"entries": [
 				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 18, 19, or 20 on the {@dice d20}."
@@ -1126,9 +1126,9 @@
 		},
 		{
 			"name": "Subclass Feature",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 10,
 			"entries": [
 				"You gain a feature from your Gunslinger Subclass."
@@ -1136,9 +1136,9 @@
 		},
 		{
 			"name": "Overkill",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 11,
 			"entries": [
 				"When you deal damage with a Ranged weapon that doesn't add your ability modifier to the roll, you add your ability modifier nonetheless. If you already add your modifier to the damage roll, the target takes an extra {@damage 1d8} damage of the weapon's type.",
@@ -1147,9 +1147,9 @@
 		},
 		{
 			"name": "Ability Score Improvement",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 12,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1157,9 +1157,9 @@
 		},
 		{
 			"name": "Cheat Death",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 13,
 			"entries": [
 				"When you are reduced to 0 {@variantrule Hit Points|XPHB} and not killed outright, you can drop to 1 {@variantrule Hit Points|XPHB|Hit Point} instead, and you regain a number of {@variantrule Hit Points|XPHB} equal to your Gunslinger level.",
@@ -1168,9 +1168,9 @@
 		},
 		{
 			"name": "Subclass Feature",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 14,
 			"entries": [
 				"You gain a feature from your Gunslinger Subclass."
@@ -1178,9 +1178,9 @@
 		},
 		{
 			"name": "Dire Gambit",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 15,
 			"entries": [
 				"Whenever you roll {@variantrule Initiative|XPHB} or score a {@variantrule Critical Hit|XPHB}, you regain one expended {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}."
@@ -1188,9 +1188,9 @@
 		},
 		{
 			"name": "Ability Score Improvement",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 16,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1198,9 +1198,9 @@
 		},
 		{
 			"name": "Critical Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 17,
 			"entries": [
 				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 17-20 on the {@dice d20}."
@@ -1208,9 +1208,9 @@
 		},
 		{
 			"name": "Deft Maneuver",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 18,
 			"entries": [
 				"You gain a special additional {@variantrule Bonus Action|XPHB} that you can take once on each of your turns. You can take this special {@variantrule Bonus Action|XPHB} only to use a maneuver."
@@ -1218,9 +1218,9 @@
 		},
 		{
 			"name": "Epic Boon",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 19,
 			"entries": [
 				"You gain an {@filter Epic Boon feat|feats|category=EB} or another feat of your choice for which you qualify. {@feat Boon of Irresistible Offense|XPHB} is recommended."
@@ -1228,9 +1228,9 @@
 		},
 		{
 			"name": "Headshot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 20,
 			"entries": [
 				"When you score a {@variantrule Critical Hit|XPHB} against a creature using a Ranged weapon, you can choose for it to be a Headshot. If the creature has less than 100 {@variantrule Hit Points|XPHB}, it dies. Otherwise, it takes an extra {@damage 10d10} damage of the weapon's type.",
@@ -1241,9 +1241,9 @@
 	"foundryClassFeature": [
 		{
 			"name": "Quick Draw",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 1,
 			"effects": [
 				{
@@ -1262,9 +1262,9 @@
 		},
 		{
 			"name": "Critical Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 2,
 			"effects": [
 				{
@@ -1283,9 +1283,9 @@
 		},
 		{
 			"name": "Risk",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 2,
 			"system": {
 				"uses": {
@@ -1295,9 +1295,9 @@
 		},
 		{
 			"name": "Gut Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 5,
 			"activities": [
 				{
@@ -1326,17 +1326,17 @@
 		},
 		{
 			"name": "Critical Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 9,
 			"isIgnored": true
 		},
 		{
 			"name": "Overkill",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 11,
 			"activities": [
 				{
@@ -1417,9 +1417,9 @@
 		},
 		{
 			"name": "Cheat Death",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 13,
 			"activities": [
 				{
@@ -1467,9 +1467,9 @@
 		},
 		{
 			"name": "Dire Gambit",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 15,
 			"activities": [
 				{
@@ -1500,17 +1500,17 @@
 		},
 		{
 			"name": "Critical Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 17,
 			"isIgnored": true
 		},
 		{
 			"name": "Headshot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"level": 20,
 			"activities": [
 				{
@@ -1576,11 +1576,11 @@
 	"subclassFeature": [
 		{
 			"name": "Deadeye",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"{@i Shoot with Bullseye Precision}",
@@ -1597,11 +1597,11 @@
 		},
 		{
 			"name": "Eagle Eye [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -1610,11 +1610,11 @@
 		},
 		{
 			"name": "Sharpshooter's Stance",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -1637,11 +1637,11 @@
 		},
 		{
 			"name": "Concealed Position",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -1664,11 +1664,11 @@
 		},
 		{
 			"name": "Reposition",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"header": 2,
 			"entries": [
@@ -1677,11 +1677,11 @@
 		},
 		{
 			"name": "Focused Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"header": 2,
 			"entries": [
@@ -1690,11 +1690,11 @@
 		},
 		{
 			"name": "High Roller",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"{@i Gamble with Life and Death}",
@@ -1711,11 +1711,11 @@
 		},
 		{
 			"name": "Liar's Dice [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -1745,11 +1745,11 @@
 		},
 		{
 			"name": "Poker Face",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"skillProficiencies": [
 				{
@@ -1779,11 +1779,11 @@
 		},
 		{
 			"name": "Risky Business",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -1792,11 +1792,11 @@
 		},
 		{
 			"name": "Risk Taker",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"header": 2,
 			"entries": [
@@ -1805,11 +1805,11 @@
 		},
 		{
 			"name": "Double or Nothing",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"header": 2,
 			"entries": [
@@ -1818,11 +1818,11 @@
 		},
 		{
 			"name": "Secret Agent",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"{@i Engage in Espionage and Assassination}",
@@ -1839,11 +1839,11 @@
 		},
 		{
 			"name": "Operative Training",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"skillProficiencies": [
 				{
@@ -1893,11 +1893,11 @@
 		},
 		{
 			"name": "Parting Shot [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -1906,11 +1906,11 @@
 		},
 		{
 			"name": "Fieldcraft",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -1933,11 +1933,11 @@
 		},
 		{
 			"name": "Exit Strategy",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"header": 2,
 			"entries": [
@@ -1947,11 +1947,11 @@
 		},
 		{
 			"name": "License to Kill",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"header": 2,
 			"entries": [
@@ -1960,11 +1960,11 @@
 		},
 		{
 			"name": "Spellslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"{@i Complement Your Gunslinging with Arcana}",
@@ -1981,11 +1981,11 @@
 		},
 		{
 			"name": "Bang, You're Dead!",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -2008,11 +2008,11 @@
 		},
 		{
 			"name": "Spellcasting",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -2065,11 +2065,11 @@
 		},
 		{
 			"name": "Spellshot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -2078,11 +2078,11 @@
 		},
 		{
 			"name": "Counter-Mage",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"header": 2,
 			"entries": [
@@ -2112,11 +2112,11 @@
 		},
 		{
 			"name": "Magic Bullet [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"header": 2,
 			"entries": [
@@ -2125,11 +2125,11 @@
 		},
 		{
 			"name": "Trick Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"{@i Ricochet Bullets from Every Angle}",
@@ -2146,11 +2146,11 @@
 		},
 		{
 			"name": "Creative Trajectory",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -2159,11 +2159,11 @@
 		},
 		{
 			"name": "Ricochet [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -2172,11 +2172,11 @@
 		},
 		{
 			"name": "Fancy Gunplay",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -2199,11 +2199,11 @@
 		},
 		{
 			"name": "Deft Deflection [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"header": 2,
 			"entries": [
@@ -2212,11 +2212,11 @@
 		},
 		{
 			"name": "Pinball Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"header": 2,
 			"entries": [
@@ -2226,11 +2226,11 @@
 		},
 		{
 			"name": "White Hat",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"{@i Protect Your Allies and Uphold the Law}",
@@ -2247,11 +2247,11 @@
 		},
 		{
 			"name": "Lay Down the Law [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -2260,11 +2260,11 @@
 		},
 		{
 			"name": "Steely-Eyed Aura",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"header": 1,
 			"entries": [
@@ -2273,11 +2273,11 @@
 		},
 		{
 			"name": "Reach for the Skies",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"header": 2,
 			"entries": [
@@ -2286,11 +2286,11 @@
 		},
 		{
 			"name": "Long Arm of the Law",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"header": 2,
 			"entries": [
@@ -2299,11 +2299,11 @@
 		},
 		{
 			"name": "Gold Star Hero",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"header": 2,
 			"entries": [
@@ -2335,11 +2335,11 @@
 	"foundrySubclassFeature": [
 		{
 			"name": "Eagle Eye [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"activities": [
 				{
@@ -2370,11 +2370,11 @@
 		},
 		{
 			"name": "Liar's Dice [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"activities": [
 				{
@@ -2402,11 +2402,11 @@
 		},
 		{
 			"name": "Risky Business",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"activities": [
 				{
@@ -2433,11 +2433,11 @@
 		},
 		{
 			"name": "Double or Nothing",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"activities": [
 				{
@@ -2454,11 +2454,11 @@
 		},
 		{
 			"name": "Parting Shot [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"activities": [
 				{
@@ -2499,11 +2499,11 @@
 		},
 		{
 			"name": "Exit Strategy",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"activities": [
 				{
@@ -2560,11 +2560,11 @@
 		},
 		{
 			"name": "License to Kill",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"activities": [
 				{
@@ -2612,11 +2612,11 @@
 		},
 		{
 			"name": "Bang, You're Dead!",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"activities": [
 				{
@@ -2661,11 +2661,11 @@
 		},
 		{
 			"name": "Counter-Mage",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"activities": [
 				{
@@ -2683,11 +2683,11 @@
 		},
 		{
 			"name": "Magic Bullet [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"activities": [
 				{
@@ -2717,11 +2717,11 @@
 		},
 		{
 			"name": "Ricochet [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"activities": [
 				{
@@ -2751,11 +2751,11 @@
 		},
 		{
 			"name": "Fancy Gunplay",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
 			"activities": [
 				{
@@ -2773,11 +2773,11 @@
 		},
 		{
 			"name": "Deft Deflection [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
 			"activities": [
 				{
@@ -2819,11 +2819,11 @@
 		},
 		{
 			"name": "Pinball Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
 			"activities": [
 				{
@@ -2879,11 +2879,11 @@
 		},
 		{
 			"name": "Lay Down the Law [Maneuver]",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classSource": "ValdaGunslinger",
+			"classsource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
-			"subclassSource": "ValdaGunslinger",
+			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
 			"activities": [
 				{
@@ -2932,7 +2932,7 @@
 	"optionalfeature": [
 		{
 			"name": "Bite the Bullet",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"featureType": [
 				"MV:G"
 			],
@@ -2943,7 +2943,7 @@
 		},
 		{
 			"name": "Blindfire",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"featureType": [
 				"MV:G"
 			],
@@ -2954,7 +2954,7 @@
 		},
 		{
 			"name": "Dodge Roll",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"featureType": [
 				"MV:G"
 			],
@@ -2965,7 +2965,7 @@
 		},
 		{
 			"name": "Grazing Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"featureType": [
 				"MV:G"
 			],
@@ -2976,7 +2976,7 @@
 		},
 		{
 			"name": "Maverick Spirit",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"featureType": [
 				"MV:G"
 			],
@@ -2987,7 +2987,7 @@
 		},
 		{
 			"name": "Skin of Your Teeth",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"featureType": [
 				"MV:G"
 			],
@@ -3000,7 +3000,7 @@
 	"foundryOptionalfeature": [
 		{
 			"name": "Bite the Bullet",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"activities": [
 				{
 					"type": "heal",
@@ -3045,7 +3045,7 @@
 		},
 		{
 			"name": "Blindfire",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"activities": [
 				{
 					"type": "utility",
@@ -3071,7 +3071,7 @@
 		},
 		{
 			"name": "Dodge Roll",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"activities": [
 				{
 					"type": "utility",
@@ -3097,7 +3097,7 @@
 		},
 		{
 			"name": "Grazing Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"activities": [
 				{
 					"type": "damage",
@@ -3134,7 +3134,7 @@
 		},
 		{
 			"name": "Maverick Spirit",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"activities": [
 				{
 					"type": "utility",
@@ -3163,7 +3163,7 @@
 		},
 		{
 			"name": "Skin of Your Teeth",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"activities": [
 				{
 					"type": "utility",
@@ -3192,7 +3192,7 @@
 	"feat": [
 		{
 			"name": "Gun-Mage Adept",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"category": "G",
 			"prerequisite": [
 				{
@@ -3246,7 +3246,7 @@
 		},
 		{
 			"name": "Iron Hero",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaPlayerPack"
@@ -3295,7 +3295,7 @@
 		},
 		{
 			"name": "Marksman's Luck",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"category": "G",
 			"prerequisite": [
 				{
@@ -3334,7 +3334,7 @@
 	"spell": [
 		{
 			"name": "Antiballistics Field",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3388,7 +3388,7 @@
 		},
 		{
 			"name": "Ballistic Smite",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3453,7 +3453,7 @@
 		},
 		{
 			"name": "Concealed Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3516,7 +3516,7 @@
 		},
 		{
 			"name": "Conjure Cannonball",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3590,7 +3590,7 @@
 		},
 		{
 			"name": "Conjure Cover",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3657,7 +3657,7 @@
 		},
 		{
 			"name": "Finger Guns",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaPlayerPack"
@@ -3730,7 +3730,7 @@
 		},
 		{
 			"name": "Jam Weapon",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3783,7 +3783,7 @@
 		},
 		{
 			"name": "Jethro's Instant Reload",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3839,7 +3839,7 @@
 		},
 		{
 			"name": "Perforating Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"otherSources": [
 				{
 					"source": "ValdaSpire24"
@@ -3900,7 +3900,7 @@
 	"item": [
 		{
 			"name": "Assault Rifle",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -3932,7 +3932,7 @@
 		},
 		{
 			"name": "Blunderbuss",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -3962,7 +3962,7 @@
 		},
 		{
 			"name": "Bullet",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"type": "A|XPHB",
 			"rarity": "none",
 			"weight": 0.15,
@@ -3979,7 +3979,7 @@
 		},
 		{
 			"name": "Cannon",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4010,7 +4010,7 @@
 		},
 		{
 			"name": "Cannonball",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"type": "A|XPHB",
 			"rarity": "none",
 			"weight": 2,
@@ -4027,7 +4027,7 @@
 		},
 		{
 			"name": "Double-Barrel Shotgun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4059,7 +4059,7 @@
 		},
 		{
 			"name": "Flare",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"type": "A|XPHB",
 			"rarity": "none",
 			"weight": 1,
@@ -4076,7 +4076,7 @@
 		},
 		{
 			"name": "Flare Gun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4105,7 +4105,7 @@
 		},
 		{
 			"name": "Gatling Gun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4137,7 +4137,7 @@
 		},
 		{
 			"name": "Handgun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4168,7 +4168,7 @@
 		},
 		{
 			"name": "Hunting Rifle",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4199,7 +4199,7 @@
 		},
 		{
 			"name": "Magnum",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4231,7 +4231,7 @@
 		},
 		{
 			"name": "Musket",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4257,7 +4257,7 @@
 		},
 		{
 			"name": "Parlor Gun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4288,7 +4288,7 @@
 		},
 		{
 			"name": "Pistol",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4316,7 +4316,7 @@
 		},
 		{
 			"name": "Pump Shotgun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4349,7 +4349,7 @@
 		},
 		{
 			"name": "Revolver",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4381,7 +4381,7 @@
 		},
 		{
 			"name": "Shell",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"type": "A|XPHB",
 			"rarity": "none",
 			"weight": 0.15,
@@ -4398,7 +4398,7 @@
 		},
 		{
 			"name": "Shot",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"type": "A|XPHB",
 			"rarity": "none",
 			"weight": 0.2,
@@ -4415,7 +4415,7 @@
 		},
 		{
 			"name": "Sniper Rifle",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4446,7 +4446,7 @@
 		},
 		{
 			"name": "Submachine Gun",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"edition": "one",
 			"type": "R|XPHB",
 			"rarity": "none",
@@ -4479,7 +4479,7 @@
 	"itemFluff": [
 		{
 			"name": "Assault Rifle",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -4494,7 +4494,7 @@
 		},
 		{
 			"name": "Revolver",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -4512,7 +4512,7 @@
 		{
 			"name": "Firearm",
 			"abbreviation": "GC:VSS-F",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				{
 					"type": "entries",
@@ -4526,17 +4526,17 @@
 		{
 			"name": "Industrial Era",
 			"abbreviation": "GC:VSS-I",
-			"source": "ValdaGunslinger"
+			"source": "ItemsValdaGunslinger"
 		},
 		{
 			"name": "Modern Era",
 			"abbreviation": "GC:VSS-M",
-			"source": "ValdaGunslinger"
+			"source": "ItemsValdaGunslinger"
 		},
 		{
 			"name": "Recoil",
 			"abbreviation": "GC:VSS-R",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				{
 					"type": "entries",
@@ -4550,34 +4550,34 @@
 		{
 			"name": "Renaissance Era",
 			"abbreviation": "GC:VSS-Ren",
-			"source": "ValdaGunslinger"
+			"source": "ItemsValdaGunslinger"
 		}
 	],
 	"itemMastery": [
 		{
 			"name": "Automatic",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				"When you make an attack with this weapon, you can choose to make two attacks instead. These attacks are always made with {@variantrule Disadvantage|XPHB}, regardless of circumstance. You can't replace these attacks. If this weapon has {@itemProperty AF|XDMG|Ammunition}, these attacks use twice the normal amount of ammunition."
 			]
 		},
 		{
 			"name": "Explode",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				"When you take the {@action Attack|XPHB} action, you can replace one of your attacks with an explosion from this weapon's projectile. This explosion is a 5-foot-radius {@variantrule Sphere [Area of Effect]|XPHB|Sphere} centered on a point you choose within the weapon's normal range. Each creature within the {@variantrule Sphere [Area of Effect]|XPHB|Sphere} makes a Dexterity saving throw (DC 8 plus your Strength or Dexterity modifier and your {@variantrule Proficiency|XPHB|Proficiency Bonus}). On a failed save, a creature takes the weapon's damage, but don't add your ability modifier to that damage unless that modifier is negative. On a successful save, a creature takes half as much damage. You can create an explosion only once per turn."
 			]
 		},
 		{
 			"name": "Scatter",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				"Being within 5 feet of an enemy doesn't impose {@variantrule Disadvantage|XPHB} on your ranged attack rolls with this weapon."
 			]
 		},
 		{
 			"name": "Sighted",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"entries": [
 				"Attacking at long range with this weapon doesn't impose {@variantrule Disadvantage|XPHB} on your attack rolls. When you hit a creature with an attack using this weapon at long range, you can reroll any of the damage dice and must use the new roll."
 			]
@@ -4587,7 +4587,7 @@
 		{
 			"name": "The Gunslinger Class: Valda's Spire of Secrets",
 			"id": "ValdaGunslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"group": "supplement-alt",
 			"cover": {
 				"type": "external",
@@ -4630,7 +4630,7 @@
 	"bookData": [
 		{
 			"id": "ValdaGunslinger",
-			"source": "ValdaGunslinger",
+			"source": "ItemsValdaGunslinger",
 			"data": [
 				{
 					"type": "section",

--- a/item/CaioTome; Valda's Gunslinger.json
+++ b/item/CaioTome; Valda's Gunslinger.json
@@ -400,7 +400,7 @@
 			"shortName": "Deadeye",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"Deadeye|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|3",
 				"Concealed Position|Gunslinger|ValdaGunslinger|Deadeye|ValdaGunslinger|6",
@@ -414,7 +414,7 @@
 			"shortName": "High Roller",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"High Roller|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|3",
 				"Risky Business|Gunslinger|ValdaGunslinger|High Roller|ValdaGunslinger|6",
@@ -428,7 +428,7 @@
 			"shortName": "Secret Agent",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"additionalSpells": [
 				{
 					"ability": {
@@ -461,7 +461,7 @@
 			"shortName": "Spellslinger",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"spellcastingAbility": "int",
 			"casterProgression": "1/3",
 			"preparedSpellsProgression": [
@@ -775,7 +775,7 @@
 			"shortName": "Trick Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"Trick Shot|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|3",
 				"Fancy Gunplay|Gunslinger|ValdaGunslinger|Trick Shot|ValdaGunslinger|6",
@@ -789,7 +789,7 @@
 			"shortName": "White Hat",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassFeatures": [
 				"White Hat|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|3",
 				"Reach for the Skies|Gunslinger|ValdaGunslinger|White Hat|ValdaGunslinger|6",
@@ -805,7 +805,7 @@
 			"shortName": "Deadeye",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -823,7 +823,7 @@
 			"shortName": "High Roller",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -841,7 +841,7 @@
 			"shortName": "Secret Agent",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -859,7 +859,7 @@
 			"shortName": "Spellslinger",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -877,7 +877,7 @@
 			"shortName": "Trick Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -895,7 +895,7 @@
 			"shortName": "White Hat",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"images": [
 				{
 					"type": "image",
@@ -914,7 +914,7 @@
 			"name": "Fighting Style",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 1,
 			"entries": [
 				"You gain a {@filter Fighting Style feat|feats|category=FS} of your choice. If you choose a feat, such as {@feat Great Weapon Fighting|XPHB}, that requires you to hold a Melee weapon in one or two hands, you can use that feat with Ranged weapons.",
@@ -925,7 +925,7 @@
 			"name": "Quick Draw",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 1,
 			"entries": [
 				"You're adept at drawing and firing before others have time to react, granting you the following benefits.",
@@ -954,7 +954,7 @@
 			"name": "Weapon Mastery",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 1,
 			"entries": [
 				"Your training with weapons allows you to use the mastery properties of two kinds of {@filter Simple|items|type=simple weapon} or {@filter Martial Ranged weapons|items|type=ranged weapon} of your choice. Whenever you finish a {@variantrule Long Rest|XPHB}, you can practice weapon drills and change one of those weapon choices.",
@@ -965,7 +965,7 @@
 			"name": "Critical Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 2,
 			"entries": [
 				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 19 or 20 on the {@dice d20}.",
@@ -976,7 +976,7 @@
 			"name": "Risk",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 2,
 			"entries": [
 				"You can perform incredible feats of daring fueled by special dice called Risk Dice.",
@@ -1047,7 +1047,7 @@
 			"name": "Gunslinger Subclass",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 3,
 			"entries": [
 				"You gain a Gunslinger subclass of your choice. A subclass is a specialization that grants you features at certain Gunslinger levels. For the rest of your career, you gain each of your subclass's features that are of your Gunslinger level or lower."
@@ -1057,7 +1057,7 @@
 			"name": "Ability Score Improvement",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 4,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1067,7 +1067,7 @@
 			"name": "Extra Attack",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 5,
 			"entries": [
 				"You can attack twice instead of once whenever you take the {@action Attack|XPHB} action on your turn."
@@ -1077,7 +1077,7 @@
 			"name": "Gut Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 5,
 			"entries": [
 				"Whenever you score a {@variantrule Critical Hit|XPHB} against a Large or smaller creature with a ranged attack using a weapon, the projectile lodges itself in the target. For 1 minute or until the target replaces one of its attacks with dislodging the projectile, its {@variantrule Speed|XPHB} is halved and it has {@variantrule Disadvantage|XPHB} on attack rolls."
@@ -1087,7 +1087,7 @@
 			"name": "Subclass Feature",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 6,
 			"entries": [
 				"You gain a feature from your Gunslinger Subclass."
@@ -1097,7 +1097,7 @@
 			"name": "Evasion",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 7,
 			"entries": [
 				"When you're subjected to an effect that allows you to make a Dexterity saving throw to take only half damage, you instead take no damage if you succeed on the saving throw and only half damage if you fail.",
@@ -1108,7 +1108,7 @@
 			"name": "Ability Score Improvement",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 8,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1118,7 +1118,7 @@
 			"name": "Critical Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 9,
 			"entries": [
 				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 18, 19, or 20 on the {@dice d20}."
@@ -1128,7 +1128,7 @@
 			"name": "Subclass Feature",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 10,
 			"entries": [
 				"You gain a feature from your Gunslinger Subclass."
@@ -1138,7 +1138,7 @@
 			"name": "Overkill",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 11,
 			"entries": [
 				"When you deal damage with a Ranged weapon that doesn't add your ability modifier to the roll, you add your ability modifier nonetheless. If you already add your modifier to the damage roll, the target takes an extra {@damage 1d8} damage of the weapon's type.",
@@ -1149,7 +1149,7 @@
 			"name": "Ability Score Improvement",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 12,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1159,7 +1159,7 @@
 			"name": "Cheat Death",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 13,
 			"entries": [
 				"When you are reduced to 0 {@variantrule Hit Points|XPHB} and not killed outright, you can drop to 1 {@variantrule Hit Points|XPHB|Hit Point} instead, and you regain a number of {@variantrule Hit Points|XPHB} equal to your Gunslinger level.",
@@ -1170,7 +1170,7 @@
 			"name": "Subclass Feature",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 14,
 			"entries": [
 				"You gain a feature from your Gunslinger Subclass."
@@ -1180,7 +1180,7 @@
 			"name": "Dire Gambit",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 15,
 			"entries": [
 				"Whenever you roll {@variantrule Initiative|XPHB} or score a {@variantrule Critical Hit|XPHB}, you regain one expended {@classFeature Risk|Gunslinger|ValdaGunslinger|2|ValdaGunslinger|Risk Die}."
@@ -1190,7 +1190,7 @@
 			"name": "Ability Score Improvement",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 16,
 			"entries": [
 				"You gain the {@feat Ability Score Improvement|XPHB} feat or another {@5etools feat|feats.html} of your choice for which you qualify."
@@ -1200,7 +1200,7 @@
 			"name": "Critical Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 17,
 			"entries": [
 				"Your attack rolls with Ranged weapons can score a {@variantrule Critical Hit|XPHB} on a roll of 17-20 on the {@dice d20}."
@@ -1210,7 +1210,7 @@
 			"name": "Deft Maneuver",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 18,
 			"entries": [
 				"You gain a special additional {@variantrule Bonus Action|XPHB} that you can take once on each of your turns. You can take this special {@variantrule Bonus Action|XPHB} only to use a maneuver."
@@ -1220,7 +1220,7 @@
 			"name": "Epic Boon",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 19,
 			"entries": [
 				"You gain an {@filter Epic Boon feat|feats|category=EB} or another feat of your choice for which you qualify. {@feat Boon of Irresistible Offense|XPHB} is recommended."
@@ -1230,7 +1230,7 @@
 			"name": "Headshot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 20,
 			"entries": [
 				"When you score a {@variantrule Critical Hit|XPHB} against a creature using a Ranged weapon, you can choose for it to be a Headshot. If the creature has less than 100 {@variantrule Hit Points|XPHB}, it dies. Otherwise, it takes an extra {@damage 10d10} damage of the weapon's type.",
@@ -1243,7 +1243,7 @@
 			"name": "Quick Draw",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 1,
 			"effects": [
 				{
@@ -1264,7 +1264,7 @@
 			"name": "Critical Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 2,
 			"effects": [
 				{
@@ -1285,7 +1285,7 @@
 			"name": "Risk",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 2,
 			"system": {
 				"uses": {
@@ -1297,7 +1297,7 @@
 			"name": "Gut Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 5,
 			"activities": [
 				{
@@ -1328,7 +1328,7 @@
 			"name": "Critical Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 9,
 			"isIgnored": true
 		},
@@ -1336,7 +1336,7 @@
 			"name": "Overkill",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 11,
 			"activities": [
 				{
@@ -1419,7 +1419,7 @@
 			"name": "Cheat Death",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 13,
 			"activities": [
 				{
@@ -1469,7 +1469,7 @@
 			"name": "Dire Gambit",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 15,
 			"activities": [
 				{
@@ -1502,7 +1502,7 @@
 			"name": "Critical Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 17,
 			"isIgnored": true
 		},
@@ -1510,7 +1510,7 @@
 			"name": "Headshot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"level": 20,
 			"activities": [
 				{
@@ -1578,7 +1578,7 @@
 			"name": "Deadeye",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1599,7 +1599,7 @@
 			"name": "Eagle Eye [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1612,7 +1612,7 @@
 			"name": "Sharpshooter's Stance",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1639,7 +1639,7 @@
 			"name": "Concealed Position",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -1666,7 +1666,7 @@
 			"name": "Reposition",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -1679,7 +1679,7 @@
 			"name": "Focused Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -1692,7 +1692,7 @@
 			"name": "High Roller",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1713,7 +1713,7 @@
 			"name": "Liar's Dice [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1747,7 +1747,7 @@
 			"name": "Poker Face",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1781,7 +1781,7 @@
 			"name": "Risky Business",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -1794,7 +1794,7 @@
 			"name": "Risk Taker",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -1807,7 +1807,7 @@
 			"name": "Double or Nothing",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -1820,7 +1820,7 @@
 			"name": "Secret Agent",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1841,7 +1841,7 @@
 			"name": "Operative Training",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1895,7 +1895,7 @@
 			"name": "Parting Shot [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1908,7 +1908,7 @@
 			"name": "Fieldcraft",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -1935,7 +1935,7 @@
 			"name": "Exit Strategy",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -1949,7 +1949,7 @@
 			"name": "License to Kill",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -1962,7 +1962,7 @@
 			"name": "Spellslinger",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -1983,7 +1983,7 @@
 			"name": "Bang, You're Dead!",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2010,7 +2010,7 @@
 			"name": "Spellcasting",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2067,7 +2067,7 @@
 			"name": "Spellshot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -2080,7 +2080,7 @@
 			"name": "Counter-Mage",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -2114,7 +2114,7 @@
 			"name": "Magic Bullet [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2127,7 +2127,7 @@
 			"name": "Trick Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2148,7 +2148,7 @@
 			"name": "Creative Trajectory",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2161,7 +2161,7 @@
 			"name": "Ricochet [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2174,7 +2174,7 @@
 			"name": "Fancy Gunplay",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -2201,7 +2201,7 @@
 			"name": "Deft Deflection [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -2214,7 +2214,7 @@
 			"name": "Pinball Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2228,7 +2228,7 @@
 			"name": "White Hat",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2249,7 +2249,7 @@
 			"name": "Lay Down the Law [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2262,7 +2262,7 @@
 			"name": "Steely-Eyed Aura",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2275,7 +2275,7 @@
 			"name": "Reach for the Skies",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -2288,7 +2288,7 @@
 			"name": "Long Arm of the Law",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -2301,7 +2301,7 @@
 			"name": "Gold Star Hero",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2337,7 +2337,7 @@
 			"name": "Eagle Eye [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Deadeye",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2372,7 +2372,7 @@
 			"name": "Liar's Dice [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2404,7 +2404,7 @@
 			"name": "Risky Business",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -2435,7 +2435,7 @@
 			"name": "Double or Nothing",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "High Roller",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2456,7 +2456,7 @@
 			"name": "Parting Shot [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2501,7 +2501,7 @@
 			"name": "Exit Strategy",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -2562,7 +2562,7 @@
 			"name": "License to Kill",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Secret Agent",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2614,7 +2614,7 @@
 			"name": "Bang, You're Dead!",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2663,7 +2663,7 @@
 			"name": "Counter-Mage",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -2685,7 +2685,7 @@
 			"name": "Magic Bullet [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Spellslinger",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2719,7 +2719,7 @@
 			"name": "Ricochet [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,
@@ -2753,7 +2753,7 @@
 			"name": "Fancy Gunplay",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 6,
@@ -2775,7 +2775,7 @@
 			"name": "Deft Deflection [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 10,
@@ -2821,7 +2821,7 @@
 			"name": "Pinball Shot",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "Trick Shot",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 14,
@@ -2881,7 +2881,7 @@
 			"name": "Lay Down the Law [Maneuver]",
 			"source": "ItemsValdaGunslinger",
 			"className": "Gunslinger",
-			"classsource": "ItemsValdaGunslinger",
+			"classSource": "ItemsValdaGunslinger",
 			"subclassShortName": "White Hat",
 			"subclasssource": "ItemsValdaGunslinger",
 			"level": 3,

--- a/item/CaioTome; Valda's Gunslinger.json
+++ b/item/CaioTome; Valda's Gunslinger.json
@@ -2,7 +2,7 @@
 	"_meta": {
 		"sources": [
 			{
-				"json": "ValdaGunslinger",
+				"json": "ItemsValdaGunslinger",
 				"abbreviation": "GC:VSS'24",
 				"full": "The Gunslinger Class: Valda's Spire of Secrets",
 				"url": "https://marketplace.dndbeyond.com/category/DBGYLCFKE",
@@ -12,7 +12,7 @@
 					"Mage Hand Press"
 				],
 				"convertedBy": [
-					"Unknown"
+					"CaioTome"
 				],
 				"partnered": true,
 				"color": "ca8464"


### PR DESCRIPTION
Add new homebrew JSON file item/CaioTome; Valda's Gunslinger.json containing the full 'Gunslinger' class (ValdaGunslinger) and its subclasses (Deadeye, High Roller, Secret Agent, Spellslinger, Trick Shot, White Hat). Includes class features, subclass features, maneuvers, spells, starting equipment, fluff and images, Foundry advancement/effect configurations, and source metadata (Mage Hand Press conversion). To use on betterR20