### PR TITLE
Add Synology @eaDir to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ scratch/
 _scratch/
 *.DS_Store
 Thumbs.db
+**/@eaDir


### PR DESCRIPTION
Synology NAS stores a lot of stuff no one else wants/that should never be committed in @eadir folders, so ignore it.